### PR TITLE
[Mail]: Formatting does not apply properly to line breaks, causing the selectors to appear blank.

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -5111,12 +5111,23 @@ RefPtr<Font> Editor::fontForSelection(bool& hasMultipleFonts)
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     RefPtr<Font> font;
+    RefPtr<Font> lineBreakFont;
     for (Ref node : intersectingNodes(*range)) {
         CheckedPtr renderer = node->renderer();
         if (!renderer)
             continue;
+
+        // A line break renders no text of its own, so its font must not make uniformly styled text report multiple fonts.
+        if (renderer->isBR()) {
+            if (!lineBreakFont) {
+                Ref primaryFont = renderer->style().fontCascade().primaryFont();
+                lineBreakFont = const_cast<Font*>(primaryFont.ptr());
+            }
+            continue;
+        }
+
         // The font of intermediate nodes that don't affect the rendering of text are not necessary to report, so limit to only such nodes.
-        if (!node->isTextNode() && !renderer->isBR() && !TextNodeTraversal::firstChild(node))
+        if (!node->isTextNode() && !TextNodeTraversal::firstChild(node))
             continue;
         Ref primaryFont = renderer->style().fontCascade().primaryFont();
         if (!font)
@@ -5127,7 +5138,7 @@ RefPtr<Font> Editor::fontForSelection(bool& hasMultipleFonts)
         }
     }
 
-    return font;
+    return font ? font : lineBreakFont;
 }
 
 bool Editor::canCopyExcludingStandaloneImages() const

--- a/Tools/Scripts/webkitpy/api_tests/allowlist.txt
+++ b/Tools/Scripts/webkitpy/api_tests/allowlist.txt
@@ -4219,7 +4219,8 @@ TestWebKitAPI._WKDownload.SystemPreviewUSDZBlobNaming
 [ ios ] TestWebKitAPI.FontManagerTests.ChangeFontWithPanel
 [ ios ] TestWebKitAPI.FontManagerTests.ChangeTypingAttributesWithInspectorBar
 [ ios ] TestWebKitAPI.FontManagerTests.ObservingFontPanelShouldNotCrashWhenUnparentingViewTwice
-[ ios ] TestWebKitAPI.FontManagerTests.SelectionSpanningBRDoesReportMultipleFonts
+[ ios ] TestWebKitAPI.FontManagerTests.SelectionContainingOnlyBRStillReportsAFont
+[ ios ] TestWebKitAPI.FontManagerTests.SelectionSpanningBRDoesNotReportMultipleFonts
 [ ios ] TestWebKitAPI.FontManagerTests.SelectionSpanningEmptyElementDoesNotReportMultipleFonts
 [ ios ] TestWebKitAPI.FontManagerTests.SelectionSpanningTwoFontsDoesReportMultipleFonts
 [ ios ] TestWebKitAPI.FontManagerTests.SetSelectedSystemFontAfterTogglingBold

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
@@ -623,7 +623,7 @@ TEST(FontManagerTests, SelectionSpanningTwoFontsDoesReportMultipleFonts)
     EXPECT_TRUE([fontManager isMultiple]);
 }
 
-TEST(FontManagerTests, SelectionSpanningBRDoesReportMultipleFonts)
+TEST(FontManagerTests, SelectionSpanningBRDoesNotReportMultipleFonts)
 {
     NSFontManager *fontManager = NSFontManager.sharedFontManager;
 
@@ -633,7 +633,20 @@ TEST(FontManagerTests, SelectionSpanningBRDoesReportMultipleFonts)
     [webView waitForNextPresentationUpdate];
 
     EXPECT_WK_STREQ([[fontManager selectedFont] fontName], "Helvetica");
-    EXPECT_TRUE([fontManager isMultiple]);
+    EXPECT_FALSE([fontManager isMultiple]);
+}
+
+TEST(FontManagerTests, SelectionContainingOnlyBRStillReportsAFont)
+{
+    RetainPtr fontManager = [NSFontManager sharedFontManager];
+
+    RetainPtr webView = webViewForFontManagerTesting(fontManager, @"<body contenteditable><div id=empty style='font-family: Helvetica'><br></div></body>");
+    [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(empty)"];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ([[fontManager selectedFont] fontName], "Helvetica");
+    EXPECT_FALSE([fontManager isMultiple]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7a12760719f1be2057e8d1d6732f9e99a14bd89e
<pre>
[Mail]: Formatting does not apply properly to line breaks, causing the selectors to appear blank.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322227">https://bugs.webkit.org/show_bug.cgi?id=322227</a>
<a href="https://rdar.apple.com/177949036">rdar://177949036</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

In Mail, type a line, hit Return, type some more, then select all and change the font or size:
the font and size selectors go blank.

Editor::fontForSelection decides hasMultipleFonts by comparing the primary font of every node in
the selection, and that includes any &lt;br&gt;. A &lt;br&gt; that isn&apos;t inside a styled wrapper inherits its
font from an ancestor, so this comes back as &quot;multiple&quot; even though every bit of text is Helvetica:

    &lt;font face=Helvetica&gt;First&lt;/font&gt;&lt;br&gt;&lt;font face=Helvetica&gt;Second&lt;/font&gt;

On macOS that lands in -[NSFontManager setSelectedFont:isMultiple:], which blanks out the panel&apos;s fields.

So stop letting a line break&apos;s font decide this; it contributes no text and shouldn&apos;t outvote the text
that&apos;s actually selected. It&apos;s kept as a fallback rather than skipped outright, because a selection
containing only a line break still has to report something — otherwise NSFontAttributeName drops out of
the dictionary and clients get empty attributes instead of a merely wrong font.

This overturns the expectation added in 308562@main, which fixed the neighboring unstyled-wrapper case and
recorded the line-break case as reporting multiple fonts. That commit&apos;s stated rule was to count only
&quot;elements with immediate text node children&quot;, which a &lt;br&gt; isn&apos;t, so the carve-out reads as preserving
old behavior rather than asking for it, and neither the bug nor the PR says otherwise. It is a real
trade: a bare &lt;br&gt; on a blank line does affect that line&apos;s height, so a selection containing one is no
longer reported as mixed. For a formatting UI, showing the selected text&apos;s font is the more useful answer.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontForSelection):
* Tools/Scripts/webkitpy/api_tests/allowlist.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST(FontManagerTests, SelectionSpanningBRDoesNotReportMultipleFonts)):
(TestWebKitAPI::TEST(FontManagerTests, SelectionContainingOnlyBRStillReportsAFont)):
(TestWebKitAPI::TEST(FontManagerTests, SelectionSpanningBRDoesReportMultipleFonts)): Deleted.

Canonical link: <a href="https://commits.webkit.org/319747@main">https://commits.webkit.org/319747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6df2027d085e6c5f889f05dcce5d72151c4d91b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146911 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f177294-116c-405c-afef-3b2b46f08c3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dae7d4b0-0582-4b88-b8e0-53a4d1abbdf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46241 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163273 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e10c2da1-8576-4844-802d-a1de8c4fbd66) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181951 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44925 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43172 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42800 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56216 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40717 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56920 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151659 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46236 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129188 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125207 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55428 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17800 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55038 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->