### PR TITLE
Cherry-pick(s) ae0bf14abc6d. rdar://184744035

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -64,9 +64,12 @@ public:
     Type type() const { return m_type; }
     uint64_t allocatedUnusedCapacity();
     std::optional<WebCore::ClientOrigin> origin() const;
+<<<<<<< HEAD
 
     const Markable<WebCore::FileSystemHandleGlobalIdentifier>& globalIdentifier() const { return m_globalIdentifier; }
     void setGlobalIdentifier(WebCore::FileSystemHandleGlobalIdentifier globalIdentifier) { m_globalIdentifier = globalIdentifier; }
+=======
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     void close();
     bool isSameEntry(WebCore::FileSystemHandleIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -28,7 +28,10 @@
 #include "FileSystemStorageHandle.h"
 #include "FileSystemStorageManagerLock.h"
 #include <WebCore/ClientOrigin.h>
+<<<<<<< HEAD
 #include <WebCore/FileSystemHandleGlobalIdentifier.h>
+=======
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemHandleKind.h>
 #include <WebCore/FileSystemHandleRecord.h>

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1067,7 +1067,11 @@ void NetworkStorageManager::fileSystemGetDirectory(IPC::Connection& connection, 
     ASSERT(!RunLoop::isMain());
     MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
 
+<<<<<<< HEAD
     Ref fileSystemStorageManager = originStorageManager(origin, ShouldWriteOriginFile::Yes, ShouldUpdateOriginAccessTime::Yes)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry), origin);
+=======
+    Ref fileSystemStorageManager = checkedOriginStorageManager(origin)->fileSystemStorageManager(*protectedFileSystemStorageHandleRegistry(), origin);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     auto result = fileSystemStorageManager->getDirectory(connection.uniqueID());
     if (!result)
         return completionHandler(makeUnexpected(result.error()));
@@ -1079,11 +1083,19 @@ void NetworkStorageManager::closeHandle(IPC::Connection& connection, WebCore::Fi
 {
     ASSERT(!RunLoop::isMain());
 
+<<<<<<< HEAD
     RefPtr handle = m_fileSystemStorageHandleRegistry->getHandle(identifier);
     if (!handle)
         return;
 
     MESSAGE_CHECK(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection);
+=======
+    RefPtr handle = protectedFileSystemStorageHandleRegistry()->getHandle(identifier);
+    if (!handle)
+        return;
+
+    STORAGE_MESSAGE_CHECK(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     handle->close();
 }
@@ -1096,7 +1108,11 @@ void NetworkStorageManager::isSameEntry(IPC::Connection& connection, WebCore::Fi
     if (!handle)
         return completionHandler(false);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(false));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(false));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->isSameEntry(targetIdentifier));
 }
@@ -1109,7 +1125,11 @@ void NetworkStorageManager::move(IPC::Connection& connection, WebCore::FileSyste
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->move(destinationIdentifier, newName));
 }
@@ -1122,6 +1142,7 @@ void NetworkStorageManager::getFileHandle(IPC::Connection& connection, WebCore::
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
 
     auto result = handle->getFileHandle(connection.uniqueID(), WTF::move(name), createIfNecessary);
@@ -1129,6 +1150,11 @@ void NetworkStorageManager::getFileHandle(IPC::Connection& connection, WebCore::
         return completionHandler(makeUnexpected(result.error()));
 
     completionHandler(result.value());
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+
+    completionHandler(handle->getFileHandle(connection.uniqueID(), WTF::move(name), createIfNecessary));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 }
 
 void NetworkStorageManager::getDirectoryHandle(IPC::Connection& connection, WebCore::FileSystemHandleIdentifier identifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleGlobalIdentifier, WebCore::FileSystemHandleIdentifier>, FileSystemStorageError>)>&& completionHandler)
@@ -1139,6 +1165,7 @@ void NetworkStorageManager::getDirectoryHandle(IPC::Connection& connection, WebC
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
 
     auto result = handle->getDirectoryHandle(connection.uniqueID(), WTF::move(name), createIfNecessary);
@@ -1146,6 +1173,11 @@ void NetworkStorageManager::getDirectoryHandle(IPC::Connection& connection, WebC
         return completionHandler(makeUnexpected(result.error()));
 
     completionHandler(result.value());
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+
+    completionHandler(handle->getDirectoryHandle(connection.uniqueID(), WTF::move(name), createIfNecessary));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 }
 
 void NetworkStorageManager::removeEntry(IPC::Connection& connection, WebCore::FileSystemHandleIdentifier identifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&& completionHandler)
@@ -1156,12 +1188,20 @@ void NetworkStorageManager::removeEntry(IPC::Connection& connection, WebCore::Fi
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->removeEntry(name, deleteRecursively));
 }
 
+<<<<<<< HEAD
 void NetworkStorageManager::resolve(IPC::Connection& connection, WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier, CompletionHandler<void(Expected<std::optional<Vector<String>>, FileSystemStorageError>)>&& completionHandler)
+=======
+void NetworkStorageManager::resolve(IPC::Connection& connection, WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 {
     ASSERT(!RunLoop::isMain());
 
@@ -1169,7 +1209,11 @@ void NetworkStorageManager::resolve(IPC::Connection& connection, WebCore::FileSy
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->resolve(targetIdentifier));
 }
@@ -1182,10 +1226,14 @@ void NetworkStorageManager::getFile(IPC::Connection& connection, WebCore::FileSy
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
 
     if (!FileSystem::fileExists(handle->path()))
         return completionHandler(makeUnexpected(FileSystemStorageError::FileNotFound));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, connection = Ref { connection }, path = crossThreadCopy(handle->path()), completionHandler = WTF::move(completionHandler)] mutable {
         if (RefPtr process = protectedThis->m_process.get()) {
@@ -1206,7 +1254,11 @@ void NetworkStorageManager::createSyncAccessHandle(IPC::Connection& connection, 
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->createSyncAccessHandle());
 }
@@ -1215,11 +1267,19 @@ void NetworkStorageManager::closeSyncAccessHandle(IPC::Connection& connection, W
 {
     ASSERT(!RunLoop::isMain());
 
+<<<<<<< HEAD
     RefPtr handle = m_fileSystemStorageHandleRegistry->getHandle(identifier);
     if (!handle)
         return completionHandler();
 
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler());
+=======
+    RefPtr handle = protectedFileSystemStorageHandleRegistry()->getHandle(identifier);
+    if (!handle)
+        return completionHandler();
+
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler());
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     handle->closeSyncAccessHandle(accessHandleIdentifier);
 
@@ -1234,7 +1294,11 @@ void NetworkStorageManager::requestNewCapacityForSyncAccessHandle(IPC::Connectio
     if (!handle)
         return completionHandler(std::nullopt);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(std::nullopt));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(std::nullopt));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     handle->requestNewCapacityForSyncAccessHandle(accessHandleIdentifier, newCapacity, WTF::move(completionHandler));
 }
@@ -1247,7 +1311,11 @@ void NetworkStorageManager::createWritable(IPC::Connection& connection, WebCore:
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->createWritable(keepExistingData));
 }
@@ -1260,7 +1328,11 @@ void NetworkStorageManager::closeWritable(IPC::Connection& connection, WebCore::
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->closeWritable(streamIdentifier, reason));
 }
@@ -1273,7 +1345,11 @@ void NetworkStorageManager::executeCommandForWritable(IPC::Connection& connectio
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(FileSystemStorageError::Unknown));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     handle->executeCommandForWritable(streamIdentifier, type, position, size, dataBytes, hasDataError, WTF::move(completionHandler));
 }
@@ -1286,7 +1362,11 @@ void NetworkStorageManager::getHandleNames(IPC::Connection& connection, WebCore:
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     completionHandler(handle->getHandleNames());
 }
@@ -1299,7 +1379,11 @@ void NetworkStorageManager::getHandle(IPC::Connection& connection, WebCore::File
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
+<<<<<<< HEAD
     MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+=======
+    STORAGE_MESSAGE_CHECK_COMPLETION(canConnectionAccessFileSystemHandle(connection.uniqueID(), *handle), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
 
     auto result = handle->getHandle(connection.uniqueID(), WTF::move(name));
     if (!result)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -205,6 +205,7 @@ private:
     void estimate(IPC::Connection&, const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::StorageEstimate>)>&&);
 
     // Message handlers for FileSystem.
+<<<<<<< HEAD
     void fileSystemGetDirectory(IPC::Connection&, WebCore::ClientOrigin&&, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleGlobalIdentifier, WebCore::FileSystemHandleIdentifier>, FileSystemStorageError>)>&&);
     void closeHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier);
     void isSameEntry(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(bool)>&&);
@@ -213,6 +214,16 @@ private:
     void getDirectoryHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleGlobalIdentifier, WebCore::FileSystemHandleIdentifier>, FileSystemStorageError>)>&&);
     void removeEntry(IPC::Connection&, WebCore::FileSystemHandleIdentifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void resolve(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<std::optional<Vector<String>>, FileSystemStorageError>)>&&);
+=======
+    void fileSystemGetDirectory(IPC::Connection&, WebCore::ClientOrigin&&, CompletionHandler<void(Expected<std::optional<WebCore::FileSystemHandleIdentifier>, FileSystemStorageError>)>&&);
+    void closeHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier);
+    void isSameEntry(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(bool)>&&);
+    void move(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, const String& newName, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
+    void getFileHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
+    void getDirectoryHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
+    void removeEntry(IPC::Connection&, WebCore::FileSystemHandleIdentifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
+    void resolve(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     void getFile(IPC::Connection&, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
     void createSyncAccessHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&&);
     void closeSyncAccessHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
@@ -221,11 +232,16 @@ private:
     void closeWritable(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void executeCommandForWritable(IPC::Connection&, WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void getHandleNames(IPC::Connection&, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
+<<<<<<< HEAD
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<WebCore::FileSystemHandleInfo>, FileSystemStorageError>)>&&);
     void addGlobalIdentifierReference(IPC::Connection&, WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier);
     void removeGlobalIdentifierReferences(IPC::Connection&, WebCore::ClientOrigin&&, Vector<WebCore::FileSystemHandleGlobalIdentifier>&&);
     void resolveGlobalIdentifier(IPC::Connection&, WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
 
+=======
+    void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, FileSystemStorageError>)>&&);
+    
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     // Message handlers for WebStorage.
     void connectToStorageArea(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<StorageAreaIdentifier>, HashMap<String, String>, uint64_t)>&&);
     void connectToStorageAreaSync(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<StorageAreaIdentifier>, HashMap<String, String>, uint64_t)>&&);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -74,7 +74,11 @@ public:
     void connectionClosed(IPC::Connection::UniqueID);
     String typeStoragePath(StorageType) const;
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&, const WebCore::ClientOrigin&, FileSystemStorageManager::QuotaCheckFunction&&);
+<<<<<<< HEAD
     FileSystemStorageManager* NODELETE existingFileSystemStorageManager() { return m_fileSystemStorageManager.get(); }
+=======
+    FileSystemStorageManager* existingFileSystemStorageManager() { return m_fileSystemStorageManager.get(); }
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);
     LocalStorageManager* NODELETE existingLocalStorageManager() { return m_localStorageManager.get(); }
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
@@ -684,6 +688,14 @@ OriginQuotaManager& OriginStorageManager::quotaManager()
 
 FileSystemStorageManager& OriginStorageManager::fileSystemStorageManager(FileSystemStorageHandleRegistry& registry, const WebCore::ClientOrigin& origin)
 {
+<<<<<<< HEAD
+=======
+    return m_quotaManager.get();
+}
+
+FileSystemStorageManager& OriginStorageManager::fileSystemStorageManager(FileSystemStorageHandleRegistry& registry, const WebCore::ClientOrigin& origin)
+{
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     return defaultBucket().fileSystemStorageManager(registry, origin, [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {
         auto strongReference = quotaManager.get();
         if (!strongReference)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -68,8 +68,14 @@ public:
 
     void connectionClosed(IPC::Connection::UniqueID);
     WebCore::StorageEstimate estimate();
+<<<<<<< HEAD
     const String& path() const LIFETIME_BOUND { return m_path; }
     OriginQuotaManager& NODELETE quotaManager();
+=======
+    const String& path() const { return m_path; }
+    OriginQuotaManager& quotaManager();
+    Ref<OriginQuotaManager> protectedQuotaManager();
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier)
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&, const WebCore::ClientOrigin&);
     FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&) LIFETIME_BOUND;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
@@ -1041,7 +1041,11 @@ IPC.addOutgoingMessageListener('Networking', function(msg) {
     }
 });
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
 var run = async() => {
+=======
+async function run() {
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
     var root = await navigator.storage.getDirectory();
     await root.getFileHandle('test.txt', { create: true });
     for await (var entry of root.entries()) { }
@@ -1049,13 +1053,18 @@ var run = async() => {
         alert('id:' + capturedIdentifier.toString());
     else
         alert('error:no-identifier-captured');
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
 };
+=======
+}
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
 run();
 </script>
 )TESTRESOURCE"_s;
 
 static constexpr auto fileSystemBadPageHTML = R"TESTRESOURCE(
 <script>
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
 var attack = (stolenId) => {
     var net = IPC.connectionForProcessTarget('Networking');
     var onReply = (reply) => {
@@ -1068,6 +1077,23 @@ var attack = (stolenId) => {
     };
     net.sendWithAsyncReply(0, IPC.messages.NetworkStorageManager_GetHandleNames.name, [ { type: 'uint64_t', value: BigInt(stolenId) } ], onReply);
 };
+=======
+function attack(stolenId) {
+    var net = IPC.connectionForProcessTarget('Networking');
+    net.sendWithAsyncReply(0,
+        IPC.messages.NetworkStorageManager_GetHandleNames.name,
+        [{ type: 'uint64_t', value: BigInt(stolenId) }],
+        function(reply) {
+            var buf = new DataView(reply.buffer);
+            var hasValue = !!buf.getUint8(16);
+            if (hasValue)
+                alert('FAIL:access-granted');
+            else
+                alert('PASS:access-denied');
+        }
+    );
+}
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
 </script>
 )TESTRESOURCE"_s;
 
@@ -1075,6 +1101,7 @@ TEST(IPCTestingAPI, FileSystemForgedHandleIdentifierRejected)
 {
     using namespace TestWebKitAPI;
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
     RetainPtr tempDir = retainPtr([[NSFileManager defaultManager] URLForDirectory:NSItemReplacementDirectory inDomain:NSUserDomainMask appropriateForURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] create:YES error:nil]);
     RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setGeneralStorageDirectory:[tempDir URLByAppendingPathComponent:@"Storage"]];
@@ -1082,6 +1109,15 @@ TEST(IPCTestingAPI, FileSystemForgedHandleIdentifierRejected)
     [dataStore _setStorageSiteValidationEnabled:YES];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+=======
+    auto tempDir = retainPtr([[NSFileManager defaultManager] URLForDirectory:NSItemReplacementDirectory inDomain:NSUserDomainMask appropriateForURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] create:YES error:nil]);
+    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    [dataStoreConfiguration setGeneralStorageDirectory:[tempDir URLByAppendingPathComponent:@"Storage"]];
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    [dataStore _setStorageSiteValidationEnabled:YES];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
             [[configuration preferences] _setEnabled:YES forFeature:feature];
@@ -1090,8 +1126,13 @@ TEST(IPCTestingAPI, FileSystemForgedHandleIdentifierRejected)
     }
     [configuration setWebsiteDataStore:dataStore.get()];
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
     RetainPtr goodUIDelegate = adoptNS([TestUIDelegate new]);
     RetainPtr goodView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+=======
+    auto goodUIDelegate = adoptNS([TestUIDelegate new]);
+    auto goodView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
     [goodView setUIDelegate:goodUIDelegate.get()];
     [goodView synchronouslyLoadHTMLString:[NSString stringWithUTF8String:fileSystemGoodPageHTML.characters()] baseURL:[NSURL URLWithString:@"https://good.example/"]];
 
@@ -1101,8 +1142,13 @@ TEST(IPCTestingAPI, FileSystemForgedHandleIdentifierRejected)
 
     auto goodPID = [goodView _webProcessIdentifier];
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
     RetainPtr badUIDelegate = adoptNS([TestUIDelegate new]);
     RetainPtr badView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+=======
+    auto badUIDelegate = adoptNS([TestUIDelegate new]);
+    auto badView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+>>>>>>> ae0bf14abc6d (Validate connection access to FileSystem storage with FileSystemHandleIdentifier):Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
     [badView setUIDelegate:badUIDelegate.get()];
     [badView synchronouslyLoadHTMLString:[NSString stringWithUTF8String:fileSystemBadPageHTML.characters()] baseURL:[NSURL URLWithString:@"https://bad.example/"]];
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://184744035 to main. The following sources [9945ade1f70a] will still need to be cherry-picked once the conflict is resolved.

```
Validate connection access to FileSystem storage with FileSystemHandleIdentifier
rdar://176773267

Reviewed by Chris Dumez.

Many FileSystem-related messages sent to NetworkStorageManager only carries FileSystemHandleIdentifier when asking to
operate on FileSystem storage, and NetworkStorageManager does not check whether the sender process actually has access
to requested handle. This lets a compromised process forge FileSystemHandleIdentifier and access data from other
origins. To fix it, this patch stores the origin in FileSystemStorageManager and adding an origin accessor to
FileSystemStorageHandle, so that NetworkStorageManager can run isSiteAllowedForConnection in FileSystem-related message
handlers.

API test: IPCTestingAPI.FileSystemForgedHandleIdentifierRejected

* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::origin const):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::create):
(WebKit::FileSystemStorageManager::FileSystemStorageManager):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::closeHandle):
(WebKit::NetworkStorageManager::isSameEntry):
(WebKit::NetworkStorageManager::move):
(WebKit::NetworkStorageManager::getFileHandle):
(WebKit::NetworkStorageManager::getDirectoryHandle):
(WebKit::NetworkStorageManager::removeEntry):
(WebKit::NetworkStorageManager::resolve):
(WebKit::NetworkStorageManager::getFile):
(WebKit::NetworkStorageManager::createSyncAccessHandle):
(WebKit::NetworkStorageManager::closeSyncAccessHandle):
(WebKit::NetworkStorageManager::requestNewCapacityForSyncAccessHandle):
(WebKit::NetworkStorageManager::createWritable):
(WebKit::NetworkStorageManager::closeWritable):
(WebKit::NetworkStorageManager::executeCommandForWritable):
(WebKit::NetworkStorageManager::getHandleNames):
(WebKit::NetworkStorageManager::getHandle):
(WebKit::NetworkStorageManager::canConnectionAccessFileSystemHandle const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::fileSystemStorageManager):
(WebKit::OriginStorageManager::fileSystemStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(function):
((IPCTestingAPI, FileSystemForgedHandleIdentifierRejected)):
(CGColorInNSSecureCoding)): Deleted.
(NSURLWithBaseURLInNSSecureCoding)): Deleted.

Originally-landed-as: 305413.935@safari-7624-branch (ae0bf14abc6d). rdar://184744035


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d4d8f7ec4af32a6a0c69512b9c24e286c3b1943

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181882 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55829 "") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192107 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183744 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57143 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55551 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192107 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184837 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57143 "") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192107 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57143 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/55551 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192107 "") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57143 "") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3269 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48460 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/55551 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194034 "") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194034 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56188 "") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194034 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56188 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128471 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124233 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54701 "") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->