### PR TITLE
Make hidden page throttling heuristics apply to newly created pages

### DIFF
--- a/LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit-expected.txt
@@ -1,0 +1,13 @@
+Tests that the hidden-page DOM timer throttling auto-increase limit reaches the process of an out-of-process subframe whose view was created while the page was hidden
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The page is hidden, so create the subframe now.
+PASS mainFrameLimit is > 1000
+PASS subframeLimit is mainFrameLimit
+PASS subframeAlignmentInterval is subframeLimit
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit.html
+++ b/LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true HiddenPageDOMTimerThrottlingEnabled=true HiddenPageDOMTimerThrottlingAutoIncreases=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that the hidden-page DOM timer throttling auto-increase limit reaches the process of an out-of-process subframe whose view was created while the page was hidden");
+
+var jsTestIsAsync = true;
+var mainFrameLimit;
+var subframeLimit;
+var subframeAlignmentInterval;
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    subframeLimit = event.data.limit;
+    subframeAlignmentInterval = event.data.alignmentInterval;
+    checkResults();
+}, false);
+
+function runTest()
+{
+    // This test starts working before DOMContentLoaded, which is when js-test.js would call this. Arm
+    // the watchdog of the harness first, so that a failing run reports its output instead of hanging.
+    testRunner.waitUntilDone();
+
+    // Wait for the main frame to observe the change, so that the subframe is created after the page is
+    // already hidden. The limit is a pool-wide value that the UI process only broadcasts when its page
+    // counter changes, so the process of a subframe created now is one that launched after the last
+    // broadcast.
+    document.addEventListener("visibilitychange", pageDidHide);
+    testRunner.setPageVisibility("hidden");
+}
+
+function pageDidHide()
+{
+    document.removeEventListener("visibilitychange", pageDidHide);
+
+    mainFrameLimit = internals.domTimerAlignmentIntervalIncreaseLimit();
+
+    debug("The page is hidden, so create the subframe now.");
+    testFrame = document.createElement("iframe");
+    testFrame.src = "http://localhost:8000/site-isolation/resources/dom-timer-throttling-state-frame.html";
+    testFrame.onload = frameDidLoad;
+    document.body.appendChild(testFrame);
+}
+
+function frameDidLoad()
+{
+    testFrame.contentWindow.postMessage("report-dom-timer-throttling-state", "*");
+}
+
+function checkResults()
+{
+    // Restore visibility before asserting: leaving the page hidden costs the harness the result of the
+    // test if one of these assertions fails.
+    testRunner.resetPageVisibility();
+
+    // The exact limit is 20 s per page with the preference enabled, but the number of such pages in the
+    // pool is not this test's business. What matters is that the subframe's process agrees with the main
+    // frame's rather than being stuck at the default of 0.
+    shouldBeGreaterThan("mainFrameLimit", "1000");
+    shouldBe("subframeLimit", "mainFrameLimit");
+
+    // The subframe's view was created while the page was already hidden, so maximum throttling applies
+    // to it immediately instead of ramping. This is the value that used to be clamped to the 1 s floor.
+    shouldBe("subframeAlignmentInterval", "subframeLimit");
+
+    finishJSTest();
+}
+
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/dom-timer-throttling-state-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/dom-timer-throttling-state-frame.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+// The embedder is cross-origin, so it cannot reach this internals object. It asks for the DOM timer
+// throttling state of this frame's page through messages.
+window.addEventListener("message", function() {
+    if (!window.internals) {
+        parent.postMessage("no internals", "*");
+        return;
+    }
+    parent.postMessage({
+        limit: internals.domTimerAlignmentIntervalIncreaseLimit(),
+        alignmentInterval: internals.domTimerAlignmentInterval()
+    }, "*");
+}, false);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -562,6 +562,7 @@ public:
     ElementTargetingController& elementTargetingController() { return m_elementTargetingController.get(); }
 
     Seconds domTimerAlignmentInterval() const { return m_domTimerAlignmentInterval; }
+    Seconds domTimerAlignmentIntervalIncreaseLimit() const { return m_domTimerAlignmentIntervalIncreaseLimit; }
 
     void setTabKeyCyclesThroughElements(bool b) { m_tabKeyCyclesThroughElements = b; }
     bool tabKeyCyclesThroughElements() const { return m_tabKeyCyclesThroughElements; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1751,6 +1751,24 @@ bool Internals::areTimersThrottled() const
     return contextDocument()->isTimerThrottlingEnabled();
 }
 
+double Internals::domTimerAlignmentInterval() const
+{
+    RefPtr document = contextDocument();
+    RefPtr page = document ? document->page() : nullptr;
+    if (!page)
+        return 0;
+    return page->domTimerAlignmentInterval().milliseconds();
+}
+
+double Internals::domTimerAlignmentIntervalIncreaseLimit() const
+{
+    RefPtr document = contextDocument();
+    RefPtr page = document ? document->page() : nullptr;
+    if (!page)
+        return 0;
+    return page->domTimerAlignmentIntervalIncreaseLimit().milliseconds();
+}
+
 void Internals::setEventThrottlingBehaviorOverride(std::optional<EventThrottlingBehavior> value)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -319,6 +319,8 @@ public:
     double requestAnimationFrameInterval() const;
     bool NODELETE scriptedAnimationsAreSuspended() const;
     bool NODELETE areTimersThrottled() const;
+    double domTimerAlignmentInterval() const;
+    double domTimerAlignmentIntervalIncreaseLimit() const;
 
     enum EventThrottlingBehavior { Responsive, Unresponsive };
     void NODELETE setEventThrottlingBehaviorOverride(std::optional<EventThrottlingBehavior>);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -964,6 +964,9 @@ enum ContentsFormat {
     DOMString requestAnimationFrameThrottlingReasons();
     boolean areTimersThrottled();
 
+    double domTimerAlignmentInterval();
+    double domTimerAlignmentIntervalIncreaseLimit();
+
     undefined setLowPowerModeEnabled(boolean enabled);
     undefined setAggressiveThermalMitigationEnabled(boolean enabled);
     undefined setOutsideViewportThrottlingEnabled(boolean enabled);

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -286,6 +286,7 @@ struct WebProcessCreationParameters {
     HashSet<WebCore::RegistrableDomain> storageAccessPromptQuirksDomains;
     ScriptTrackingPrivacyRules scriptTrackingPrivacyRules;
 
+    Seconds hiddenPageDOMTimerThrottlingIncreaseLimit;
     Seconds memoryFootprintPollIntervalForTesting;
     Vector<uint64_t> memoryFootprintNotificationThresholds;
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -224,6 +224,7 @@ using WebCore::SystemSettings::State = WebCore::SystemSettingsState;
     HashSet<WebCore::RegistrableDomain> storageAccessPromptQuirksDomains;
     WebKit::ScriptTrackingPrivacyRules scriptTrackingPrivacyRules;
 
+    Seconds hiddenPageDOMTimerThrottlingIncreaseLimit;
     Seconds memoryFootprintPollIntervalForTesting;
     Vector<uint64_t> memoryFootprintNotificationThresholds;
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1043,6 +1043,7 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
 #endif
 
     parameters.memoryCacheDisabled = m_memoryCacheDisabled;
+    parameters.hiddenPageDOMTimerThrottlingIncreaseLimit = m_hiddenPageDOMTimerThrottlingIncreaseLimit;
     parameters.attrStyleEnabled = m_configuration->attrStyleEnabled();
     parameters.shouldThrowExceptionForGlobalConstantRedeclaration = m_configuration->shouldThrowExceptionForGlobalConstantRedeclaration();
     parameters.crossOriginMode = process.crossOriginMode();
@@ -2085,7 +2086,8 @@ void WebProcessPool::updateHiddenPageThrottlingAutoIncreaseLimit()
     static int maximumTimerThrottlePerPageInMS = 200 * 100;
 
     int limitInMilliseconds = maximumTimerThrottlePerPageInMS * m_hiddenPageThrottlingAutoIncreasesCounter.value();
-    sendToAllProcesses(Messages::WebProcess::SetHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds::fromMilliseconds(limitInMilliseconds)));
+    m_hiddenPageDOMTimerThrottlingIncreaseLimit = Seconds::fromMilliseconds(limitInMilliseconds);
+    sendToAllProcesses(Messages::WebProcess::SetHiddenPageDOMTimerThrottlingIncreaseLimit(m_hiddenPageDOMTimerThrottlingIncreaseLimit));
 }
 
 void WebProcessPool::reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -883,6 +883,7 @@ private:
     ProcessSuppressionDisabledCounter m_processSuppressionDisabledForPageCounter;
     HiddenPageThrottlingAutoIncreasesCounter m_hiddenPageThrottlingAutoIncreasesCounter;
     RunLoop::Timer m_hiddenPageThrottlingTimer;
+    Seconds m_hiddenPageDOMTimerThrottlingIncreaseLimit;
 
 #if ENABLE(GPU_PROCESS)
     RunLoop::Timer m_resetGPUProcessCrashCountTimer;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -689,6 +689,8 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
     setMemoryCacheDisabled(parameters.memoryCacheDisabled);
 
+    setHiddenPageDOMTimerThrottlingIncreaseLimit(parameters.hiddenPageDOMTimerThrottlingIncreaseLimit);
+
     WebCore::DeprecatedGlobalSettings::setAttrStyleEnabled(parameters.attrStyleEnabled);
 
     // Push the launching page's feature-flag options into the process-global JSC::Options
@@ -1060,6 +1062,8 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
     // It is necessary to check for page existence here since during a window.open() (or targeted
     // link) the WebPage gets created both in the synchronous handler and through the normal way.
     if (addResult.isNewEntry) {
+        page->setHiddenPageDOMTimerThrottlingIncreaseLimit(m_hiddenPageDOMTimerThrottlingIncreaseLimit);
+
 #if ENABLE(GPU_PROCESS)
         if (RefPtr gpuProcessConnection = m_gpuProcessConnection)
             page->gpuProcessConnectionDidBecomeAvailable(*gpuProcessConnection);
@@ -1726,6 +1730,7 @@ void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteD
 
 void WebProcess::setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds seconds)
 {
+    m_hiddenPageDOMTimerThrottlingIncreaseLimit = seconds;
     for (auto& page : m_pageMap.values())
         page->setHiddenPageDOMTimerThrottlingIncreaseLimit(seconds);
 }

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -780,6 +780,8 @@ private:
     HashMap<PageGroupIdentifier, Ref<WebPageGroupProxy>> m_pageGroupMap;
     const RefPtr<InjectedBundle> m_injectedBundle;
 
+    Seconds m_hiddenPageDOMTimerThrottlingIncreaseLimit;
+
     EventDispatcher m_eventDispatcher;
 #if PLATFORM(IOS_FAMILY)
     ViewUpdateDispatcher m_viewUpdateDispatcher;


### PR DESCRIPTION
#### 7b56a059223f8116c20cfd668ae8935e84d800de
<pre>
Make hidden page throttling heuristics apply to newly created pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=322231">https://bugs.webkit.org/show_bug.cgi?id=322231</a>
<a href="https://rdar.apple.com/185461584">rdar://185461584</a>

Reviewed by Ryosuke Niwa.

A newly created page can run with the wrong hidden page throttling timer state:

- If the page is created in a new WebProcess, then the initial state is incorrect, because we don&apos;t
  pass the hidden page throttling state as part of process creation.

- If the page is created in an existing WebProcess, then the initial state is incorrect, because we
  don&apos;t store the last used hidden page throttling state anywhere and apply it to the newly created
  page.

Fix this by adding hiddenPageDOMTimerThrottlingIncreaseLimit as a process creation parameter and
also store it globally on the WebProcess side.

This happens more when Site Isolation is enabled, since creating a new iframe while hidden will
create a new process with potentially stale throttling flags.

* LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/hidden-page-dom-timer-throttling-limit.html: Added.
* LayoutTests/http/tests/site-isolation/resources/dom-timer-throttling-state-frame.html: Added.
* Source/WebCore/page/Page.h:
(WebCore::Page::domTimerAlignmentIntervalIncreaseLimit const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::domTimerAlignmentInterval const):
(WebCore::Internals::domTimerAlignmentIntervalIncreaseLimit const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::initializeNewWebProcess):
(WebKit::WebProcessPool::updateHiddenPageThrottlingAutoIncreaseLimit):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::setHiddenPageDOMTimerThrottlingIncreaseLimit):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/319630@main">https://commits.webkit.org/319630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6acd00cdede85a7abc512acae3cdd15886cdb297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/586ee5a3-1670-45a4-b796-57b558d20e18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142000 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bd97851-05f5-4c49-a003-7a9a1e386bc2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122436 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a9f4b62-4a3c-4456-ad0f-ac0b6f2fcf99) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44368 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42634 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42264 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3283 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194047 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40581 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151123 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45687 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128484 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54714 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17260 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54096 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->