### PR TITLE
[Site Isolation] Web Inspector: Rework protocol test inspector/animation/tracking.html to prep for frame target enablement

### DIFF
--- a/LayoutTests/inspector/animation/tracking-expected.txt
+++ b/LayoutTests/inspector/animation/tracking-expected.txt
@@ -6,11 +6,15 @@ Tests that Animation.startTracking and Animation.stopTracking trigger Animation.
 Animation.trackingStart
 PASS: Should have a timestamp when starting.
 Animation.trackingUpdate
-PASS: Should should have a timestamp number.
+PASS: Should have a timestamp number.
 PASS: Should have an event object.
 PASS: Event should have an animation tracking ID.
 PASS: Event should have an animation state.
 PASS: Event should have a node ID.
 PASS: Event should have the related CSS animation's name.
+PASS: Should have a node for the event's node ID.
+PASS: The animating node should be a <div>.
+PASS: The animating node should have the id "animating".
 Animation.trackingComplete
+PASS: Should have a timestamp when completing.
 

--- a/LayoutTests/inspector/animation/tracking.html
+++ b/LayoutTests/inspector/animation/tracking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <style>
 @keyframes test {
     to { opacity: 0; }
@@ -13,46 +13,97 @@
 <script>
 function startCSSAnimation() {
     let element = document.body.appendChild(document.createElement("div"));
+    element.id = "animating";
     element.className = "test";
 }
 
 function test()
 {
-    let suite = ProtocolTest.createAsyncSuite("Animation.Tracking");
-
-    InspectorProtocol.sendCommand("DOM.getDocument");
+    let suite = InspectorTest.createAsyncSuite("Animation.Tracking");
 
     suite.addTestCase({
         name: "Animation.Tracking.StartAndStopTrackingWithEvent",
-        test(resolve, reject) {
-            InspectorProtocol.awaitEvent({event: "Animation.trackingStart"}).then((messageObject) => {
-                ProtocolTest.log("Animation.trackingStart");
-                ProtocolTest.expectEqual(typeof messageObject.params.timestamp, "number", "Should have a timestamp when starting.");
+        description: "Animation.startTracking and Animation.stopTracking should produce trackingStart, trackingUpdate, and trackingComplete with the expected data.",
+        async test() {
+            // The node id in `Animation.trackingUpdate` comes from the page target's DOM agent, and
+            // that agent only pushes nodes to the frontend once its document has been requested.
+            // `WI.domManager` requests the document from that same agent, so the ids it hands out
+            // and the ids in the event name the same nodes.
+            let documentNode = await WI.domManager.requestDocument();
+            InspectorTest.assert(documentNode, "Should have a document node.");
 
-                ProtocolTest.evaluateInPage("startCSSAnimation()");
+            // `WI.timelineManager` is the only consumer of these events, and it drops them unless a
+            // timeline recording is active. Take them at that seam, so this test stays about the
+            // Animation domain instead of about timeline recording.
+            let trackingStart = null;
+            let trackingUpdate = null;
+            let trackingComplete = null;
+
+            let didTrackingStart = new Promise((resolve) => {
+                WI.timelineManager.animationTrackingStarted = (timestamp) => {
+                    trackingStart = {timestamp};
+                    resolve();
+                };
             });
 
-            InspectorProtocol.awaitEvent({event: "Animation.trackingUpdate"}).then((messageObject) => {
-                ProtocolTest.log("Animation.trackingUpdate");
-                ProtocolTest.expectEqual(typeof messageObject.params.timestamp, "number", "Should should have a timestamp number.");
-                ProtocolTest.expectEqual(typeof messageObject.params.event, "object", "Should have an event object.");
-                ProtocolTest.expectEqual(typeof messageObject.params.event.trackingAnimationId, "string", "Event should have an animation tracking ID.");
-                ProtocolTest.expectEqual(typeof messageObject.params.event.animationState, "string", "Event should have an animation state.");
-                ProtocolTest.expectEqual(typeof messageObject.params.event.nodeId, "number", "Event should have a node ID.");
-                ProtocolTest.expectEqual(messageObject.params.event.animationName, "test", "Event should have the related CSS animation's name.");
+            let didTrackingUpdate = new Promise((resolve) => {
+                WI.timelineManager.animationTrackingUpdated = (timestamp, event) => {
+                    // A single animation reports several state changes; only the first creates the
+                    // event this test checks.
+                    if (trackingUpdate)
+                        return;
 
-                ProtocolTest.assert(typeof messageObject.params.event.transitionProperty === "undefined", "Event should not have a `transitionProperty` if it has an `animationName`.");
-
-                InspectorProtocol.sendCommand("Animation.stopTracking", {});
+                    trackingUpdate = {timestamp, event};
+                    resolve();
+                };
             });
 
-            InspectorProtocol.awaitEvent({event: "Animation.trackingComplete"}).then((messageObject) => {
-                ProtocolTest.log("Animation.trackingComplete");
-                resolve();
+            let didTrackingComplete = new Promise((resolve) => {
+                WI.timelineManager.animationTrackingCompleted = (timestamp) => {
+                    trackingComplete = {timestamp};
+                    resolve();
+                };
             });
 
-            InspectorProtocol.sendCommand("Animation.startTracking", {});
-        }
+            try {
+                let target = WI.assumingMainTarget();
+
+                target.AnimationAgent.startTracking();
+                await didTrackingStart;
+
+                InspectorTest.log("Animation.trackingStart");
+                InspectorTest.expectEqual(typeof trackingStart.timestamp, "number", "Should have a timestamp when starting.");
+
+                await InspectorTest.evaluateInPage(`startCSSAnimation()`);
+                await didTrackingUpdate;
+
+                InspectorTest.log("Animation.trackingUpdate");
+                InspectorTest.expectEqual(typeof trackingUpdate.timestamp, "number", "Should have a timestamp number.");
+                InspectorTest.expectEqual(typeof trackingUpdate.event, "object", "Should have an event object.");
+
+                let event = trackingUpdate.event;
+                InspectorTest.expectEqual(typeof event.trackingAnimationId, "string", "Event should have an animation tracking ID.");
+                InspectorTest.expectEqual(typeof event.animationState, "string", "Event should have an animation state.");
+                InspectorTest.expectEqual(typeof event.nodeId, "number", "Event should have a node ID.");
+                InspectorTest.expectEqual(event.animationName, "test", "Event should have the related CSS animation's name.");
+                InspectorTest.assert(typeof event.transitionProperty === "undefined", "Event should not have a `transitionProperty` if it has an `animationName`.");
+
+                let node = WI.domManager.nodeForId(event.nodeId);
+                InspectorTest.expectNotNull(node, "Should have a node for the event's node ID.");
+                InspectorTest.expectEqual(node?.localName(), "div", "The animating node should be a <div>.");
+                InspectorTest.expectEqual(node?.getAttribute("id"), "animating", "The animating node should have the id \"animating\".");
+
+                target.AnimationAgent.stopTracking();
+                await didTrackingComplete;
+
+                InspectorTest.log("Animation.trackingComplete");
+                InspectorTest.expectEqual(typeof trackingComplete.timestamp, "number", "Should have a timestamp when completing.");
+            } finally {
+                delete WI.timelineManager.animationTrackingStarted;
+                delete WI.timelineManager.animationTrackingUpdated;
+                delete WI.timelineManager.animationTrackingCompleted;
+            }
+        },
     });
 
     suite.runTestCasesAndFinish();


### PR DESCRIPTION
#### 0aa45699cc77928adace2bfa1e5c8ea4f46a520f
<pre>
[Site Isolation] Web Inspector: Rework protocol test inspector/animation/tracking.html to prep for frame target enablement
<a href="https://bugs.webkit.org/show_bug.cgi?id=322229">https://bugs.webkit.org/show_bug.cgi?id=322229</a>
<a href="https://rdar.apple.com/185461510">rdar://185461510</a>

Reviewed by BJ Burg.

This is a step toward enabling frame target, vending them and using them
in the frontend, by preemptively reworking layout tests that fail when
frame targets are enabled by a fix to webkit.org/b/321734.

A protocol test cannot pick which target a command goes to, so its
DOM.getDocument is answered by the main frame&apos;s DOM agent. The node id
in Animation.trackingUpdate comes from the page&apos;s DOM agent instead,
which will not push a node before its own document has been requested,
so the event omits nodeId and the &quot;Event should have a node ID&quot;
assertion fails. Every other assertion in the test passes, which is why
this failure reads as unrelated to node ids at first.

Rewrite the test as a frontend inspector test instead, where
WI.domManager requests the document from the page target, which is the
agent the ids in the event come from.

- That dependency is temporary. Once Animation is served per frame, its
  node ids will be minted by the frame&apos;s DOM agent instead, and the
  WI.domManager call here is the line that will have to follow them.
  Resolving them that way today would compare ids from two different
  spaces, which is the failure this patch removes.

These tracking events have no frontend model of their own:
AnimationObserver forwards them to WI.timelineManager, which drops them
unless a timeline recording is active. The test stubs those three
methods instead of starting a recording, so it keeps testing the
Animation domain rather than acquiring a dependency on the Timeline
domain, which is still page-level and has frame-target problems of its
own.

While here, check what the node id resolves to. Asserting only that
nodeId is a number would also have passed on an id from the wrong
agent&apos;s space, which is the bug this test now covers, so the node is
looked up through WI.domManager and matched against the animating
element. The baseline also loses a doubled word in one assertion
message.

No behavior change. inspector/animation/tracking.html now also passes
with frame targets enabled.

* LayoutTests/inspector/animation/tracking-expected.txt:
* LayoutTests/inspector/animation/tracking.html:

Canonical link: <a href="https://commits.webkit.org/319971@main">https://commits.webkit.org/319971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b9b6d2f6ec60398f56d9854f21e71de7051a732

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146216 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e3489a6-4631-48b8-8e9b-65e301d7dcbc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141992 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98577 "13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c66cc57-07b8-4b8d-87e0-d1870f59aa44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122428 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/233d2c8f-23f8-4522-9916-0cbf1cb6f09d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42626 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42256 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3274 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194039 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40895 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151113 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45677 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124238 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54706 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->