### PR TITLE
Deleting all content of an inline editing host inserts a placeholder <br>

### DIFF
--- a/LayoutTests/editing/deleting/5272440-expected.txt
+++ b/LayoutTests/editing/deleting/5272440-expected.txt
@@ -10,5 +10,4 @@ layer at (0,0) size 800x600
         RenderInline {SPAN} at (1,1) size 394x18
           RenderText {#text} at (1,1) size 394x18
             text run at (1,1) width 394: "There shouldn't be any blank lines in the black bordered area."
-          RenderBR {BR} at (394,1) size 1x18
 caret: position 62 of child 0 {#text} of child 0 {SPAN} of child 2 {DIV} of body

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/br-tag-not-added-with-inline-root-editable-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/br-tag-not-added-with-inline-root-editable-element-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL BR tag is not inserted after deleting the text node content since root editable element is inline assert_not_equals: First child is not a <br> tag got disallowed value "BR"
+PASS BR tag is not inserted after deleting the text node content since root editable element is inline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element-expected.txt
@@ -1,5 +1,4 @@
 
-
 PASS The editing host should have inserted text
-FAIL The editing host should have no text assert_equals: expected "" but got "<br>"
+PASS The editing host should have no text
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element-expected.txt
@@ -1,5 +1,4 @@
 
-
 PASS The editing host should have inserted text
-FAIL The editing host should have no text assert_equals: expected "" but got "<br>"
+PASS The editing host should have no text
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/run/delete_7001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/run/delete_7001-last-expected.txt
@@ -193,7 +193,7 @@ PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contentedita
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>a[b]c</unknown-element></p>" queryCommandValue("delete") after
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>": execCommand("delete", false, "") return value
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" checks for modifications to non-editable content
-FAIL [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><span contenteditable=\"\"></span></p>" but got "<p contenteditable=\"false\"><span contenteditable=\"\"><br></span></p>"
+PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" compare innerHTML
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandIndeterm("delete") before
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandState("delete") before
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandValue("delete") before
@@ -211,7 +211,7 @@ PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>a[bc<br
 PASS [["delete",""]] "<p contenteditable=\"false\"><span contenteditable>a[bc<br>de]f</span></p>" queryCommandValue("delete") after
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>": execCommand("delete", false, "") return value
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" checks for modifications to non-editable content
-FAIL [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><unknown-element contenteditable=\"\"></unknown-element></p>" but got "<p contenteditable=\"false\"><unknown-element contenteditable=\"\"><br></unknown-element></p>"
+PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" compare innerHTML
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandIndeterm("delete") before
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandState("delete") before
 PASS [["delete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandValue("delete") before

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/run/forwarddelete_6001-7000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/run/forwarddelete_6001-7000-expected.txt
@@ -662,7 +662,7 @@ PASS [["forwarddelete",""]] "<p><span>[abc]</span><br></p>" queryCommandState("f
 PASS [["forwarddelete",""]] "<p><span>[abc]</span><br></p>" queryCommandValue("forwarddelete") after
 PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>": execCommand("forwarddelete", false, "") return value
 PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" checks for modifications to non-editable content
-FAIL [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><span contenteditable=\"true\"></span></p>" but got "<p contenteditable=\"false\"><span contenteditable=\"true\"><br></span></p>"
+PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" compare innerHTML
 PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandIndeterm("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandState("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandValue("forwarddelete") before
@@ -860,7 +860,7 @@ PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element conte
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>a[b]c</unknown-element></p>" queryCommandValue("forwarddelete") after
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>": execCommand("forwarddelete", false, "") return value
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" checks for modifications to non-editable content
-FAIL [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><span contenteditable=\"\"></span></p>" but got "<p contenteditable=\"false\"><span contenteditable=\"\"><br></span></p>"
+PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" compare innerHTML
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandIndeterm("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandState("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>[abc]</span></p>" queryCommandValue("forwarddelete") before
@@ -878,7 +878,7 @@ PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><span contenteditable>a[bc<br>de]f</span></p>" queryCommandValue("forwarddelete") after
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>": execCommand("forwarddelete", false, "") return value
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" checks for modifications to non-editable content
-FAIL [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><unknown-element contenteditable=\"\"></unknown-element></p>" but got "<p contenteditable=\"false\"><unknown-element contenteditable=\"\"><br></unknown-element></p>"
+PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" compare innerHTML
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandIndeterm("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandState("forwarddelete") before
 PASS [["forwarddelete",""]] "<p contenteditable=\"false\"><unknown-element contenteditable>[abc]</unknown-element></p>" queryCommandValue("forwarddelete") before

--- a/LayoutTests/platform/glib/editing/deleting/5272440-expected.txt
+++ b/LayoutTests/platform/glib/editing/deleting/5272440-expected.txt
@@ -10,5 +10,4 @@ layer at (0,0) size 800x600
         RenderInline {SPAN} at (1,1) size 387x18
           RenderText {#text} at (1,1) size 387x18
             text run at (1,1) width 387: "There shouldn't be any blank lines in the black bordered area."
-          RenderBR {BR} at (388,1) size 0x18
 caret: position 62 of child 0 {#text} of child 0 {SPAN} of child 2 {DIV} of body

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt
@@ -995,7 +995,7 @@ PASS [["delete",""]] "<p><span>[abc]</span><br></p>" queryCommandState("delete")
 PASS [["delete",""]] "<p><span>[abc]</span><br></p>" queryCommandValue("delete") after
 PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>": execCommand("delete", false, "") return value
 PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" checks for modifications to non-editable content
-FAIL [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p contenteditable=\"false\"><span contenteditable=\"true\"></span></p>" but got "<p contenteditable=\"false\"><span contenteditable=\"true\"><br></span></p>"
+PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" compare innerHTML
 PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandIndeterm("delete") before
 PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandState("delete") before
 PASS [["delete",""]] "<p contenteditable=false><span contenteditable=true>[abc]</span></p>" queryCommandValue("delete") before

--- a/LayoutTests/platform/win/editing/deleting/5272440-expected.txt
+++ b/LayoutTests/platform/win/editing/deleting/5272440-expected.txt
@@ -10,5 +10,4 @@ layer at (0,0) size 800x600
         RenderInline {SPAN} at (0,0) size 387x17
           RenderText {#text} at (1,1) size 387x17
             text run at (1,1) width 387: "There shouldn't be any blank lines in the black bordered area."
-          RenderBR {BR} at (388,1) size 0x17
 caret: position 62 of child 0 {#text} of child 0 {SPAN} of child 2 {DIV} of body

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -988,6 +988,18 @@ void DeleteSelectionCommand::removeRedundantBlocks()
     }
 }
 
+static bool isEmptyInlineEditingHost(const Position& position)
+{
+    RefPtr container = position.containerNode();
+    if (!container)
+        return false;
+    RefPtr editableRoot = container->rootEditableElement();
+    if (!editableRoot || editableRoot->hasChildNodes())
+        return false;
+    CheckedPtr renderer = editableRoot->renderer();
+    return renderer && renderer->isRenderInline();
+}
+
 void DeleteSelectionCommand::doApply()
 {
     // If selection has not been set to a custom selection when the command was created,
@@ -1061,7 +1073,8 @@ void DeleteSelectionCommand::doApply()
         // a different ending position.
         if (!m_endingPosition.containerNode() || !m_endingPosition.containerNode()->isConnected())
             return;
-        insertNodeAt(HTMLBRElement::create(document()), m_endingPosition);
+        if (!isEmptyInlineEditingHost(m_endingPosition))
+            insertNodeAt(HTMLBRElement::create(document()), m_endingPosition);
     }
 
     bool shouldRebalaceWhiteSpace = true;


### PR DESCRIPTION
#### c70dc20b24a99702ee6d7a1eaabf356240747e48
<pre>
Deleting all content of an inline editing host inserts a placeholder &lt;br&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=322232">https://bugs.webkit.org/show_bug.cgi?id=322232</a>
<a href="https://rdar.apple.com/185462543">rdar://185462543</a>

Reviewed by NOBODY (OOPS!).

DeleteSelectionCommand inserts a placeholder &lt;br&gt; at the ending position
whenever it deletes a whole paragraph, so that the emptied block does not
collapse to zero height and the caret still has somewhere to go.

An inline editing host has no block of its own, so there is nothing to hold
open: the placeholder is rendered as ordinary content and introduces a blank
line. It also makes the host stop matching :empty, which breaks the common
pattern of drawing placeholder text with an :empty::before/::after rule.

Skip the placeholder when the ending position is inside an editable root that
is a RenderInline and has no remaining children. Keeping the &quot;no children&quot;
condition means an inline host that still ends in a &lt;br&gt; after the deletion
keeps its trailing placeholder, so caret placement there is unchanged.

editing/deleting/5272440.html was added for exactly this bug in 2007 and its
baseline has been carrying the extra RenderBR ever since; it is updated here.

* LayoutTests/editing/deleting/5272440-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/editing/other/br-tag-not-added-with-inline-root-editable-element-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/editing/run/delete_7001-last-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/editing/run/forwarddelete_6001-7000-expected.txt: Ditto
* LayoutTests/platform/glib/editing/deleting/5272440-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt: Progression
* LayoutTests/platform/win/editing/deleting/5272440-expected.txt: Rebaselined
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isEmptyInlineEditingHost):
(WebCore::DeleteSelectionCommand::doApply):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c70dc20b24a99702ee6d7a1eaabf356240747e48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49795 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192330 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146371 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5ffbdb1-9b32-49e4-b9af-ecd2becba673) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55712 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192330 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98694 "3 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5a62469-666b-424b-a408-6eada72c2ca1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162865 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192330 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06a5ca82-1194-4176-9048-a24412e4802c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42766 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192330 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154898 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42390 "Found 1 new test failure: imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-deleting-single-character-inside-inline-element.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3432 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48620 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47021 "Found 1 new test failure: imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-deleting-single-character-inside-inline-element.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194195 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55660 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151546 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56351 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39015 "Found 1 new test failure: imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-deleting-single-character-inside-inline-element.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151250 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45817 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128634 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124456 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54862 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17385 "Found 1 new test failure: imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-deleting-single-character-inside-inline-element.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54243 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->