### PR TITLE
CSSFontFace::setStatus should commit m_status before notifying clients

### DIFF
--- a/LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash-expected.txt
+++ b/LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no assertion

--- a/LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash.html
+++ b/LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// OffscreenCanvas installs no ScriptDisallowedScope, so promise resolution is not deferred.
+function measure(size)
+{
+    const context = new OffscreenCanvas(1, 1).getContext('2d');
+    context.font = size + 'px A';
+    context.measureText('a');
+}
+
+onload = function () {
+    setTimeout(function () {
+        // A local() source loads synchronously, so pump() reaches setStatus(Success) inline.
+        const face = new FontFace('A', 'local(Helvetica)');
+
+        // Reading .loaded while Pending appends a DeferredPromise for resolve() to call.
+        face.loaded;
+        document.fonts.add(face);
+
+        // An accessor named `then` makes promise resolution do an observable lookup,
+        // running this getter while setStatus() is still notifying its clients.
+        let reentered = false;
+        Object.defineProperty(FontFace.prototype, 'then', {
+            configurable: true,
+            get() {
+                if (!reentered) {
+                    reentered = true;
+                    // The size must differ from the outer measure below. Reusing it would hit
+                    // the FontCascadeCache, so fontRangesForFamily would never run and this
+                    // would not re-enter pump().
+                    measure(20);
+                }
+                return undefined;
+            }
+        });
+
+        measure(10);
+
+        document.body.textContent = 'PASS if no assertion';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+};
+</script>

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -651,11 +651,11 @@ void CSSFontFace::setStatus(Status newStatus)
         break;
     }
 
-    iterateClients(m_clients, [&](CSSFontFaceClient& client) {
-        client.fontStateChanged(*this, m_status, newStatus);
-    });
+    auto oldStatus = std::exchange(m_status, newStatus);
 
-    m_status = newStatus;
+    iterateClients(m_clients, [&](CSSFontFaceClient& client) {
+        client.fontStateChanged(*this, oldStatus, newStatus);
+    });
 
     Seconds blockPeriodTimeout;
     Seconds swapPeriodTimeout;


### PR DESCRIPTION
#### 64a55fd574c40d8fda92b4f114d2a2afb9f0ec71
<pre>
CSSFontFace::setStatus should commit m_status before notifying clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=322233">https://bugs.webkit.org/show_bug.cgi?id=322233</a>
<a href="https://rdar.apple.com/185462848">rdar://185462848</a>

Reviewed by Brent Fulgham.

Two clients implement fontStateChanged:

A: FontFace, backing new FontFace(&apos;A&apos;, &apos;local(Helvetica)&apos;). It resolves the
face.loaded promise, so notifying it can run author script.
B: CSSFontFaceSet, backing document.fonts. It validates the transition it is
handed.

setStatus() passed the m_status member to each client and assigned newStatus only
after the loop ended. Script run from A re-enters pump(), which still sees Loading
and drives setStatus(Success) again, committing m_status. B, visited after that,
gets Success as its oldState and hits its assertion.

Committing m_status first gives every client the same pair and makes the nested
pump() skip a transition that is already done.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setStatus):
* LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash.html: Added.
* LayoutTests/fast/text/font-face/css-font-face-setstatus-reentrancy-crash-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319575@main">https://commits.webkit.org/319575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be3734f581cae8b7de2d1366ed1ccfc602045f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146233 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e37c775-9a68-45de-9730-6e36d68b52f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2b96e01-1c74-4eca-8b1e-250e4b10637d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122448 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44372 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42642 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42270 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3293 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151422 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56210 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151128 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45691 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128524 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124255 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17266 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54170 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->