### PR TITLE
REGRESSION(312373@main): [iPad] Spotify music videos fail to play

### DIFF
--- a/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
@@ -238,6 +238,7 @@ https://soylent.com/
     (none)
 https://open.spotify.com/
     NeedsBodyScrollbarWidthNoneDisabledQuirk
+    NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk
     NeedsWebKitMediaTextTrackDisplayQuirk
     ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
     ShouldBlockAudiblePlaybackWhileAudioIsPlaying

--- a/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
@@ -253,6 +253,7 @@ https://soylent.com/
     (none)
 https://open.spotify.com/
     NeedsBodyScrollbarWidthNoneDisabledQuirk
+    NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk
     NeedsWebKitMediaTextTrackDisplayQuirk
     ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
     ShouldBlockAudiblePlaybackWhileAudioIsPlaying

--- a/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
@@ -234,6 +234,7 @@ https://soylent.com/
     (none)
 https://open.spotify.com/
     NeedsBodyScrollbarWidthNoneDisabledQuirk
+    NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk
     NeedsWebKitMediaTextTrackDisplayQuirk
     ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
     ShouldBlockAudiblePlaybackWhileAudioIsPlaying

--- a/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
@@ -234,6 +234,7 @@ https://soylent.com/
     (none)
 https://open.spotify.com/
     NeedsBodyScrollbarWidthNoneDisabledQuirk
+    NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk
     NeedsWebKitMediaTextTrackDisplayQuirk
     ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
     ShouldBlockAudiblePlaybackWhileAudioIsPlaying

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
+#include "DocumentQuirks.h"
 #include "HTMLMediaElement.h"
 #include "JSDOMPromiseDeferred.h"
 #include "MediaKeySystemRequest.h"
@@ -115,12 +116,21 @@ ExceptionOr<Ref<WebKitMediaKeySession>> WebKitMediaKeys::createSession(Document&
     return session;
 }
 
-bool WebKitMediaKeys::isTypeSupported(const String& keySystem, const String& mimeType)
+bool WebKitMediaKeys::isTypeSupported(const Document& document, const String& keySystem, const String& mimeType)
 {
     // 1. If keySystem contains an unrecognized or unsupported Key System, return false and abort these steps.
     // Key system string comparison is case-sensitive.
     if (keySystem.isEmpty() || !LegacyCDM::supportsKeySystem(keySystem))
         return false;
+
+#if PLATFORM(COCOA)
+    if (document.quirks().needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk()
+        && keySystem == "com.apple.fps.1_0"_s
+        && mimeType.startsWithIgnoringASCIICase("video/mp2t"_s))
+        return true;
+#else
+    UNUSED_PARAM(document);
+#endif
 
     // 2. If type is null or an empty string, return true and abort these steps.
     if (mimeType.isEmpty())

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
@@ -52,7 +52,7 @@ public:
     void incrementCheckedPtrCount() const { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
 
     ExceptionOr<Ref<WebKitMediaKeySession>> createSession(Document&, const String& mimeType, Ref<Uint8Array>&& initData);
-    static bool isTypeSupported(const String& keySystem, const String& mimeType);
+    static bool isTypeSupported(const Document&, const String& keySystem, const String& mimeType);
     const String& keySystem() const LIFETIME_BOUND { return m_keySystem; }
 
     LegacyCDM& cdm() { return m_cdm; }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.idl
@@ -31,6 +31,6 @@
     constructor(DOMString keySystem);
 
     [CallWith=CurrentDocument] WebKitMediaKeySession createSession(DOMString type, Uint8Array initData);
-    static boolean isTypeSupported(DOMString keySystem, optional DOMString type);
+    [CallWith=CurrentDocument] static boolean isTypeSupported(DOMString keySystem, optional DOMString type);
     readonly attribute DOMString keySystem;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2886,6 +2886,15 @@ bool Quirks::shouldReportVisibleDueToActivePictureInPictureContent() const
 }
 #endif
 
+#if PLATFORM(COCOA)
+bool Quirks::needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk);
+}
+#endif
+
 URL Quirks::topDocumentURL() const
 {
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
@@ -3557,6 +3566,9 @@ static constexpr Quirk table[] = {
             NeedsWebKitMediaTextTrackDisplayQuirk,
             ShouldDeferIntersectionObserversDuringResize,
             ShouldBlockAudiblePlaybackWhileAudioIsPlaying,
+#if PLATFORM(COCOA)
+            NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk,
+#endif
         }) },
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -380,6 +380,10 @@ public:
     bool NODELETE shouldSendFakeTouchForceChangeEvent() const;
 #endif
 
+#if PLATFORM(COCOA)
+    bool needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk() const;
+#endif
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -287,7 +287,9 @@ struct QuirksData {
         ShouldSuppressHLSSubtitles,
         ShouldSuppressMediaSessionPauseActionOnInterruption,
         ShouldBlockAudiblePlaybackWhileAudioIsPlaying,
-
+#if PLATFORM(COCOA)
+        NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk,
+#endif
         NumberOfQuirks
     };
 


### PR DESCRIPTION
#### ef91821a05e7c4bc43099f8c20aa29fab35d6e95
<pre>
REGRESSION(312373@main): [iPad] Spotify music videos fail to play
<a href="https://rdar.apple.com/178167054">rdar://178167054</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322239">https://bugs.webkit.org/show_bug.cgi?id=322239</a>

Reviewed by Eric Carlson.

Spotify gates music video playback on whether the following call returns true:
&gt; WebKitMediaKeys.isTypeSupported(&quot;com.apple.fps.1_0&quot;, &quot;video/mp2t; ...&quot;);

However, 312373@main fixed a bug where the MSE MediaPlayer would report that it
was capable of playing back MIME types like &quot;video/mp2t&quot;, and web-facing APIs
like HTMLMediaElement.canPlayType() and WebKitMediaKeys.isTypeSupported() would
falsely return that those MIME types were playable.

Fixing this bug broke Spotify&apos;s query, which was always incorrect. Restore the
behavior prior to 312373@main by quirking WebKitMediaKeys.isTypeSupported()
to return `true` when asked about MPEG-2 transport streams.

* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp:
(WebCore::WebKitMediaKeys::isTypeSupported):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.idl:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/319625@main">https://commits.webkit.org/319625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/663c03cbf2823d79f3c9b4105be81258d4fddb16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146345 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142112 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94159ee4-17d8-4eab-b4ef-cdde1593d9d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45789 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162857 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionContext.CleanUpOldOriginDataAfterMigration (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122547 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42748 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42382 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194169 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55634 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40579 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56325 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151230 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45798 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128607 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124427 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54836 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17377 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54456 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->