### PR TITLE
[webkitpy] Support pre-boot launchd configuration for simulated devices

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -24,6 +24,7 @@ import atexit
 import json
 import logging
 import os
+import plistlib
 import re
 import time
 
@@ -81,6 +82,7 @@ class SimulatedDeviceManager(object):
     xcrun = '/usr/bin/xcrun'
     simulator_device_path = '~/Library/Developer/CoreSimulator/Devices'
     simulator_bundle_id = 'com.apple.iphonesimulator'
+    launchd_state_path = '/private/var/tmp/com.apple.CoreSimulator.SimDevice.{}'
     _device_identifier_to_name = {}
     _managing_simulator_app = False
     _last_updated_state = 0
@@ -373,11 +375,44 @@ class SimulatedDeviceManager(object):
             state = device.platform_device.is_usable(force_update=True)
 
     @staticmethod
+    def _configure_launchd_before_booting(device, host):
+        """Puts the device's launchd configuration in place before the simulator starts.
+
+        launchd_sim reads its configuration as it starts, so what is written here applies to the boot itself rather
+        than having to be applied to a running device afterwards. The directory is named after the UDID, which is
+        known before the device boots.
+
+        On a key this configuration sets, its value wins; other pre-existing keys the runtime shipped are preserved."""
+        configuration = getattr(device.platform_device, 'launchd_configuration', None)
+        if not configuration:
+            return
+
+        directory = SimulatedDeviceManager.launchd_state_path.format(device.udid)
+        for name, entries in configuration.items():
+            path = host.filesystem.join(directory, name)
+            contents = {}
+            if host.filesystem.exists(path):
+                try:
+                    contents = plistlib.loads(host.filesystem.read_binary_file(path))
+                except Exception as error:
+                    _log.warning(u'Could not read {}, replacing it: {}'.format(path, error))
+            contents.update(entries)
+            try:
+                host.filesystem.maybe_make_directory(directory)
+                host.filesystem.write_binary_file(path, plistlib.dumps(contents))
+                _log.debug(u'Wrote {} for {} before booting'.format(name, device.udid))
+            except Exception as error:
+                # Not fatal: the device still boots, just without this configuration.
+                _log.warning(u'Could not write {} for {} before booting: {}'.format(name, device.udid, error))
+
+    @staticmethod
     def _boot_device(device, host=None):
         host = host or SystemHost.get_default()
 
         # FIXME: remove this workaround after rdar://129789675 has been resolved.
         host.executive.run_command(['sh', '-c', "mkdir -m 700 -p " + "~/Library/Developer/CoreSimulator/Devices/" + device.udid + "/data/private/var/db"])
+
+        SimulatedDeviceManager._configure_launchd_before_booting(device, host)
 
         _log.debug(u"Booting device '{}'".format(device.udid))
         device.platform_device.booted_by_script = True
@@ -536,6 +571,10 @@ class SimulatedDeviceManager(object):
             return
 
         deadline = time.time() + timeout
+        launchd_state_directories = [
+            SimulatedDeviceManager.launchd_state_path.format(device.udid)
+            for device in SimulatedDeviceManager.INITIALIZED_DEVICES if device
+        ]
         while SimulatedDeviceManager.INITIALIZED_DEVICES:
             device = SimulatedDeviceManager.INITIALIZED_DEVICES[0]
             if device is None:
@@ -544,6 +583,9 @@ class SimulatedDeviceManager(object):
             device.platform_device._tear_down(deadline - time.time())
 
         SimulatedDeviceManager.INITIALIZED_DEVICES = None
+
+        for directory in launchd_state_directories:
+            host.filesystem.rmtree(directory)
 
         # If we were managing the simulator, there are some cache files we need to remove
         for directory in host.filesystem.glob('/tmp/com.apple.CoreSimulator.SimDevice.*'):
@@ -589,12 +631,17 @@ class SimulatedDevice(object):
         self.filesystem = host.filesystem
         self.platform = host.platform
 
-        self.environment_extras = [
-            [SimulatedDeviceManager.xcrun, 'simctl', 'spawn', self.udid, 'launchctl', 'unload', '-w', f'{runtime_root}/System/Library/LaunchDaemons/com.apple.chronod.plist'],  # FIXME: rdar://129075664
-        ]
+        self.launchd_configuration = {
+            'disabled.plist': {'com.apple.chronod': True},  # FIXME: rdar://129075664
+        }
+
+        self.environment_extras = []
 
         if apple_additions():
             self.environment_extras.extend(apple_additions().environment_extras(udid))
+            additional = getattr(apple_additions(), 'launchd_configuration', lambda: {})() or {}
+            for plist_name, entries in additional.items():
+                self.launchd_configuration.setdefault(plist_name, {}).update(entries)
 
         # Determine tear down behavior
         self.booted_by_script = False

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import plistlib
 import unittest
 
 from webkitcorepy import Version
@@ -29,6 +30,7 @@ from webkitpy.common.system.executive_mock import MockExecutive2
 from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.xcode.device_type import DeviceType
+from webkitpy.xcode import simulated_device
 from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager, SimulatedDevice
 
 simctl_json_output = """{
@@ -655,3 +657,95 @@ class SimulatedDeviceTest(unittest.TestCase):
 
         for device in devices:
             self.assertEqual(SimulatedDevice.DeviceState.SHUT_DOWN, device.state(force_update=True))
+
+
+class LaunchdConfigurationBeforeBootTest(unittest.TestCase):
+    """Configuration a device needs launchd to have is written before it boots, so it applies to the boot itself.
+    webkitpy defines the configuration; ports add to it through apple_additions."""
+
+    class FakeDevice(object):
+        udid = 'UDID-1'
+
+        def __init__(self, configuration):
+            self.platform_device = self
+            self.launchd_configuration = configuration
+
+    def _write(self, configuration, files=None):
+        host = MockSystemHost(filesystem=MockFileSystem(files=files or {}))
+        SimulatedDeviceManager._configure_launchd_before_booting(self.FakeDevice(configuration), host)
+        return host
+
+    def _path(self, name='example.plist'):
+        return '/private/var/tmp/com.apple.CoreSimulator.SimDevice.UDID-1/' + name
+
+    def test_configuration_is_written_before_boot(self):
+        host = self._write({'example.plist': {'first': True, 'second': False}})
+        self.assertEqual(
+            plistlib.loads(host.filesystem.read_binary_file(self._path())),
+            {'first': True, 'second': False})
+
+    def test_every_named_file_is_written(self):
+        host = self._write({'one.plist': {'a': True}, 'two.plist': {'b': True}})
+        self.assertEqual(plistlib.loads(host.filesystem.read_binary_file(self._path('one.plist'))), {'a': True})
+        self.assertEqual(plistlib.loads(host.filesystem.read_binary_file(self._path('two.plist'))), {'b': True})
+
+    def test_nothing_written_without_configuration(self):
+        host = self._write({})
+        self.assertFalse(host.filesystem.exists(self._path()))
+
+    def test_existing_keys_are_kept(self):
+        existing = plistlib.dumps({'keep': False})
+        host = self._write({'example.plist': {'first': True}}, files={self._path(): existing})
+        self.assertEqual(
+            plistlib.loads(host.filesystem.read_binary_file(self._path())),
+            {'keep': False, 'first': True})
+
+    def test_unreadable_file_is_replaced_rather_than_raising(self):
+        host = self._write({'example.plist': {'first': True}}, files={self._path(): b'not a plist'})
+        self.assertEqual(plistlib.loads(host.filesystem.read_binary_file(self._path())), {'first': True})
+
+    def test_failure_to_write_is_not_fatal(self):
+        host = MockSystemHost(filesystem=MockFileSystem())
+
+        def refuse(path, contents):
+            raise IOError('read-only')
+
+        host.filesystem.write_binary_file = refuse
+        # A device that boots unconfigured is better than a run that cannot start.
+        SimulatedDeviceManager._configure_launchd_before_booting(
+            self.FakeDevice({'example.plist': {'first': True}}), host)
+
+
+class LaunchdStateCleanupTest(unittest.TestCase):
+    """The configuration we write lives in the device's temp directory, so it goes away when the device does."""
+
+    def test_state_directory_is_removed_on_tear_down(self):
+        SimulatedDeviceTest.reset_simulated_device_manager()
+        host = SimulatedDeviceTest.mock_host_for_simctl()
+        devices = SimulatedDeviceManager.available_devices(host)
+        self.assertTrue(devices)
+
+        device = devices[0]
+        SimulatedDeviceManager.INITIALIZED_DEVICES = [device]
+        path = host.filesystem.join(
+            SimulatedDeviceManager.launchd_state_path.format(device.udid), 'disabled.plist')
+        host.filesystem.maybe_make_directory(host.filesystem.dirname(path))
+        host.filesystem.write_binary_file(path, b'contents')
+        self.assertTrue(host.filesystem.exists(path))
+
+        SimulatedDeviceManager.tear_down(host)
+        self.assertFalse(host.filesystem.exists(path), 'the plist we wrote should not outlive the device')
+
+
+class LaunchdConfigurationDefaultTest(unittest.TestCase):
+    """webkitpy defines the configuration a simulator boots with; apple_additions only adds to it."""
+
+    def test_chronod_is_disabled_by_default(self):
+        host = SimulatedDeviceTest.mock_host_for_simctl()
+        SimulatedDeviceTest.reset_simulated_device_manager()
+        devices = SimulatedDeviceManager.available_devices(host)
+        self.assertTrue(devices)
+        # FIXME: rdar://129075664
+        self.assertEqual(
+            devices[0].platform_device.launchd_configuration.get('disabled.plist'),
+            {'com.apple.chronod': True})


### PR DESCRIPTION
#### e7ffac0f4edddadd2999733b109277919ae9bab9
<pre>
[webkitpy] Support pre-boot launchd configuration for simulated devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=322243">https://bugs.webkit.org/show_bug.cgi?id=322243</a>
<a href="https://rdar.apple.com/185473232">rdar://185473232</a>

Reviewed by David Kilzer.

launchd_sim reads its config when it starts, so if a port wants something in
place for the boot itself it has to be written before we boot the device.
This allows for a port to supply something for the boot.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager):
(SimulatedDeviceManager._configure_launchd_before_booting):
(SimulatedDeviceManager._boot_device):
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py:
(FakeDevice):
(FakeAdditions):
(FakeAdditions.__init__):
(FakeAdditions.launchd_configuration):
(setUp):
(tearDown):
(_run_with):
(_path):
(test_configuration_is_written_before_boot):
(test_every_named_file_is_written):
(test_nothing_written_without_apple_additions):
(test_nothing_written_when_no_configuration_is_given):
(test_existing_keys_are_kept):
(test_unreadable_file_is_replaced_rather_than_raising):
(test_failure_to_write_is_not_fatal):
(test_failure_to_write_is_not_fatal.refuse):

Canonical link: <a href="https://commits.webkit.org/319656@main">https://commits.webkit.org/319656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/390719480edbb5a52867b86b6f18d00f043e7321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146556 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0cc2788-473b-4a78-96bb-313eacae1e08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142244 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cd8d1f9-1452-4ffe-b837-92fc75ecbdac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e37e6d0d-f5d3-4e0e-bccf-60f1064c9181) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181552 "Found 1 webkitpy test failure: webkitpy.test.runner_unittest.RunnerTest.test_run_expected_failures") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42905 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42529 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3617 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194383 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55845 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151668 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56536 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39154 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/post-from-cross-site-popup.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/post-goback-same-url.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-insecure-page.https.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151367 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45955 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124719 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55047 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17525 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54428 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->