### PR TITLE
[YARR] Compile lookbehinds containing quantified groups in the JIT

### DIFF
--- a/JSTests/microbenchmarks/regexp-lookbehind-fixed-count-group.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-fixed-count-group.js
@@ -1,0 +1,10 @@
+let text = "abababab-abab-ababab-ab-abababab-".repeat(300);
+let re = /(?<=(?:ab){3})-/g;
+let result = 0;
+for (let i = 0; i < 1e4; ++i) {
+    re.lastIndex = 0;
+    while (re.exec(text))
+        result++;
+}
+if (result !== 3 * 300 * 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/regexp-lookbehind-quantified-group.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-quantified-group.js
@@ -1,0 +1,10 @@
+let text = "1,234,567 12,345 999 1,000,000 42 7,777,777,777 ".repeat(200);
+let re = /(?<=\b(?:\d{1,3},)+\d{3}) /g;
+let result = 0;
+for (let i = 0; i < 1e4; ++i) {
+    re.lastIndex = 0;
+    while (re.exec(text))
+        result++;
+}
+if (result !== 4 * 200 * 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/regexp-lookbehind-jit-quantified-groups-unicode.js
+++ b/JSTests/stress/regexp-lookbehind-jit-quantified-groups-unicode.js
@@ -1,0 +1,193 @@
+//@ skip if not $jitTests
+//@ runDefault
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected " + expected);
+}
+
+function stringify(match) {
+    if (match === null)
+        return "null";
+    return "[" + Array.from(match, (x) => x === undefined ? "undefined" : JSON.stringify(x)).join(",") + "]";
+}
+
+function stringifyIndices(match) {
+    if (match === null)
+        return "null";
+    return JSON.stringify(Array.from(match.indices, (x) => x === undefined ? null : x));
+}
+
+shouldBe(stringify(/(?<=(?:\u{1F600}b)+)c/u.exec("\ud83d\ude00b\ud83d\ude00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:\u{1F600}b)+)c/u.exec("bc")), "null");
+shouldBe(stringify(/(?<=(?:\u{1F600}b)+)c/v.exec("\ud83d\ude00b\ud83d\ude00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(\u{1F600}b)+)c/u.exec("\ud83d\ude00b\ud83d\ude00bc")), "[\"c\",\"\ud83d\ude00b\"]");
+shouldBe(stringify(/(?<=(\u{1F600})+)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=(\u{1F600})*)b/u.exec("b")), "[\"b\",undefined]");
+shouldBe(stringify(/(?<=^(\u{1F600})+)b/u.exec("\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600})+)b/u.exec("a\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(\u{1F600})+?)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(?:\u{1F600})+?)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:\u{1F600})*?)b/u.exec("\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F601})+)b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F601})+?)b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F601}\u{1F601})+)b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F601}\u{1F601})+)b/u.exec("\ud83d\ude00\ud83d\ude01b")), "null");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601})+)b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}\u{1F601}|\u{1F600})+)b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601})+)b/v.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00\ud83d\ude00\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=(?:\u{1F600}b){2})c/u.exec("\ud83d\ude00b\ud83d\ude00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:\u{1F600}b){2})c/u.exec("\ud83d\ude00bc")), "null");
+shouldBe(stringify(/(?<=(\u{1F600}){3})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=(\u{1F600}){3})b/u.exec("\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(\u{1F600}){3})b/u.exec("a\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=(\u{1F600}|\u{1F601}){2})b/u.exec("\ud83d\ude00\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=(\u{1F600}|\u{1F601}){2})b/u.exec("\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=(\u{1F600}|\u{1F601}){2})b/u.exec("\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){2})b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}\u{1F601}|\u{1F600}){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){2,3})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){2,3}?)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){1,2})b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\ud83d\ude01\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}|\u{1F600}\u{1F601}){1,2})b/u.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(?:\u{1F600}+){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}+?){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\ud83d\ude00\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(\u{1F600}*){2})b/u.exec("\ud83d\ude00\ud83d\ude00b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(?:[\u{1F600}-\u{1F64F}]b)+)c/u.exec("\ud83d\ude00b\ud83d\ude01bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:[\u{1F600}-\u{1F64F}]b){2})c/u.exec("\ud83d\ude00b\ud83d\ude01bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:[\u{1F600}-\u{1F64F}]b){2})c/u.exec("\ud83d\ude00bc")), "null");
+shouldBe(stringify(/(?<=^(?:\p{Lu}){2,3})b/u.exec("\ud801\udc00A\ud801\udc00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:\p{Lu}){2,3})b/u.exec("A\ud801\udc00\ud801\udc28b")), "null");
+shouldBe(stringify(/(?<=^(\p{Lu}|\u{10428}){2,3})b/u.exec("A\ud801\udc00\ud801\udc28b")), "[\"b\",\"A\"]");
+shouldBe(stringify(/(?<=^(\p{Lu}|\u{10428}){2,3}?)b/u.exec("A\ud801\udc00\ud801\udc28b")), "[\"b\",\"A\"]");
+shouldBe(stringify(/(?<=^(?:[^a]){2})b/u.exec("\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:[^a]){2})b/u.exec("\ud83d\ude00ab")), "null");
+shouldBe(stringify(/(?<=^(?:.){2})b/u.exec("\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:.){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(?:.){2,3})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:.){2,3}?)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:\P{L}){2})b/v.exec("\ud83d\ude00\ud83d\ude01b")), "[\"b\"]");
+shouldBe(stringify(/(?<=[\p{L}--[a-z]](?:\u{1F601}){0,2})b/v.exec("A\ud83d\ude01\ud83d\ude01b")), "[\"b\"]");
+shouldBe(stringify(/(?<=[\p{L}--[a-z]](?:\u{1F601}){0,2})b/v.exec("a\ud83d\ude01\ud83d\ude01b")), "null");
+shouldBe(stringify(/(?<=(?:\u{10400}b)+)c/iu.exec("\ud801\udc28B\ud801\udc00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:\u{10400}b){2})c/iu.exec("\ud801\udc28B\ud801\udc00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:\u{10400}b){2})c/iu.exec("\ud801\udc28Bc")), "null");
+shouldBe(stringify(/(?<=^(\u{10400}|k)+)c/iu.exec("\ud801\udc28K\u212a\ud801\udc00c")), "[\"c\",\"\ud801\udc28\"]");
+shouldBe(stringify(/(?<=\b(?:\u{1F600}b)+)c/u.exec("x \ud83d\ude00b\ud83d\ude00bc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:^|,)(\u{1F600}|\u{1F601}){2})c/u.exec("x,\ud83d\ude00\ud83d\ude01c")), "[\"c\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=(?:^|,)(\u{1F600}|\u{1F601}){2})c/u.exec("x\ud83d\ude00\ud83d\ude01c")), "null");
+shouldBe(stringify(/(?<=^(\u{1F600})\1+)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude00b")), "null");
+shouldBe(stringify(/(?<=^(?:(\u{1F600}|\u{1F601})\1)+)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(?:(\u{1F600}|\u{1F601})\1)+)b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01b")), "[\"b\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=^(?:(\u{1F600}|\u{1F601})\1){2})b/u.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01\ud83d\ude01b")), "null");
+shouldBe(stringify(/(?<=(\u{1F600}|\u{1F601})+)b\1/u.exec("\ud83d\ude00\ud83d\ude01b\ud83d\ude01")), "null");
+shouldBe(stringify(/(?<=(\u{1F600}|\u{1F601})+)b\1/u.exec("\ud83d\ude00\ud83d\ude01b\ud83d\ude00")), "[\"b\ud83d\ude00\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=y(y\u{1F600}|\u{1F600}){1,2}?c)d/u.exec("xy\ud83d\ude00cd")), "[\"d\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=y(y\u{1F600}|\u{1F600}){1,2}c)d/u.exec("xy\ud83d\ude00cd")), "[\"d\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<=\u{1F601}(\u{1F601}\u{1F600}|\u{1F600}){1,2}?c)d/u.exec("x\ud83d\ude01\ud83d\ude00cd")), "[\"d\",\"\ud83d\ude00\"]");
+shouldBe(stringify(/(?<!(?:\u{1F600}b)+)c/u.exec("\ud83d\ude00b\ud83d\ude00bc")), "null");
+shouldBe(stringify(/(?<!(?:\u{1F600}b)+)c/u.exec("xc")), "[\"c\"]");
+shouldBe(stringify(/(?<!(\u{1F600}|\u{1F601}){2})c/u.exec("\ud83d\ude00\ud83d\ude01c")), "null");
+shouldBe(stringify(/(?<!(\u{1F600}|\u{1F601}){2})c/u.exec("a\ud83d\ude01c")), "[\"c\",undefined]");
+
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/gu;
+    re.lastIndex = 0;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/gu;
+    re.lastIndex = 1;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/gu;
+    re.lastIndex = 3;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/gu;
+    re.lastIndex = 6;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/yu;
+    re.lastIndex = 0;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/yu;
+    re.lastIndex = 6;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/yu;
+    re.lastIndex = 7;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(?:\u{1F600}b)+)c/yu;
+    re.lastIndex = 10;
+    let match = re.exec("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc");
+    shouldBe(match === null ? "null" : match.index, 10);
+    shouldBe(re.lastIndex, 11);
+}
+{
+    let re = /(?<=(\u{1F600}|\u{1F600}\u{1F601}){2})c/gu;
+    re.lastIndex = 0;
+    let match = re.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(\u{1F600}|\u{1F600}\u{1F601}){2})c/gu;
+    re.lastIndex = 1;
+    let match = re.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(\u{1F600}|\u{1F600}\u{1F601}){2})c/gu;
+    re.lastIndex = 8;
+    let match = re.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c");
+    shouldBe(match === null ? "null" : match.index, 11);
+    shouldBe(re.lastIndex, 12);
+}
+{
+    let re = /(?<=(\u{1F600}|\u{1F600}\u{1F601}){1,2}?)c/gu;
+    re.lastIndex = 0;
+    let match = re.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c");
+    shouldBe(match === null ? "null" : match.index, 6);
+    shouldBe(re.lastIndex, 7);
+}
+{
+    let re = /(?<=(\u{1F600}|\u{1F600}\u{1F601}){1,2}?)c/gu;
+    re.lastIndex = 7;
+    let match = re.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c");
+    shouldBe(match === null ? "null" : match.index, 11);
+    shouldBe(re.lastIndex, 12);
+}
+
+shouldBe("\ud83d\ude00b\ud83d\ude00bc\ud83d\ude00bcc".replace(/(?<=(?:\u{1F600}b)+)c/gu, "-"), "\ud83d\ude00b\ud83d\ude00b-\ud83d\ude00b-c");
+shouldBe("\ud83d\ude00\ud83d\ude01c\ud83d\ude01c".replace(/(?<=(\u{1F600}|\u{1F601})+)c/gu, "[$1]"), "\ud83d\ude00\ud83d\ude01[\ud83d\ude00]\ud83d\ude01[\ud83d\ude01]");
+shouldBe("\ud83d\ude00\ud83d\ude00\ud83d\ude01c\ud83d\ude00\ud83d\ude00c".replace(/(?<=(\u{1F600}|\u{1F600}\u{1F601}){2})c/gu, "[$1]"), "\ud83d\ude00\ud83d\ude00\ud83d\ude01[\ud83d\ude00]\ud83d\ude00\ud83d\ude00[\ud83d\ude00]");
+
+shouldBe(stringifyIndices(/(?<=(\u{1F600}b)+)c/du.exec("\ud83d\ude00b\ud83d\ude00bc")), "[[6,7],[0,3]]");
+shouldBe(stringifyIndices(/(?<=(\u{1F600}|\u{1F601})+)b/du.exec("\ud83d\ude00\ud83d\ude01\ud83d\ude00b")), "[[6,7],[0,2]]");
+shouldBe(stringifyIndices(/(?<=(\u{1F600}|\u{1F600}\u{1F601}){2})b/du.exec("\ud83d\ude00\ud83d\ude00\ud83d\ude01b")), "[[6,7],[0,2]]");
+shouldBe(stringifyIndices(/(?<=y(y\u{1F600}|\u{1F600}){1,2}?c)d/du.exec("xy\ud83d\ude00cd")), "[[5,6],[2,4]]");
+shouldBe(stringifyIndices(/(?<=^(\u{1F600}*){2})b/du.exec("\ud83d\ude00\ud83d\ude00b")), "[[4,5],[0,0]]");

--- a/JSTests/stress/regexp-lookbehind-jit-quantified-groups.js
+++ b/JSTests/stress/regexp-lookbehind-jit-quantified-groups.js
@@ -1,0 +1,575 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected " + expected);
+}
+
+function stringify(match) {
+    if (match === null)
+        return "null";
+    return "[" + Array.from(match, (x) => x === undefined ? "undefined" : JSON.stringify(x)).join(",") + "]";
+}
+
+function stringifyIndices(match) {
+    if (match === null)
+        return "null";
+    return JSON.stringify(Array.from(match.indices, (x) => x === undefined ? null : x));
+}
+
+shouldBe(stringify(/(?<=(?:ab)+)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab)+)c/.exec("abc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab)+)c/.exec("c")), "null");
+shouldBe(stringify(/(?<=(?:ab)+)c/.exec("xabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab)+)c/.exec("aabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab)+)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab)+)c/.exec("xababc")), "null");
+shouldBe(stringify(/(?<=(?:ab)*)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab)*)c/.exec("c")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:ab)*)c/.exec("xababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:ab)*)c/.exec("xc")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:ab)*)c/.exec("ababc")), "null");
+shouldBe(stringify(/(?<=(ab)+)c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab)+)c/.exec("abc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab)*)c/.exec("c")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<=(a)+)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a)*)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a)*)b/.exec("b")), "[\"b\",undefined]");
+shouldBe(stringify(/(?<=(a)+)b/.exec("b")), "null");
+shouldBe(stringify(/(?<=^(a)+)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a)+)b/.exec("xaaab")), "null");
+shouldBe(stringify(/(?<=^(a)*)b/.exec("xaaab")), "null");
+shouldBe(stringify(/(?<=(a|b)+)c/.exec("abbac")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(a|b)+)c/.exec("c")), "null");
+shouldBe(stringify(/(?<=(a|bb)+)c/.exec("abbac")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(a|bb)+)c/.exec("bbc")), "[\"c\",\"bb\"]");
+shouldBe(stringify(/(?<=(a|bb)+)c/.exec("bc")), "null");
+shouldBe(stringify(/(?<=^(a|ab)+)c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|ab)+)c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(ab|a)+)c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(ab|a)+)c/.exec("abac")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(?:a|ab)+)c/.exec("abaabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab|a)+)c/.exec("abaabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:a|b)*)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:a|b)*)c/.exec("xababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:a|b)*)c/.exec("xc")), "[\"c\"]");
+shouldBe(stringify(/(?<=x(?:a|b)*)c/.exec("yababc")), "null");
+shouldBe(stringify(/(?<=(a|b)*)c/.exec("ababc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(a|b)*)c/.exec("abbc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(?:ab)+?)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab)+?)c/.exec("c")), "null");
+shouldBe(stringify(/(?<=^(?:ab)+?)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab)+?)c/.exec("xababc")), "null");
+shouldBe(stringify(/(?<=^(?:a)+?)b/.exec("aaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:a)+?)b/.exec("ab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:a)+?)b/.exec("b")), "null");
+shouldBe(stringify(/(?<=^(?:a)*?)b/.exec("aaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:a)*?)b/.exec("b")), "[\"b\"]");
+shouldBe(stringify(/(?<=x(?:a)*?)b/.exec("xaaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=x(?:a)*?)b/.exec("aaab")), "null");
+shouldBe(stringify(/(?<=(a)+?)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a)*?)b/.exec("aaab")), "[\"b\",undefined]");
+shouldBe(stringify(/(?<=^(a)+?)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a)*?)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|b)+?)c/.exec("abbac")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|bb)+?)c/.exec("abbac")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|bb)*?)c/.exec("abbac")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|bb)*?)c/.exec("c")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<=^(?:a|ab)+?)c/.exec("abaabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab|a)+?)c/.exec("abaabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(a|ab){1,2}?c)d/.exec("abacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){1,2}?c)d/.exec("aabcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?c)d/.exec("abacd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?c)d/.exec("aabcd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?c)d/.exec("abcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?c)d/.exec("acd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,2}?c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,3}?c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,}?c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,2}c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,3}c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,}c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){2,3}?c)d/.exec("xybbcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){2,3}c)d/.exec("xybbcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(?:(yb)|(b)){1,2}?c)d/.exec("xybcd")), "[\"d\",undefined,\"b\"]");
+shouldBe(stringify(/(?<=y(?<g>yb|b){1,2}?c)d/.exec("xybcd")), "[\"d\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,2}?c)d\1/.exec("xybcdb")), "[\"db\",\"b\"]");
+shouldBe(stringify(/(?<=y(yb|b){1,2}?c)d\1/.exec("xybcdyb")), "null");
+shouldBe(stringify(/(?<=(?:ab){2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab){2})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=(?:ab){2})c/.exec("abababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){2})c/.exec("abababc")), "null");
+shouldBe(stringify(/(?<=^(?:ab){3})c/.exec("abababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(ab){2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab){2})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=(a){3})b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a){3})b/.exec("aab")), "null");
+shouldBe(stringify(/(?<=x(a){3})b/.exec("xaaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=x(a){3})b/.exec("aaaab")), "null");
+shouldBe(stringify(/(?<=([ab]){2})c/.exec("abc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=([ab]){2})c/.exec("bac")), "[\"c\",\"b\"]");
+shouldBe(stringify(/(?<=([ab]){2})c/.exec("ac")), "null");
+shouldBe(stringify(/(?<=(\d{2},){2})x/.exec("12,34,x")), "[\"x\",\"12,\"]");
+shouldBe(stringify(/(?<=(\d{2},){2})x/.exec("12,3,x")), "null");
+shouldBe(stringify(/(?<=(?:a|ab){2})c/.exec("aabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:a|ab){2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:a|ab){2})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=^(?:a|ab){2})c/.exec("aabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2})c/.exec("abac")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=^(?:ab|a){2})c/.exec("aabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab|a){2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab|a){2})c/.exec("abac")), "[\"c\"]");
+shouldBe(stringify(/(?<=(a|ab){2})c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){2})c/.exec("abac")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(ab|a){2})c/.exec("abac")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(ab|a){2})c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=(?:a+){2})b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:a+){2})b/.exec("ab")), "null");
+shouldBe(stringify(/(?<=(?:a+){2})b/.exec("aaaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:a+){2})b/.exec("aaaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(?:a+?){2})b/.exec("aaaab")), "[\"b\"]");
+shouldBe(stringify(/(?<=^(a+){2})b/.exec("aaaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a+?){2})b/.exec("aaaab")), "[\"b\",\"aaa\"]");
+shouldBe(stringify(/(?<=^(a*){2})b/.exec("aaaab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=^(a*){2})b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a*?){2})b/.exec("aaaab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=^(a\d*){2})b/.exec("a12a3b")), "[\"b\",\"a12\"]");
+shouldBe(stringify(/(?<=^(a\d*){2})b/.exec("a12ab")), "[\"b\",\"a12\"]");
+shouldBe(stringify(/(?<=^(a\d*){2})b/.exec("a123b")), "null");
+shouldBe(stringify(/(?<=(?:ab){1,2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab){1,2})c/.exec("abc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab){1,2})c/.exec("c")), "null");
+shouldBe(stringify(/(?<=^(?:ab){1,2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){1,2})c/.exec("abababc")), "null");
+shouldBe(stringify(/(?<=^(?:ab){2,3})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){2,3})c/.exec("abababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){2,3})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=^(?:ab){2,3})c/.exec("ababababc")), "null");
+shouldBe(stringify(/(?<=^(?:ab){2,})c/.exec("ababababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){2,})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=^(?:ab){0,2})c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){0,2})c/.exec("c")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:ab){0,2})c/.exec("abababc")), "null");
+shouldBe(stringify(/(?<=(ab){1,2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab){2,3})c/.exec("abababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab){2,3})c/.exec("ababababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab){2,3})c/.exec("abc")), "null");
+shouldBe(stringify(/(?<=(ab){2,})c/.exec("ababababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab){0,2})c/.exec("c")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<=(ab){0,2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2})c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){2,3})c/.exec("aababc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|ab){2,3})c/.exec("abababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){2,3})c/.exec("ac")), "null");
+shouldBe(stringify(/(?<=^(?:a|ab){2,3})c/.exec("aababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2,3})c/.exec("abababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2,3}?)c/.exec("aababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a|ab){2,3}?)c/.exec("abababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(a|ab){2,3}?)c/.exec("aababc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?)c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,}?)c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,})c/.exec("ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(\d{1,3},)*\d+)x/.exec("1,22,333x")), "[\"x\",\"1,\"]");
+shouldBe(stringify(/(?<=(\d{1,3},)*\d+)x/.exec("1x")), "[\"x\",undefined]");
+shouldBe(stringify(/(?<=(\d{1,3},)*\d+)x/.exec("x")), "null");
+shouldBe(stringify(/(?<=^(\d{1,3},)*\d+)x/.exec("1,22,333x")), "[\"x\",\"1,\"]");
+shouldBe(stringify(/(?<=^(\d{1,3},)*\d+)x/.exec("1,2222,333x")), "null");
+shouldBe(stringify(/(?<=^(\d{1,3},)*\d{1,3})x/.exec("1,2222,333x")), "null");
+shouldBe(stringify(/(?<=^(\d{1,3},)+\d+)x/.exec("1x")), "null");
+shouldBe(stringify(/(?<=^(\d{1,3},)+\d+)x/.exec("1,2x")), "[\"x\",\"1,\"]");
+shouldBe(stringify(/(?<=(?:(?:ab)+c)+)d/.exec("ababcabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=(?:(?:ab)+c)+)d/.exec("cd")), "null");
+shouldBe(stringify(/(?<=(?:(?:ab)+c)+)d/.exec("d")), "null");
+shouldBe(stringify(/(?<=^(?:(?:ab)+c)+)d/.exec("ababcabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=^(?:(?:ab)+c)+)d/.exec("xababcabcd")), "null");
+shouldBe(stringify(/(?<=^((ab)+c)+)d/.exec("ababcabcd")), "[\"d\",\"ababc\",\"ab\"]");
+shouldBe(stringify(/(?<=^((ab)+c)+)d/.exec("abcababcd")), "[\"d\",\"abc\",\"ab\"]");
+shouldBe(stringify(/(?<=^((ab)+?c)+?)d/.exec("abcababcd")), "[\"d\",\"abc\",\"ab\"]");
+shouldBe(stringify(/(?<=^((?:ab){2}c){2})d/.exec("ababcababcd")), "[\"d\",\"ababc\"]");
+shouldBe(stringify(/(?<=^((?:ab){2}c){2})d/.exec("ababcabcd")), "null");
+shouldBe(stringify(/(?<=^(?:(a|b){2}c)+)d/.exec("abcbacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a|b){2}c)+)d/.exec("abcbcd")), "null");
+shouldBe(stringify(/(?<=^(?:(a|b)+c){2})d/.exec("abcbacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a|b)+c){2})d/.exec("abcd")), "null");
+shouldBe(stringify(/(?<=(?:(?:a|b)+c){2,3})d/.exec("acbcabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=^(?:(?:a|b)+c){2,3})d/.exec("acbcabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=^(?:(?:a|b)+c){2,3})d/.exec("acbcabcbcd")), "null");
+shouldBe(stringify(/(?<=^(?:(?:a|b)+?c){2,3}?)d/.exec("acbcabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=(?:a){1,2}(?:b){1,2})c/.exec("aabbc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:a){1,2}(?:b){1,2})c/.exec("abc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:a){1,2}(?:b){1,2})c/.exec("ac")), "null");
+shouldBe(stringify(/(?<=(?:a){1,2}(?:b){1,2})c/.exec("bbc")), "null");
+shouldBe(stringify(/(?<=^(?:a){1,2}(?:b){1,2})c/.exec("aabbc")), "[\"c\"]");
+shouldBe(stringify(/(?<=^(?:a){1,2}(?:b){1,2})c/.exec("aaabbc")), "null");
+shouldBe(stringify(/(?<=^(?:a){1,2}(?:b){1,2})c/.exec("aabbbc")), "null");
+shouldBe(stringify(/(?<=^(a){1,2}(b){1,2})c/.exec("aabbc")), "[\"c\",\"a\",\"b\"]");
+shouldBe(stringify(/(?<=^(a){1,2}(b){1,2})c/.exec("abc")), "[\"c\",\"a\",\"b\"]");
+shouldBe(stringify(/(?<=^(a){1,2}?(b){1,2}?)c/.exec("aabbc")), "[\"c\",\"a\",\"b\"]");
+shouldBe(stringify(/(?<=^(a){2,}(b){2,})c/.exec("aaabbbc")), "[\"c\",\"a\",\"b\"]");
+shouldBe(stringify(/(?<=^(a){2,}(b){2,})c/.exec("aabc")), "null");
+shouldBe(stringify(/(?<=^(a|b){1,3}(c|d){1,3})e/.exec("abcde")), "[\"e\",\"a\",\"c\"]");
+shouldBe(stringify(/(?<=^(a|b){1,3}(c|d){1,3})e/.exec("abbcdde")), "[\"e\",\"a\",\"c\"]");
+shouldBe(stringify(/(?<=^(a|b){1,3}(c|d){1,3})e/.exec("abbbcde")), "null");
+shouldBe(stringify(/(?<=^(?:a|b){1,3}(?:c|d){1,3})e/.exec("abcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=^(?:a|b){1,3}(?:c|d){1,3}?)e/.exec("abcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=(?:ab)+(?:cd)+)e/.exec("ababcdcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=(?:ab)+(?:cd)+)e/.exec("abcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=(?:ab)+(?:cd)+)e/.exec("abe")), "null");
+shouldBe(stringify(/(?<=^(?:ab)+(?:cd)+)e/.exec("ababcdcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=^(?:ab)+(?:cd)+)e/.exec("xababcdcde")), "null");
+shouldBe(stringify(/(?<=^(?:ab)+?(?:cd)+?)e/.exec("ababcdcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=^(ab)+(cd)+)e/.exec("ababcdcde")), "[\"e\",\"ab\",\"cd\"]");
+shouldBe(stringify(/(?<=^(ab)+?(cd)+?)e/.exec("ababcdcde")), "[\"e\",\"ab\",\"cd\"]");
+shouldBe(stringify(/(?<=^(?:ab){2}(?:cd){2})e/.exec("ababcdcde")), "[\"e\"]");
+shouldBe(stringify(/(?<=^(?:ab){2}(?:cd){2})e/.exec("abcdcde")), "null");
+shouldBe(stringify(/(?<=^(ab){2}(cd){2})e/.exec("ababcdcde")), "[\"e\",\"ab\",\"cd\"]");
+shouldBe(stringify(/(?<=\b(?:ab)+)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=\b(?:ab)+)c/.exec("xababc")), "null");
+shouldBe(stringify(/(?<=\b(?:ab)+)c/.exec("x ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=\b(ab)+)c/.exec("x ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=\b(a|ab)+)c/.exec("x aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=\B(?:ab)+)c/.exec("xababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=\B(?:ab)+)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:^|,)(?:ab)+)c/.exec("ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:^|,)(?:ab)+)c/.exec("x,ababc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:^|,)(?:ab)+)c/.exec("xababc")), "null");
+shouldBe(stringify(/(?<=(?:^|,)(ab){2})c/.exec("x,ababc")), "[\"c\",\"ab\"]");
+shouldBe(stringify(/(?<=(?:^|,)(ab){2})c/.exec("x,abababc")), "null");
+shouldBe(stringify(/(?<=^(?:ab)+$)/.exec("abab")), "[\"\"]");
+shouldBe(stringify(/(?<=^(?:ab)+$)/.exec("aba")), "null");
+shouldBe(stringify(/(?<=^(ab)+$)/.exec("abab")), "[\"\",\"ab\"]");
+shouldBe(stringify(/(?<=^(a|ab)+$)/.exec("abaab")), "[\"\",\"ab\"]");
+shouldBe(stringify(/(?<=^(?:ab)+)$/m.exec("ab\nabab")), "[\"\"]");
+shouldBe(stringify(/(?<=^(ab)+)$/m.exec("ab\nabab")), "[\"\",\"ab\"]");
+shouldBe(stringify(/(?<=^(ab)+)$/m.exec("ab\nabab\nx")), "[\"\",\"ab\"]");
+shouldBe(stringify(/(?<=(?:ab)+c)d/.exec("ababcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=(?:ab)+c)d/.exec("cd")), "null");
+shouldBe(stringify(/(?<=(?:ab)+c)d/.exec("abcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=(ab)+c)d/.exec("ababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=(a|b)+c)d/.exec("abbacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=(a|b)+c)d/.exec("cd")), "null");
+shouldBe(stringify(/(?<=(a|b)*c)d/.exec("cd")), "[\"d\",undefined]");
+shouldBe(stringify(/(?<=(a|b)*c)d/.exec("abcd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=(?:ab){2}c)d/.exec("ababcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=(?:ab){2}c)d/.exec("abcd")), "null");
+shouldBe(stringify(/(?<=(ab){2}c)d/.exec("ababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=(a|ab){2}c)d/.exec("ababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=(a|ab){2}c)d/.exec("aabcd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){2}c)d/.exec("abacd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=(a|ab){1,2}c)d/.exec("abacd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=(a|ab){1,2}c)d/.exec("acd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){1,2}c)d/.exec("cd")), "null");
+shouldBe(stringify(/(?<=x(?:ab)+c)d/.exec("xababcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=x(?:ab)+c)d/.exec("xcd")), "null");
+shouldBe(stringify(/(?<=x(ab)+c)d/.exec("xababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(a|b)+c)d/.exec("xabbacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=x(?:ab)+?c)d/.exec("xababcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=x(ab)+?c)d/.exec("xababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(a|b)+?c)d/.exec("xabbacd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=x(a|ab)+?c)d/.exec("xabaabcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(?:a|ab)+?c)d/.exec("xabaabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=x(?:a|ab)+c)d/.exec("xabaabcd")), "[\"d\"]");
+shouldBe(stringify(/(?<=x(a|ab)+c)d/.exec("xabaabcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(ab|a)+c)d/.exec("xabaabcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(a|ab){2}c)d/.exec("xabacd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(ab|a){2}c)d/.exec("xabacd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(a|ab){2}c)d/.exec("xaabcd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=x(ab|a){2}c)d/.exec("xaabcd")), "[\"d\",\"a\"]");
+shouldBe(stringify(/(?<=x(a|ab){2}c)d/.exec("xababcd")), "[\"d\",\"ab\"]");
+shouldBe(stringify(/(?<=x(a|ab){2}c)d/.exec("xabcd")), "null");
+shouldBe(stringify(/(?<!(?:ab)+)c/.exec("ababc")), "null");
+shouldBe(stringify(/(?<!(?:ab)+)c/.exec("xc")), "[\"c\"]");
+shouldBe(stringify(/(?<!(?:ab)+)c/.exec("c")), "[\"c\"]");
+shouldBe(stringify(/(?<!(?:ab){2})c/.exec("ababc")), "null");
+shouldBe(stringify(/(?<!(?:ab){2})c/.exec("abc")), "[\"c\"]");
+shouldBe(stringify(/(?<!(ab){2})c/.exec("abc")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<!(a|ab){2})c/.exec("aabc")), "null");
+shouldBe(stringify(/(?<!(a|ab){2})c/.exec("bc")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<!^(a|ab){2})c/.exec("abac")), "null");
+shouldBe(stringify(/(?<!^(a|ab){2})c/.exec("xabac")), "[\"c\",undefined]");
+shouldBe(stringify(/(?<!(?:ab)+?)c/.exec("ababc")), "null");
+shouldBe(stringify(/(?<!(?:ab)+?)c/.exec("xc")), "[\"c\"]");
+shouldBe(stringify(/(?<!(\d{1,3},)*\d+)x/.exec("1,22,333x")), "null");
+shouldBe(stringify(/(?<!(\d{1,3},)*\d+)x/.exec("ax")), "[\"x\",undefined]");
+shouldBe(stringify(/(?<=(ab)+)c\1/.exec("ababcab")), "[\"cab\",\"ab\"]");
+shouldBe(stringify(/(?<=(ab)+)c\1/.exec("ababcba")), "null");
+shouldBe(stringify(/(?<=(a|b)+)c\1/.exec("abcb")), "null");
+shouldBe(stringify(/(?<=(a|b)+)c\1/.exec("abca")), "[\"ca\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){2})c\1/.exec("aabcab")), "[\"ca\",\"a\"]");
+shouldBe(stringify(/(?<=(a|ab){2})c\1/.exec("aabca")), "[\"ca\",\"a\"]");
+shouldBe(stringify(/(?<=(ab){2})c\1/.exec("ababcab")), "[\"cab\",\"ab\"]");
+shouldBe(stringify(/(?<=(?<x>ab)+)c\k<x>/.exec("ababcab")), "[\"cab\",\"ab\"]");
+shouldBe(stringify(/(?<=(?<x>a|b)+)c\k<x>/.exec("abcb")), "null");
+shouldBe(stringify(/(?<=(a)\1+)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a)\1+)b/.exec("aaab")), "null");
+shouldBe(stringify(/(?<=^(a)\1{2})b/.exec("aaab")), "null");
+shouldBe(stringify(/(?<=^(a)\1{2})b/.exec("aab")), "null");
+shouldBe(stringify(/(?<=^(?:(a)\1)+)b/.exec("aaaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a)\1)+)b/.exec("aaab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a|b)\1)+)c/.exec("aabbc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a|b)\1)+)c/.exec("aabc")), "[\"c\",\"a\"]");
+shouldBe(stringify(/(?<=^(?:(a|b)\1){2})c/.exec("aabbc")), "null");
+shouldBe(stringify(/(?<=^(?:(a|b)\1){2})c/.exec("bbc")), "[\"c\",\"b\"]");
+shouldBe(stringify(/(?<=(?:(a|b)\1){2})c/.exec("xaabbc")), "[\"c\",\"b\"]");
+shouldBe(stringify(/(?<=(?:ab)+)c/i.exec("aBAbC")), "[\"C\"]");
+shouldBe(stringify(/(?<=(?:ab){2})c/i.exec("ABabc")), "[\"c\"]");
+shouldBe(stringify(/(?<=(?:ab){2})c/i.exec("ABc")), "null");
+shouldBe(stringify(/(?<=(a|ab){2})c/i.exec("AaBc")), "[\"c\",\"A\"]");
+shouldBe(stringify(/(?<=^(a|ab){1,2}?)c/i.exec("AABC")), "[\"C\",\"A\"]");
+shouldBe(stringify(/(?<=(\w{1,3},)*\w+)x/i.exec("A,bb,CCCx")), "[\"x\",\"A,\"]");
+shouldBe(stringify(/(?<=(?:a*)+)b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:a*)+)b/.exec("b")), "[\"b\"]");
+shouldBe(stringify(/(?<=(a*)+)b/.exec("aab")), "[\"b\",\"aa\"]");
+shouldBe(stringify(/(?<=(a*)+)b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a*)*)b/.exec("aab")), "[\"b\",\"aa\"]");
+shouldBe(stringify(/(?<=(a*)*)b/.exec("b")), "[\"b\",undefined]");
+shouldBe(stringify(/(?<=(a*){2})b/.exec("aab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a*){2})b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a?){2})b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a?){2})b/.exec("ab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a?){2})b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a?){2,3})b/.exec("ab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(?:a|){2})b/.exec("ab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:a|){2})b/.exec("b")), "[\"b\"]");
+shouldBe(stringify(/(?<=(a|){2})b/.exec("ab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a|){2})b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a|){2})b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=^(a|){2})b/.exec("ab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=^(a|){2})b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=^(a|){2})b/.exec("aaab")), "null");
+shouldBe(stringify(/(?<=(|a){2})b/.exec("aab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=^(|a){2})b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a|)+)b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a|)+?)b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a|)*)b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(?:a|)+)b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:a|)+?)b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(?:\b|a)+)b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(a|\b)+)b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(a|\b)*)b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(?:a|\b){2})b/.exec("aab")), "[\"b\"]");
+shouldBe(stringify(/(?<=(a|\b){2})b/.exec("ab")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(a|\b){2})b/.exec("b")), "[\"b\",\"\"]");
+shouldBe(stringify(/(?<=(\b|a){2})b/.exec("aab")), "[\"b\",\"a\"]");
+shouldBe(stringify(/(?<=(\b|a){2})b/.exec("ab")), "[\"b\",\"\"]");
+
+{
+    let re = /(?<=(?:ab)+)c/g;
+    re.lastIndex = 0;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(?:ab)+)c/g;
+    re.lastIndex = 3;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(?:ab)+)c/g;
+    re.lastIndex = 6;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, 7);
+    shouldBe(re.lastIndex, 8);
+}
+{
+    let re = /(?<=(?:ab)+)c/y;
+    re.lastIndex = 0;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(?:ab)+)c/y;
+    re.lastIndex = 4;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(?:ab)+)c/y;
+    re.lastIndex = 5;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(?:ab)+)c/y;
+    re.lastIndex = 8;
+    let match = re.exec("ababcabcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(ab){2})c/g;
+    re.lastIndex = 0;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(ab){2})c/g;
+    re.lastIndex = 2;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(ab){2})c/g;
+    re.lastIndex = 6;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, 9);
+    shouldBe(re.lastIndex, 10);
+}
+{
+    let re = /(?<=(ab){2})c/y;
+    re.lastIndex = 4;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(ab){2})c/y;
+    re.lastIndex = 9;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, 9);
+    shouldBe(re.lastIndex, 10);
+}
+{
+    let re = /(?<=(ab){2})c/y;
+    re.lastIndex = 10;
+    let match = re.exec("ababcababcc");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(a|ab){1,2}?c)d/g;
+    re.lastIndex = 0;
+    let match = re.exec("abacdaabcd");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(a|ab){1,2}?c)d/g;
+    re.lastIndex = 4;
+    let match = re.exec("abacdaabcd");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(a|ab){1,2}?c)d/g;
+    re.lastIndex = 5;
+    let match = re.exec("abacdaabcd");
+    shouldBe(match === null ? "null" : match.index, 9);
+    shouldBe(re.lastIndex, 10);
+}
+{
+    let re = /(?<=(a|ab){1,2}?c)d/y;
+    re.lastIndex = 4;
+    let match = re.exec("abacdaabcd");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=(a|ab){1,2}?c)d/y;
+    re.lastIndex = 9;
+    let match = re.exec("abacdaabcd");
+    shouldBe(match === null ? "null" : match.index, 9);
+    shouldBe(re.lastIndex, 10);
+}
+{
+    let re = /(?<=^(?:a|b){1,3}(?:c|d){1,3})e/gm;
+    re.lastIndex = 0;
+    let match = re.exec("abcde\nabbcdde\nabbbcde");
+    shouldBe(match === null ? "null" : match.index, 4);
+    shouldBe(re.lastIndex, 5);
+}
+{
+    let re = /(?<=^(?:a|b){1,3}(?:c|d){1,3})e/gm;
+    re.lastIndex = 6;
+    let match = re.exec("abcde\nabbcdde\nabbbcde");
+    shouldBe(match === null ? "null" : match.index, 12);
+    shouldBe(re.lastIndex, 13);
+}
+{
+    let re = /(?<=^(?:a|b){1,3}(?:c|d){1,3})e/gm;
+    re.lastIndex = 14;
+    let match = re.exec("abcde\nabbcdde\nabbbcde");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(\d{1,3},)*\d+)x/g;
+    re.lastIndex = 0;
+    let match = re.exec("1,22,333x 4x x");
+    shouldBe(match === null ? "null" : match.index, 8);
+    shouldBe(re.lastIndex, 9);
+}
+{
+    let re = /(?<=(\d{1,3},)*\d+)x/g;
+    re.lastIndex = 9;
+    let match = re.exec("1,22,333x 4x x");
+    shouldBe(match === null ? "null" : match.index, 11);
+    shouldBe(re.lastIndex, 12);
+}
+{
+    let re = /(?<=(\d{1,3},)*\d+)x/g;
+    re.lastIndex = 10;
+    let match = re.exec("1,22,333x 4x x");
+    shouldBe(match === null ? "null" : match.index, 11);
+    shouldBe(re.lastIndex, 12);
+}
+{
+    let re = /(?<=(?:(?:ab)+c)+)d/g;
+    re.lastIndex = 0;
+    let match = re.exec("ababcabcd d cd");
+    shouldBe(match === null ? "null" : match.index, 8);
+    shouldBe(re.lastIndex, 9);
+}
+{
+    let re = /(?<=(?:(?:ab)+c)+)d/g;
+    re.lastIndex = 8;
+    let match = re.exec("ababcabcd d cd");
+    shouldBe(match === null ? "null" : match.index, 8);
+    shouldBe(re.lastIndex, 9);
+}
+{
+    let re = /(?<=(?:(?:ab)+c)+)d/g;
+    re.lastIndex = 9;
+    let match = re.exec("ababcabcd d cd");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+{
+    let re = /(?<=(?:(?:ab)+c)+)d/g;
+    re.lastIndex = 10;
+    let match = re.exec("ababcabcd d cd");
+    shouldBe(match === null ? "null" : match.index, "null");
+    shouldBe(re.lastIndex, 0);
+}
+
+shouldBe("ababcabcc".replace(/(?<=(?:ab)+)c/g, "-"), "abab-ab-c");
+shouldBe("ababcabcc".replace(/(?<=(ab)+)c/g, "[$1]"), "abab[ab]ab[ab]c");
+shouldBe("abcbcc".replace(/(?<=(a|b)+)c/g, "[$1]"), "ab[a]b[b]c");
+shouldBe("aabcababcc".replace(/(?<=(a|ab){2})c/g, "[$1]"), "aab[a]abab[ab]c");
+shouldBe("aabcababcc".replace(/(?<=(a|ab){1,2}?)c/g, "[$1]"), "aab[ab]abab[ab]c");
+shouldBe("1,22,333x 4x x".replace(/(?<=(\d{1,3},)*\d+)x/g, "[$1]"), "1,22,333[1,] 4[] x");
+shouldBe("aabbc".replace(/(?<=^(a){1,2}(b){1,2})c/g, "[$1$2]"), "aabb[ab]");
+
+shouldBe(stringifyIndices(/(?<=(ab)+)c/d.exec("ababc")), "[[4,5],[0,2]]");
+shouldBe(stringifyIndices(/(?<=(a|b)+)c/d.exec("abbac")), "[[4,5],[0,1]]");
+shouldBe(stringifyIndices(/(?<=(a|ab){2})c/d.exec("aabc")), "[[3,4],[0,1]]");
+shouldBe(stringifyIndices(/(?<=(a|ab){1,2}?c)d/d.exec("abacd")), "[[4,5],[2,3]]");
+shouldBe(stringifyIndices(/(?<=(\d{1,3},)*\d+)x/d.exec("1,22,333x")), "[[8,9],[0,2]]");
+shouldBe(stringifyIndices(/(?<=^(a){1,2}(b){1,2})c/d.exec("aabbc")), "[[4,5],[0,1],[2,3]]");
+shouldBe(stringifyIndices(/(?<=^((ab)+c)+)d/d.exec("ababcabcd")), "[[8,9],[0,5],[0,2]]");
+shouldBe(stringifyIndices(/(?<=(a*){2})b/d.exec("aab")), "[[2,3],[0,0]]");
+shouldBe(stringifyIndices(/(?<=(a|){2})b/d.exec("ab")), "[[1,2],[0,0]]");
+shouldBe(stringifyIndices(/(?<=^(a|){2})b/d.exec("aab")), "[[2,3],[0,1]]");
+shouldBe(stringifyIndices(/(?<=y(yb|b){1,2}?c)d/d.exec("xybcd")), "[[4,5],[2,3]]");
+shouldBe(stringifyIndices(/(?<=y(yb|b){1,2}c)d/d.exec("xybcd")), "[[4,5],[2,3]]");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5402,7 +5402,8 @@ class YarrGenerator final : public YarrJITInfo {
                     // This is because NonGreedy already tried with count = 0, failing and reaching here.
                     // So there is no way to proceed further, just propagate a failure.
                     noPreviousIteration.link(&m_jit);
-                    emitClearCapturesForTerm(term);
+                    if (!term->parentheses.isCopy)
+                        emitClearCapturesForTerm(term);
                     storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                     m_backtrackingState.fallthrough();
                     break;
@@ -5495,7 +5496,7 @@ class YarrGenerator final : public YarrJITInfo {
                         exceededMatchLimit.append(m_jit.branch32(MacroAssembler::AboveOrEqual, countTemporary, MacroAssembler::Imm32(term->quantityMaxCount)));
                     }
 
-                    m_jit.branch32(MacroAssembler::Above, m_regs.index, beginTemporary).linkTo(beginOp.m_reentry, &m_jit);
+                    m_jit.branch32(m_direction == Backward ? MacroAssembler::Below : MacroAssembler::Above, m_regs.index, beginTemporary).linkTo(beginOp.m_reentry, &m_jit);
 
                     exceededMatchLimit.link(&m_jit);
                     break;
@@ -5802,15 +5803,13 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
 
                 case PatternTerm::Type::ParenthesesSubpattern:
-                    if (term.quantityMaxCount != 1 || term.parentheses.isCopy)
-                        return unsupported();
                     ASSERT(!term.parentheses.isStringList && !term.parentheses.isTerminal);
                     if (auto reversed = reverseDisjunctionForBackward(term.parentheses.disjunction, inputPosition)) {
                         term.parentheses.disjunction = reversed.get();
                         m_reversedDisjunctions.append(WTF::move(reversed));
                     } else
                         return nullptr;
-                    if (term.quantityType == QuantifierType::FixedCount)
+                    if (term.quantityMaxCount == 1 && !term.parentheses.isCopy && term.quantityType == QuantifierType::FixedCount)
                         inputPosition += term.parentheses.disjunction->m_minimumSize;
                     term.inputPosition = inputPosition;
                     break;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1909,8 +1909,7 @@ public:
             // FixedCount{min} + Greedy/NonGreedy{0,max-min}. The split would deep-copy
             // the disjunction subtree, which can hit OffsetTooLarge / pattern-size limits
             // for very large bounds (e.g. (?:x){2147483648,...}). Backward parens
-            // (lookbehinds) still use the expansion path; the JIT's right-to-left
-            // backtracking machinery hasn't been generalized for single-term VariableMin.
+            // (lookbehinds) still use the expansion path.
             term.quantify(min, max, greedy ? QuantifierType::Greedy : QuantifierType::NonGreedy);
         } else {
             if (term.matchDirection() == Forward) {


### PR DESCRIPTION
#### d21310b806f3d23c9a6c0ea4478221c5eb6eafd7
<pre>
[YARR] Compile lookbehinds containing quantified groups in the JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=322244">https://bugs.webkit.org/show_bug.cgi?id=322244</a>

Reviewed by Daniel Liu.

A group quantified with anything other than {1} or ? inside a lookbehind, e.g. (?&lt;=(?:ab)+),
sent the whole pattern to the interpreter.

The counted and ParenContext group opcodes only save, compare and restore the index, so they
work in either direction. Two checks did depend on it: the lazy group&apos;s &quot;try one more iteration&quot;
test must see the index move down when matching backward, and the optional copy the parser
splits a backward X{n,m} into must not clear the captures it shares with the mandatory part
when it backtracks out of zero iterations. Forward code generation is unchanged.

                                                 Baseline                  Patched

regexp-lookbehind-quantified-group         2598.3586+-382.2034   ^    200.9308+-11.4910       ^ definitely 12.9316x faster
regexp-lookbehind-fixed-count-group        3523.6885+-262.9262   ^    218.0944+-3.0137        ^ definitely 16.1567x faster

Tests: JSTests/microbenchmarks/regexp-lookbehind-fixed-count-group.js
       JSTests/microbenchmarks/regexp-lookbehind-quantified-group.js
       JSTests/stress/regexp-lookbehind-jit-quantified-groups-unicode.js
       JSTests/stress/regexp-lookbehind-jit-quantified-groups.js

* JSTests/microbenchmarks/regexp-lookbehind-fixed-count-group.js: Added.
(let.re):
* JSTests/microbenchmarks/regexp-lookbehind-quantified-group.js: Added.
* JSTests/stress/regexp-lookbehind-jit-quantified-groups-unicode.js: Added.
(shouldBe):
(stringify):
(stringifyIndices):
(shouldBe.stringify):
(a.z):
(shouldBe.stringify.y):
(c.u.exec):
(shouldBe.string_appeared_here.replace):
(shouldBe.stringifyIndices):
(shouldBe.stringifyIndices.y):
* JSTests/stress/regexp-lookbehind-jit-quantified-groups.js: Added.
(shouldBe):
(stringify):
(stringifyIndices):
(shouldBe.stringify):
(shouldBe.stringify.y):
(shouldBe.stringify.y.yb):
(shouldBe.stringify.x):
(b.exec):
(shouldBe.string_appeared_here.replace):
(shouldBe.stringifyIndices):
(shouldBe.stringifyIndices.y):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::quantifyAtom):

Canonical link: <a href="https://commits.webkit.org/319743@main">https://commits.webkit.org/319743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc5fa9519f059ff2884eabc3a15f9932b22ee6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142032 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98602 "4 flakes 13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44397 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42662 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4434 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11235 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42292 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3316 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43206 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55544 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40712 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56233 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151149 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45716 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128516 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54747 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->