### PR TITLE
[JSC] `WTF::weekDay` overflows for days near `INT32_MAX` and is duplicated in Temporal

### DIFF
--- a/JSTests/stress/date-get-day-full-range.js
+++ b/JSTests/stress/date-get-day-full-range.js
@@ -1,0 +1,42 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected} (${message})`);
+}
+
+function referenceDay(days) {
+    let r = (days + 4) % 7;
+    return r < 0 ? r + 7 : r;
+}
+
+const msPerDay = 86400000;
+const maxDays = 100000000;
+
+// 0: Sunday ... 6: Saturday
+shouldBe(new Date(Date.UTC(1970, 0, 1)).getUTCDay(), 4, "1970-01-01 is Thursday");
+shouldBe(new Date(Date.UTC(1969, 11, 31)).getUTCDay(), 3, "1969-12-31 is Wednesday");
+shouldBe(new Date(Date.UTC(2000, 0, 1)).getUTCDay(), 6, "2000-01-01 is Saturday");
+shouldBe(new Date(Date.UTC(1900, 0, 1)).getUTCDay(), 1, "1900-01-01 is Monday");
+shouldBe(new Date(Date.UTC(1600, 0, 1)).getUTCDay(), 6, "1600-01-01 is Saturday");
+shouldBe(new Date(0).getUTCDay(), 4);
+
+// Extremes of the ECMAScript time range.
+shouldBe(new Date(maxDays * msPerDay).getUTCDay(), referenceDay(maxDays), "max time value");
+shouldBe(new Date(-maxDays * msPerDay).getUTCDay(), referenceDay(-maxDays), "min time value");
+shouldBe(new Date(maxDays * msPerDay).getUTCDay(), 6, "+275760-09-13 is Saturday");
+shouldBe(new Date(-maxDays * msPerDay).getUTCDay(), 2, "-271821-04-20 is Tuesday");
+
+// Days around zero and around each boundary.
+for (let days = -20; days <= 20; ++days)
+    shouldBe(new Date(days * msPerDay).getUTCDay(), referenceDay(days), `days=${days}`);
+for (let days = maxDays - 20; days <= maxDays; ++days) {
+    shouldBe(new Date(days * msPerDay).getUTCDay(), referenceDay(days), `days=${days}`);
+    shouldBe(new Date(-days * msPerDay).getUTCDay(), referenceDay(-days), `days=${-days}`);
+}
+
+// Strided sweep over the whole range.
+for (let days = -maxDays; days <= maxDays; days += 4093)
+    shouldBe(new Date(days * msPerDay).getUTCDay(), referenceDay(days), `days=${days}`);
+
+// Last millisecond of a day still belongs to that day.
+for (let days = -1000; days <= 1000; days += 97)
+    shouldBe(new Date(days * msPerDay + msPerDay - 1).getUTCDay(), referenceDay(days), `days=${days} end`);

--- a/JSTests/stress/temporal-plaindate-dayofweek-full-range.js
+++ b/JSTests/stress/temporal-plaindate-dayofweek-full-range.js
@@ -1,0 +1,40 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected} (${message})`);
+}
+
+// Temporal.PlainDate.dayOfWeek is 1 (Monday) ... 7 (Sunday).
+function dayOfWeekFromLegacy(isoString) {
+    let day = new Date(isoString + "T00:00:00Z").getUTCDay();
+    return day === 0 ? 7 : day;
+}
+
+const cases = [
+    ["1970-01-01", 4],
+    ["1969-12-31", 3],
+    ["1970-01-04", 7],
+    ["1970-01-05", 1],
+    ["2000-01-01", 6],
+    ["1600-01-01", 6],
+    ["0001-01-01", 1],
+    ["0000-12-31", 7],
+    ["-000001-12-31", 5],
+    ["+275760-09-13", 6],
+    ["-271821-04-20", 2],
+];
+
+for (let [iso, expected] of cases) {
+    let plainDate = Temporal.PlainDate.from(iso);
+    shouldBe(plainDate.dayOfWeek, expected, iso);
+    shouldBe(plainDate.dayOfWeek, dayOfWeekFromLegacy(iso), `${iso} vs Date`);
+}
+
+for (let year = -271820; year <= 275759; year += 3001) {
+    for (let month = 1; month <= 12; month += 5) {
+        let plainDate = new Temporal.PlainDate(year, month, 1);
+        let iso = plainDate.toString();
+        shouldBe(plainDate.dayOfWeek, dayOfWeekFromLegacy(iso), iso);
+    }
+}

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1437,10 +1437,8 @@ std::optional<ParsedISODateTime> parseISODateTime(StringView string, TemporalPro
 
 uint8_t dayOfWeek(PlainDate plainDate)
 {
-    Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(plainDate.year(), plainDate.month() - 1, plainDate.day()));
-    int weekDay = static_cast<int>((dateDays + 4) % 7);
-    if (weekDay < 0)
-        weekDay += 7;
+    int32_t days = WTF::daysFromYearMonth(plainDate.year(), plainDate.month() - 1) + (plainDate.day() - 1);
+    int32_t weekDay = WTF::weekDay(days);
     return !weekDay ? 7 : weekDay;
 }
 

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -373,18 +373,14 @@ inline int msToSeconds(double ms)
 }
 
 // 0: Sunday, 1: Monday, etc.
-inline int msToWeekDay(double ms)
-{
-    int wd = (static_cast<int>(msToDays(ms)) + 4) % 7;
-    if (wd < 0)
-        wd += 7;
-    return wd;
-}
-
+// Branchless (days + 4) mod 7 over the whole int32_t range, using x mod 7 == floor(x * 8 / 7) mod 8:
+// multiply by ceil(2^40 / 7) << 24, add 4 * 2^61 (1970-01-01 is Thursday) plus a rounding bias, and keep the top 3 bits.
+// Ben Joffe, "A faster way to calculate the day-of-the-week" (2026), https://www.benjoffe.com/fast-day-of-week
 inline int32_t weekDay(int32_t days)
 {
-    int32_t result = (days + 4) % 7;
-    return result >= 0 ? result : result + 7;
+    constexpr uint64_t multiplier = 0x2492492493000000ull;
+    constexpr uint64_t thursdayOffset = 0x9400ull << 48;
+    return static_cast<int32_t>((static_cast<uint64_t>(static_cast<int64_t>(days)) * multiplier + thursdayOffset) >> 61);
 }
 
 inline int monthFromDayInYear(int dayInYear, bool leapYear)


### PR DESCRIPTION
#### e1fdc80a34f021efa512e23d136c5727b18687e8
<pre>
[JSC] `WTF::weekDay` overflows for days near `INT32_MAX` and is duplicated in Temporal
<a href="https://bugs.webkit.org/show_bug.cgi?id=322247">https://bugs.webkit.org/show_bug.cgi?id=322247</a>

Reviewed by Yusuke Suzuki.

WTF::weekDay computed (days + 4) % 7, which is signed overflow for
days &gt; INT32_MAX - 4. No caller reaches that today because days is
clipped to +-1e8, but the function is declared for any int32_t.
ISO8601::dayOfWeek carried its own copy of the same modulo, converting
the day count through double and Int128 on the way.

Compute the weekday with the multiply-and-shift from Ben Joffe&apos;s
article [1]: since 7 = 2^3 - 1, x mod 7 equals floor(x * 8 / 7) mod 8,
so a 64-bit multiply by ceil(2^40 / 7) &lt;&lt; 24, an add of the Thursday
offset and a shift by 61 yield the weekday. Every step is unsigned
arithmetic, so the result is defined for the whole int32_t range; all
2^32 inputs were checked against the old formula evaluated in int64_t.
On arm64 this is sxtw / madd / lsr instead of a magic-number division
with cmp/csel.

Make ISO8601::dayOfWeek build the day count with daysFromYearMonth, as
TemporalZonedDateTimePrototype already does, and call WTF::weekDay.
Remove msToWeekDay, which has no callers.

[1]: <a href="https://www.benjoffe.com/fast-day-of-week">https://www.benjoffe.com/fast-day-of-week</a>

Tests: JSTests/stress/date-get-day-full-range.js
       JSTests/stress/temporal-plaindate-dayofweek-full-range.js

* JSTests/stress/date-get-day-full-range.js: Added.
(shouldBe):
* JSTests/stress/temporal-plaindate-dayofweek-full-range.js: Added.
(shouldBe):
(expected.of.cases.dayOfWeekFromLegacy):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::dayOfWeek):
* Source/WTF/wtf/DateMath.h:
(WTF::weekDay):
(WTF::msToWeekDay): Deleted.

Canonical link: <a href="https://commits.webkit.org/319583@main">https://commits.webkit.org/319583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f7361413c2c4f3f5e62a2696872b7a160e04a1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146263 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142043 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44399 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4445 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11247 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42298 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3323 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43213 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55551 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40548 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56240 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151158 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45723 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128523 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54754 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->