### PR TITLE
[cmake] Provide ability to run Safari with webkit built by cmake

### DIFF
--- a/Source/JavaScriptCore/PlatformCocoa.cmake
+++ b/Source/JavaScriptCore/PlatformCocoa.cmake
@@ -183,10 +183,6 @@ if (WEBKIT_SDK_IS_IOS_FAMILY)
     set_target_properties(JavaScriptCore PROPERTIES
         INSTALL_NAME_DIR "${JavaScriptCore_INSTALL_NAME_DIR}"
     )
-    target_link_options(JavaScriptCore PRIVATE
-        -compatibility_version 1.0.0
-        -current_version ${WEBKIT_MAC_VERSION}
-    )
 
     if (WTF_LIBRARY_TYPE STREQUAL "STATIC")
         target_link_options(JavaScriptCore PRIVATE

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -3,10 +3,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set_target_properties(WebCore PROPERTIES
         INSTALL_NAME_DIR "${WebCore_INSTALL_NAME_DIR}"
     )
-    target_link_options(WebCore PRIVATE
-        -compatibility_version 1.0.0
-        -current_version ${WEBKIT_MAC_VERSION}
-    )
 endif ()
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/WebCore/Modules")

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -39,10 +39,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set_target_properties(WebGPU PROPERTIES
         INSTALL_NAME_DIR "${WebGPU_INSTALL_NAME_DIR}"
     )
-    target_link_options(WebGPU PRIVATE
-        -compatibility_version 1.0.0
-        -current_version ${WEBKIT_MAC_VERSION}
-    )
     set(MACOSX_FRAMEWORK_IDENTIFIER com.apple.WebGPU)
     set(BUNDLE_VERSION "${MACOSX_FRAMEWORK_BUNDLE_VERSION}")
     set(SHORT_VERSION_STRING "${WEBKIT_MAC_VERSION}")

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -122,6 +122,10 @@ list(APPEND WebKit_SOURCES
     UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
     UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm
     ${WEBKIT_DIR}/UIProcess/API/Cocoa/Logger+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/WKContentWorld.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
 
     UIProcess/Cocoa/PreferenceObserver.mm
     UIProcess/Cocoa/WKShareSheet.mm
@@ -500,11 +504,8 @@ list(APPEND WebKit_SOURCES
     ${WEBKIT_DIR}/ModelProcess/cocoa/WKUSDStageConverter.swift
     ${WEBKIT_DIR}/Platform/spi/visionos/WKSurroundingsEffect.swift
     ${WEBKIT_DIR}/Platform/spi/visionos/WKSurroundingsEffectView.swift
-    ${WEBKIT_DIR}/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
-    ${WEBKIT_DIR}/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
     ${WEBKIT_DIR}/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
     ${WEBKIT_DIR}/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
-    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
     ${WEBKIT_DIR}/UIProcess/API/Swift/URLSchemeHandler.swift
     ${WEBKIT_DIR}/UIProcess/API/Swift/WebPage.swift
     ${WEBKIT_DIR}/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -627,7 +628,6 @@ set(WebKit_FORWARDING_HEADERS_DIRECTORIES
     WebProcess/InjectedBundle/API/mac
 )
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
 target_link_options(WebKit PRIVATE -framework AuthKit)
 
 
@@ -2525,6 +2525,10 @@ add_custom_target(WebKit_CopyModules ALL DEPENDS
         "${_wk_modules_dir}/module.modulemap"
         "${_wk_modules_dir}/module.private.modulemap")
 list(APPEND WebKit_DEPENDENCIES WebKit_CopyModules)
+
+# The staging command above depends on WebKit, so this target must not be added
+# to WebKit_DEPENDENCIES; ALL is what gets it built.
+add_custom_target(WebKit_StageSwiftModuleMac ALL DEPENDS ${_wk_swiftmodule_outputs})
 
 add_custom_command(
     OUTPUT "${_wk_modules_dir}/WebKit.swiftcrossimport/SwiftUI.swiftoverlay"

--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -258,10 +258,6 @@ set(WebKitLegacy_POST_BUILD_COMMAND
 set_target_properties(WebKitLegacy PROPERTIES
     INSTALL_NAME_DIR "${WebKitLegacy_INSTALL_NAME_DIR}"
 )
-target_link_options(WebKitLegacy PRIVATE
-    -compatibility_version 1.0.0
-    -current_version ${WEBKIT_MAC_VERSION}
-)
 
 target_link_options(WebKitLegacy PRIVATE
     -exported_symbols_list ${WEBKITLEGACY_DIR}/WebKitLegacy-iOS.exp
@@ -1725,4 +1721,4 @@ set(WebKitLegacy_PROJECT_HEADERS
     mac/WebView/WebViewRenderingUpdateScheduler.h
 )
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION} -framework SecurityInterface")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -framework SecurityInterface")

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -357,6 +357,13 @@ endif ()
 add_link_options("$<$<NOT:$<CONFIG:Debug>>:-Wl,-dead_strip>")
 add_link_options(-Wl,-dead_strip_dylibs)
 
+# Mirrors DYLIB_COMPATIBILITY_VERSION / DYLIB_CURRENT_VERSION in
+# Configurations/Version.xcconfig. Set globally rather than per framework so that
+# every dylib carries them: clients linked against the Xcode frameworks record a
+# required compatibility version of 1.0.0, and dyld refuses to substitute a dylib
+# that declares 0.0.0. Shared-only, since ld rejects these flags for executables.
+string(APPEND CMAKE_SHARED_LINKER_FLAGS " -compatibility_version 1.0.0 -current_version ${WEBKIT_MAC_VERSION}")
+
 # Linked globally because PAL has Swift sources that get force-loaded into WebCore,
 # and WebCore does not link JavaScriptCore directly on all platforms.
 find_library(SWIFTCORE_LIBRARY swiftCore HINTS ${CMAKE_OSX_SYSROOT}/usr/lib/swift REQUIRED)

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -569,7 +569,11 @@ sub determineArchitecture
         }
     }
 
-    if (isCMakeBuild()) {
+    # Apple Cocoa already resolved the architecture above, and it is the one the
+    # CMake presets build (CMAKE_OSX_ARCHITECTURES=arm64e); cmake --system-information
+    # reports CMAKE_SYSTEM_PROCESSOR, which is arm64, and probing it costs a full
+    # compiler run on every invocation.
+    if (isCMakeBuild() && !isAppleCocoaWebKit()) {
         if (isCrossCompilation()) {
             my $compiler = "gcc";
             $compiler = $ENV{'CC'} if (defined($ENV{'CC'}));
@@ -872,6 +876,7 @@ sub argumentsForConfiguration()
     push(@args, '--visionos-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'xrsimulator');
     push(@args, '--maccatalyst') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'maccatalyst');
     push(@args, '--32-bit') if ($architecture eq "x86");
+    push(@args, '--cmake') if (isAppleCocoaWebKit() && isCMakeBuild());
     push(@args, '--gtk') if isGtk();
     push(@args, '--wpe') if isWPE();
     push(@args, '--jsc-only') if isJSCOnly();
@@ -1186,6 +1191,19 @@ sub usesPerConfigurationBuildDirectory
     return (defined $ENV{"WEBKIT_OUTPUTDIR"});
 }
 
+# The directory Xcode builds into, whether or not this invocation selected the
+# CMake tree. Products only Xcode knows how to build (Safari and the frameworks
+# above WebKit) live here even when WebKit itself came from cmake-mac.
+sub xcodeConfigurationProductDir
+{
+    determineBaseProductDir();
+    determineConfiguration();
+    return $baseProductDir if usesPerConfigurationBuildDirectory();
+    my $dir = File::Spec->catdir($baseProductDir, $configuration);
+    $dir .= "-" . xcodeSDKPlatformName() if isEmbeddedWebKit() || isMacCatalystWebKit();
+    return $dir;
+}
+
 sub determineConfigurationProductDir
 {
     return if defined $configurationProductDir;
@@ -1193,23 +1211,19 @@ sub determineConfigurationProductDir
     determineConfiguration();
     if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
         $configurationProductDir = File::Spec->catdir($baseProductDir, $configuration);
+    } elsif (usesPerConfigurationBuildDirectory()) {
+        $configurationProductDir = "$baseProductDir";
+    } elsif (isGtk() or isWPE() or isJSCOnly() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
+        $configurationProductDir = "$baseProductDir/$portName/$configuration";
+    } elsif (isAppleCocoaWebKit() && isCMakeBuild()) {
+        # Sanitizer presets build into a dedicated dir, e.g. cmake-mac/ASan.
+        my $cmakeConfiguration = $configuration;
+        $cmakeConfiguration = "ASan" if asanIsEnabled();
+        $cmakeConfiguration = "TSan" if tsanIsEnabled();
+        $configurationProductDir = "$baseProductDir/cmake-mac/$cmakeConfiguration";
+        $configurationProductDir .= "-" . xcodeSDKPlatformName() if isEmbeddedWebKit() || isMacCatalystWebKit();
     } else {
-        if (usesPerConfigurationBuildDirectory()) {
-            $configurationProductDir = "$baseProductDir";
-        } else {
-            if (isGtk() or isWPE() or isJSCOnly() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
-                $configurationProductDir = "$baseProductDir/$portName/$configuration";
-            } elsif (isAppleCocoaWebKit() && isCMakeBuild()) {
-                # Sanitizer presets build into a dedicated dir, e.g. cmake-mac/ASan.
-                my $cmakeConfiguration = $configuration;
-                $cmakeConfiguration = "ASan" if asanIsEnabled();
-                $cmakeConfiguration = "TSan" if tsanIsEnabled();
-                $configurationProductDir = "$baseProductDir/cmake-mac/$cmakeConfiguration";
-            } else {
-                $configurationProductDir = "$baseProductDir/$configuration";
-            }
-            $configurationProductDir .= "-" . xcodeSDKPlatformName() if isEmbeddedWebKit() || isMacCatalystWebKit();
-        }
+        $configurationProductDir = xcodeConfigurationProductDir();
     }
 }
 
@@ -1598,6 +1612,11 @@ sub safariPath
         # Use Safari.app in product directory if present (good for Safari development team).
         if (-d "$configurationProductDir/Safari.app") {
             $safariBundle = "$configurationProductDir/Safari.app";
+        } else {
+            # Safari is built by Xcode, so with --cmake the product directory holds
+            # no Safari.app. Fall back to the Xcode tree before the installed Safari.
+            my $xcodeProductDir = xcodeConfigurationProductDir();
+            $safariBundle = "$xcodeProductDir/Safari.app" if -d "$xcodeProductDir/Safari.app";
         }
     }
 
@@ -3270,6 +3289,8 @@ Usage: @{[basename($0)]} [options] <application-path>
   --help                            Show this help message
   --no-saved-state                  Launch the application without state restoration
   --debug|release                   build configuration
+  --cmake                           Use the CMake build
+  --xcode                           Use the Xcode build
 
 Options specific to macOS:
   -g|--guard-malloc                 Enable Guard Malloc
@@ -3307,7 +3328,7 @@ sub argumentsForRunAndDebugMacWebKitApp()
     return @args;
 }
 
-sub setupMacWebKitEnvironment($)
+sub prependMacWebKitDyldPaths($)
 {
     my ($dyldFrameworkPath) = @_;
 
@@ -3317,6 +3338,13 @@ sub setupMacWebKitEnvironment($)
     prependToEnvironmentVariableList("__XPC_DYLD_FRAMEWORK_PATH", $dyldFrameworkPath);
     prependToEnvironmentVariableList("DYLD_LIBRARY_PATH", $dyldFrameworkPath);
     prependToEnvironmentVariableList("__XPC_DYLD_LIBRARY_PATH", $dyldFrameworkPath);
+}
+
+sub setupMacWebKitEnvironment
+{
+    # Prepended in reverse so the first path given ends up searched first.
+    prependMacWebKitDyldPaths($_) for reverse @_;
+
     $ENV{WEBKIT_UNSET_DYLD_FRAMEWORK_PATH} = "YES";
 
     setUpGuardMallocIfNeeded();
@@ -3671,14 +3699,29 @@ sub commandLineArgumentsForRestrictedEnvironmentVariables($)
     return map { ($prefix, "$_=$ENV{$_}") } grep { /^DYLD_/ } keys %ENV;
 }
 
+sub dyldFrameworkPathsForMacWebKitApp($)
+{
+    my ($appPath) = @_;
+    my @paths = (productDir());
+
+    # An app taken from the Xcode tree while WebKit came from cmake-mac needs both:
+    # WebKit and friends from the CMake tree, everything above WebKit (SafariShared,
+    # SafariSharedUI, ...) from the Xcode one. Listed second so the CMake tree wins
+    # for the frameworks both trees provide.
+    my $xcodeProductDir = xcodeConfigurationProductDir();
+    push(@paths, $xcodeProductDir) if $xcodeProductDir ne $paths[0] && index($appPath, "$xcodeProductDir/") == 0;
+
+    return @paths;
+}
+
 sub runMacWebKitApp($;$$)
 {
     my ($appPath, $useOpenCommand, $openDocumentPath) = @_;
-    my $productDir = productDir();
-    print "Starting @{[basename($appPath)]} with DYLD_FRAMEWORK_PATH set to point to built WebKit in $productDir.\n";
+    my @frameworkPaths = dyldFrameworkPathsForMacWebKitApp($appPath);
+    print "Starting @{[basename($appPath)]} with DYLD_FRAMEWORK_PATH set to point to built WebKit in @{[join(', ', @frameworkPaths)]}.\n";
 
     local %ENV = %ENV;
-    setupMacWebKitEnvironment($productDir);
+    setupMacWebKitEnvironment(@frameworkPaths);
 
     if (defined($useOpenCommand) && $useOpenCommand == USE_OPEN_COMMAND) {
         my $appPathForOpen = $appPath;
@@ -3719,11 +3762,11 @@ sub execMacWebKitAppForDebugging($)
     chomp $debuggerPath;
     die "Can't find the lldb executable.\n" unless -x $debuggerPath;
 
-    my $productDir = productDir();
-    setupMacWebKitEnvironment($productDir);
+    my @frameworkPaths = dyldFrameworkPathsForMacWebKitApp($appPath);
+    setupMacWebKitEnvironment(@frameworkPaths);
 
     my @architectureFlags = ($architectureSwitch, architecture());
-    print "Starting @{[basename($appPath)]} under lldb with DYLD_FRAMEWORK_PATH set to point to built WebKit in $productDir.\n";
+    print "Starting @{[basename($appPath)]} under lldb with DYLD_FRAMEWORK_PATH set to point to built WebKit in @{[join(', ', @frameworkPaths)]}.\n";
     exec { $debuggerPath } $debuggerPath, @architectureFlags, $argumentsSeparator, $appPath, argumentsForRunAndDebugMacWebKitApp() or die;
 }
 


### PR DESCRIPTION
#### bc9f76805019f00c439c5b5cc4fa197b5fc4cc1a
<pre>
[cmake] Provide ability to run Safari with webkit built by cmake
<a href="https://bugs.webkit.org/show_bug.cgi?id=322249">https://bugs.webkit.org/show_bug.cgi?id=322249</a>
<a href="https://rdar.apple.com/185482522">rdar://185482522</a>

Reviewed by Zak Ridouh.

Make --cmake option given to run-safari works.
Couple of issues with the cmake webkit build that prevented Safari to start:
- compatibility version returned was 0.0.0 instead of the required 1.0.0
- Some swift overlays were missing from the cmake files, so some symbols loaded by Safari were missing.

The macOS Swift module staging target is named WebKit_StageSwiftModuleMac, as the
iOS family section of PlatformCocoa.cmake already defines WebKit_StageSwiftModule.

Manually tested with run-safari --release --cmake

* Source/JavaScriptCore/PlatformCocoa.cmake:
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebGPU/WebGPU/CMakeLists.txt:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKitLegacy/PlatformCocoa.cmake:
* Source/cmake/OptionsCocoa.cmake:
* Tools/Scripts/webkitdirs.pm:
(determineArchitecture):
(argumentsForConfiguration):
(xcodeConfigurationProductDir): Where Xcode builds for the current configuration; also used by determineConfigurationProductDir so the two can&apos;t drift.
(determineConfigurationProductDir):
(safariPath):
(printHelpAndExitForRunAndDebugWebKitAppIfNeeded):
(prependMacWebKitDyldPaths):
(setupMacWebKitEnvironment):
(dyldFrameworkPathsForMacWebKitApp):
(runMacWebKitApp):
(execMacWebKitAppForDebugging): Use the same framework path list as runMacWebKitApp, so debug-safari --cmake finds Safari&apos;s own frameworks too.

Canonical link: <a href="https://commits.webkit.org/319673@main">https://commits.webkit.org/319673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a0ace05d18cc0ccf631c567252298da65fe65c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/364ba932-6e73-4d3e-9151-1138689fa949) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5175a002-d790-4e7b-b2c8-a9c973d68f55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122630 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19f8ee8f-5a1a-4d04-9dd5-c30818d1aba3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42865 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4596 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11431 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42488 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3559 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43453 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55787 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151620 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56478 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39113 "Too many flaky failures: http/tests/cookies/same-site/popup-same-site.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/postredirect-basic.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/cached-svg-image-with-css-cross-domain.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-with-http-url-allowed-by-csp-img-src-star.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/site-isolation/draw-after-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151321 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45918 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128761 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124620 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54989 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17484 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->