### PR TITLE
<table border> and <table rules> cell borders should not inherit the table's CSS border-color

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt
@@ -2,7 +2,7 @@ cell
 cell
 cell
 
-FAIL A <table border> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
-FAIL A <table rules=all> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS A <table border> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor
+PASS A <table rules=all> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor
 PASS The legacy bordercolor attribute still propagates to interior cell borders
 

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug965-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug965-expected.txt
@@ -56,10 +56,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,158) size 74x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 70x26
           RenderTableRow {TR} at (0,2) size 70x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,188) size 784x36
@@ -69,9 +69,9 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,224) size 76x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 70x26
           RenderTableRow {TR} at (0,2) size 70x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"

--- a/LayoutTests/platform/glib/tables/mozilla/core/borders-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/core/borders-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 74x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 70x26
           RenderTableRow {TR} at (0,2) size 70x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,30) size 784x18
@@ -17,10 +17,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,48) size 76x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 70x26
           RenderTableRow {TR} at (0,2) size 70x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderTable {TABLE} at (0,80) size 63x28 [border: (1px outset #000000)]
@@ -49,10 +49,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,168) size 72x28 [border: (1px solid #FF0000)]
         RenderTableSection {TBODY} at (1,1) size 70x26
           RenderTableRow {TR} at (0,2) size 70x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (35,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,196) size 784x36

--- a/LayoutTests/platform/glib/tables/mozilla/marvin/tables_style-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/marvin/tables_style-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x50 [border: (3px dashed #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 778x44
           RenderTableRow {TR} at (0,2) size 778x40
-            RenderTableCell {TD} at (2,2) size 386x40 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 386x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 366x36
                 text run at (2,2) width 366: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,20) width 204: "attribute of the TABLE element."
-            RenderTableCell {TD} at (390,2) size 386x40 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (390,2) size 386x40 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 366x36
                 text run at (2,2) width 366: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,20) width 204: "attribute of the TABLE element."

--- a/LayoutTests/platform/gtk/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/gtk/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (71,0) size 642x200 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 638x197
             RenderTableRow {TR} at (0,0) size 638x22
-              RenderTableCell {TD} at (0,0) size 638x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 638x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 176x18
                   text run at (3,3) width 176: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 638x175
-              RenderTableCell {TD} at (0,22) size 153x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 153x175 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 149x155
                   RenderTable {TABLE} at (0,0) size 149x155 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 146x152
                       RenderTableRow {TR} at (0,0) size 146x22
-                        RenderTableCell {TD} at (0,0) size 146x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 146x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 23x18
                             text run at (3,3) width 23: "text"
                       RenderTableRow {TR} at (0,22) size 146x37
-                        RenderTableCell {TD} at (0,22) size 146x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 146x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 141x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 138x31
                               RenderTableRow {TR} at (0,0) size 138x31
-                                RenderTableCell {TD} at (0,1) size 115x29 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,1) size 115x29 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (3,4) size 111x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (115,0) size 23x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (115,0) size 23x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,7) size 19x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 146x21
-                        RenderTableCell {TD} at (0,59) size 146x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 146x21 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x18
                             text run at (3,2) width 23: "text"
                       RenderTableRow {TR} at (0,80) size 146x50
-                        RenderTableCell {TD} at (0,80) size 146x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 146x50 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 141x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 52x18
                                     text run at (3,3) width 52: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 52x18
                                     text run at (3,2) width 52: "problem"
                       RenderTableRow {TR} at (0,130) size 146x22
-                        RenderTableCell {TD} at (0,130) size 146x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 146x22 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x18
                             text run at (3,2) width 23: "text"
-              RenderTableCell {TD} at (153,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (153,22) size 485x30 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 47x18
                           text run at (3,3) width 47: "overlap"
 layer at (95,66) size 105x18

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x212 [border: (1.50px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 629x210
             RenderTableRow {TR} at (0,0) size 628x24
-              RenderTableCell {TD} at (0,0) size 628x24 [border: (1.50px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x24 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (2,2) size 181x20
                   text run at (2,2) width 181: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,24) size 628x185
-              RenderTableCell {TD} at (0,24) size 143x185 [border: (0.50px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,24) size 143x185 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (2,1) size 140x166
                   RenderTable {TABLE} at (0,0) size 139x165 [border: (1.50px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 137x163
                       RenderTableRow {TR} at (0,0) size 136x24
-                        RenderTableCell {TD} at (0,0) size 136x24 [border: (1.50px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x24 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,2) size 25x20
                             text run at (2,2) width 25: "text"
                       RenderTableRow {TR} at (0,24) size 136x37
-                        RenderTableCell {TD} at (0,24) size 136x37 [border: (0.50px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,24) size 136x37 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (2,1) size 132x35 [border: (1.50px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 129x32
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,2) size 104x27 [border: (1.50px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,2) size 104x27 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (2,4) size 93x23 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (103,0) size 26x31 [border: (1.50px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (103,0) size 26x31 [border: (1.50px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,6) size 20x19
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,61) size 136x23
-                        RenderTableCell {TD} at (0,61) size 136x23 [border: (0.50px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,61) size 136x23 [border: (0.50px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,1) size 25x20
                             text run at (2,1) width 25: "text"
                       RenderTableRow {TR} at (0,84) size 136x54
-                        RenderTableCell {TD} at (0,84) size 136x54 [border: (0.50px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,84) size 136x54 [border: (0.50px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (2,1) size 132x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (2,1) size 132x52 [border: (1.50px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 129x49
                               RenderTableRow {TR} at (0,0) size 128x24
-                                RenderTableCell {TD} at (0,0) size 128x24 [border: (1.50px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x24 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (2,2) size 54x20
                                     text run at (2,2) width 54: "problem"
                               RenderTableRow {TR} at (0,24) size 128x24
-                                RenderTableCell {TD} at (0,24) size 128x24 [border: (0.50px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,24) size 128x24 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (2,1) size 54x20
                                     text run at (2,1) width 54: "problem"
                       RenderTableRow {TR} at (0,138) size 136x24
-                        RenderTableCell {TD} at (0,138) size 136x24 [border: (0.50px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,138) size 136x24 [border: (0.50px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,1) size 25x20
                             text run at (2,1) width 25: "text"
-              RenderTableCell {TD} at (143,24) size 485x32 [border: (0.50px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,24) size 485x32 [border: (0.50px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (1,1) size 482x29 [border: (1.50px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 479x26
                     RenderTableRow {TR} at (0,0) size 478x25
-                      RenderTableCell {TD} at (0,0) size 478x25 [border: (1.50px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x25 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (2,2) size 49x20
                           text run at (2,2) width 49: "overlap"
 layer at (103,71) size 78x14

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x200 [border: (1.50px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 629x198
             RenderTableRow {TR} at (0,0) size 628x22
-              RenderTableCell {TD} at (0,0) size 628x22 [border: (1.50px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (2,2) size 181x19
                   text run at (2,2) width 181: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 628x175
-              RenderTableCell {TD} at (0,22) size 143x175 [border: (0.50px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (2,1) size 140x156
                   RenderTable {TABLE} at (0,0) size 139x155 [border: (1.50px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 137x153
                       RenderTableRow {TR} at (0,0) size 136x22
-                        RenderTableCell {TD} at (0,0) size 136x22 [border: (1.50px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,2) size 25x19
                             text run at (2,2) width 25: "text"
                       RenderTableRow {TR} at (0,22) size 136x37
-                        RenderTableCell {TD} at (0,22) size 136x37 [border: (0.50px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (2,1) size 132x35 [border: (1.50px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 129x32
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,3) size 104x25 [border: (1.50px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,3) size 104x25 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (2,6) size 92x19 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (103,0) size 26x31 [border: (1.50px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (103,0) size 26x31 [border: (1.50px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,6) size 20x19
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 136x21
-                        RenderTableCell {TD} at (0,59) size 136x21 [border: (0.50px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (0.50px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,1) size 25x19
                             text run at (2,1) width 25: "text"
                       RenderTableRow {TR} at (0,80) size 136x50
-                        RenderTableCell {TD} at (0,80) size 136x50 [border: (0.50px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (0.50px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (2,1) size 132x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (2,1) size 132x48 [border: (1.50px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 129x45
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (1.50px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (2,2) size 54x19
                                     text run at (2,2) width 54: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (0.50px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (0.50px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (2,1) size 54x19
                                     text run at (2,1) width 54: "problem"
                       RenderTableRow {TR} at (0,130) size 136x22
-                        RenderTableCell {TD} at (0,130) size 136x22 [border: (0.50px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (0.50px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (2,1) size 25x19
                             text run at (2,1) width 25: "text"
-              RenderTableCell {TD} at (143,22) size 485x30 [border: (0.50px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (0.50px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (1,1) size 482x27 [border: (1.50px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 479x24
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (1.50px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (1.50px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (2,2) size 49x19
                           text run at (2,2) width 49: "overlap"
 layer at (103,69) size 79x13 backgroundClip at (103,69) size 78x13 clip at (103,69) size 78x13

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug965-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug965-expected.txt
@@ -56,10 +56,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,158) size 73x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,188) size 784x36
@@ -69,9 +69,9 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,224) size 75x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"

--- a/LayoutTests/platform/ios/tables/mozilla/core/borders-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/core/borders-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 73x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,30) size 784x18
@@ -17,10 +17,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,48) size 75x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderTable {TABLE} at (0,80) size 64x28 [border: (1px outset #000000)]
@@ -49,10 +49,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,168) size 71x28 [border: (1px solid #FF0000)]
         RenderTableSection {TBODY} at (1,1) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,196) size 784x36

--- a/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x200 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 628x197
             RenderTableRow {TR} at (0,0) size 628x22
-              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 180x18
                   text run at (3,3) width 180: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 628x175
-              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 139x155
                   RenderTable {TABLE} at (0,0) size 139x155 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 136x152
                       RenderTableRow {TR} at (0,0) size 136x22
-                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 24x18
                             text run at (3,3) width 24: "text"
                       RenderTableRow {TR} at (0,22) size 136x37
-                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 128x31
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,3) size 102x25 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,3) size 102x25 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (3,6) size 85x20 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (101,0) size 28x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (101,0) size 28x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (3,7) size 20x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 136x21
-                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
                       RenderTableRow {TR} at (0,80) size 136x50
-                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 54x18
                                     text run at (3,3) width 54: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 54x18
                                     text run at (3,2) width 54: "problem"
                       RenderTableRow {TR} at (0,130) size 136x22
-                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
-              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 48x18
                           text run at (3,3) width 48: "overlap"
 layer at (100,69) size 79x13 backgroundClip at (100,69) size 78x13 clip at (100,69) size 78x13

--- a/LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x200 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 628x197
             RenderTableRow {TR} at (0,0) size 628x22
-              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 180x18
                   text run at (3,3) width 180: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 628x175
-              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 139x155
                   RenderTable {TABLE} at (0,0) size 139x155 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 136x152
                       RenderTableRow {TR} at (0,0) size 136x22
-                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 24x18
                             text run at (3,3) width 24: "text"
                       RenderTableRow {TR} at (0,22) size 136x37
-                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 128x31
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,2) size 104x27 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,2) size 104x27 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (3,5) size 93x22 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (103,0) size 26x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (103,0) size 26x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,7) size 20x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 136x21
-                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
                       RenderTableRow {TR} at (0,80) size 136x50
-                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 54x18
                                     text run at (3,3) width 54: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 54x18
                                     text run at (3,2) width 54: "problem"
                       RenderTableRow {TR} at (0,130) size 136x22
-                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
-              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 48x18
                           text run at (3,3) width 48: "overlap"
 layer at (104,69) size 79x13 backgroundClip at (104,69) size 78x13 clip at (104,69) size 78x13

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x200 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 628x197
             RenderTableRow {TR} at (0,0) size 628x22
-              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 180x18
                   text run at (3,3) width 180: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 628x175
-              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 139x155
                   RenderTable {TABLE} at (0,0) size 139x155 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 136x152
                       RenderTableRow {TR} at (0,0) size 136x22
-                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 24x18
                             text run at (3,3) width 24: "text"
                       RenderTableRow {TR} at (0,22) size 136x37
-                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 128x31
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,3) size 102x25 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,3) size 102x25 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (3,6) size 85x20 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (101,0) size 28x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (101,0) size 28x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (3,7) size 20x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 136x21
-                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
                       RenderTableRow {TR} at (0,80) size 136x50
-                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 54x18
                                     text run at (3,3) width 54: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 54x18
                                     text run at (3,2) width 54: "problem"
                       RenderTableRow {TR} at (0,130) size 136x22
-                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 24x18
                             text run at (3,2) width 24: "text"
-              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 48x18
                           text run at (3,3) width 48: "overlap"
 layer at (100,69) size 79x13 backgroundClip at (100,69) size 78x13 clip at (100,69) size 78x13

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug965-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug965-expected.txt
@@ -56,10 +56,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,158) size 73x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,188) size 784x36
@@ -69,9 +69,9 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,224) size 75x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"

--- a/LayoutTests/platform/mac/tables/mozilla/core/borders-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/borders-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 73x30 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,30) size 784x18
@@ -17,10 +17,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,48) size 75x32 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderTable {TABLE} at (0,80) size 64x28 [border: (1px outset #000000)]
@@ -49,10 +49,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,168) size 71x28 [border: (1px solid #FF0000)]
         RenderTableSection {TBODY} at (1,1) size 69x26
           RenderTableRow {TR} at (0,2) size 69x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "One"
-            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 29x18
                 text run at (2,2) width 29: "Two"
       RenderBlock (anonymous) at (0,196) size 784x36

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x212 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 628x209
             RenderTableRow {TR} at (0,0) size 628x24
-              RenderTableCell {TD} at (0,0) size 628x24 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 173x19
                   text run at (3,3) width 173: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,24) size 628x185
-              RenderTableCell {TD} at (0,24) size 143x185 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,24) size 143x185 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 139x165
                   RenderTable {TABLE} at (0,0) size 139x165 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 136x162
                       RenderTableRow {TR} at (0,0) size 136x24
-                        RenderTableCell {TD} at (0,0) size 136x24 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 22x19
                             text run at (3,3) width 22: "text"
                       RenderTableRow {TR} at (0,24) size 136x37
-                        RenderTableCell {TD} at (0,24) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,24) size 136x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 128x31
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,0) size 104x31 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 104x31 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (5,5) size 87x22 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (103,0) size 26x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (103,0) size 26x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,7) size 20x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,61) size 136x23
-                        RenderTableCell {TD} at (0,61) size 136x23 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,61) size 136x23 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 22x19
                             text run at (3,2) width 22: "text"
                       RenderTableRow {TR} at (0,84) size 136x54
-                        RenderTableCell {TD} at (0,84) size 136x54 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,84) size 136x54 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x51 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x48
                               RenderTableRow {TR} at (0,0) size 128x24
-                                RenderTableCell {TD} at (0,0) size 128x24 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 50x19
                                     text run at (3,3) width 50: "problem"
                               RenderTableRow {TR} at (0,24) size 128x24
-                                RenderTableCell {TD} at (0,24) size 128x24 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,24) size 128x24 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 50x19
                                     text run at (3,2) width 50: "problem"
                       RenderTableRow {TR} at (0,138) size 136x24
-                        RenderTableCell {TD} at (0,138) size 136x24 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,138) size 136x24 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 22x19
                             text run at (3,2) width 22: "text"
-              RenderTableCell {TD} at (143,24) size 485x32 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,24) size 485x32 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x28 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x25
                     RenderTableRow {TR} at (0,0) size 478x25
-                      RenderTableCell {TD} at (0,0) size 478x25 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x25 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 45x19
                           text run at (3,3) width 45: "overlap"
 layer at (101,71) size 83x16

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug965-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug965-expected.txt
@@ -56,10 +56,10 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,172) size 72x32 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 68x28
           RenderTableRow {TR} at (0,2) size 68x24
-            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 26x19
                 text run at (2,2) width 26: "One"
-            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "Two"
       RenderBlock (anonymous) at (0,204) size 784x40
@@ -69,9 +69,9 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,244) size 74x34 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 68x28
           RenderTableRow {TR} at (0,2) size 68x24
-            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 26x19
                 text run at (2,2) width 26: "One"
-            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "Two"

--- a/LayoutTests/platform/win/tables/mozilla/core/borders-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/core/borders-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 785x620
       RenderTable {TABLE} at (0,0) size 72x32 [border: (2px solid #FF0000)]
         RenderTableSection {TBODY} at (2,2) size 68x28
           RenderTableRow {TR} at (0,2) size 68x24
-            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 26x19
                 text run at (2,2) width 26: "One"
-            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "Two"
       RenderBlock (anonymous) at (0,32) size 769x20
@@ -17,10 +17,10 @@ layer at (0,0) size 785x620
       RenderTable {TABLE} at (0,52) size 74x34 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 68x28
           RenderTableRow {TR} at (0,2) size 68x24
-            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 26x19
                 text run at (2,2) width 26: "One"
-            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "Two"
       RenderTable {TABLE} at (0,86) size 61x30 [border: (1px outset #000000)]
@@ -49,10 +49,10 @@ layer at (0,0) size 785x620
       RenderTable {TABLE} at (0,182) size 70x30 [border: (1px solid #FF0000)]
         RenderTableSection {TBODY} at (1,1) size 68x28
           RenderTableRow {TR} at (0,2) size 68x24
-            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 30x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 26x19
                 text run at (2,2) width 26: "One"
-            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "Two"
       RenderBlock (anonymous) at (0,212) size 769x40

--- a/LayoutTests/platform/win/tables/mozilla/marvin/tables_style-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/marvin/tables_style-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x54 [border: (3px dashed #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 778x48
           RenderTableRow {TR} at (0,2) size 778x44
-            RenderTableCell {TD} at (2,2) size 386x44 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 386x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 352x39
                 text run at (2,2) width 352: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,22) width 193: "attribute of the TABLE element."
-            RenderTableCell {TD} at (390,2) size 386x44 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (390,2) size 386x44 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 352x39
                 text run at (2,2) width 352: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,22) width 193: "attribute of the TABLE element."

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt
@@ -7,56 +7,56 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (76,0) size 632x200 [border: (1px solid #FF0000)]
           RenderTableSection {TBODY} at (1,1) size 628x197
             RenderTableRow {TR} at (0,0) size 628x22
-              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 176x18
                   text run at (3,3) width 176: "parent table, 1st row, 1st col"
             RenderTableRow {TR} at (0,22) size 628x175
-              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderBlock {FORM} at (3,2) size 139x155
                   RenderTable {TABLE} at (0,0) size 139x155 [border: (1px solid #00FF00)]
                     RenderTableSection {TBODY} at (1,1) size 136x152
                       RenderTableRow {TR} at (0,0) size 136x22
-                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 23x18
                             text run at (3,3) width 23: "text"
                       RenderTableRow {TR} at (0,22) size 136x37
-                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
                             RenderTableSection {TBODY} at (1,1) size 128x31
                               RenderTableRow {TR} at (0,0) size 128x31
-                                RenderTableCell {TD} at (0,1) size 105x29 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,1) size 105x29 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderTextControl {INPUT} at (3,4) size 101x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (105,0) size 23x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (105,0) size 23x31 [border: (2px solid #000000)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,7) size 19x18
                                   RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,59) size 136x21
-                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #000000)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x18
                             text run at (3,2) width 23: "text"
                       RenderTableRow {TR} at (0,80) size 136x50
-                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #000000)] [r=3 c=0 rs=1 cs=1]
                           RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
                               RenderTableRow {TR} at (0,0) size 128x22
-                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,0) size 128x22 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,3) size 52x18
                                     text run at (3,3) width 52: "problem"
                               RenderTableRow {TR} at (0,22) size 128x22
-                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
+                                RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 52x18
                                     text run at (3,2) width 52: "problem"
                       RenderTableRow {TR} at (0,130) size 136x22
-                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #000000)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x18
                             text run at (3,2) width 23: "text"
-              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
-                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+                      RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 47x18
                           text run at (3,3) width 47: "overlap"
 layer at (100,66) size 95x18

--- a/LayoutTests/tables/mozilla/marvin/tables_style-expected.txt
+++ b/LayoutTests/tables/mozilla/marvin/tables_style-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x50 [border: (3px dashed #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 778x44
           RenderTableRow {TR} at (0,2) size 778x40
-            RenderTableCell {TD} at (2,2) size 386x40 [border: (1px inset #FF0000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 386x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 372x36
                 text run at (2,2) width 372: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,20) width 208: "attribute of the TABLE element."
-            RenderTableCell {TD} at (390,2) size 386x40 [border: (1px inset #FF0000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (390,2) size 386x40 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 372x36
                 text run at (2,2) width 372: "This is a table with a red dashed border to test the STYLE"
                 text run at (2,20) width 208: "attribute of the TABLE element."

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -25,7 +25,10 @@
 #include "config.h"
 #include "HTMLTableElement.h"
 
+#include "CSSColor.h"
+#include "CSSColorValue.h"
 #include "CSSImageValue.h"
+#include "CSSKeywordColor.h"
 #include "CSSPropertyNames.h"
 #include "CSSValueKeywords.h"
 #include "CSSValuePool.h"
@@ -402,8 +405,12 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
 
     CellBorders bordersBefore = cellBorders();
     unsigned short oldPadding = m_padding;
+    bool hadBorderColorAttr = m_borderColorAttr;
 
     switch (name.nodeName()) {
+    case AttributeNames::bordercolorAttr:
+        m_borderColorAttr = !newValue.isEmpty();
+        break;
     case AttributeNames::borderAttr:
         // FIXME: This attribute is a mess.
         m_borderAttr = parseBorderWidthAttribute(newValue);
@@ -440,7 +447,7 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     }
 
-    if (bordersBefore != cellBorders() || oldPadding != m_padding) {
+    if (bordersBefore != cellBorders() || oldPadding != m_padding || hadBorderColorAttr != m_borderColorAttr) {
         m_sharedCellStyle = nullptr;
         bool cellChanged = false;
         for (auto& child : childrenOfType<Element>(*this))
@@ -504,30 +511,39 @@ Ref<MutableStyleProperties> HTMLTableElement::createSharedCellStyle() const
 {
     auto style = MutableStyleProperties::create();
 
+    // border-color is not an inherited property, so the interior cell borders implied by the border and
+    // rules attributes resolve to the cell's own currentColor. The legacy bordercolor attribute is the
+    // exception: it propagates to those borders, via border-color: inherit on the table sections and rows.
+    auto cellBorderColor = [&] -> Ref<CSSValue> {
+        if (m_borderColorAttr)
+            return CSSKeywordValue::create(CSSValueInherit);
+        return CSSColorValue::create(CSS::Color { CSS::KeywordColor { CSSValueCurrentcolor } });
+    };
+
     switch (cellBorders()) {
     case CellBorders::SolidColsOnly:
         style->setProperty(CSSPropertyBorderLeftWidth, CSSValueThin);
         style->setProperty(CSSPropertyBorderRightWidth, CSSValueThin);
         style->setProperty(CSSPropertyBorderLeftStyle, CSSValueSolid);
         style->setProperty(CSSPropertyBorderRightStyle, CSSValueSolid);
-        style->setProperty(CSSPropertyBorderColor, CSSKeywordValue::create(CSSValueInherit));
+        style->setProperty(CSSPropertyBorderColor, cellBorderColor());
         break;
     case CellBorders::SolidRowsOnly:
         style->setProperty(CSSPropertyBorderTopWidth, CSSValueThin);
         style->setProperty(CSSPropertyBorderBottomWidth, CSSValueThin);
         style->setProperty(CSSPropertyBorderTopStyle, CSSValueSolid);
         style->setProperty(CSSPropertyBorderBottomStyle, CSSValueSolid);
-        style->setProperty(CSSPropertyBorderColor, CSSKeywordValue::create(CSSValueInherit));
+        style->setProperty(CSSPropertyBorderColor, cellBorderColor());
         break;
     case CellBorders::Solid:
         style->setProperty(CSSPropertyBorderWidth, CSSPrimitiveValue::create(1, CSSUnitType::Px));
         style->setProperty(CSSPropertyBorderStyle, CSSKeywordValue::create(CSSValueSolid));
-        style->setProperty(CSSPropertyBorderColor, CSSKeywordValue::create(CSSValueInherit));
+        style->setProperty(CSSPropertyBorderColor, cellBorderColor());
         break;
     case CellBorders::Inset:
         style->setProperty(CSSPropertyBorderWidth, CSSPrimitiveValue::create(1, CSSUnitType::Px));
         style->setProperty(CSSPropertyBorderStyle, CSSKeywordValue::create(CSSValueInset));
-        style->setProperty(CSSPropertyBorderColor, CSSKeywordValue::create(CSSValueInherit));
+        style->setProperty(CSSPropertyBorderColor, cellBorderColor());
         break;
     case CellBorders::None:
         // If 'rules=none' then allow any borders set at cell level to take effect. 

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -94,6 +94,7 @@ private:
 
     bool m_borderAttr { false }; // Sets a precise border width and creates an outset border for the table and for its cells.
     bool m_frameAttr { false }; // Implies a thin border width if no border is set and then a certain set of solid/hidden borders based off the value.
+    bool m_borderColorAttr { false }; // Makes the borders of the table's cells inherit the table's border-color; border-color is otherwise not inherited.
     TableRules m_rulesAttr { TableRules::Unset }; // Implies a thin border width, a collapsing border model, and all borders on the table becoming set to hidden (if frame/border are present, to none otherwise).
     unsigned short m_padding { 1 };
     mutable RefPtr<const MutableStyleProperties> m_sharedCellStyle;


### PR DESCRIPTION
#### 09a6b62b1d6c501ba1f08d40904fc65abbdf4960
<pre>
&lt;table border&gt; and &lt;table rules&gt; cell borders should not inherit the table&apos;s CSS border-color
<a href="https://bugs.webkit.org/show_bug.cgi?id=322253">https://bugs.webkit.org/show_bug.cgi?id=322253</a>
<a href="https://rdar.apple.com/185487698">rdar://185487698</a>

Reviewed by NOBODY (OOPS!).

The border and rules attributes create borders on a table&apos;s interior cells.
We built those cell borders with `border-color: inherit`, which - combined with
the `border-color: inherit` html.css already puts on thead/tbody/tfoot/tr -
formed an unbroken chain from the cell up to the table, so a border-color set
on the &lt;table&gt; via CSS cascaded down onto the cell borders.

That is wrong: border-color is not an inherited property per CSS Backgrounds 3,
and the HTML rendering spec&apos;s rules for `table[border] &gt; tr &gt; td` and
`table[rules=all i] &gt; tr &gt; td` set only border-width and border-style, leaving
the cells&apos; border-color at its initial `currentcolor`. Gecko already resolves
these borders to the cell&apos;s own currentColor.

Interior cell borders now resolve to `currentColor`, following the cell&apos;s own
color rather than the table&apos;s border-color. The legacy bordercolor attribute
path is preserved: when that attribute is present the cell borders still
inherit the table&apos;s (attribute-set) colour, which is what the `inherit` was
there for in the first place. Whether the attribute is present is now tracked
in m_borderColorAttr, and the shared cell style is invalidated when it changes
so that adding or removing bordercolor dynamically re-cascades the cells.

Blink has made the same change behind a TableCellBorderColorInherit flag that
still defaults to the legacy behaviour, so Chrome does not match this yet.

* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::attributeChanged):
(WebCore::HTMLTableElement::createSharedCellStyle const):
* Source/WebCore/html/HTMLTableElement.h:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt: Progression

&gt; Rebaselines:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug965-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/core/borders-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/marvin/tables_style-expected.txt:
* LayoutTests/platform/gtk/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug965-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/core/borders-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug965-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/borders-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug965-expected.txt:
* LayoutTests/platform/win/tables/mozilla/core/borders-expected.txt:
* LayoutTests/platform/win/tables/mozilla/marvin/tables_style-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/tables/mozilla/marvin/tables_style-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a6b62b1d6c501ba1f08d40904fc65abbdf4960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a104fadb-7c77-4079-9a46-91729641b2b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142047 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98617 "5 flakes 34 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb62d6e8-f040-477b-bd4a-37f604e73834) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8653198b-cdad-45f1-bf9f-fbacdf4e5300) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42677 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42307 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3334 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194097 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151461 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56251 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38932 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/post-308-response.html, http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html, http/tests/security/cached-cross-origin-preloaded-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src2.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-insecure-page.https.html, http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151165 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45732 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128534 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124310 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17302 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54145 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->