### PR TITLE
Use copyNativeImage in 2D context drawImage

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -37,6 +37,7 @@
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
 #include "IntRect.h"
+#include "NativeImage.h"
 #include "NoiseInjectionPolicy.h"
 #include "RenderElementInlines.h"
 #include "ScriptTrackingPrivacyCategory.h"
@@ -97,6 +98,15 @@ RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostPro
         return nullptr;
     // Currently we don't cache transparent black bitmaps of canvases that do not have a context.
     return ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+}
+
+RefPtr<NativeImage> CanvasBase::copyNativeImage() const
+{
+    if (RefPtr context = renderingContext())
+        return context->surfaceBufferToNativeImage(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
+    if (!validateArea())
+        return nullptr;
+    return ImageBuffer::sinkIntoNativeImage(ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8));
 }
 
 static inline size_t NODELETE maxCanvasArea()

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -48,6 +48,7 @@ class GraphicsContext;
 class Image;
 class ImageBuffer;
 class IntRect;
+class NativeImage;
 class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
@@ -75,6 +76,11 @@ public:
     virtual void setSizeForControllingContext(IntSize) = 0;
 
     WEBCORE_EXPORT RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+
+    // Returns the rendering results as an image, for contexts that can produce one without an
+    // intermediate ImageBuffer. Returns nullptr if the caller must use
+    // makeRenderingResultsAvailable() instead.
+    WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const;
 
     void setOriginClean() { m_originClean = true; }
     void setOriginTainted() { m_originClean = false; }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -860,11 +860,10 @@ SecurityOrigin* HTMLCanvasElement::securityOrigin() const
 
 Image* HTMLCanvasElement::copiedImage() const
 {
-    if (!m_copiedImage) {
-        RefPtr buffer = const_cast<HTMLCanvasElement*>(this)->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-        if (buffer)
-            m_copiedImage = BitmapImage::create(buffer->copyNativeImage());
-    }
+    if (m_copiedImage)
+        return m_copiedImage.get();
+    if (RefPtr image = copyNativeImage())
+        m_copiedImage = BitmapImage::create(WTF::move(image));
     return m_copiedImage.get();
 }
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -359,12 +359,10 @@ Image* OffscreenCanvas::copiedImage() const
 {
     if (m_detached)
         return nullptr;
-
-    if (!m_copiedImage) {
-        RefPtr buffer = const_cast<OffscreenCanvas*>(this)->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-        if (buffer)
-            m_copiedImage = BitmapImage::create(buffer->copyNativeImage());
-    }
+    if (m_copiedImage)
+        return m_copiedImage;
+    if (RefPtr image = const_cast<OffscreenCanvas*>(this)->copyNativeImage())
+        m_copiedImage = BitmapImage::create(WTF::move(image));
     return m_copiedImage.get();
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -49,6 +49,7 @@ class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
 class ImageBitmap;
+class NativeImage;
 class SVGImageElement;
 class WebGLObject;
 enum class PixelFormat : uint8_t;
@@ -98,6 +99,10 @@ public:
 
     // Draws the source buffer to the canvasBase().buffer().
     virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) = 0;
+    // Returns the contents of the source buffer as an image. The image is immutable, so it stays
+    // valid after the context is drawn to again. Returns nullptr if the contents cannot be
+    // obtained as an image, in which case the caller must use surfaceBufferToImageBuffer().
+    virtual RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) = 0;
     virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const = 0;
     bool NODELETE delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -68,6 +68,7 @@
 #include "ImageBuffer.h"
 #include "ImageData.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include "PaintRenderingContext2D.h"
 #include "Path2D.h"
@@ -290,6 +291,17 @@ RefPtr<ImageBuffer> CanvasRenderingContext2DBase::surfaceBufferToImageBuffer(Sur
     return buffer();
 }
 
+RefPtr<NativeImage> CanvasRenderingContext2DBase::surfaceBufferToNativeImage(SurfaceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = this->buffer();
+    if (!buffer)
+        return nullptr;
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
+}
+
 bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
 {
     // Before the first draw (or first access to the drawing buffer), the drawing buffer is transparent black.
@@ -337,6 +349,7 @@ void CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties(bool sizeChange
         restore();
     m_stateStack.first() = State();
     m_path.clear();
+    m_bufferNativeImage = nullptr;
     m_cachedContents.emplace<CachedContentsTransparent>();
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();
@@ -1840,8 +1853,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
 
     auto targetSwitcher = CanvasFilterContextSwitcher::create(*this, normalizedDstRect);
 
-    GraphicsContext* c = effectiveDrawingContext();
-    if (!c)
+    if (!effectiveDrawingContext())
         return { };
     if (!hasInvertibleTransform()) [[unlikely]]
         return { };
@@ -1849,31 +1861,14 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     Ref protectedCanvas { sourceCanvas };
     checkOrigin(&sourceCanvas);
 
-    RefPtr buffer = sourceCanvas.makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-    if (!buffer)
+    // The contents are obtained as an immutable image, so no intermediate ImageBuffer is needed.
+    // This also makes drawing the canvas to itself work, as the image stays valid after the canvas
+    // is cleared.
+    RefPtr image = sourceCanvas.copyNativeImage();
+    if (!image)
         return { };
 
-    bool repaintEntireCanvas = false;
-    if (rectContainsCanvas(normalizedDstRect)) {
-        c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
-        repaintEntireCanvas = true;
-    } else if (isFullCanvasCompositeMode(state().globalComposite)) {
-        fullCanvasCompositedDrawImage(*buffer, normalizedDstRect, normalizedSrcRect, state().globalComposite);
-        repaintEntireCanvas = true;
-    } else if (state().globalComposite == CompositeOperator::Copy) {
-        if (&sourceCanvas == &canvasBase()) {
-            if (auto copy = createCompatibleImageBuffer(*c, normalizedSrcRect.size())) {
-                copy->context().drawImageBuffer(*buffer, -normalizedSrcRect.location());
-                clearCanvas();
-                c->drawImageBuffer(*copy, normalizedDstRect, { { }, normalizedSrcRect.size() }, { state().globalComposite, state().globalBlend });
-            }
-        } else {
-            clearCanvas();
-            c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
-        }
-        repaintEntireCanvas = true;
-    } else
-        c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
+    bool repaintEntireCanvas = drawSourceImage(*image, normalizedDstRect, normalizedSrcRect);
 
     auto shouldUseDrawOptionsWithoutPostProcessing = sourceCanvas.renderingContext() && sourceCanvas.renderingContext()->is2d() && !sourceCanvas.havePendingCanvasNoiseInjection();
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, shouldUseDrawOptionsWithoutPostProcessing ? defaultDidDrawOptionsWithoutPostProcessing() : defaultDidDrawOptions());
@@ -2006,6 +2001,7 @@ ExceptionOr<Ref<DOMMatrix>> CanvasRenderingContext2DBase::drawElementImage(Canva
 
 void CanvasRenderingContext2DBase::clearCanvas()
 {
+    m_bufferNativeImage = nullptr;
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
@@ -2080,6 +2076,37 @@ static void drawImageToContext(Image& image, GraphicsContext& context, const Flo
 static void drawImageToContext(ImageBuffer& imageBuffer, GraphicsContext& context, const FloatRect& dest, const FloatRect& src, ImagePaintingOptions options)
 {
     context.drawImageBuffer(imageBuffer, dest, src, options);
+}
+
+static void drawImageToContext(NativeImage& image, GraphicsContext& context, const FloatRect& dest, const FloatRect& src, ImagePaintingOptions options)
+{
+    context.drawNativeImage(image, dest, src, options);
+}
+
+// Draws the source to the canvas, obeying the compositing rules of the canvas 2D context.
+// Returns true if the whole canvas was repainted.
+template<class T> bool CanvasRenderingContext2DBase::drawSourceImage(T& source, const FloatRect& dstRect, const FloatRect& srcRect)
+{
+    auto* c = effectiveDrawingContext();
+    if (!c)
+        return false;
+
+    ImagePaintingOptions options { state().globalComposite, state().globalBlend };
+    if (rectContainsCanvas(dstRect)) {
+        drawImageToContext(source, *c, dstRect, srcRect, options);
+        return true;
+    }
+    if (isFullCanvasCompositeMode(state().globalComposite)) {
+        fullCanvasCompositedDrawImage(source, dstRect, srcRect, state().globalComposite);
+        return true;
+    }
+    if (state().globalComposite == CompositeOperator::Copy) {
+        clearCanvas();
+        drawImageToContext(source, *c, dstRect, srcRect, options);
+        return true;
+    }
+    drawImageToContext(source, *c, dstRect, srcRect, options);
+    return false;
 }
 
 template<class T> void CanvasRenderingContext2DBase::fullCanvasCompositedDrawImage(T& image, const FloatRect& dest, const FloatRect& src, CompositeOperator op)
@@ -2391,6 +2418,7 @@ void CanvasRenderingContext2DBase::didDrawEntireCanvas(OptionSet<DidDrawOption> 
 
 void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, OptionSet<DidDrawOption> options)
 {
+    m_bufferNativeImage = nullptr;
     if (!options.contains(DidDrawOption::PreserveCachedContents))
         m_cachedContents.emplace<CachedContentsUnknown>();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -499,8 +499,10 @@ private:
     FloatRect inflatedStrokeRect(const FloatRect&) const;
 
     template<class T> void fullCanvasCompositedDrawImage(T&, const FloatRect&, const FloatRect&, CompositeOperator);
+    template<class T> bool drawSourceImage(T&, const FloatRect& dstRect, const FloatRect& srcRect);
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
 #if USE(SKIA)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
@@ -520,6 +522,7 @@ private:
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;
     mutable RefPtr<ImageBuffer> m_buffer;
+    RefPtr<NativeImage> m_bufferNativeImage;
 
     // When layers are opened, m_stateStack contains target switchers where the top
     // targetSwitcher on the stack draws to the targetSwitcher under it, ... until

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -65,6 +65,7 @@ public:
     std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond() const override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) override;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     // GPUCanvasContext methods:
@@ -139,7 +140,8 @@ private:
     bool m_suppressEDR { false };
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
-    RefPtr<ImageBuffer> m_readDisplayBuffer;
+    RefPtr<ImageBuffer> m_readDisplayBuffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_readDisplayBufferImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -42,6 +42,7 @@
 #include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "Page.h"
 #include "PlatformCALayerDelegatedContents.h"
 #include "PlatformScreen.h"
@@ -339,6 +340,7 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
         m_currentTexture = nullptr;
     }
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     auto newSize = canvasBase().size();
     auto newWidth = static_cast<GPUIntegerCoordinate>(newSize.width());
@@ -425,6 +427,27 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     return buffer;
 }
 
+RefPtr<NativeImage> GPUCanvasContextCocoa::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    // The inspector reads the last presented frame instead of the current contents, so it does not
+    // use the cached image of the read buffer.
+    bool useCache = sourceBuffer != SurfaceBuffer::DisplayBufferForInspector;
+    if (useCache && m_readDisplayBufferImage)
+        return m_readDisplayBufferImage;
+    RefPtr imageBuffer = surfaceBufferToImageBuffer(sourceBuffer);
+    if (!imageBuffer)
+        return nullptr;
+    // The copy is what GraphicsContext::drawImageBuffer would make for each individual draw of a
+    // deferred context. It is cached here, as the read buffer is discarded whenever the contents
+    // of the canvas change.
+    RefPtr image = imageBuffer->copyNativeImage();
+    if (!useCache)
+        return image;
+    m_readDisplayBufferImage = WTF::move(image);
+    updateMemoryCost();
+    return m_readDisplayBufferImage;
+}
+
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
 {
     RefPtr scriptExecutionContext = protect(canvasBase())->scriptExecutionContext();
@@ -443,6 +466,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
         m_presentationContext->present(m_configuration->frameCount, true);
         m_configuration->lastPresentedFrameIndex = std::nullopt;
         m_readDisplayBuffer = nullptr;
+        m_readDisplayBufferImage = nullptr;
         updateMemoryCost();
     }
     return bufferRef;
@@ -581,6 +605,7 @@ void GPUCanvasContextCocoa::unconfigure()
     auto configuration = std::exchange(m_configuration, std::nullopt);
     m_currentTexture = nullptr;
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     ASSERT(!isConfigured());
 
@@ -669,6 +694,7 @@ void GPUCanvasContextCocoa::prepareForDisplay()
     if (!isConfigured())
         return;
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     ASSERT(m_configuration->frameCount < m_configuration->renderBuffers.size());
 
@@ -725,8 +751,9 @@ std::optional<FramesPerSecond> GPUCanvasContextCocoa::preferredRenderingUpdateFr
 void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
 {
     m_compositingResultsNeedsUpdating = true;
-    if (m_readDisplayBuffer) {
+    if (m_readDisplayBuffer || m_readDisplayBufferImage) {
         m_readDisplayBuffer = nullptr;
+        m_readDisplayBufferImage = nullptr;
         updateMemoryCost();
     }
     markCanvasChanged();
@@ -738,6 +765,8 @@ void GPUCanvasContextCocoa::updateMemoryCost() const
     size_t newMemoryCost = 0;
     if (m_readDisplayBuffer)
         newMemoryCost += m_readDisplayBuffer->memoryCost();
+    if (m_readDisplayBufferImage)
+        newMemoryCost += m_readDisplayBufferImage->sizeInBytes();
     if (m_currentTexture)
         newMemoryCost += m_currentTexture->memoryCost();
     CanvasRenderingContext::updateMemoryCost(newMemoryCost);

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -30,6 +30,7 @@
 #include "ImageBitmap.h"
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -90,6 +91,7 @@ ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<Im
         m_buffer = nullptr;
         updateMemoryCost(0);
     }
+    m_bufferNativeImage = nullptr;
     canvasBase->didDraw(FloatRect { { }, canvasBase->size() });
     return { };
 }
@@ -101,6 +103,7 @@ RefPtr<ImageBuffer> ImageBitmapRenderingContext::transferToImageBuffer()
     if (!m_buffer)
         return ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     RefPtr result = std::exchange(m_buffer, { });
+    m_bufferNativeImage = nullptr;
     updateMemoryCost(0);
     canvasBase->setOriginClean();
     canvasBase->didDraw(FloatRect { { }, size });
@@ -117,6 +120,20 @@ RefPtr<ImageBuffer> ImageBitmapRenderingContext::surfaceBufferToImageBuffer(Surf
         }
     }
     return m_buffer;
+}
+
+RefPtr<NativeImage> ImageBitmapRenderingContext::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = surfaceBufferToImageBuffer(sourceBuffer);
+    if (!buffer)
+        return nullptr;
+    // The copy is what GraphicsContext::drawImageBuffer would make for each individual draw of a
+    // deferred context. It is cached here, as it stays valid until the next bitmap is transferred
+    // in, and the buffer might be transferred out to a context that draws to it.
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
 }
 
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -57,6 +57,7 @@ public:
     bool hasAlpha() { return m_settings.alpha; }
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return !m_buffer; }
     void didUpdateCanvasSizeProperties(bool) final { }
 
@@ -65,7 +66,8 @@ private:
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    RefPtr<ImageBuffer> m_buffer;
+    RefPtr<ImageBuffer> m_buffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_bufferNativeImage;
     ImageBitmapRenderingContextSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsLayer.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "HTMLCanvasElement.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -116,6 +117,8 @@ PlaceholderRenderingContext::PlaceholderRenderingContext(HTMLCanvasElement& canv
 {
 }
 
+PlaceholderRenderingContext::~PlaceholderRenderingContext() = default;
+
 HTMLCanvasElement& PlaceholderRenderingContext::canvas() const
 {
     return downcast<HTMLCanvasElement>(canvasBase());
@@ -137,6 +140,7 @@ void PlaceholderRenderingContext::setPlaceholderBuffer(Ref<ImageBuffer>&& newBuf
     IntSize newSize = newBuffer->truncatedLogicalSize();
     updateMemoryCost(newBuffer->memoryCost());
     m_buffer = WTF::move(newBuffer);
+    m_bufferNativeImage = nullptr;
     Ref canvas = this->canvas();
     canvas->setSizeForControllingContext(newSize);
     if (originClean)
@@ -156,6 +160,19 @@ PixelFormat PlaceholderRenderingContext::pixelFormat() const
 RefPtr<ImageBuffer> PlaceholderRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
 {
     return m_buffer;
+}
+
+RefPtr<NativeImage> PlaceholderRenderingContext::surfaceBufferToNativeImage(SurfaceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = m_buffer;
+    if (!buffer)
+        return nullptr;
+    // The copy is what GraphicsContext::drawImageBuffer would make for each individual draw of a
+    // deferred context. It is cached here, as it stays valid until the next placeholder buffer.
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
 }
 
 bool PlaceholderRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) const

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -66,6 +66,8 @@ class PlaceholderRenderingContext final : public CanvasRenderingContext {
 public:
     static std::unique_ptr<PlaceholderRenderingContext> create(HTMLCanvasElement&);
 
+    ~PlaceholderRenderingContext();
+
     HTMLCanvasElement& NODELETE canvas() const;
     IntSize NODELETE size() const;
     void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool originClean, bool opaque);
@@ -73,6 +75,7 @@ public:
     PlaceholderRenderingContextSource& source() const { return m_source; }
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final;
     void didUpdateCanvasSizeProperties(bool) final;
 
@@ -83,7 +86,8 @@ private:
     bool isOpaque() const final { return m_opaque; }
 
     const Ref<PlaceholderRenderingContextSource> m_source;
-    RefPtr<ImageBuffer> m_buffer;
+    RefPtr<ImageBuffer> m_buffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_bufferNativeImage;
     bool m_opaque { false };
 };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -80,6 +80,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "NVShaderNoperspectiveInterpolation.h"
+#include "NativeImage.h"
 #include "NavigatorWebXR.h"
 #include "NotImplemented.h"
 #include "OESDrawBuffersIndexed.h"
@@ -536,8 +537,8 @@ void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> cont
 void WebGLRenderingContextBase::initializeContextState()
 {
     m_errors = { };
-    m_readDisplayBuffer = nullptr;
-    m_readDrawingBuffer = nullptr;
+    m_readDisplayBuffer.clear();
+    m_readDrawingBuffer.clear();
     m_compositingResultsNeedUpdating = false;
     m_activeTextureUnit = 0;
     m_packParameters = { };
@@ -689,8 +690,8 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
         return;
 
     m_compositingResultsNeedUpdating = true;
-    if (m_readDrawingBuffer) {
-        m_readDrawingBuffer = nullptr;
+    if (!m_readDrawingBuffer.isEmpty()) {
+        m_readDrawingBuffer.clear();
         updateMemoryCost();
     }
     markCanvasChanged();
@@ -776,6 +777,44 @@ static RefPtr<ImageBuffer> createImageBufferForWebGLContextReads(IntSize size, S
     return ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext.graphicsClient());
 }
 
+void WebGLRenderingContextBase::ReadSurfaceBuffer::clear()
+{
+    image = nullptr;
+    buffer = nullptr;
+}
+
+size_t WebGLRenderingContextBase::ReadSurfaceBuffer::memoryCost() const
+{
+    size_t cost = 0;
+    if (image)
+        cost += image->sizeInBytes();
+    if (buffer)
+        cost += buffer->memoryCost();
+    return cost;
+}
+
+auto WebGLRenderingContextBase::readSurfaceBuffer(SurfaceBuffer sourceBuffer) -> ReadSurfaceBuffer&
+{
+    return sourceBuffer == SurfaceBuffer::DrawingBuffer ? m_readDrawingBuffer : m_readDisplayBuffer;
+}
+
+RefPtr<NativeImage> WebGLRenderingContextBase::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    if (isContextLost())
+        return nullptr;
+    if (clampedCanvasSize().isEmpty())
+        return nullptr;
+    auto& readBuffer = readSurfaceBuffer(sourceBuffer);
+    if (readBuffer.image)
+        return readBuffer.image;
+    if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
+        clearIfComposited(CallerTypeOther);
+    readBuffer.image = protect(graphicsContextGL())->copyNativeImage(toGCGLSurfaceBuffer(sourceBuffer));
+    if (readBuffer.image)
+        updateMemoryCost();
+    return readBuffer.image;
+}
+
 RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
@@ -784,33 +823,23 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(Surfac
     auto size = clampedCanvasSize();
     if (size.isEmpty())
         return nullptr;
-    RefPtr<ImageBuffer> buffer;
-    if (sourceBuffer == SurfaceBuffer::DrawingBuffer) {
-        if (m_readDrawingBuffer)
-            return m_readDrawingBuffer;
-        m_readDrawingBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
-        updateMemoryCost();
-        buffer = m_readDrawingBuffer;
-    } else {
-        if (m_readDisplayBuffer)
-            return m_readDisplayBuffer;
-        m_readDisplayBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
-        updateMemoryCost();
-        buffer = m_readDisplayBuffer;
-    }
-    if (isContextLost())
-        return buffer;
+    auto& readBuffer = readSurfaceBuffer(sourceBuffer);
+    if (readBuffer.buffer)
+        return readBuffer.buffer;
+    // Obtain the image before creating the buffer, as obtaining it might invalidate the cache.
+    RefPtr image = surfaceBufferToNativeImage(sourceBuffer);
+    readBuffer.buffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
+    updateMemoryCost();
+    RefPtr buffer = readBuffer.buffer;
     if (!buffer)
+        return nullptr;
+    // A lost context or a failed read is a transparent black buffer.
+    if (!image)
         return buffer;
-    if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
-        clearIfComposited(CallerTypeOther);
     // FIXME: Remote ImageBuffers do not flush the buffers that are drawn to a buffer.
     // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
     // canvas element repeatedly.
     buffer->flushDrawingContext();
-    RefPtr image = protect(graphicsContextGL())->copyNativeImage(toGCGLSurfaceBuffer(sourceBuffer));
-    if (!image)
-        return buffer;
     GraphicsContextGL::paintToCanvas(*image, buffer->backendSize(), buffer->context());
     return buffer;
 }
@@ -893,8 +922,8 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
 {
     if (isContextLost()) {
-        m_readDrawingBuffer = nullptr;
-        m_readDisplayBuffer = nullptr;
+        m_readDrawingBuffer.clear();
+        m_readDisplayBuffer.clear();
         updateMemoryCost();
         return;
     }
@@ -903,8 +932,8 @@ void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
     if (newSize == m_defaultFramebuffer->size())
         return;
 
-    m_readDrawingBuffer = nullptr;
-    m_readDisplayBuffer = nullptr;
+    m_readDrawingBuffer.clear();
+    m_readDisplayBuffer.clear();
 
     m_defaultFramebuffer->reshape(newSize);
     updateMemoryCost();
@@ -5709,8 +5738,8 @@ void WebGLRenderingContextBase::prepareForDisplay()
     m_defaultFramebuffer->markAllUnpreservedBuffersDirty();
 
     m_compositingResultsNeedUpdating = false;
-    m_readDisplayBuffer = nullptr;
-    m_readDrawingBuffer = nullptr;
+    m_readDisplayBuffer.clear();
+    m_readDrawingBuffer.clear();
     updateMemoryCost();
 
     if (hasActiveInspectorCanvasCallTracer()) [[unlikely]]
@@ -5748,10 +5777,8 @@ void WebGLRenderingContextBase::updateMemoryCost() const
 {
     // Computes only a rough ballpark figure to drive garbage collection and Web Inspector.
     size_t newMemoryCost = 0;
-    if (m_readDisplayBuffer)
-        newMemoryCost += m_readDisplayBuffer->memoryCost();
-    if (m_readDrawingBuffer)
-        newMemoryCost += m_readDrawingBuffer->memoryCost();
+    newMemoryCost += m_readDisplayBuffer.memoryCost();
+    newMemoryCost += m_readDrawingBuffer.memoryCost();
     if (!isContextLost()) {
         size_t area = m_defaultFramebuffer->size().unclampedArea();
         size_t bytesPerSample = 4;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -101,6 +101,7 @@ class HTMLImageElement;
 class ImageData;
 class IntSize;
 class KHRParallelShaderCompile;
+class NativeImage;
 class NVShaderNoperspectiveInterpolation;
 class OESDrawBuffersIndexed;
 class OESElementIndexUint;
@@ -444,6 +445,7 @@ public:
     void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     RefPtr<ByteArrayPixelBuffer> drawingBufferToPixelBuffer();
@@ -724,8 +726,21 @@ protected:
 
     bool m_compositingResultsNeedUpdating { false };
     bool m_memoryCostUpdateScheduled { false };
-    RefPtr<ImageBuffer> m_readDrawingBuffer;
-    RefPtr<ImageBuffer> m_readDisplayBuffer;
+
+    // Temporary holder for both ImageBuffer and NativeImage requests.
+    // Once ImageBuffer requests have been removed, this will be reverted to RefPtr<NativeImage>.
+    struct ReadSurfaceBuffer {
+        RefPtr<NativeImage> image;
+        RefPtr<ImageBuffer> buffer;
+
+        bool isEmpty() const { return !image && !buffer; }
+        void clear();
+        size_t memoryCost() const;
+    };
+    ReadSurfaceBuffer& readSurfaceBuffer(SurfaceBuffer);
+
+    ReadSurfaceBuffer m_readDrawingBuffer;
+    ReadSurfaceBuffer m_readDisplayBuffer;
 
     // Enabled extension objects.
     // FIXME: Move some of these to WebGLRenderingContext, the ones not needed for WebGL2


### PR DESCRIPTION
#### 7fbf125bfdc098635c117c67fbb321d7e66ebbde
<pre>
Use copyNativeImage in 2D context drawImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=322254">https://bugs.webkit.org/show_bug.cgi?id=322254</a>
<a href="https://rdar.apple.com/185487825">rdar://185487825</a>

Reviewed by NOBODY (OOPS!).

Obtain the draw source as NativeImage in
CanvasRenderingContext2DBase::drawImage().  This continues the refactor
to use NativeImages as the only draw source, removing ImageBuffers.

Implements the fast path for WebGL as an example: WebGL provides
the GPUP side NativeImage as the result.

Later commits will modify other canvas rendering contexts to obtain
the image directly as a NativeImage.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::copyNativeImage):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::copiedImage const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::copiedImage const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::surfaceBufferToNativeImage):
(WebCore::CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::clearCanvas):
(WebCore::drawImageToContext):
(WebCore::CanvasRenderingContext2DBase::drawSourceImage):
(WebCore::CanvasRenderingContext2DBase::didDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToNativeImage):
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::unconfigure):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
(WebCore::GPUCanvasContextCocoa::updateMemoryCost const):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
(WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
(WebCore::ImageBitmapRenderingContext::surfaceBufferToNativeImage):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
(WebCore::PlaceholderRenderingContext::surfaceBufferToNativeImage):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::clear):
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::memoryCost const):
(WebCore::WebGLRenderingContextBase::readSurfaceBuffer):
(WebCore::WebGLRenderingContextBase::surfaceBufferToNativeImage):
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::didUpdateCanvasSizeProperties):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
(WebCore::WebGLRenderingContextBase::updateMemoryCost const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::isEmpty const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fbf125bfdc098635c117c67fbb321d7e66ebbde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146274 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33d5aea1-564c-4e9c-b404-28e042ef80ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55614 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142049 "Found 163 new test failures: fast/canvas/webgl/canvas-getImageData.html fast/canvas/webgl/tex-image-webgl.html webgl/1.0.x/conformance/glsl/samplers/glsl-function-texture2dprojlod.html webgl/1.0.x/conformance/textures/misc/tex-image-webgl.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_short_5_6_5.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/033b805e-8a44-4cff-a0ce-8185e0b652ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122484 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92a7f58c-48d1-4525-a4d5-e127c879c753) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42679 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42310 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3335 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48523 "Found 4 new failures in html/canvas/WebGLRenderingContextBase.cpp, html/canvas/GPUCanvasContextCocoa.mm") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46935 "Found 1 new test failure: http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194098 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55562 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151463 "Found 162 new test failures: fast/canvas/webgl/tex-image-webgl.html webgl/1.0.x/conformance/glsl/samplers/glsl-function-texture2dprojlod.html webgl/1.0.x/conformance/textures/misc/tex-image-webgl.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_short_5_6_5.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_byte.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html webgl/1.0.x/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56256 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151167 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45736 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128538 "Found 4 new failures in html/canvas/GPUCanvasContextCocoa.mm, html/canvas/WebGLRenderingContextBase.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54765 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17305 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54146 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->