### PR TITLE
[JSC] Fix boundary related code in BBQ / OMG

### DIFF
--- a/JSTests/wasm/stress/ref-cast-null-without-fault-signal-handler.js
+++ b/JSTests/wasm/stress/ref-cast-null-without-fault-signal-handler.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--useWasmFaultSignalHandler=false")
+
+// ref.cast of a null reference must trap even when the fault signal handler is
+// unavailable. The JIT is allowed to skip the explicit null check only because the
+// cast dereferences the reference and the handler turns the resulting fault into a
+// trap; with no handler installed the check has to be emitted, or this crashes.
+//
+// (module
+//   (type $s (struct (field (mut i32))))
+//   (func (export "f") (param (ref null $s)) (result (ref $s))
+//     local.get 0
+//     ref.cast (ref $s)))
+
+import * as assert from "../assert.js";
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x0c, 0x02, 0x5f, 0x01, 0x7f, 0x01, 0x60, 0x01, 0x63, 0x00, 0x01, 0x64, 0x00,
+    0x03, 0x02, 0x01, 0x01,
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0xfb, 0x16, 0x00, 0x0b,
+]);
+
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+
+// The reported trap kind differs between tiers (CastFailure vs NullAccess), so only
+// require that a trap is what comes out.
+for (let i = 0; i < 2000; ++i)
+    assert.throws(() => instance.exports.f(null), WebAssembly.RuntimeError, "");

--- a/JSTests/wasm/stress/signaling-memory-large-offset-bounds-check.js
+++ b/JSTests/wasm/stress/signaling-memory-large-offset-bounds-check.js
@@ -1,0 +1,82 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+
+// A memory32 access folds a 32-bit index and an unsigned 32-bit immediate offset in 64-bit
+// arithmetic, so it can reach far above 4GiB. Signaling memories reserve 4GiB plus a redzone
+// and omit the explicit bounds check for offsets the redzone can absorb, which is only sound
+// while the whole access stays inside the reservation. Offsets here bracket the redzone size
+// so that widening the set of accesses that skip the check turns into a missing trap rather
+// than a read or write reaching whatever the next reservation holds.
+
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const pageSize = 65536;
+const iterations = 5;
+
+const accesses = [
+    { size: 1, load: "i32.load8_u", store: "i32.store8", type: "i32", stored: "(i32.const 0xa5)", expected: 0xa5 },
+    { size: 2, load: "i32.load16_u", store: "i32.store16", type: "i32", stored: "(i32.const 0xa5a5)", expected: 0xa5a5 },
+    { size: 4, load: "i32.load", store: "i32.store", type: "i32", stored: "(i32.const 0x12345678)", expected: 0x12345678 },
+    { size: 8, load: "i64.load", store: "i64.store", type: "i64", stored: "(i64.const 0x123456789abcdef0)", expected: 0x123456789abcdef0n },
+    { size: 16, load: "v128.load", store: "v128.store", type: "i64", stored: "(v128.const i64x2 0x123456789abcdef0 0x123456789abcdef0)", expected: 0x123456789abcdef0n },
+];
+
+// The redzone defaults to 128 pages, putting its end at 0x800000. The expectations below do
+// not depend on that: an access is out of bounds exactly when its last byte leaves the memory.
+const offsets = [0, 1, 0xffff, 0x10000, 0x7ffff1, 0x7ffff8, 0x7fffff, 0x800000, 0x800001, 0x1000000, 0x7fffffff, 0xffffffff];
+const indices = [0, 1, 0xffff, 0x10000, 0x7fffffff, 0xffffffff];
+
+function loadExpression(access, offset) {
+    const load = `(${access.load} offset=${offset} (local.get 0))`;
+    return access.size === 16 ? `(i64x2.extract_lane 0 ${load})` : load;
+}
+
+function instantiateForPages(pages) {
+    let functions = "";
+    for (const access of accesses) {
+        for (const offset of offsets) {
+            functions += `
+                (func (export "load${access.size}_${offset}") (param i32) (result ${access.type})
+                    ${loadExpression(access, offset)})
+                (func (export "store${access.size}_${offset}") (param i32)
+                    (${access.store} offset=${offset} (local.get 0) ${access.stored}))`;
+        }
+    }
+    return instantiate(`(module (memory ${pages}) ${functions})`, {});
+}
+
+async function testPages(pages) {
+    const instance = await instantiateForPages(pages);
+    const limit = pages * pageSize;
+
+    for (const access of accesses) {
+        for (const offset of offsets) {
+            const load = instance.exports[`load${access.size}_${offset}`];
+            const store = instance.exports[`store${access.size}_${offset}`];
+            for (const index of indices) {
+                const argument = index | 0;
+                if (index + offset + access.size - 1 >= limit) {
+                    for (let i = 0; i < iterations; ++i) {
+                        assert.throws(() => load(argument), WebAssembly.RuntimeError, "Out of bounds memory access");
+                        assert.throws(() => store(argument), WebAssembly.RuntimeError, "Out of bounds memory access");
+                    }
+                } else {
+                    for (let i = 0; i < iterations; ++i) {
+                        store(argument);
+                        assert.eq(load(argument), access.expected);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async function test() {
+    // One page leaves every large offset out of bounds; 300 pages reaches past the default
+    // redzone, so the offsets that need an explicit check are also exercised in bounds.
+    await testPages(1);
+    await testPages(300);
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -1381,7 +1381,7 @@ private:
 
             Value* isNull = nullptr;
             if (referenceIsNullable) {
-                if (auto offset = castAccessOffset(); offset && offset.value() <= Wasm::maxAcceptableOffsetForNullReference()) {
+                if (auto offset = castAccessOffset(); Options::useWasmFaultSignalHandler() && offset && offset.value() <= Wasm::maxAcceptableOffsetForNullReference()) {
                     isNull = constant(Int32, 0);
                     canTrap = true;
                 } else

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1191,7 +1191,7 @@ public:
             // PROT_NONE region, but it's better if we use a smaller immediate because it can codegens better. We know that anything equal to or greater
             // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
             // any access equal to or greater than 4GiB will trap, no need to add the redzone.
-            if (uoffset >= Memory::fastMappedRedzoneBytes()) {
+            if (boundary >= Memory::fastMappedRedzoneBytes()) {
                 uint64_t maximum = m_info.memory(memoryIndex).maximum() ? m_info.memory(memoryIndex).maximum().bytes() : std::numeric_limits<uint32_t>::max();
                 m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
                 if (boundary)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2285,8 +2285,10 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
     JumpList doneCases;
     if (typedValue.type().isNullable()) {
-        if (auto offset = castAccessOffset(); offset && offset.value() <= maxAcceptableOffsetForNullReference()) {
-            // We will have access which will be trapped.
+        if (auto offset = castAccessOffset(); Options::useWasmFaultSignalHandler() && offset && offset.value() <= maxAcceptableOffsetForNullReference()) {
+            // The cast below dereferences the reference at this offset, so a null lands in the
+            // guard region and the fault handler turns it into a trap. Without the handler
+            // installed there is nothing to catch it, so the check must be emitted.
         } else {
             if (allowNull)
                 doneCases.append(m_jit.branchIfNull(valueGPR));

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -136,7 +136,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
         // PROT_NONE region, but it's better if we use a smaller immediate because it can codegens better. We know that anything equal to or greater
         // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
         // any access equal to or greater than 4GiB will trap, no need to add the redzone.
-        if (uoffset >= Memory::fastMappedRedzoneBytes()) {
+        if (boundary >= Memory::fastMappedRedzoneBytes()) {
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_info.memory(memoryIndex).isMemory64());
             uint64_t maximum = m_info.memory(memoryIndex).maximum() ? m_info.memory(memoryIndex).maximum().bytes() : std::numeric_limits<uint32_t>::max();
             m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2539,10 +2539,9 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_
             // PROT_NONE region, but it's better if we use a smaller immediate because it can codegens better. We know that anything equal to or greater
             // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
             // any access equal to or greater than 4GiB will trap, no need to add the redzone.
-            if (offset >= Memory::fastMappedRedzoneBytes()) {
+            uint64_t lastLoadedOffset = static_cast<uint64_t>(offset) + static_cast<uint64_t>(sizeOfOperation - 1);
+            if (lastLoadedOffset >= Memory::fastMappedRedzoneBytes()) {
                 size_t maximum = m_info.memory(memoryIndex).maximum() ? m_info.memory(memoryIndex).maximum().bytes() : std::numeric_limits<uint32_t>::max();
-                uint64_t lastLoadedOffset = static_cast<uint64_t>(offset);
-                lastLoadedOffset += static_cast<uint64_t>(sizeOfOperation - 1);
                 m_currentBlock->appendNew<WasmBoundsCheckValue>(m_proc, origin(), pointer, lastLoadedOffset, maximum);
             }
             break;


### PR DESCRIPTION
#### 3b9afb2b4f23fc2eb9555835a2ce0c6ebdb26056
<pre>
[JSC] Fix boundary related code in BBQ / OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=322255">https://bugs.webkit.org/show_bug.cgi?id=322255</a>
<a href="https://rdar.apple.com/185488178">rdar://185488178</a>

Reviewed by Yijia Huang.

1. ref.cast&apos;s trapping null check should be used only when
   Options::useWasmFaultSignalHandler() is true. (in practice, currently
   all wasm environment is having useWasmFaultSignalHandler = true).
2. Instead of offset, we should use boundary for check skipping. But
   actually this does not matter in practice since we end up crossing
   trapping zone, so anyway, we get a trap correctly. But anyway,
   computation was slightly wrong and slightly conservative.

Tests: JSTests/wasm/stress/ref-cast-null-without-fault-signal-handler.js
       JSTests/wasm/stress/signaling-memory-large-offset-bounds-check.js

* JSTests/wasm/stress/ref-cast-null-without-fault-signal-handler.js: Added.
* JSTests/wasm/stress/signaling-memory-large-offset-bounds-check.js: Added.
(loadExpression):
(instantiateForPages):
(async testPages):
(async test):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):

Canonical link: <a href="https://commits.webkit.org/319621@main">https://commits.webkit.org/319621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/315a6c2a4be2ac2ba323f5fe8a1511c2eaf8a024

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146275 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7436b441-0dac-447b-84a1-7cacc222728c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142050 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1050f02c-0868-4237-95f5-d99ea493b054) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122485 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17e3445f-8ff7-4969-93e3-3dab0d4015d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44410 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42680 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4452 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11252 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42309 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3336 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43227 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48524 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46936 "Found 1 new test failure: http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55563 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56253 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151168 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45733 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128536 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124316 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54766 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17304 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54386 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54214 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->