### PR TITLE
[WTF] Fix roundevenf / roundeven sign for 0

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -180,8 +180,11 @@ inline float roundevenf(float value)
 {
     float rounded = std::round(value);
     if (std::fabs(value - rounded) == 0.5f) {
-        if (std::fmod(rounded, 2.0f) != 0.0f)
-            return rounded - std::copysign(1.0f, value);
+        if (std::fmod(rounded, 2.0f) != 0.0f) {
+            // copysign is needed for the tie that rounds to zero: -0.5 lands on
+            // -1.0 - -1.0, which is +0.0, but roundeven(-0.5) is -0.0.
+            return std::copysign(rounded - std::copysign(1.0f, value), value);
+        }
     }
     return rounded;
 }
@@ -190,8 +193,11 @@ inline double roundeven(double value)
 {
     double rounded = std::round(value);
     if (std::fabs(value - rounded) == 0.5) {
-        if (std::fmod(rounded, 2.0) != 0.0)
-            return rounded - std::copysign(1.0, value);
+        if (std::fmod(rounded, 2.0) != 0.0) {
+            // copysign is needed for the tie that rounds to zero: -0.5 lands on
+            // -1.0 - -1.0, which is +0.0, but roundeven(-0.5) is -0.0.
+            return std::copysign(rounded - std::copysign(1.0, value), value);
+        }
     }
     return rounded;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -786,4 +786,45 @@ TEST(WTF, divideRoundedUp)
     EXPECT_EQ(divideRoundedUp<size_t>(std::numeric_limits<size_t>::max() - 1, std::numeric_limits<size_t>::max()), 1U);
 }
 
+static bool isNegativeZero(float value)
+{
+    return !value && std::signbit(value);
+}
+
+static bool isNegativeZero(double value)
+{
+    return !value && std::signbit(value);
+}
+
+TEST(WTF, roundeven)
+{
+    EXPECT_EQ(roundevenf(0.5f), 0.0f);
+    EXPECT_EQ(roundevenf(1.5f), 2.0f);
+    EXPECT_EQ(roundevenf(2.5f), 2.0f);
+    EXPECT_EQ(roundevenf(3.5f), 4.0f);
+    EXPECT_EQ(roundevenf(-1.5f), -2.0f);
+    EXPECT_EQ(roundevenf(-2.5f), -2.0f);
+    EXPECT_EQ(roundevenf(-3.5f), -4.0f);
+
+    EXPECT_EQ(roundeven(0.5), 0.0);
+    EXPECT_EQ(roundeven(1.5), 2.0);
+    EXPECT_EQ(roundeven(2.5), 2.0);
+    EXPECT_EQ(roundeven(3.5), 4.0);
+    EXPECT_EQ(roundeven(-1.5), -2.0);
+    EXPECT_EQ(roundeven(-2.5), -2.0);
+    EXPECT_EQ(roundeven(-3.5), -4.0);
+
+    // A tie that rounds to zero keeps the sign of the operand. wasm's f32.nearest and
+    // f64.nearest are specified this way and the hardware instructions agree, so the
+    // polyfill used when __builtin_roundeven is unavailable must too.
+    EXPECT_TRUE(isNegativeZero(roundevenf(-0.5f)));
+    EXPECT_TRUE(isNegativeZero(roundeven(-0.5)));
+    EXPECT_TRUE(isNegativeZero(roundevenf(-0.0f)));
+    EXPECT_TRUE(isNegativeZero(roundeven(-0.0)));
+    EXPECT_TRUE(isNegativeZero(roundevenf(-0.25f)));
+    EXPECT_TRUE(isNegativeZero(roundeven(-0.25)));
+    EXPECT_FALSE(isNegativeZero(roundevenf(0.5f)));
+    EXPECT_FALSE(isNegativeZero(roundeven(0.5)));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b74760b1824cecb3c476eee726a722e558f633a2
<pre>
[WTF] Fix roundevenf / roundeven sign for 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=322252">https://bugs.webkit.org/show_bug.cgi?id=322252</a>
<a href="https://rdar.apple.com/185487391">rdar://185487391</a>

Reviewed by Keith Miller.

non ARM64 architecture&apos;s roundevenf / roundeven implementations have a
problem that it returns roundevenf(-0.5) =&gt; +0.0 instead of -0.0. This
patch fixes it.

Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

* Source/WTF/wtf/MathExtras.h:
(roundevenf):
(roundeven):
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::isNegativeZero):
(TestWebKitAPI::TEST(WTF, roundeven)):

Canonical link: <a href="https://commits.webkit.org/319609@main">https://commits.webkit.org/319609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6759f4a2aabc2590b32a2e31dc4d9e4880e7819

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146276 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/666aadf7-a383-4d1c-a5f2-eaaef6d59099) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/830c043a-fb41-43e2-aa4c-3a4c6ed906cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122496 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8d8e2b0-d596-441c-971b-2cecaa04c553) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42683 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4463 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11258 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42315 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3337 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43228 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194100 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55565 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151471 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56254 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151175 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45740 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128537 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54767 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17310 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->