### PR TITLE
Remove redundant paint state save/restore around SVG gradient fill/stroke

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -162,7 +162,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PathOrShapeGradientApplier);
 
 bool PathOrShapeGradientApplier::applyResource(RenderElement& renderer, const Style::ComputedStyle& style, GraphicsContext*& context, const GradientData& gradientData, OptionSet<RenderSVGResourceMode> resourceMode)
 {
-    context->save();
     applyGradientResource(renderer, style, *context, gradientData, resourceMode);
     return true;
 }
@@ -170,7 +169,6 @@ bool PathOrShapeGradientApplier::applyResource(RenderElement& renderer, const St
 void PathOrShapeGradientApplier::postApplyResource(RenderElement&, GraphicsContext*& context, const GradientData&, SVGUnitTypes::SVGUnitType, const AffineTransform&, OptionSet<RenderSVGResourceMode> resourceMode, const Path* path, const RenderElement* shape)
 {
     LegacyRenderSVGResource::fillAndStrokePathOrShape(*context, resourceMode, path, shape);
-    context->restore();
 }
 
 #if USE(CG)


### PR DESCRIPTION
#### c22c85fd52be074f029f80ab95d154c45802a991
<pre>
Remove redundant paint state save/restore around SVG gradient fill/stroke
<a href="https://bugs.webkit.org/show_bug.cgi?id=322250">https://bugs.webkit.org/show_bug.cgi?id=322250</a>
<a href="https://rdar.apple.com/185485580">rdar://185485580</a>

Reviewed by Simon Fraser.

PathOrShapeGradientApplier bracketed each gradient apply in its own
context-&gt;save()/restore() pair, costing two IPC messages per gradient-filled shape
paint when rendering in the GPU process. The pair has been vestigial since
32921@main moved the CTM mutations it was originally added for into the gradient&apos;s
own space transform.

Remove it. All callers already bracket the apply/postApply sequence in an outer
GraphicsContextStateSaver, and LegacyRenderSVGResourceSolidColor has never restored
this state either, so gradient paint now behaves like solid-color paint.

Worth ~2.5% on MotionMark 1.3 Suits.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::PathOrShapeGradientApplier::applyResource):
(WebCore::PathOrShapeGradientApplier::postApplyResource):

Canonical link: <a href="https://commits.webkit.org/319635@main">https://commits.webkit.org/319635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a58936d55fa666c6c0a6123ec235efa2dfeb30b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146278 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e3bff14-aa87-406a-9a27-f2453fd4f6e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a3d4cde-58d0-4653-b398-6a6f4365ac2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184904 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45735 "Found 1 new test failure: fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122487 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3f2e5b4-be38-47fa-af01-ed2157e3330a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44420 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42681 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42314 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3339 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194102 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55567 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56258 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151169 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45741 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128540 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124319 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54769 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17309 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->