### PR TITLE
[iOS] Current time stops updating on youtube.com after switching playback to an AVSystemRoute

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range-expected.txt
@@ -1,0 +1,23 @@
+
+Test that the element does not report HAVE_ENOUGH_DATA until the MediaDeviceRoute publishes a seekable time range, so a seek issued as soon as the element becomes playable is honored rather than silently dropped.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 0 })
+RUN(video.play())
+A route that is ready but has published no seekable range should not make the element playable.
+RUN(route.ready = true)
+EXPECTED (video.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA == 'true') OK
+EXPECTED (video.seekable.length == '0') OK
+Publishing a time range should make the element playable and seekable.
+RUN(route.timeRange = { start: 0, duration: 60 })
+EXPECTED (video.readyState == '4') OK
+EXPECTED (video.seekable.length == '1') OK
+EXPECTED (video.seekable.end(0) == '60') OK
+A seek issued once the element is playable should be honored, not silently dropped.
+RUN(video.currentTime = 30)
+EVENT(seeked)
+EXPECTED (video.currentTime > 29) OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range.html
+++ b/LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 0 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                consoleWrite('A route that is ready but has published no seekable range should not make the element playable.');
+                run(`route.ready = true`);
+                await sleepFor(100);
+                testExpected('video.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA', true);
+                testExpected('video.seekable.length', 0);
+
+                consoleWrite('Publishing a time range should make the element playable and seekable.');
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                await testExpectedEventually('video.readyState', HTMLMediaElement.HAVE_ENOUGH_DATA, '==', 2000);
+                testExpected('video.seekable.length', 1);
+                testExpected('video.seekable.end(0)', 60);
+
+                consoleWrite('A seek issued once the element is playable should be honored, not silently dropped.');
+                run(`video.currentTime = 30`);
+                await waitFor(video, 'seeked');
+                await waitForConditionOrTimeout('video.currentTime > 29', false, 2000);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the element does not report HAVE_ENOUGH_DATA until the MediaDeviceRoute publishes a seekable time range, so a seek issued as soon as the element becomes playable is honored rather than silently dropped.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -448,6 +448,15 @@ void MediaPlayerPrivateWirelessPlayback::setReadyState(MediaPlayer::ReadyState r
         player->readyStateChanged();
 }
 
+void MediaPlayerPrivateWirelessPlayback::updateReadyState()
+{
+    RefPtr route = this->route();
+    if (!route || !route->ready() || !maxTimeSeekable())
+        return;
+
+    setReadyState(MediaPlayerReadyState::HaveEnoughData);
+}
+
 String MediaPlayerPrivateWirelessPlayback::engineDescription() const
 {
     static NeverDestroyed<String> description(MAKE_STATIC_STRING_IMPL("Cocoa Wireless Playback Engine"));
@@ -461,6 +470,8 @@ void MediaPlayerPrivateWirelessPlayback::timeRangeDidChange(MediaDeviceRoute& ro
 
     if (RefPtr player = m_player.get())
         player->durationChanged();
+
+    updateReadyState();
 }
 
 void MediaPlayerPrivateWirelessPlayback::readyDidChange(MediaDeviceRoute& route)
@@ -468,8 +479,7 @@ void MediaPlayerPrivateWirelessPlayback::readyDidChange(MediaDeviceRoute& route)
     ASSERT(&route == this->route());
     ALWAYS_LOG(LOGIDENTIFIER, route.ready());
 
-    if (route.ready())
-        setReadyState(MediaPlayerReadyState::HaveEnoughData);
+    updateReadyState();
 }
 
 void MediaPlayerPrivateWirelessPlayback::errorDidChange(MediaDeviceRoute& route)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -77,6 +77,7 @@ private:
 
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
+    void updateReadyState();
 
     // MediaPlayerPrivateInterface
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::WirelessPlayback; }

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -78,6 +78,16 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 @synthesize routeDisplayName;
 @synthesize protocolType;
 
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    timeRange = CMTimeRangeMake(kCMTimeZero, CMTimeMakeWithSeconds(60, 1000));
+
+    return self;
+}
+
 - (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {
     RetainPtr playbackPosition = adoptNS([allocAVPlaybackUserInterfacePlaybackPositionInstance() initWithPosition:position hostTime:CMClockGetTime(CMClockGetHostTimeClock()) rate:0]);


### PR DESCRIPTION
#### d960e0221dda2a1db726c47230cbbdbcd3031be2
<pre>
[iOS] Current time stops updating on youtube.com after switching playback to an AVSystemRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=322256">https://bugs.webkit.org/show_bug.cgi?id=322256</a>
<a href="https://rdar.apple.com/184547900">rdar://184547900</a>

Reviewed by Eric Carlson.

After switching to a MediaDeviceRoute, WebKit issues a seek to the current playback position.
MediaPlayerPrivateWirelessPlayback::readyDidChange advanced the ready state to HaveEnoughData as
soon as the route reported itself ready, without regard for whether the route had yet published a
seekable time range. HTMLMediaElement::seekTask treats an empty seekable range as &quot;no seek required&quot;
and returns early; since the target time differs from the current time, it does so without firing
seeking, seeked, or timeupdate, so a page waiting on seeked stalls indefinitely.

Resolved this by gating the transition to HaveEnoughData on the route having published a non-empty
seekable range in addition to being ready, and re-evaluate that condition from both readyDidChange
and timeRangeDidChange so whichever arrives second completes the transition.

WebMockMediaDeviceRoute previously left timeRange default-initialized. Gave it a valid default so
that existing tests which set `route.ready = true` without specifying a time range continue to
become playable.

Test: media/wireless-playback-media-player/ready-state-requires-seekable-range.html

* LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/ready-state-requires-seekable-range.html: Added.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::updateReadyState):
(WebCore::MediaPlayerPrivateWirelessPlayback::timeRangeDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::readyDidChange):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute init]):

Canonical link: <a href="https://commits.webkit.org/319610@main">https://commits.webkit.org/319610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5822abd63ffbb99176d6c58c9f04b5f4207a8194

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146280 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff02756e-2d4a-4945-bba5-3ede8a30aad0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76dac575-c308-4e20-b06f-63ecff8943fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122486 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b7cdb2c-e710-42c2-9bac-515fdc7714ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42682 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42311 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3341 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194104 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40569 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56260 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151170 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45734 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128542 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54771 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17306 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54152 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54391 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->