### PR TITLE
Stop restoring the CTM by hand in LegacyRenderSVGResourceClipper

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -150,7 +150,6 @@ auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
     }
 
     // Transform path by animatedLocalTransform.
-    AffineTransform oldCTM = context.getCTM();
     context.concatCTM(animatedLocalTransform);
     if (transform)
         context.concatCTM(*transform);
@@ -170,7 +169,6 @@ auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
     }
 
     context.clipPath(clipPath, clipRule);
-    context.setCTM(oldCTM);
     return result;
 }
 


### PR DESCRIPTION
#### a83e8a313765a190a2451acff39cfb3bc7535950
<pre>
Stop restoring the CTM by hand in LegacyRenderSVGResourceClipper
<a href="https://bugs.webkit.org/show_bug.cgi?id=322257">https://bugs.webkit.org/show_bug.cgi?id=322257</a>
<a href="https://rdar.apple.com/185490181">rdar://185490181</a>

Reviewed by NOBODY (OOPS!).

pathOnlyClipping() saved the CTM, concatenated the clip transform, then restored
the CTM by value with setCTM(), costing an extra SetCTM IPC message per clipped
paint when rendering in the GPU process.

Remove the manual save/restore. Every caller of applyClippingToContext() already
wraps the call in a GraphicsContextStateSaver, and structurally must, since the
clipPath() applied here is never undone internally. All three callers were
checked.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::pathOnlyClipping):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a83e8a313765a190a2451acff39cfb3bc7535950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146282 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55623 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142055 "Found 12 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/smil/transform/translate-clipPath-1.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98623 "1 flakes 17 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/056a3fbc-a0aa-41a4-b679-5d376a1b5d97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184908 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45731 "Found 7 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/smil/transform/translate-clipPath-1.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml svg/resource-invalidation/clip-path-resource-invalidation.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122490 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44416 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path/reference-mutated.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42687 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154813 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42316 "Found 11 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path/reference-mutated.html ... (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3343 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48531 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46943 "Found 12 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/smil/transform/translate-clipPath-1.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55571 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151469 "Found 12 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/smil/transform/translate-clipPath-1.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56262 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38941 "Found 11 new test failures: css3/masking/reference-clip-path-objectBoundingBox-path-clip.html imported/mozilla/svg/objectBoundingBox-and-clipPath.svg imported/mozilla/svg/svg-integration/clipPath-html-02.xhtml imported/mozilla/svg/svg-integration/clipPath-html-05.xhtml imported/mozilla/svg/svg-integration/clipPath-html-06.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg imported/w3c/web-platform-tests/css/css-masking/clip-path/reference-mutated.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151173 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45742 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128544 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124323 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54773 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17311 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->