### PR TITLE
Avoid an out-of-line call per stream IPC send to check whether signposts are enabled

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -194,23 +194,15 @@ void StreamClientConnection::removeWorkQueueMessageReceiver(ReceiverName name, u
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
 
-static bool streamingIPCSignpostsEnabled = false;
-
 void StreamClientConnection::forceEnableSignposts()
 {
-    streamingIPCSignpostsEnabled = true;
+    s_signpostState.store(SignpostState::Enabled, std::memory_order_relaxed);
 }
 
-bool StreamClientConnection::signpostsEnabled()
+void StreamClientConnection::signpostsEnabledSlow()
 {
-    static bool hasReadPreferences = false;
-    if (!hasReadPreferences) [[unlikely]] {
-        if (!isInAuxiliaryProcess() && CFPreferencesGetAppBooleanValue(CFSTR("WebKitDebugStreamingIPCSignposts"), kCFPreferencesCurrentApplication, nullptr))
-            streamingIPCSignpostsEnabled = true;
-        hasReadPreferences = true;
-    }
-
-    return streamingIPCSignpostsEnabled;
+    bool enabled = !isInAuxiliaryProcess() && CFPreferencesGetAppBooleanValue(CFSTR("WebKitDebugStreamingIPCSignposts"), kCFPreferencesCurrentApplication, nullptr);
+    s_signpostState.store(enabled ? SignpostState::Enabled : SignpostState::Disabled, std::memory_order_relaxed);
 }
 
 uintptr_t StreamClientConnection::generateSignpostIdentifier()

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -32,6 +32,7 @@
 #include "MessageNames.h"
 #include "StreamClientConnectionBuffer.h"
 #include "StreamServerConnection.h"
+#include <atomic>
 #include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Scope.h>
@@ -112,7 +113,15 @@ public:
     Seconds defaultTimeoutDuration() const { return m_defaultTimeoutDuration; }
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    static bool signpostsEnabled();
+    static inline bool signpostsEnabled()
+    {
+        auto state = s_signpostState.load(std::memory_order_relaxed);
+        if (state == SignpostState::NotChecked) [[unlikely]] {
+            signpostsEnabledSlow();
+            state = s_signpostState.load(std::memory_order_relaxed);
+        }
+        return state == SignpostState::Enabled;
+    }
     static void NODELETE forceEnableSignposts();
 #endif
 
@@ -134,6 +143,10 @@ private:
     void wakeUpServer(WakeUpServer);
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
+    enum class SignpostState : uint8_t { NotChecked, Disabled, Enabled };
+    static inline std::atomic<SignpostState> s_signpostState { SignpostState::NotChecked };
+
+    static void signpostsEnabledSlow();
     static uintptr_t generateSignpostIdentifier();
     void emitSendSignpost(MessageName);
 #endif
@@ -173,7 +186,8 @@ template<typename T, typename U, typename V>
 Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V> destinationID)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    emitSendSignpost(message.name());
+    if (signpostsEnabled())
+        emitSendSignpost(message.name());
 #endif
 
     static_assert(!T::isSync, "Message is sync!");


### PR DESCRIPTION
#### 60eee3f8f2c5bd21389fedb90964c8e78942800e
<pre>
Avoid an out-of-line call per stream IPC send to check whether signposts are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=322260">https://bugs.webkit.org/show_bug.cgi?id=322260</a>
<a href="https://rdar.apple.com/185491104">rdar://185491104</a>

Reviewed by Kimmo Kinnunen.

StreamClientConnection::send() called emitSendSignpost() unconditionally on every
message, and both it and signpostsEnabled() were defined out-of-line in the .cpp
while send&lt;T&gt;() is a header template. Without LTO, which local Release builds
disable, the compiler could not inline the enabled check, so every send paid a
call just to read a static bool. ENABLE_CORE_IPC_SIGNPOSTS is unconditionally 1
on Cocoa, so release builds paid it too.

Move the fast path inline and guard the emitSendSignpost() call on it, leaving
only the one-time preference read out-of-line in signpostsEnabledSlow().

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::forceEnableSignposts):
(IPC::StreamClientConnection::signpostsEnabledSlow):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::signpostsEnabled):
(IPC::StreamClientConnection::send):

Canonical link: <a href="https://commits.webkit.org/319680@main">https://commits.webkit.org/319680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34e36131a0ecd6b850a653d9d379ee3287985bfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146694 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35671cfc-39bf-425c-b99e-7e66e2568a11) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9367872-033b-4bb7-97ee-685fdb1e5fed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f97f083f-cfa6-4e19-bf91-9dfdebfb1cbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43011 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42632 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194521 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55983 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151778 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56674 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151479 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46058 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128958 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124919 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55185 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17631 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->