### PR TITLE
Avoid constructing a Timeout on the common stream IPC send path

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -177,14 +177,21 @@ Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W>
 #endif
 
     static_assert(!T::isSync, "Message is sync!");
-    Timeout timeout = defaultTimeout();
-    auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
-    if (error != Error::NoError)
-        return error;
 
-    auto span = m_buffer.tryAcquire(timeout);
-    if (!span)
-        return Error::FailedToAcquireBufferSpan;
+    std::optional<std::span<uint8_t>> span;
+    if (destinationID.toUInt64() == m_currentDestinationID)
+        span = m_buffer.acquireNoWait();
+
+    if (!span) {
+        Timeout timeout = defaultTimeout();
+        auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
+        if (error != Error::NoError)
+            return error;
+        span = m_buffer.tryAcquire(timeout);
+        if (!span)
+            return Error::FailedToAcquireBufferSpan;
+    }
+
     if constexpr (T::isStreamEncodable) {
         if (trySendStream(*span, message))
             return Error::NoError;

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -39,6 +39,7 @@ public:
     StreamClientConnectionBuffer(StreamClientConnectionBuffer&&);
     StreamClientConnectionBuffer& operator=(StreamClientConnectionBuffer&&);
 
+    std::optional<std::span<uint8_t>> acquireNoWait();
     std::optional<std::span<uint8_t>> tryAcquire(Timeout);
     std::optional<std::span<uint8_t>> tryAcquireAll(Timeout);
 
@@ -126,6 +127,21 @@ inline StreamClientConnectionBuffer::StreamClientConnectionBuffer(Ref<WebCore::S
     sharedClientOffset().store(ClientOffset::serverIsSleepingTag, std::memory_order_relaxed);
     // Write starts from 0 with a limit of the whole buffer.
     sharedClientLimit().store(static_cast<ClientLimit>(0), std::memory_order_relaxed);
+}
+
+inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::acquireNoWait()
+{
+    ClientLimit clientLimit = sharedClientLimit().load(std::memory_order_acquire);
+    // This would mean we try to send messages after a timeout. It is a programming error.
+    // Since the value is trusted, we only assert.
+    ASSERT(clientLimit != ClientLimit::clientIsWaitingTag);
+
+    if (clientLimit == ClientLimit::clientIsWaitingTag)
+        return std::nullopt;
+    auto result = alignedMutableSpan(m_clientOffset, toLimit(clientLimit));
+    if (result.size() >= minimumMessageSize)
+        return result;
+    return std::nullopt;
 }
 
 inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquire(Timeout timeout)


### PR DESCRIPTION
#### 4f1ddc1d813f89f2a529c841dcdbb5b038d8d63a
<pre>
Avoid constructing a Timeout on the common stream IPC send path
<a href="https://bugs.webkit.org/show_bug.cgi?id=322259">https://bugs.webkit.org/show_bug.cgi?id=322259</a>
<a href="https://rdar.apple.com/185490398">rdar://185490398</a>

Reviewed by Kimmo Kinnunen.

Timeout&apos;s constructor eagerly computes ApproximateTime::now() + delta, but
StreamClientConnection::send() only consults the deadline if tryAcquire() has to
block, which is rare since the ring buffer normally has room. The cost was paid
on every message, and showed up in MotionMark 1.3 Suits profiles where IPC
accounted for ~22% of samples.

Add StreamClientConnectionBuffer::acquireNoWait() for the non-blocking case and
try it first when the destination ID is unchanged, falling back to the existing
Timeout-based path otherwise. Skipping trySendDestinationIDIfNeeded() on that
fast path is equivalent to the early return it would have taken, since
m_currentDestinationID is only assigned after the SetStreamDestinationID message
has been released. Timeout keeps its by-value semantics, so the shared budget
across trySendDestinationIDIfNeeded() + tryAcquire() is unaffected.

* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
(IPC::StreamClientConnectionBuffer::acquireNoWait):

Canonical link: <a href="https://commits.webkit.org/319636@main">https://commits.webkit.org/319636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57376a4fbfcf2a83e71c6a9df0a6c4a02b0ecc15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146285 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122495 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42688 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42320 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3346 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194109 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55574 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40585 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56265 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151178 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45744 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128547 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124326 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54776 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17315 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54157 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->