### PR TITLE
Implement CSS module scripts

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -868,10 +868,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-s
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/inert/inert-with-fullscreen-element.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Pass Failure ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/relative-urls.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-no-referrer.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin.sub.html [ Skip ]
@@ -1088,8 +1084,6 @@ imported/w3c/web-platform-tests/user-timing/mark.html [ Failure Pass ]
 imported/w3c/web-platform-tests/user-timing/measure_associated_with_navigation_timing.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/sharedworker-partitioning.tentative.https.window.html [ Failure Pass ]
 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing-extended.https.html [ Failure Pass ]
-
-webkit.org/b/222750 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/css-module-worker-test.html [ Pass Failure Crash ]
 
 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/clients-matchall-order.https.html [ Slow Pass Failure ]
 webkit.org/b/217617 [ Release ] imported/w3c/web-platform-tests/service-workers/service-worker/clients-matchall-order.https.html [ Pass Failure ]
@@ -6311,10 +6305,6 @@ imported/mozilla/svg/blend-color-burn.svg [ Pass ImageOnlyFailure ]
 
 webkit.org/b/233267 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_window_open_download_block_downloads.tentative.html [ Pass Failure ]
 
-# Flaky because of network ordering
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset.html [ Pass Failure ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests.html [ Pass Failure ]
-
 # modulepreload is not supported
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]
@@ -6518,12 +6508,6 @@ webkit.org/b/245905 imported/w3c/web-platform-tests/css/css-text/line-breaking/l
 js/dom/Promise-reject-large-string.html [ DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/251624 fast/images/animated-heics-verify.html [ Skip ]
-
-# Import-assertion gets reverted to stage-2.
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events.html [ Skip ]
 
 # Early hints require network callbacks that are only present in macOS 12 / iOS 15 or greater.
 http/wpt/loading/early-hints [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-allowed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-allowed.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL import should be allowed promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
+PASS import should be allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-blocked.sub-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT import-style-blocked Test timed out
+PASS import-style-blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
@@ -12,7 +12,7 @@ PASS HTMLVideoElement fetches with a "video" Request.destination
 PASS HTMLScriptElement fetches with a "script" Request.destination
 FAIL AudioWorklet module fetches with a "audioworklet" Request.destination promise_test: Unhandled rejection with value: object "TypeError: 'application/octet-stream' is not a valid JavaScript MIME type for module script 'https://web-platform.test:9443/fetch/api/request/destination/resources/dummy?dest=audioworklet'."
 PASS HTMLLinkElement with rel=stylesheet fetches with a "style" Request.destination
-FAIL Import declaration with `type: "css"` fetches with a "style" Request.destination promise_test: Unhandled rejection with value: "TypeError: Import attribute type \"css\" is not valid"
+PASS Import declaration with `type: "css"` fetches with a "style" Request.destination
 PASS Import declaration with `type: "json"` fetches with a "json" Request.destination
 PASS Import declaration with `type: "text"` fetches with a "text" Request.destination
 PASS HTMLLinkElement with rel=preload and as=fetch fetches with an empty string Request.destination

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt
@@ -1,5 +1,5 @@
 Test content
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
+Harness Error (FAIL), message = TypeError: Module name, 'foo' does not resolve to a valid URL.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt
@@ -1,5 +1,5 @@
 Test content
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
+Harness Error (FAIL), message = TypeError: Module name, 'foo' does not resolve to a valid URL.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS CSS module should be loaded as utf-8 even if it is encoded in windows-1250 and served with a windows-1250 charset response header, and this document's encoding is windows-1250
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom-expected.txt
@@ -1,4 +1,5 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS UTF-8 BOM should be stripped when decoding CSS module script
+PASS UTF-16BE BOM should be ignored, so CSS module should be UTF-8 decoded
+PASS UTF-16LE BOM should be ignored, so CSS module should be UTF-8 decoded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html
@@ -6,7 +6,7 @@
     import utf8BOMSheet from './resources/bom-utf-8.css' with { type: 'css' };
     test(function() {
         assert_equals(utf8BOMSheet.rules[0].selectorText, 'div', 'No UTF-8 BOM expected in selector');
-    }, 'UTF-8 BOM should be stripped when decoding JSON module script');
+    }, 'UTF-8 BOM should be stripped when decoding CSS module script');
 
     import utf16BEBOMSheet from './resources/bom-utf-16be.css' with { type: 'css' };
     test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS CSS module should be loaded as utf-8 when charset=utf8 is specified
+PASS CSS module should be loaded as utf-8 when charset=shift-jis is specified
+PASS CSS module should be loaded as utf-8 when charset=windows-1252 is specified
+PASS CSS module should be loaded as utf-8 when charset=utf-7 is specified
+PASS CSS module should be loaded as utf-8 even if it is encoded in windows-1250 and served with a windows-1250 charset response header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking-expected.txt
@@ -1,17 +1,8 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
-NOTRUN text/css
-NOTRUN application/css
-NOTRUN text/html+css
-NOTRUN text/css;boundary=something
-NOTRUN text/css;foo=bar
-
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
-NOTRUN text/css
-NOTRUN application/css
-NOTRUN text/html+css
-NOTRUN text/css;boundary=something
-NOTRUN text/css;foo=bar
+PASS text/css
+PASS application/css
+PASS text/html+css
+PASS application/javascript
+PASS text/css;boundary=something
+PASS text/css;foo=bar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html
@@ -14,26 +14,37 @@ function check(t, styleSheet) {
 const t1 = async_test("text/css");
 const t2 = async_test("application/css");
 const t3 = async_test("text/html+css");
-const t4 = async_test("text/css;boundary=something");
-const t5 = async_test("text/css;foo=bar");
+const t4 = async_test("application/javascript");
+const t5 = async_test("text/css;boundary=something");
+const t6 = async_test("text/css;foo=bar");
 </script>
+
 <script type="module" onerror="t1.unreached_func()()">
   import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/css" with { type: "css"};
   check(t1, styleSheet);
 </script>
+
 <script type="module" onerror="t2.step_func_done()()">
   import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=application/css" with { type: "css"};
   t2.unreached_func("Should not have loaded with MIME type application/css")();
 </script>
+
 <script type="module" onerror="t3.step_func_done()()">
   import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/html+css" with { type: "css"};
   t3.unreached_func("Should not have loaded with MIME type text/html+css")();
 </script>
-<script type="module" onerror="t4.unreached_func()()">
-  import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/css;boundary=something" with { type: "css"};
-  check(t4, styleSheet);
+
+<script type="module" onerror="t4.step_func_done()()">
+  import module from "../serve-with-content-type.py?fn=css-module/resources/should-not-be-loaded.js&ct=application/javascript" with { type: "css"};
+  t4.unreached_func("Should not have loaded with MIME type application/javascript")();
 </script>
+
 <script type="module" onerror="t5.unreached_func()()">
-import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/css;foo=bar" with { type: "css"};
-check(t5, styleSheet);
+  import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/css;boundary=something" with { type: "css"};
+  check(t5, styleSheet);
+</script>
+
+<script type="module" onerror="t6.unreached_func()()">
+  import styleSheet from "../serve-with-content-type.py?fn=css-module/resources/basic.css&ct=text/css;foo=bar" with { type: "css"};
+  check(t6, styleSheet);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests-expected.txt
@@ -2,7 +2,7 @@ css-module-crossorigin
 
 
 
-FAIL Imported CSS module, cross-origin with CORS assert_equals: Unexpected _log value expected "imported CSS: #test { background-color: rgb(255, 0, 0); }" but got "TypeError"
-FAIL Imported CSS module, cross-origin, missing CORS ACAO header assert_equals: Unexpected _log value expected "error" but got "TypeError"
-FAIL Imported CSS module with parse error, cross-origin, with CORS assert_equals: Unexpected _log value expected "imported CSS rules count: 0" but got "TypeError"
+PASS Imported CSS module, cross-origin with CORS
+PASS Imported CSS module, cross-origin, missing CORS ACAO header
+PASS Imported CSS module with parse error, cross-origin, with CORS
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL CSS Modules should be loaded with or without the credentials based on the same-origin-ness and the crossOrigin attribute assert_equals: Descendant CSS modules should be loaded with the credentials when the crossOrigin attribute is not specified and the target is same-origin expected (boolean) true but got (undefined) undefined
+PASS CSS Modules should be loaded with or without the credentials based on the same-origin-ness and the crossOrigin attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/css-module-parse-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/css-module-parse-error-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL CSS module with parse errors imports successfully with empty rules. promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
-FAIL Repeated import of parse-error CSS module returns same sheet. promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
-FAIL CSS module with partially malformed CSS imports with valid rules. promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
+PASS CSS module with parse errors imports successfully with empty rules.
+PASS Repeated import of parse-error CSS module returns same sheet.
+PASS CSS module with partially malformed CSS imports with valid rules.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic-expected.txt
@@ -5,6 +5,10 @@ I am a test div.
 I am a test div.
 I am a test div.
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
 
+PASS A CSS Module should load
+PASS A large CSS Module should load
+PASS An @import CSS Module should not load, but should not throw an exception
+PASS A parse error should not prevent subsequent rules from being included in a CSS module
+PASS CSS module without type attribute should result in a fetch error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Load a CSS module with dynamic import() promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
+PASS Load a CSS module with dynamic import()
 PASS Ensure that loading a CSS module with dymnamic import() fails without a type attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS The integrity attribute must be verified on the top-level of a module loading a CSS module and allow it to execute when it matches
+PASS The integrity attribute must be verified on the top-level of a module loading a CSS module and not allow it to execute when there's a mismatch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events-expected.txt
@@ -1,23 +1,10 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
-NOTRUN inline, 200, parser-inserted
-NOTRUN inline, 404, parser-inserted
-NOTRUN src, 200, parser-inserted
-NOTRUN src, 404, parser-inserted
-NOTRUN src, 200, not parser-inserted
-NOTRUN src, 404, not parser-inserted
-NOTRUN inline, 200, not parser-inserted
-NOTRUN inline, 404, not parser-inserted
-
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
-NOTRUN inline, 200, parser-inserted
-NOTRUN inline, 404, parser-inserted
-NOTRUN src, 200, parser-inserted
-NOTRUN src, 404, parser-inserted
-NOTRUN src, 200, not parser-inserted
-NOTRUN src, 404, not parser-inserted
-NOTRUN inline, 200, not parser-inserted
-NOTRUN inline, 404, not parser-inserted
+PASS inline, 200, parser-inserted
+PASS inline, 404, parser-inserted
+PASS src, 200, parser-inserted
+PASS src, 404, parser-inserted
+PASS src, 200, not parser-inserted
+PASS src, 404, not parser-inserted
+PASS inline, 200, not parser-inserted
+PASS inline, 404, not parser-inserted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/redirect-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL A CSS module fetched through a redirect loads and applies promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
-FAIL Repeated import of a redirecting URL returns the same CSSStyleSheet promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
-FAIL A redirecting URL and its target are distinct module map entries promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "css" is not valid"
+PASS A CSS module fetched through a redirect loads and applies
+PASS Repeated import of a redirecting URL returns the same CSSStyleSheet
+PASS A redirecting URL and its target are distinct module map entries
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub-expected.txt
@@ -1,4 +1,10 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS Importing a same-origin top-level script with the default referrer policy.
+PASS Importing a remote-origin top-level script with the default referrer policy.
+PASS Importing a same-origin top-level script with the origin policy.
+PASS Importing a remote-origin top-level script with the origin policy.
+PASS Importing a same-origin top-level script with the no-referrer policy.
+PASS Importing a remote-origin top-level script with the no-referrer policy.
+PASS Importing a same-origin top-level script with the unsafe-url referrer policy.
+PASS Importing a remote-origin top-level script with the unsafe-url referrer policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/relative-urls-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/relative-urls-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
-
+PASS A relative URL in a CSS module should be resolved relative to the CSS file's URL, not the importing document's URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/repeated-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/repeated-import-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL CSS Module repeated imports assert_not_equals: Import should have attempted to fetch got disallowed value "0"
-FAIL CSS Module repeated serial imports assert_unreached: CSS module should load successfully on multiple imports Reached unreachable code
-FAIL CSS Module repeated parallel imports assert_unreached: CSS module should load successfully on parallel imports Reached unreachable code
+PASS CSS Module repeated imports
+PASS CSS Module repeated serial imports
+PASS CSS Module repeated parallel imports
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/resources/should-not-be-loaded.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/resources/should-not-be-loaded.js
@@ -1,0 +1,1 @@
+export default "SHOULD NOT BE LOADED";

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/tentative/shadowrootadoptedstylesheets/shadowrootadoptedstylesheets-fetched-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/tentative/shadowrootadoptedstylesheets/shadowrootadoptedstylesheets-fetched-module-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Import attribute type "css" is not valid
-
+FAIL Already-fetched module populates adoptedStyleSheets synchronously and applies styles. assert_equals: adoptedStyleSheets should have one entry. expected 1 but got 0
 

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -60,6 +60,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &codeForEval,
         &canCompileStrings,
         &trustedScriptStructure,
+        nullptr // moduleTypeCanBeLoaded
     };
     return &table;
 }

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.h
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "JSGlobalObject.h"
+#include "ScriptFetchParameters.h"
 #include <wtf/RefPtr.h>
 
 OBJC_CLASS JSScript;
@@ -33,7 +34,6 @@ OBJC_CLASS JSScript;
 namespace JSC {
 
 class ScriptFetcher;
-class ScriptFetchParameters;
 
 class JSAPIGlobalObject final : public JSGlobalObject {
 public:
@@ -64,6 +64,7 @@ private:
     static JSPromise* moduleLoaderFetch(JSGlobalObject*, JSModuleLoader*, JSValue, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     static JSObject* moduleLoaderCreateImportMetaProperties(JSGlobalObject*, JSModuleLoader*, JSValue, JSModuleRecord*, RefPtr<ScriptFetcher>);
     static JSValue moduleLoaderEvaluate(JSGlobalObject*, JSModuleLoader*, JSValue, JSValue, RefPtr<ScriptFetcher>, JSValue, JSValue);
+    static bool moduleTypeCanBeLoaded(ScriptFetchParameters::Type);
 };
 
 }

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -78,6 +78,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &codeForEval,
         &canCompileStrings,
         &trustedScriptStructure,
+        nullptr // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -104,6 +104,8 @@ static Protocol::Debugger::ScriptType scriptTypeForScript(const JSC::Debugger::S
     case JSC::SourceProviderSourceType::JSON:
     case JSC::SourceProviderSourceType::Text:
     case JSC::SourceProviderSourceType::ImportMap:
+    // FIXME: Maybe it should be treated as a separate CSS type and not just Program?
+    case JSC::SourceProviderSourceType::CSS:
         return Protocol::Debugger::ScriptType::Program;
     }
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -996,6 +996,7 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     &codeForEval,
     &canCompileStrings,
     &trustedScriptStructure,
+    nullptr // moduleTypeCanBeLoaded
 };
 
 GlobalObject::GlobalObject(VM& vm, Structure* structure)
@@ -1515,6 +1516,8 @@ JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModul
             promise->resolve(globalObject, vm, sourceCode);
             return promise;
         }
+        case ScriptFetchParameters::Type::CSS:
+            RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, "Loading CSS as modules is not supported in this environment"_s)));
         default:
             break;
         }

--- a/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
+++ b/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
@@ -51,8 +51,13 @@ static Expected<RefPtr<ScriptFetchParameters>, std::tuple<ErrorType, String>> tr
     for (auto& [key, value] : attributesList->attributes()) {
         if (*key == vm.propertyNames->type) {
             type = ScriptFetchParameters::parseType(value->impl());
+
+            // Types that are gated by feature flags.
             if (type == ScriptFetchParameters::Type::Text && !Options::useImportText())
                 type = std::nullopt;
+            if (type == ScriptFetchParameters::Type::CSS && !Options::useCSSModuleScripts())
+                type = std::nullopt;
+
             if (!type)
                 return makeUnexpected(std::tuple { ErrorType::TypeError, makeString("Import attribute type \""_s, StringView(value->impl()), "\" is not valid"_s) });
         }

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -56,6 +56,7 @@ enum class SourceProviderSourceType : uint8_t {
     JSON,
     Text,
     ImportMap,
+    CSS
 };
 
 using BytecodeCacheGenerator = Function<RefPtr<CachedBytecode>()>;
@@ -97,6 +98,7 @@ public:
         case SourceProviderSourceType::Module:
         case SourceProviderSourceType::JSON:
         case SourceProviderSourceType::Text:
+        case SourceProviderSourceType::CSS:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -1422,6 +1422,8 @@ ScriptFetchParameters::Type AbstractModuleRecord::moduleType() const
         return ScriptFetchParameters::Type::JavaScript;
     case SourceProviderSourceType::WebAssembly:
         return ScriptFetchParameters::Type::WebAssembly;
+    case SourceProviderSourceType::CSS:
+        return ScriptFetchParameters::Type::CSS;
     case SourceProviderSourceType::ImportMap:
         RELEASE_ASSERT_NOT_REACHED();
         return ScriptFetchParameters::Type::None;

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -206,6 +206,8 @@ static ScriptFetchParameters::Type getSourceType(const SourceCode& source)
         return ScriptFetchParameters::Type::JSON;
     case SourceProviderSourceType::Text:
         return ScriptFetchParameters::Type::Text;
+    case SourceProviderSourceType::CSS:
+        return ScriptFetchParameters::Type::CSS;
     case SourceProviderSourceType::WebAssembly:
         return ScriptFetchParameters::Type::WebAssembly;
     case SourceProviderSourceType::Module:
@@ -365,8 +367,13 @@ std::optional<ScriptFetchParameters::Type> retrieveTypeImportAttribute(JSGlobalO
 
     String value = iterator->value;
     auto result = ScriptFetchParameters::parseType(value);
+
+    // Import types that are gated by feature flags.
     if (result == ScriptFetchParameters::Type::Text && !Options::useImportText())
         result = std::nullopt;
+    if (result == ScriptFetchParameters::Type::CSS && !Options::useCSSModuleScripts())
+        result = std::nullopt;
+
     if (result)
         return result;
 

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <JavaScriptCore/Exception.h>
+#include <JavaScriptCore/ScriptFetchParameters.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 
@@ -42,7 +43,6 @@ class JSValue;
 class Microtask;
 class RuntimeFlags;
 class ScriptFetcher;
-class ScriptFetchParameters;
 class SourceOrigin;
 class Structure;
 class QueuedTask;
@@ -87,6 +87,8 @@ struct GlobalObjectMethodTable {
     String (*codeForEval)(JSGlobalObject*, JSValue);
     bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, const ArgList&);
     Structure* (*trustedScriptStructure)(JSGlobalObject*);
+
+    bool (*moduleTypeCanBeLoaded)(ScriptFetchParameters::Type);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -695,6 +695,7 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         &codeForEval,
         &canCompileStrings,
         &trustedScriptStructure,
+        nullptr // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -986,8 +986,8 @@ static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, Thr
     auto* modulePromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* jsSourceCode = downcast<JSSourceCode>(arguments[1]);
-        JSPromise* makeModulePromise = JSModuleLoader::makeModule(globalObject, entry->key(), jsSourceCode);
+        auto moduleData = arguments[1];
+        JSPromise* makeModulePromise = JSModuleLoader::makeModule(globalObject, entry->key(), moduleData);
         if (scope.exception()) {
             modulePromise->rejectWithCaughtException(vm, scope);
             return;
@@ -1126,13 +1126,13 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
     auto* intermediatePromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* jsSourceCode = downcast<JSSourceCode>(arguments[1]);
+        auto moduleData = arguments[1];
 
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
         ScriptFetcher* scriptFetcher = context->scriptFetcher();
 
-        globalObject->moduleLoader()->provideFetch(globalObject, specifier, type, jsSourceCode);
+        globalObject->moduleLoader()->provideFetch(globalObject, specifier, type, moduleData);
         if (scope.exception()) {
             intermediatePromise->rejectWithCaughtException(vm, scope);
             return;

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -338,11 +338,11 @@ void JSModuleLoader::provideFetch(JSGlobalObject* globalObject, const Identifier
         entry->provideFetch(globalObject, WTF::move(sourceCode)); // can throw
 }
 
-void JSModuleLoader::provideFetch(JSGlobalObject* globalObject, const Identifier& key, ScriptFetchParameters::Type type, JSSourceCode* jsSourceCode)
+void JSModuleLoader::provideFetch(JSGlobalObject* globalObject, const Identifier& key, ScriptFetchParameters::Type type, JSValue moduleData)
 {
     ModuleRegistryEntry* entry = ensureRegistered(globalObject, key, type);
     if (entry->status() == ModuleRegistryEntry::Status::New)
-        entry->provideFetch(globalObject, jsSourceCode); // can throw
+        entry->provideFetch(globalObject, moduleData); // can throw
 }
 
 JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identifier& specifier, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher, OptionSet<ModuleLoadFlag> flags)
@@ -452,6 +452,29 @@ JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, con
     return resultPromise;
 }
 
+static UNUSED_FUNCTION bool NODELETE moduleTypeCanBeLoaded(JSGlobalObject* globalObject, ScriptFetchParameters::Type type)
+{
+    bool moduleTypeCanBeLoadedByJSC = [type] () {
+        switch (type) {
+        case ScriptFetchParameters::JavaScript:
+        case ScriptFetchParameters::WebAssembly:
+        case ScriptFetchParameters::JSON:
+        case ScriptFetchParameters::Text:
+        case ScriptFetchParameters::None:
+            return true;
+
+        default:
+            return false;
+        }
+    } ();
+
+    bool moduleTypeCanBeLoadedByHost = false;
+    if (globalObject->globalObjectMethodTable()->moduleTypeCanBeLoaded)
+        moduleTypeCanBeLoadedByHost = globalObject->globalObjectMethodTable()->moduleTypeCanBeLoaded(type);
+
+    return moduleTypeCanBeLoadedByJSC || moduleTypeCanBeLoadedByHost;
+}
+
 JSPromise* JSModuleLoader::importModule(JSGlobalObject* globalObject, JSString* moduleName, JSValue parameters, const SourceOrigin& referrer, bool deferred)
 {
     dataLogLnIf(Options::dumpModuleLoadingState(), "Loader [import] ", printableModuleKey(globalObject, moduleName));
@@ -465,6 +488,15 @@ JSPromise* JSModuleLoader::importModule(JSGlobalObject* globalObject, JSString* 
     auto type = retrieveTypeImportAttribute(globalObject, attributes);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+
+    if (type) {
+        if (!moduleTypeCanBeLoaded(globalObject, *type)) {
+            promise->reject(vm, createTypeError(globalObject, "Module type not supported by environment"_s));
+            RELEASE_AND_RETURN(scope, promise);
+        }
+    }
+
     RefPtr<ScriptFetchParameters> fetchParams;
     if (type)
         fetchParams = ScriptFetchParameters::create(type.value());
@@ -472,7 +504,6 @@ JSPromise* JSModuleLoader::importModule(JSGlobalObject* globalObject, JSString* 
     if (globalObject->globalObjectMethodTable()->moduleLoaderImportModule)
         RELEASE_AND_RETURN(scope, globalObject->globalObjectMethodTable()->moduleLoaderImportModule(globalObject, this, moduleName, WTF::move(fetchParams), referrer, deferred));
 
-    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     auto moduleNameString = moduleName->value(globalObject);
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
 
@@ -594,6 +625,24 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
     ModuleRegistryEntry* mapEntry = nullptr;
     const Identifier& specifier = moduleRequest.m_specifier;
     auto type = moduleRequest.type();
+
+    // 7.4 Let moduleType be the result of running the module type from module request steps given requested.
+    // 7.5 If the result of running the module type allowed steps given moduleType and settingsObject is false:
+    // 7.5.1 Let error be a new TypeError exception.
+    // 7.5.2 If loadState is not undefined and loadState.[[ErrorToRethrow]] is null, set loadState.[[ErrorToRethrow]] to error.
+    // 7.5.3 Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, ThrowCompletion(error)).
+    // 7.5.4 Return.
+    if (!moduleTypeCanBeLoaded(globalObject, type)) {
+        JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
+
+        auto error = createTypeError(globalObject, "Module type not supported by environment"_s);
+        promise->reject(vm, error);
+
+        auto exception = Exception::create(vm, error);
+        finishLoadingImportedModule(globalObject, referrer, moduleRequest, payload, exception, scriptFetcher);
+
+        RELEASE_AND_RETURN(scope, promise);
+    }
 
     ModuleMapKey moduleMapKey { specifier.impl(), type };
 
@@ -1045,10 +1094,20 @@ JSValue JSModuleLoader::ModuleReferrer::toJSValue() const
     return std::get<JSGlobalObject*>(*this);
 }
 
-JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSSourceCode* jsSourceCode)
+JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSValue moduleData)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSourceCode* jsSourceCode = dynamicDowncast<JSSourceCode>(moduleData);
+    if (!jsSourceCode) {
+        JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        promise->markAsHandled();
+        auto* moduleRecord = SyntheticModuleRecord::tryCreateDefaultExportSyntheticModule(globalObject, moduleKey, moduleData, SourceProviderSourceType::CSS);
+        RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
+        promise->fulfill(vm, moduleRecord);
+        RELEASE_AND_RETURN(scope, promise);
+    }
 
     const SourceCode& sourceCode = jsSourceCode->sourceCode();
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -91,7 +91,7 @@ public:
 
     // APIs to control the module loader.
     void provideFetch(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type, SourceCode&&);
-    void provideFetch(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type, JSSourceCode*);
+    void provideFetch(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type, JSValue);
     JSPromise* loadModule(JSGlobalObject*, const Identifier& moduleName, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>, OptionSet<ModuleLoadFlag>);
     JSPromise* linkAndEvaluateModule(JSGlobalObject*, const Identifier& moduleKey, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     JSPromise* requestImportModule(JSGlobalObject*, const Identifier& moduleName, const Identifier& referrer, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>, bool deferred = false);
@@ -161,7 +161,10 @@ public:
     void continueDynamicImport(JSGlobalObject*, JSPromise*, ModuleCompletion, RefPtr<ScriptFetcher>, bool deferred);
     JSPromise* loadRequestedModules(JSGlobalObject*, AbstractModuleRecord*, RefPtr<ScriptFetcher>);
 
-    static JSPromise* makeModule(JSGlobalObject*, const Identifier& moduleKey, JSSourceCode*);
+    // If moduleData is a JSSourceCode, then it's a JavaScript/WebAssembly/JSON/text source code,
+    // and JSC is responsible for turning it into a usable module. Otherwise, the host has already
+    // turned it into a module, and JSC should take that as the module's default export value.
+    static JSPromise* makeModule(JSGlobalObject*, const Identifier& moduleKey, JSValue moduleData);
 
     static ErrorInstance* duplicateTypeError(JSGlobalObject*, ErrorInstance*);
     static ErrorInstance* duplicateError(JSGlobalObject*, ErrorInstance*);

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -219,7 +219,7 @@ void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, SourceCode&
     provideFetch(globalObject, JSSourceCode::create(globalObject->vm(), WTF::move(sourceCode)));
 }
 
-void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, JSSourceCode* jsSourceCode)
+void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, JSValue moduleData)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -231,7 +231,7 @@ void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, JSSourceCod
 
     scope.release();
     m_status = Status::Fetching;
-    m_fetchPromise->fulfill(vm, jsSourceCode);
+    m_fetchPromise->fulfill(vm, moduleData);
 }
 
 void ModuleRegistryEntry::fetchComplete(JSGlobalObject* globalObject, AbstractModuleRecord* record)

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.h
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.h
@@ -85,7 +85,7 @@ public:
     void setStatus(Status);
 
     void provideFetch(JSGlobalObject*, SourceCode&&);
-    void provideFetch(JSGlobalObject*, JSSourceCode*);
+    void provideFetch(JSGlobalObject*, JSValue);
     void fetchComplete(JSGlobalObject*, AbstractModuleRecord*);
 
 private:

--- a/Source/JavaScriptCore/runtime/ScriptFetchParameters.h
+++ b/Source/JavaScriptCore/runtime/ScriptFetchParameters.h
@@ -39,6 +39,7 @@ public:
         WebAssembly,
         JSON,
         Text,
+        CSS
     };
 
     ScriptFetchParameters(Type type)
@@ -64,6 +65,8 @@ public:
             return Type::JSON;
         if (string == "text"_s)
             return Type::Text;
+        if (string == "css"_s)
+            return Type::CSS;
         if (string == "webassembly"_s)
             return Type::WebAssembly;
         return std::nullopt;

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
@@ -55,6 +55,8 @@ public:
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
     static SyntheticModuleRecord* create(JSGlobalObject*, VM&, Structure*, const Identifier& moduleKey, SourceProviderSourceType);
 
+    static SyntheticModuleRecord* tryCreateDefaultExportSyntheticModule(JSGlobalObject*, const Identifier& moduleKey, JSValue, SourceProviderSourceType);
+
     static SyntheticModuleRecord* parseJSONModule(JSGlobalObject*, const Identifier& moduleKey, SourceCode&&);
     static SyntheticModuleRecord* createTextModule(JSGlobalObject*, const Identifier& moduleKey, SourceCode&&);
 
@@ -64,7 +66,6 @@ public:
 private:
     SyntheticModuleRecord(VM&, Structure*, const Identifier& moduleKey, SourceProviderSourceType);
 
-    static SyntheticModuleRecord* tryCreateDefaultExportSyntheticModule(JSGlobalObject*, const Identifier& moduleKey, JSValue, SourceProviderSourceType);
     static SyntheticModuleRecord* tryCreateWithExportNamesAndValues(JSGlobalObject*, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, ArgList exportValues, SourceProviderSourceType);
 
     void finishCreation(JSGlobalObject*, VM&);

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1441,7 +1441,23 @@ CSSMathDepthEnabled:
       default: true
     WebCore:
       default: true
-      
+
+CSSModuleScriptsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Module Scripts"
+  humanReadableDescription: "Enable importing CSS into JavaScript using 'import'"
+  jscOptionName: useCSSModuleScripts
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSObjectViewBoxEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CachedModuleScriptLoader.h"
 
+#include "CachedCSSStyleSheet.h"
 #include "CachedScript.h"
 #include "CachedScriptFetcher.h"
 #include "DOMWrapperWorld.h"
@@ -52,16 +53,16 @@ CachedModuleScriptLoader::CachedModuleScriptLoader(ModuleScriptLoaderClient& cli
 
 CachedModuleScriptLoader::~CachedModuleScriptLoader()
 {
-    if (m_cachedScript) {
-        protect(m_cachedScript)->removeClient(*this);
-        m_cachedScript = nullptr;
+    if (m_cachedResource) {
+        protect(m_cachedResource)->removeClient(*this);
+        m_cachedResource = nullptr;
     }
 }
 
 bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::optional<ServiceWorkersMode> serviceWorkersMode)
 {
     ASSERT(m_promise);
-    ASSERT(!m_cachedScript);
+    ASSERT(!m_cachedResource);
     String integrity = m_parameters ? m_parameters->integrity() : String { };
     auto destination = FetchOptionsDestination::Script;
     if (m_parameters) {
@@ -72,24 +73,38 @@ bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::op
         case JSC::ScriptFetchParameters::Type::Text:
             destination = FetchOptionsDestination::Text;
             break;
+        case JSC::ScriptFetchParameters::Type::CSS:
+            destination = FetchOptionsDestination::Style;
+            break;
         default:
             break;
         }
     }
-    m_cachedScript = protect(scriptFetcher())->requestModuleScript(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode);
-    if (!m_cachedScript)
+
+    m_cachedResource = protect(scriptFetcher())->requestModuleResource(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode);
+    if (!m_cachedResource)
         return false;
     m_sourceURL = WTF::move(sourceURL);
 
     // If the content is already cached, this immediately calls notifyFinished.
-    protect(m_cachedScript)->addClient(*this);
+    protect(m_cachedResource)->addClient(*this);
     return true;
 }
 
 void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
-    ASSERT_UNUSED(resource, &resource == m_cachedScript);
-    ASSERT(m_cachedScript);
+    notifyFinishedInternal(&resource);
+}
+
+void CachedModuleScriptLoader::setCSSStyleSheet(const String&, const URL&, ASCIILiteral, const CachedCSSStyleSheet* resource)
+{
+    notifyFinishedInternal(resource);
+}
+
+void CachedModuleScriptLoader::notifyFinishedInternal(const CachedResource* resource)
+{
+    ASSERT_UNUSED(resource, resource == m_cachedResource);
+    ASSERT(m_cachedResource);
     ASSERT(m_promise);
 
     Ref<CachedModuleScriptLoader> protectedThis(*this);
@@ -98,8 +113,8 @@ void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const Ne
 
     // Remove the client after calling notifyFinished to keep the data buffer in
     // CachedResource alive while notifyFinished processes the resource.
-    protect(m_cachedScript)->removeClient(*this);
-    m_cachedScript = nullptr;
+    protect(m_cachedResource)->removeClient(*this);
+    m_cachedResource = nullptr;
 }
 
 }

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -28,6 +28,7 @@
 #include <WebCore/CachedResourceClient.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/CachedScriptFetcher.h>
+#include <WebCore/CachedStyleSheetClient.h>
 #include <WebCore/ModuleScriptLoader.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -45,7 +46,7 @@ class DeferredPromise;
 class Document;
 class JSDOMGlobalObject;
 
-class CachedModuleScriptLoader final : public ModuleScriptLoader, private CachedResourceClient {
+class CachedModuleScriptLoader final : public ModuleScriptLoader, private CachedStyleSheetClient {
 public:
     static Ref<CachedModuleScriptLoader> create(ModuleScriptLoaderClient&, DeferredPromise&, CachedScriptFetcher&, RefPtr<JSC::ScriptFetchParameters>&&);
 
@@ -57,7 +58,7 @@ public:
 
     bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>);
 
-    CachedScript* cachedScript() { return m_cachedScript.get(); }
+    CachedResource* cachedResource() { return m_cachedResource.get(); }
     CachedScriptFetcher& scriptFetcher() { return static_cast<CachedScriptFetcher&>(ModuleScriptLoader::scriptFetcher()); }
 
 private:
@@ -66,8 +67,11 @@ private:
     bool isCachedModuleScriptLoader() const final { return true; }
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+    // For whatever reasons, CachedStyleSheetClient clients uses setCSSStyleSheet, not notifyFinished.
+    void setCSSStyleSheet(const String&, const URL&, ASCIILiteral, const CachedCSSStyleSheet*) final;
+    void notifyFinishedInternal(const CachedResource*);
 
-    CachedResourceHandle<CachedScript> m_cachedScript;
+    CachedResourceHandle<CachedResource> m_cachedResource;
     URL m_sourceURL;
 };
 

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "CachedScriptFetcher.h"
 
+#include "CachedCSSStyleSheet.h"
 #include "CachedScript.h"
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginAccessControl.h"
@@ -41,12 +42,12 @@ Ref<CachedScriptFetcher> CachedScriptFetcher::create(const AtomString& charset)
     return adoptRef(*new CachedScriptFetcher(charset));
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+CachedResourceHandle<CachedResource> CachedScriptFetcher::requestModuleResource(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
-    return requestScriptWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode);
+    return requestResourceWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode);
 }
 
-RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+RefPtr<CachedResource> CachedScriptFetcher::requestResourceWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
     if (!document.settings().isScriptEnabled())
         return nullptr;
@@ -62,7 +63,6 @@ RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& docum
     options.fetchPriority = m_fetchPriority;
     options.nonce = m_nonce;
     options.destination = destination;
-    ASSERT(destination == FetchOptionsDestination::Script || destination == FetchOptionsDestination::Json || destination == FetchOptionsDestination::Text);
 
     auto request = createPotentialAccessControlRequest(URL { sourceURL }, WTF::move(options), document, crossOriginMode);
     request.upgradeInsecureRequestIfNeeded(document);
@@ -71,8 +71,25 @@ RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& docum
     if (!m_initiatorType.isNull())
         request.setInitiatorType(m_initiatorType);
 
-    auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
-    return result ? RefPtr { WTF::move(result.value()) } : nullptr;
+    switch (destination) {
+    case FetchOptionsDestination::Script:
+    case FetchOptionsDestination::Json:
+    case FetchOptionsDestination::Text: {
+        auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
+        return result ? RefPtr { WTF::move(result.value()) } : nullptr;
+    }
+
+    case FetchOptionsDestination::Style: {
+        auto result = protect(document.cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request));
+        return result ? RefPtr { WTF::move(result.value()) } : nullptr;
+    }
+
+    default:
+        break;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -42,7 +42,7 @@ enum class FetchOptionsDestination : uint8_t;
 
 class CachedScriptFetcher : public JSC::ScriptFetcher {
 public:
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
+    virtual CachedResourceHandle<CachedResource> requestModuleResource(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
 
     static Ref<CachedScriptFetcher> create(const AtomString& charset);
 
@@ -62,7 +62,7 @@ protected:
     {
     }
 
-    RefPtr<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
+    RefPtr<CachedResource> requestResourceWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
 
 private:
     bool isCachedScriptFetcher() const final { return true; }

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -779,6 +779,17 @@ JSC::JSObject* JSDOMGlobalObject::moduleLoaderCreateImportMetaProperties(JSC::JS
     return JSC::constructEmptyObject(globalObject->vm(), globalObject->nullPrototypeObjectStructure());
 }
 
+bool JSDOMGlobalObject::moduleTypeCanBeLoaded(JSC::ScriptFetchParameters::Type type)
+{
+    switch (type) {
+    case JSC::ScriptFetchParameters::CSS:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
 JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/ScriptFetchParameters.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <WebCore/ProcessQualified.h>
 #include <wtf/Compiler.h>
@@ -36,7 +37,6 @@
 
 namespace JSC {
 
-class ScriptFetchParameters;
 class ScriptFetcher;
 class WebAssemblyCompileOptions;
 enum class JSPromiseRejectionOperation : unsigned;
@@ -152,6 +152,7 @@ protected:
     static JSC::JSValue moduleLoaderEvaluate(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSValue, RefPtr<JSC::ScriptFetcher>, JSC::JSValue, JSC::JSValue);
     static JSC::JSPromise* moduleLoaderImportModule(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString*, RefPtr<JSC::ScriptFetchParameters>, const JSC::SourceOrigin&, bool deferred);
     static JSC::JSObject* moduleLoaderCreateImportMetaProperties(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSModuleRecord*, RefPtr<JSC::ScriptFetcher>);
+    static bool moduleTypeCanBeLoaded(JSC::ScriptFetchParameters::Type);
 
     JSDOMStructureMap m_structures WTF_GUARDED_BY_LOCK(m_gcLock);
     DOMGuardedObjectSet m_guardedObjects WTF_GUARDED_BY_LOCK(m_gcLock);

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -117,6 +117,7 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
         codeForEval,
         canCompileStrings,
         trustedScriptStructure,
+        &moduleTypeCanBeLoaded, // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -73,6 +73,7 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
         &codeForEval,
         &canCompileStrings,
         &trustedScriptStructure,
+        nullptr, // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -79,6 +79,7 @@ const GlobalObjectMethodTable* JSWorkerGlobalScopeBase::globalObjectMethodTable(
         codeForEval,
         canCompileStrings,
         trustedScriptStructure,
+        nullptr, // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -71,6 +71,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         codeForEval,
         canCompileStrings,
         trustedScriptStructure,
+        nullptr, // moduleTypeCanBeLoaded
     };
     return &table;
 };

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -26,14 +26,18 @@
 #include "config.h"
 #include "ScriptModuleLoader.h"
 
+#include "CSSStyleSheet.h"
+#include "CachedCSSStyleSheet.h"
 #include "CachedModuleScriptLoader.h"
 #include "CachedScript.h"
 #include "CachedScriptFetcher.h"
 #include "DocumentInlines.h"
 #include "EventLoop.h"
 #include "FrameDestructionObserverInlines.h"
+#include "JSCSSStyleSheet.h"
 #include "JSDOMBinding.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSDOMWindowBase.h"
 #include "LoadableModuleScript.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
@@ -368,6 +372,11 @@ JSC::JSPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* jsGlobalOb
     case JSC::ScriptFetchParameters::Type::Text:
         destination = FetchOptions::Destination::Text;
         break;
+    case JSC::ScriptFetchParameters::Type::CSS:
+        // FIXME: is this the best place to implement this?
+        ASSERT(m_ownerType == OwnerType::Document);
+        destination = FetchOptions::Destination::Style;
+        break;
     default:
         break;
     }
@@ -467,6 +476,67 @@ JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObjec
     return metaProperties;
 }
 
+static JSC::JSValue createCSSModule(JSC::JSGlobalObject& object, String&& source, URL&& baseURL)
+{
+    auto& vm = object.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    auto& thisObject = uncheckedDowncast<JSDOMWindowBase>(object);
+
+    RefPtr localWindow = thisObject.wrapped();
+    if (!localWindow) {
+        ASSERT_NOT_REACHED();
+        return JSC::jsUndefined();
+    }
+
+    RefPtr document = localWindow->documentIfLocal();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return JSC::jsUndefined();
+    }
+
+    if (!document->settings().cssModuleScriptsEnabled())
+        return JSC::jsUndefined();
+
+    // > Let `sheet` be the result of running the steps to create a constructed
+    // > CSSStyleSheet with an empty dictionary as the argument.
+    CSSStyleSheet::Init sheetInit {
+        .baseURL = baseURL.string(),
+        .media = emptyString(),
+        .disabled = false
+    };
+
+    auto sheetOrException = CSSStyleSheet::create(*document, WTF::move(sheetInit));
+    if (sheetOrException.hasException()) [[unlikely]] {
+        propagateException(object, throwScope, sheetOrException.releaseException());
+        return { };
+    }
+
+    auto sheet = sheetOrException.releaseReturnValue();
+
+    // From spec:
+    // * Run the steps to synchronously replace the rules of a CSSStyleSheet on sheet given source.
+    // * If this throws an exception, catch it, and set script's parse error to that exception, and return script.
+    // FIXME: set the script's parse error (how?)
+
+    if (auto maybeException = sheet->replaceSync(WTF::move(source)); maybeException.hasException()) [[unlikely]] {
+        propagateException(object, throwScope, WTF::move(maybeException));
+        return { };
+    }
+
+    auto jsValue = toJSNewlyCreated<IDLInterface<CSSStyleSheet>>(object, thisObject, WTF::move(sheet));
+    RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+
+    RELEASE_AND_RETURN(throwScope, jsValue);
+}
+
+// Stores enough information to turn a CSS source code into a CSSStyleSheet
+// (and subsequently JSCSSStyleSheet)
+struct CSSSourceCode {
+    String sourceCode;
+    URL baseURL;
+};
+
 void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, URL&& sourceURL, Ref<DeferredPromise> promise)
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
@@ -491,34 +561,41 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
         return responseURL;
     };
 
-    JSC::SourceCode sourceCode;
+    Variant<JSC::SourceCode, CSSSourceCode> jsOrCSSSourceCode;
     if (m_ownerType == OwnerType::Document) {
         auto& loader = downcast<CachedModuleScriptLoader>(moduleScriptLoader);
-        Ref cachedScript = *loader.cachedScript();
+        Ref cachedResource = *loader.cachedResource();
 
-        if (cachedScript->resourceError().isAccessControl()) {
+        if (cachedResource->resourceError().isAccessControl()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
             return;
         }
 
-        if (cachedScript->errorOccurred()) {
+        if (cachedResource->errorOccurred()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
             return;
         }
 
-        if (cachedScript->wasCanceled()) {
+        if (cachedResource->wasCanceled()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
             return;
         }
 
         ModuleType type = ModuleType::Invalid;
-        auto mimeType = cachedScript->response().mimeType();
+        auto mimeType = cachedResource->response().mimeType();
         auto requestedType = loader.parameters() ? loader.parameters()->type() : JSC::ScriptFetchParameters::Type::None;
         // A text module accepts any MIME type, and its content must never be parsed as JavaScript,
         // so it has to be decided before the JavaScript MIME type is considered.
         if (requestedType == JSC::ScriptFetchParameters::Type::Text)
             type = ModuleType::Text;
-        else if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType))
+        else if (requestedType == JSC::ScriptFetchParameters::Type::CSS) {
+            if (MIMETypeRegistry::isSupportedStyleSheetMIMEType(mimeType))
+                type = ModuleType::CSS;
+            else {
+                rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedResource->response().mimeType(), "' is not a valid CSS MIME type for module script '"_s, sourceURL.string(), "'."_s));
+                return;
+            }
+        } else if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType))
             type = ModuleType::JavaScript;
 #if ENABLE(WEBASSEMBLY)
         else if (context->settingsValues().webAssemblyESMIntegrationEnabled && MIMETypeRegistry::isSupportedWebAssemblyMIMEType(mimeType))
@@ -530,7 +607,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedScript->response().mimeType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
+            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedResource->response().mimeType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
             return;
         }
 
@@ -541,31 +618,54 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             integrity = parameters->integrity();
 
         if (!integrity.isEmpty()) {
-            if (!matchIntegrityMetadata(cachedScript, integrity)) {
-                context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(cachedScript, integrity)));
+            if (!matchIntegrityMetadata(cachedResource, integrity)) {
+                context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(cachedResource, integrity)));
                 rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, "Cannot load script due to integrity mismatch"_s);
                 return;
             }
         }
 
-        URL responseURL = canonicalizeAndRegisterResponseURL(cachedScript->response().url(), cachedScript->hasRedirections(), cachedScript->response().source());
+        URL responseURL = canonicalizeAndRegisterResponseURL(cachedResource->response().url(), cachedResource->hasRedirections(), cachedResource->response().source());
         m_requestURLToResponseURLMap.add(sourceURL.string(), WTF::move(responseURL));
         switch (type) {
-        case ModuleType::JavaScript:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Module, loader.scriptFetcher() }.jsSourceCode() };
+        case ModuleType::JavaScript: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Module, loader.scriptFetcher() }.jsSourceCode() };
             break;
+        }
+        case ModuleType::WebAssembly: {
 #if ENABLE(WEBASSEMBLY)
-        case ModuleType::WebAssembly:
-            sourceCode = JSC::SourceCode { WebAssemblyScriptSourceCode { cachedScript.ptr(), loader.scriptFetcher() }.jsSourceCode() };
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
+            jsOrCSSSourceCode = JSC::SourceCode { WebAssemblyScriptSourceCode { cachedScript.ptr(), loader.scriptFetcher() }.jsSourceCode() };
             break;
+#else
+            RELEASE_ASSERT_NOT_REACHED();
 #endif
-        case ModuleType::JSON:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::JSON, loader.scriptFetcher() }.jsSourceCode() };
+        }
+        case ModuleType::JSON: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::JSON, loader.scriptFetcher() }.jsSourceCode() };
             break;
-        case ModuleType::Text:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Text, loader.scriptFetcher() }.jsSourceCode() };
+        }
+        case ModuleType::Text: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Text, loader.scriptFetcher() }.jsSourceCode() };
             break;
-        default:
+        }
+        case ModuleType::CSS: {
+            Ref cachedStyleSheet = downcast<CachedCSSStyleSheet>(cachedResource);
+
+            bool hasValidMIMEType = true;
+            bool hasHTTPStatusOK = true;
+            auto cssSourceCode = cachedStyleSheet->sheetText(CachedCSSStyleSheet::MIMETypeCheckHint::Strict, CachedCSSStyleSheet::ForceUTF8Encoding::Yes, &hasValidMIMEType, &hasHTTPStatusOK);
+            // We already checked MIME above, so hasValidMIMEType should be true.
+            RELEASE_ASSERT(hasValidMIMEType);
+            RELEASE_ASSERT(hasHTTPStatusOK);
+
+            jsOrCSSSourceCode = CSSSourceCode { WTF::move(cssSourceCode), sourceURL };
+            break;
+        }
+        case ModuleType::Invalid:
             RELEASE_ASSERT_NOT_REACHED();
         }
     } else {
@@ -596,7 +696,10 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
         // so it has to be decided before the JavaScript MIME type is considered.
         if (requestedType == JSC::ScriptFetchParameters::Type::Text)
             type = ModuleType::Text;
-        else if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType))
+        else if (requestedType == JSC::ScriptFetchParameters::Type::CSS) {
+            // Workers aren't allowed to fetch CSS Module Scripts, so we shouldn't reach this point
+            RELEASE_ASSERT_NOT_REACHED();
+        } else if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType))
             type = ModuleType::JavaScript;
 #if ENABLE(WEBASSEMBLY)
         else if (context->settingsValues().webAssemblyESMIntegrationEnabled && MIMETypeRegistry::isSupportedWebAssemblyMIMEType(mimeType))
@@ -628,27 +731,39 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
 
         switch (type) {
         case ModuleType::JavaScript:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::Module, loader.scriptFetcher() }.jsSourceCode() };
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::Module, loader.scriptFetcher() }.jsSourceCode() };
             break;
-#if ENABLE(WEBASSEMBLY)
         case ModuleType::WebAssembly:
-            sourceCode = JSC::SourceCode { WebAssemblyScriptSourceCode { loader.script(), WTF::move(responseURL), loader.scriptFetcher() }.jsSourceCode() };
+#if ENABLE(WEBASSEMBLY)
+            jsOrCSSSourceCode = JSC::SourceCode { WebAssemblyScriptSourceCode { loader.script(), WTF::move(responseURL), loader.scriptFetcher() }.jsSourceCode() };
             break;
+#else
+            RELEASE_ASSERT_NOT_REACHED();
 #endif
         case ModuleType::JSON:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::JSON, loader.scriptFetcher() }.jsSourceCode() };
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::JSON, loader.scriptFetcher() }.jsSourceCode() };
             break;
         case ModuleType::Text:
-            sourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::Text, loader.scriptFetcher() }.jsSourceCode() };
+            jsOrCSSSourceCode = JSC::SourceCode { ScriptSourceCode { loader.script(), WTF::move(responseURL), WTF::move(sourceURL), { }, JSC::SourceProviderSourceType::Text, loader.scriptFetcher() }.jsSourceCode() };
             break;
-        default:
+        // Workers aren't allowed to fetch CSS Module Scripts, so we shouldn't reach this point.
+        case ModuleType::CSS:
+        case ModuleType::Invalid:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
 
-    protect(context->eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise), sourceCode = WTF::move(sourceCode)] mutable {
-        promise->fulfillWithCallback([&, sourceCode = WTF::move(sourceCode)](JSDOMGlobalObject& jsGlobalObject) mutable {
-            return JSC::JSSourceCode::create(jsGlobalObject.vm(), WTF::move(sourceCode));
+    protect(context->eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise), jsOrCSSSourceCode = WTF::move(jsOrCSSSourceCode)] mutable {
+        promise->fulfillWithCallback([&, jsOrCSSSourceCode = WTF::move(jsOrCSSSourceCode)](JSDOMGlobalObject& jsGlobalObject) mutable {
+            return WTF::switchOn(jsOrCSSSourceCode,
+                [&] (JSC::SourceCode& sourceCode) -> JSC::JSValue {
+                    return JSC::JSSourceCode::create(jsGlobalObject.vm(), WTF::move(sourceCode));
+                },
+                [&] (CSSSourceCode& cssSourceCode) -> JSC::JSValue {
+                    // Can only be done here, not in notifyFinished before the callback is fired,
+                    // because we have the JS global object.
+                    return createCSSModule(jsGlobalObject, WTF::move(cssSourceCode.sourceCode), WTF::move(cssSourceCode.baseURL));
+                });
         });
     });
 }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -59,7 +59,7 @@ class ScriptModuleLoader final : private ModuleScriptLoaderClient {
     WTF_MAKE_NONCOPYABLE(ScriptModuleLoader);
 public:
     enum class OwnerType : uint8_t { Document, WorkerOrWorklet };
-    enum class ModuleType : uint8_t { Invalid, JavaScript, WebAssembly, JSON, Text };
+    enum class ModuleType : uint8_t { Invalid, JavaScript, WebAssembly, JSON, Text, CSS };
     explicit ScriptModuleLoader(ScriptExecutionContext*, OwnerType);
     ~ScriptModuleLoader();
 

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -85,6 +85,10 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
     fetchOptions.destination = static_cast<WorkerScriptFetcher&>(scriptFetcher()).destination();
     fetchOptions.referrerPolicy = static_cast<WorkerScriptFetcher&>(scriptFetcher()).referrerPolicy();
 
+    // CSS modules aren't allowed in workers/worklets.
+    // It should've been blocked elsewhere before reaching here.
+    RELEASE_ASSERT(fetchOptions.destination != FetchOptions::Destination::Style);
+
     bool cspCheckFailed = false;
     ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::DoNotEnforce;
     if (!context.shouldBypassMainWorldContentSecurityPolicy()) {
@@ -93,7 +97,7 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
             sourcePosition = document->currentParserSourcePosition();
 
         CheckedPtr contentSecurityPolicy = context.contentSecurityPolicy();
-        // Worklets and scripts are governed by script-src; JSON and text modules by connect-src; workers by worker-src.
+        // Worklets and scripts are governed by script-src; Text modules by connect-src; workers by worker-src.
         bool shouldEnforceScriptSrc = fetchOptions.destination == FetchOptions::Destination::Script
             || isWorkletDestination(fetchOptions.destination);
         if (shouldEnforceScriptSrc) {

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -403,7 +403,7 @@ bool StyleSheetContents::parseAuthorStyleSheet(const CachedCSSStyleSheet* cached
     CachedCSSStyleSheet::MIMETypeCheckHint mimeTypeCheckHint = isStrictParserMode(m_parserContext.mode) || !isSameOriginRequest ? CachedCSSStyleSheet::MIMETypeCheckHint::Strict : CachedCSSStyleSheet::MIMETypeCheckHint::Lax;
     bool hasValidMIMEType = true;
     bool hasHTTPStatusOK = true;
-    String sheetText = cachedStyleSheet->sheetText(mimeTypeCheckHint, &hasValidMIMEType, &hasHTTPStatusOK);
+    String sheetText = cachedStyleSheet->sheetText(mimeTypeCheckHint, CachedCSSStyleSheet::ForceUTF8Encoding::No, &hasValidMIMEType, &hasHTTPStatusOK);
 
     if (!hasHTTPStatusOK) {
         ASSERT(sheetText.isNull());

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -149,7 +149,7 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     };
 
     m_weakDocument = document;
-    m_cachedScript = requestScriptWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { });
+    m_cachedScript = downcast<CachedScript>(requestResourceWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { }));
     if (!m_cachedScript)
         return false;
     protect(m_cachedScript)->addClient(*this);

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 
 const ASCIILiteral ScriptElementCachedScriptFetcher::defaultCrossOriginModeForModule { "anonymous"_s };
 
-CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+CachedResourceHandle<CachedResource> ScriptElementCachedScriptFetcher::requestModuleResource(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
     // If the fetcher is not module script, credential mode is always "same-origin" ("anonymous").
     // This code is for dynamic module import (`import` operator).
 
-    return requestScriptWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode);
+    return requestResourceWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode);
 }
 
 }

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -35,7 +35,7 @@ class ScriptElementCachedScriptFetcher : public CachedScriptFetcher {
 public:
     static const ASCIILiteral defaultCrossOriginModeForModule;
 
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
+    virtual CachedResourceHandle<CachedResource> requestModuleResource(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
 
     virtual ScriptType scriptType() const = 0;
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -77,7 +77,7 @@ ASCIILiteral CachedCSSStyleSheet::encoding() const
     return m_decoder->encoding().name();
 }
 
-const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
+String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, ForceUTF8Encoding forceUTF8Encoding, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
 {
     // Ensure hasValidMIMEType and hasHTTPStatusOK always get set (even if m_data is null or empty) — which in turn
     // ensures that if the MIME type isn't text/css or the HTTP status isn't an OK status, we never load the resource.
@@ -88,11 +88,18 @@ const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint,
     if (!data || data->isEmpty())
         return String();
 
-    if (!m_decodedSheetText.isNull())
-        return m_decodedSheetText;
+    switch (forceUTF8Encoding) {
+    case ForceUTF8Encoding::No:
+        if (!m_decodedSheetText.isNull())
+            return m_decodedSheetText;
 
-    // Don't cache the decoded text, regenerating is cheap and it can use quite a bit of memory.
-    return protect(m_decoder)->decodeAndFlush(data->makeContiguous()->span());
+        // Don't cache the decoded text, regenerating is cheap and it can use quite a bit of memory.
+        return protect(m_decoder)->decodeAndFlush(data->makeContiguous()->span());
+    case ForceUTF8Encoding::Yes:
+        auto utf8Decoder = TextResourceDecoder::create(cssContentTypeAtom(), PAL::UTF8Encoding());
+        utf8Decoder->setAlwaysUseUTF8();
+        return utf8Decoder->decodeAndFlush(data->makeContiguous()->span());
+    }
 }
 
 void CachedCSSStyleSheet::setBodyDataFrom(const CachedResource& resource)
@@ -160,11 +167,10 @@ bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool*
         return response().url().protocolIsInHTTPFamily() && !response().isSuccessful();
     }();
 
-    if (shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest) {
-        if (hasHTTPStatusOK)
-            *hasHTTPStatusOK = false;
+    if (hasHTTPStatusOK)
+        *hasHTTPStatusOK = !shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest;
+    if (shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest)
         return false;
-    }
 
     if (!mimeTypeAllowedByNosniff()) {
         if (hasValidMIMEType)
@@ -172,8 +178,11 @@ bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool*
         return false;
     }
 
-    if (mimeTypeCheckHint == MIMETypeCheckHint::Lax)
+    if (mimeTypeCheckHint == MIMETypeCheckHint::Lax) {
+        if (hasValidMIMEType)
+            *hasValidMIMEType = true;
         return true;
+    }
 
     // This check exactly matches Firefox.  Note that we grab the Content-Type
     // header directly because we want to see what the value is BEFORE content

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -39,7 +39,11 @@ public:
     virtual ~CachedCSSStyleSheet();
 
     enum class MIMETypeCheckHint { Strict, Lax };
-    const String sheetText(MIMETypeCheckHint = MIMETypeCheckHint::Strict, bool* hasValidMIMEType = nullptr, bool* hasHTTPStatusOK = nullptr) const;
+    // This flag control whether to always decode the CSS using UTF-8, ignoring all
+    // other encoding hints. This is needed for loading a CSS stylesheet as a JavaScript
+    // module, as the spec requires assuming UTF-8 encoding.
+    enum class ForceUTF8Encoding : bool { No, Yes };
+    String sheetText(MIMETypeCheckHint = MIMETypeCheckHint::Strict, ForceUTF8Encoding = ForceUTF8Encoding::No, bool* hasValidMIMEType = nullptr, bool* hasHTTPStatusOK = nullptr) const;
 
     RefPtr<StyleSheetContents> restoreParsedStyleSheet(const CSSParserContext&, CachePolicy, FrameLoader&);
     void saveParsedStyleSheet(Ref<StyleSheetContents>&&);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2656,7 +2656,7 @@ def check_namespace_indentation(clean_lines, line_number, file_extension, file_s
 _ALLOW_ALL_UPPERCASE_ENUM = ['JSTokenType']
 
 # Enum value allowlist
-_ALLOW_ABBREVIATION_ENUM_VALUES = ['AM', 'CF', 'COOP', 'GPU', 'JSON', 'LTR', 'PM', 'RTL', 'URL', 'XHR']
+_ALLOW_ABBREVIATION_ENUM_VALUES = ['AM', 'CF', 'COOP', 'CSS', 'GPU', 'JSON', 'LTR', 'PM', 'RTL', 'URL', 'XHR']
 
 
 def check_enum_members(clean_lines, line_number, enum_state, error):


### PR DESCRIPTION
#### 0ade3f61e31b2841ad2af9215ffd40c42b0a624f
<pre>
Implement CSS module scripts
<a href="https://rdar.apple.com/80917329">rdar://80917329</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=227967">https://bugs.webkit.org/show_bug.cgi?id=227967</a>

Reviewed by NOBODY (OOPS!).

This patch implements importing CSS stylesheets as JavaScript modules, using the
`import ... with { type: &apos;css&apos; }` and `import(..., { with: { type: &apos;css&apos; } })`
syntax.

On the JSC side, we add support for the `css` module type, and requests WebCore
to fetch it. WebCore fetches the stylesheet, constructs a CSSStyleSheet object
out of it, wraps it in a JSCSSStyleSheet, and returns it back to JSC as a JSValue.
JSC uses this as the default export value of the CSS module.

To implement this requires some changes in how script modules loading works. The
old way is that JSC asks WebCore to fetch a script, WebCore fetches the source code
and passes it back to JSC. This works for JavaScript/WASM/JSON/text, because those
are JavaScript constructs and must be handled by JSC. However, CSS is a WebCore
constructed and can only be handled by WebCore. This patch changes it so that
depending on the module type, WebCore can either return a source code for types
it can&apos;t handle (e.g JS/WASM/JSON/text.) For types it can handle like CSS,
WebCore constructs the JSValue itself, then passes it to JSC. JSC just takes
the JSValue as the default module export.

This is gated by the CSSModuleScriptsEnabled feature flag, which is disabled
by default.

Tests: imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-allowed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/import-style-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/css-module-parse-error-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/relative-urls-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/repeated-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/resources/should-not-be-loaded.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/tentative/shadowrootadoptedstylesheets/shadowrootadoptedstylesheets-fetched-module-expected.txt:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::scriptTypeForScript):
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp:
(JSC::tryCreateAttributes):
* Source/JavaScriptCore/parser/SourceProvider.h:
(JSC::SourceProvider::isModuleType const):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::moduleType const):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::getSourceType):
(JSC::retrieveTypeImportAttribute):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::moduleRegistryFetchSettled):
(JSC::moduleLoadTopSettled):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::provideFetch):
(JSC::JSModuleLoader::makeModule):
(JSC::moduleTypeCanBeLoaded):
(JSC::JSModuleLoader::importModule):
(JSC::JSModuleLoader::hostLoadImportedModule):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp:
(JSC::ModuleRegistryEntry::provideFetch):
* Source/JavaScriptCore/runtime/ModuleRegistryEntry.h:
* Source/JavaScriptCore/runtime/ScriptFetchParameters.h:
(JSC::ScriptFetchParameters::parseType):
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.h:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
(WebCore::CachedModuleScriptLoader::~CachedModuleScriptLoader):
(WebCore::CachedModuleScriptLoader::load):
(WebCore::CachedModuleScriptLoader::notifyFinished):
(WebCore::CachedModuleScriptLoader::setCSSStyleSheet):
(WebCore::CachedModuleScriptLoader::notifyFinishedInternal):
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestModuleResource const):
(WebCore::CachedScriptFetcher::requestResourceWithCache const):
(WebCore::CachedScriptFetcher::requestModuleScript const): Deleted.
(WebCore::CachedScriptFetcher::requestScriptWithCache const): Deleted.
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::importModule):
(WebCore::createCSSModule):
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::load):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp:
(WebCore::ScriptElementCachedScriptFetcher::requestModuleResource const):
(WebCore::ScriptElementCachedScriptFetcher::requestModuleScript const): Deleted.
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parseAuthorStyleSheet):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::sheetText const):
(WebCore::CachedCSSStyleSheet::canUseSheet const):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:
* Source/JavaScriptCore/API/JSAPIGlobalObject.h:
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::moduleTypeCanBeLoaded):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable):
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable):
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ade3f61e31b2841ad2af9215ffd40c42b0a624f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147329 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12676f42-83b6-41a1-88d5-5b8086e8d952) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56699 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142875 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99223 "3 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/079442ee-f9b5-42c5-9caf-7c948a523968) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123302 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d491412-15eb-4eb1-ac1c-482f038439d2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182367 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45285 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43529 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5272 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12104 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155681 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43164 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4431 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44311 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49611 "Found 1 new failure in runtime/JSModuleLoader.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195199 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163129 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152339 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/media/media-loading-state-timing.sub.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub.html (failure)") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57338 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39783 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152035 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46595 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129607 "Found 1 new failure in runtime/JSModuleLoader.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55846 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18175 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->