### PR TITLE
Stop logging the Launch Services check-in info dictionary on every WebContent process launch

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
@@ -28,6 +28,7 @@
 
 #import "CoreIPCAuditToken.h"
 #import "Logging.h"
+#import <mutex>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -119,11 +120,19 @@ void NetworkConnectionToWebProcess::checkInWebProcess(const CoreIPCAuditToken& a
         return;
     }
 
-    RELEASE_LOG(Process, "Launch Services checkin starting, infoDictionary = %{public}@", (__bridge NSDictionary *)infoDictionary.get());
+    // The info dictionary is identical for every WebContent process, so only log it once per
+    // NetworkProcess. Logging it on every checkin can quarantine this process for high logging
+    // volume when WebContent processes are launched at a high rate.
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [&] {
+        RELEASE_LOG(Process, "Launch Services checkin infoDictionary = %{public}@", (__bridge NSDictionary *)infoDictionary.get());
+    });
 
     auto block = makeBlockPtr([weakThis = WeakPtr { *this }, auditToken = auditToken](CFDictionaryRef result, CFErrorRef error) mutable {
-        NSDictionary *dictionary = (__bridge NSDictionary *)result;
-        RELEASE_LOG(Process, "Launch Services checkin completed, result = %{public}@, error = %{public}@", dictionary, (__bridge NSError *)error);
+        if (error)
+            RELEASE_LOG_ERROR(Process, "Launch Services checkin failed, error = %{public}@", (__bridge NSError *)error);
+        else
+            RELEASE_LOG(Process, "Launch Services checkin completed, result = %{public}@", (__bridge NSDictionary *)result);
 
         callOnMainRunLoop([weakThis = WTF::move(weakThis), auditToken = WTF::move(auditToken)] mutable {
             RefPtr protectedThis = weakThis.get();
@@ -138,7 +147,7 @@ void NetworkConnectionToWebProcess::checkInWebProcess(const CoreIPCAuditToken& a
     Boolean ok = _LSApplicationCheckInProxyPtr()(kLSDefaultSessionID, auditToken.auditToken(), infoDictionary.get(), block.get());
 
     if (!ok)
-        RELEASE_LOG(Process, "Launch Services checkin did not succeed");
+        RELEASE_LOG_ERROR(Process, "Launch Services checkin did not succeed");
 }
 #endif
 


### PR DESCRIPTION
#### 6e03d62f11e65f04577b3acd403b8d3e21b1c4e4
<pre>
Stop logging the Launch Services check-in info dictionary on every WebContent process launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=322261">https://bugs.webkit.org/show_bug.cgi?id=322261</a>

Reviewed by Per Arne Vollan.

NetworkConnectionToWebProcess::checkInWebProcess() runs once per WebContent
process launch and logged the whole Launch Services info dictionary at default
level each time. The dictionary is a copy of the com.apple.WebKit.WebContent.xpc
Info.plist plus a few fixed keys, so it is identical for every process; in the
field it serializes to 1162 bytes per launch.

When WebContent processes launch at a high rate that is enough for
libsystem_trace to quarantine the NetworkProcess (&quot;QUARANTINED DUE TO HIGH
LOGGING VOLUME&quot;), after which it stops logging altogether -- precisely when the
log is needed.

Log the dictionary once per NetworkProcess instead. Also report the two check-in
failure paths as errors, consistent with the existing failure paths in the same
function.

* Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm:
(WebKit::NetworkConnectionToWebProcess::checkInWebProcess):

Canonical link: <a href="https://commits.webkit.org/319672@main">https://commits.webkit.org/319672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aee33d30b1da9da51c29de07a8b0e2346c7621a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146289 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0cbb9679-3817-408f-8afc-36de983dc16a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142062 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98630 "2 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9a5ba3e-2bb1-44fa-bbc9-92fdcc4f4b44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122497 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec5923a6-adb7-4ab5-88d2-9ea0322c0ea3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44426 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42693 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42325 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3350 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194113 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55578 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151477 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56269 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151181 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45747 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128551 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124338 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54780 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17320 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->