### PR TITLE
CanvasBase and CanvasRenderingContexts should discard copies before draws

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -168,7 +168,7 @@ void CanvasCaptureMediaStreamTrack::Source::canvasResized(CanvasBase& canvas)
     setSize(IntSize(canvas.width(), canvas.height()));
 }
 
-void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase&, const FloatRect&)
+void CanvasCaptureMediaStreamTrack::Source::canvasContentsWillChange(CanvasBase&, const FloatRect&)
 {
     // If canvas needs preparation, the capture will be scheduled once document prepares the canvas.
     RefPtr canvas = m_canvas.get();

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -76,7 +76,7 @@ private:
         Source(HTMLCanvasElement&, std::optional<double>&&);
 
         // CanvasObserver overrides.
-        void canvasChanged(CanvasBase&, const FloatRect&) final;
+        void canvasContentsWillChange(CanvasBase&, const FloatRect&) final;
         void canvasResized(CanvasBase&) final;
         void canvasDestroyed(CanvasBase&) final;
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -102,7 +102,7 @@ private:
     static IntSize computeNativeWebGLFramebufferResolution();
     static IntSize computeRecommendedWebGLFramebufferResolution();
 
-    void canvasChanged(CanvasBase&, const FloatRect&) final { };
+    void canvasContentsWillChange(CanvasBase&, const FloatRect&) final { };
     void canvasResized(CanvasBase&) final;
     void canvasDestroyed(CanvasBase&) final { };
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -140,19 +140,19 @@ bool CanvasBase::hasObserver(CanvasObserver& observer) const
     return m_observers.contains(observer);
 }
 
-void CanvasBase::notifyObserversCanvasChanged(const FloatRect& rect)
+void CanvasBase::notifyObserversContentsWillChange(const FloatRect& rect)
 {
     for (CheckedRef observer : m_observers)
-        observer->canvasChanged(*this, rect);
+        observer->canvasContentsWillChange(*this, rect);
 }
 
-void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
+void CanvasBase::willUpdateContents(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     addCanvasNeedingPreparationForDisplayOrFlush();
     IntRect dirtyRect { { }, size() };
     if (rect)
         dirtyRect.intersect(enclosingIntRect(*rect));
-    notifyObserversCanvasChanged(dirtyRect);
+    notifyObserversContentsWillChange(dirtyRect);
 
     // FIXME: We should exclude rects with ShouldApplyPostProcessingToDirtyRect::No
     if (shouldInjectNoiseBeforeReadback()) {

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -90,7 +90,7 @@ public:
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);
     bool NODELETE hasObserver(CanvasObserver&) const;
-    void notifyObserversCanvasChanged(const FloatRect&);
+    void notifyObserversContentsWillChange(const FloatRect&);
     void notifyObserversCanvasResized();
     void notifyObserversCanvasDestroyed(); // Must be called in destruction before clearing m_context.
     void addDisplayBufferObserver(CanvasDisplayBufferObserver&);
@@ -100,9 +100,11 @@ public:
 
     HashSet<Ref<Element>> cssCanvasClients() const;
 
+    // Called before the canvas contents are updated, so that the observers and the pending
+    // readback post-processing are notified of the area that is about to change.
     // !rect means caller knows the full canvas is invalidated previously.
-    void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }
-    virtual void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect);
+    void willUpdateContents(const std::optional<FloatRect>& rect) { return willUpdateContents(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }
+    virtual void willUpdateContents(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect);
 
     virtual Image* copiedImage() const = 0;
     virtual void clearCopiedImage() const = 0;

--- a/Source/WebCore/html/CanvasObserver.h
+++ b/Source/WebCore/html/CanvasObserver.h
@@ -42,7 +42,7 @@ public:
 
     virtual bool isStyleCanvasImage() const { return false; }
 
-    virtual void canvasChanged(CanvasBase&, const FloatRect& changedRect) = 0;
+    virtual void canvasContentsWillChange(CanvasBase&, const FloatRect& changingRect) = 0;
     virtual void canvasResized(CanvasBase&) = 0;
     virtual void canvasDestroyed(CanvasBase&) = 0;
 };

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -58,7 +58,7 @@ public:
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
-    void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
+    void willUpdateContents(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
     void setSizeForControllingContext(IntSize) { };
 
     Image* copiedImage() const final;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -595,7 +595,7 @@ std::optional<FloatRect> HTMLCanvasElement::computeDirtyRectangleIfNeeded(const 
     return dirtyRect;
 }
 
-void HTMLCanvasElement::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
+void HTMLCanvasElement::willUpdateContents(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     clearCopiedImage();
     if (CheckedPtr renderer = renderBox()) {
@@ -605,7 +605,7 @@ void HTMLCanvasElement::didDraw(const std::optional<FloatRect>& rect, ShouldAppl
         else if (dirtyRect)
             renderer->repaintRectangle(enclosingIntRect(*dirtyRect));
     }
-    CanvasBase::didDraw(rect, shouldApplyPostProcessingToDirtyRect);
+    CanvasBase::willUpdateContents(rect, shouldApplyPostProcessingToDirtyRect);
 }
 
 void HTMLCanvasElement::didUpdateSizeProperties()

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -123,7 +123,7 @@ public:
 #endif
 
     // Used for rendering
-    void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final;
+    void willUpdateContents(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final;
 
     void paint(GraphicsContext&, const LayoutRect&);
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -348,11 +348,11 @@ void OffscreenCanvas::convertToBlob(ImageEncodeOptions&& options, Ref<DeferredPr
     promise->resolveWithNewlyCreated<IDLInterface<Blob>>(WTF::move(blob));
 }
 
-void OffscreenCanvas::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
+void OffscreenCanvas::willUpdateContents(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     clearCopiedImage();
     scheduleCommitToPlaceholderCanvas();
-    CanvasBase::didDraw(rect, shouldApplyPostProcessingToDirtyRect);
+    CanvasBase::willUpdateContents(rect, shouldApplyPostProcessingToDirtyRect);
 }
 
 Image* OffscreenCanvas::copiedImage() const

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -142,7 +142,7 @@ public:
     ExceptionOr<RefPtr<ImageBitmap>> transferToImageBitmap();
     void convertToBlob(ImageEncodeOptions&&, Ref<DeferredPromise>&&);
 
-    void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final;
+    void willUpdateContents(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final;
 
     Image* copiedImage() const final;
     void clearCopiedImage() const final;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -174,8 +174,8 @@ void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Eleme
         return;
     CheckedPtr canvasStyle = canvas->computedStyle();
     auto zoomFactor = canvasStyle ? canvasStyle->usedZoom() : 1.f;
+    willUpdateEntireContents();
     context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(protect(element.document())->styleColorOptions(canvasStyle)), zoomFactor);
-    didDrawEntireCanvas();
 
     if (CheckedPtr cache = element.document().existingAXObjectCache()) {
         auto pathBounds = path.boundingRect();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -607,11 +607,12 @@ void CanvasRenderingContext2DBase::beginLayer()
 
 void CanvasRenderingContext2DBase::endLayer()
 {
-    // The destructor of CanvasLayerContextSwitcher composites the layer to the destination context.
     realizeSaves();
-    restore();
 
-    didDrawEntireCanvas();
+    willUpdateEntireContents();
+
+    // The destructor of CanvasLayerContextSwitcher composites the layer to the destination context.
+    restore();
 }
 
 void CanvasRenderingContext2DBase::setStrokeColorImpl(Color&& color, String&& unparsedColor)
@@ -1188,22 +1189,19 @@ void CanvasRenderingContext2DBase::fillInternal(const Path& path, CanvasFillRule
     auto savedFillRule = c->fillRule();
     c->setFillRule(toWindRule(windingRule));
 
-    bool repaintEntireCanvas = false;
     if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents();
         beginCompositeLayer();
         c->fillPath(path);
         endCompositeLayer();
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents();
         clearCanvas();
         c->fillPath(path);
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect());
         c->fillPath(path);
-
-    didDraw(repaintEntireCanvas, [&] {
-        return targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect();
-    });
+    }
 
     c->setFillRule(savedFillRule);
 }
@@ -1227,22 +1225,19 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
     if (path.isEmpty())
         return;
 
-    bool repaintEntireCanvas = false;
     if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents();
         beginCompositeLayer();
         c->strokePath(path);
         endCompositeLayer();
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents();
         clearCanvas();
         c->strokePath(path);
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect()));
         c->strokePath(path);
-
-    didDraw(repaintEntireCanvas, [&] {
-        return targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect());
-    });
+    }
 }
 
 void CanvasRenderingContext2DBase::clipInternal(const Path& path, CanvasFillRule windingRule)
@@ -1344,6 +1339,8 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
         return;
     FloatRect rect(x, y, width, height);
 
+    willUpdateContents(rect, defaultWillUpdateContentsOptionsWithoutPostProcessing());
+
     bool saved = false;
     if (shouldDrawShadows()) {
         context->save();
@@ -1367,7 +1364,6 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
     context->clearRect(rect);
     if (saved)
         context->restore();
-    didDraw(rect, defaultDidDrawOptionsWithoutPostProcessing());
 }
 
 void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, double height)
@@ -1392,8 +1388,8 @@ void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, do
     if (gradient && gradient->isZeroSize())
         return;
 
-    bool repaintEntireCanvas = false;
     if (rectContainsCanvas(rect)) {
+        willUpdateEntireContents();
 #if USE(SKIA)
         const bool needsCompositeLayer = shouldDrawShadows() && isFullCanvasCompositeMode(state().globalComposite);
         if (needsCompositeLayer)
@@ -1404,20 +1400,19 @@ void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, do
         if (needsCompositeLayer)
             endCompositeLayer();
 #endif
-        repaintEntireCanvas = true;
     } else if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents();
         beginCompositeLayer();
         c->fillRect(rect);
         endCompositeLayer();
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents();
         clearCanvas();
         c->fillRect(rect);
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : rect);
         c->fillRect(rect);
-
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : rect);
+    }
 }
 
 void CanvasRenderingContext2DBase::strokeRect(double x, double y, double width, double height)
@@ -1444,20 +1439,19 @@ void CanvasRenderingContext2DBase::strokeRect(double x, double y, double width, 
     if (gradient && gradient->isZeroSize())
         return;
 
-    bool repaintEntireCanvas = false;
     if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents();
         beginCompositeLayer();
         c->strokeRect(rect, state().lineWidth);
         endCompositeLayer();
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents();
         clearCanvas();
         c->strokeRect(rect, state().lineWidth);
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect);
         c->strokeRect(rect, state().lineWidth);
-
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect);
+    }
 }
 
 void CanvasRenderingContext2DBase::setShadow(float width, float height, float blur, const String& colorString, std::optional<float> alpha)
@@ -1713,13 +1707,15 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(WebCodecsVideoFrame& f
     if (!internalFrame)
         return { };
 
+    auto normalizedDstRect = normalizeRect(dstRect);
+    // FIXME: Can we avoid post-processing in any cases?
+    if (rectContainsCanvas(normalizedDstRect))
+        willUpdateEntireContents();
+    else
+        willUpdateContents(normalizedDstRect);
+
     // FIXME: Add support for srcRect
     context->drawVideoFrame(*internalFrame, dstRect, ImageOrientation::Orientation::None, frame.shoudlDiscardAlpha());
-
-    auto normalizedDstRect = normalizeRect(dstRect);
-    bool repaintEntireCanvas = rectContainsCanvas(normalizedDstRect);
-    // FIXME: Can we avoid post-processing in any cases?
-    didDraw(repaintEntireCanvas, normalizedDstRect);
 
     return { };
 }
@@ -1785,21 +1781,22 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
         document.settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
     };
 
-    bool repaintEntireCanvas = false;
+    auto willUpdateContentsOptions = shouldPostProcess ? defaultWillUpdateContentsOptions() : defaultWillUpdateContentsOptionsWithoutPostProcessing();
+
     if (rectContainsCanvas(normalizedDstRect)) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         c->drawImage(*image, normalizedDstRect, normalizedSrcRect, options);
-        repaintEntireCanvas = true;
     } else if (isFullCanvasCompositeMode(op)) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         fullCanvasCompositedDrawImage(*image, normalizedDstRect, normalizedSrcRect, op);
-        repaintEntireCanvas = true;
     } else if (op == CompositeOperator::Copy) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         clearCanvas();
         c->drawImage(*image, normalizedDstRect, normalizedSrcRect, options);
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, willUpdateContentsOptions);
         c->drawImage(*image, normalizedDstRect, normalizedSrcRect, options);
-
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, shouldPostProcess ? defaultDidDrawOptions() : defaultDidDrawOptionsWithoutPostProcessing());
+    }
 
     return { };
 }
@@ -1838,14 +1835,17 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     if (!buffer)
         return { };
 
-    bool repaintEntireCanvas = false;
+    auto shouldUseDrawOptionsWithoutPostProcessing = sourceCanvas.renderingContext() && sourceCanvas.renderingContext()->is2d() && !sourceCanvas.havePendingCanvasNoiseInjection();
+    auto willUpdateContentsOptions = shouldUseDrawOptionsWithoutPostProcessing ? defaultWillUpdateContentsOptionsWithoutPostProcessing() : defaultWillUpdateContentsOptions();
+
     if (rectContainsCanvas(normalizedDstRect)) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
-        repaintEntireCanvas = true;
     } else if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         fullCanvasCompositedDrawImage(*buffer, normalizedDstRect, normalizedSrcRect, state().globalComposite);
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents(willUpdateContentsOptions);
         if (&sourceCanvas == &canvasBase()) {
             if (auto copy = createCompatibleImageBuffer(*c, normalizedSrcRect.size())) {
                 copy->context().drawImageBuffer(*buffer, -normalizedSrcRect.location());
@@ -1856,12 +1856,10 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
             clearCanvas();
             c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
         }
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, willUpdateContentsOptions);
         c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
-
-    auto shouldUseDrawOptionsWithoutPostProcessing = sourceCanvas.renderingContext() && sourceCanvas.renderingContext()->is2d() && !sourceCanvas.havePendingCanvasNoiseInjection();
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, shouldUseDrawOptionsWithoutPostProcessing ? defaultDidDrawOptionsWithoutPostProcessing() : defaultDidDrawOptions());
+    }
 
     return { };
 }
@@ -1895,14 +1893,15 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
 
     checkOrigin(&video);
 
-    bool repaintEntireCanvas = rectContainsCanvas(normalizedDstRect);
+    if (rectContainsCanvas(normalizedDstRect))
+        willUpdateEntireContents(defaultWillUpdateContentsOptionsWithoutPostProcessing());
+    else
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, defaultWillUpdateContentsOptionsWithoutPostProcessing());
 
 #if USE(CG)
     if (c->hasPlatformContext() && video.shouldGetNativeImageForCanvasDrawing()) {
         if (auto image = video.nativeImageForCurrentTime()) {
             c->drawNativeImage(*image, normalizedDstRect, normalizedSrcRect);
-
-            didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
             return { };
         }
     }
@@ -1916,7 +1915,6 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
     video.paintCurrentFrameInContext(*c, FloatRect(FloatPoint(), size(video)));
     stateSaver.restore();
 
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
     return { };
 }
 
@@ -1951,21 +1949,21 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
 
     checkOrigin(&imageBitmap);
 
-    bool repaintEntireCanvas = false;
     if (rectContainsCanvas(dstRect)) {
+        willUpdateEntireContents(defaultWillUpdateContentsOptionsWithoutPostProcessing());
         c->drawImageBuffer(*buffer, dstRect, srcRect, { state().globalComposite, state().globalBlend });
-        repaintEntireCanvas = true;
     } else if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents(defaultWillUpdateContentsOptionsWithoutPostProcessing());
         fullCanvasCompositedDrawImage(*buffer, dstRect, srcRect, state().globalComposite);
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents(defaultWillUpdateContentsOptionsWithoutPostProcessing());
         clearCanvas();
         c->drawImageBuffer(*buffer, dstRect, srcRect, { state().globalComposite, state().globalBlend });
-        repaintEntireCanvas = true;
-    } else
+    } else {
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : dstRect, defaultWillUpdateContentsOptionsWithoutPostProcessing());
         c->drawImageBuffer(*buffer, dstRect, srcRect, { state().globalComposite, state().globalBlend });
+    }
 
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : dstRect, defaultDidDrawOptionsWithoutPostProcessing());
     return { };
 }
 
@@ -2368,14 +2366,21 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(C
     return Exception { ExceptionCode::TypeError };
 }
 
-void CanvasRenderingContext2DBase::didDrawEntireCanvas(OptionSet<DidDrawOption> options)
+void CanvasRenderingContext2DBase::willUpdateEntireContents(OptionSet<WillUpdateContentsOption> options)
 {
-    didDraw(backingStoreBounds(), options);
+    if (isEntireBackingStoreDirty()) {
+        willUpdateContents(std::nullopt, options);
+        return;
+    }
+    // backingStoreBounds() is already in backing store coordinates, so neither the current
+    // transform nor the shadow expand it.
+    options.remove({ WillUpdateContentsOption::ApplyTransform, WillUpdateContentsOption::ApplyShadow });
+    willUpdateContents(backingStoreBounds(), options);
 }
 
-void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, OptionSet<DidDrawOption> options)
+void CanvasRenderingContext2DBase::willUpdateContents(std::optional<FloatRect> rect, OptionSet<WillUpdateContentsOption> options)
 {
-    if (!options.contains(DidDrawOption::PreserveCachedContents))
+    if (!options.contains(WillUpdateContentsOption::PreserveCachedContents))
         m_cachedContents.emplace<CachedContentsUnknown>();
 
     auto* context = effectiveDrawingContext();
@@ -2384,10 +2389,10 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
 
     m_hasDeferredOperations = true;
 
-    auto shouldApplyPostProcessing = options.contains(DidDrawOption::ApplyPostProcessing) ? ShouldApplyPostProcessingToDirtyRect::Yes : ShouldApplyPostProcessingToDirtyRect::No;
+    auto shouldApplyPostProcessing = options.contains(WillUpdateContentsOption::ApplyPostProcessing) ? ShouldApplyPostProcessingToDirtyRect::Yes : ShouldApplyPostProcessingToDirtyRect::No;
 
     if (!rect) {
-        protect(canvasBase())->didDraw(std::nullopt, shouldApplyPostProcessing);
+        protect(canvasBase())->willUpdateContents(std::nullopt, shouldApplyPostProcessing);
         return;
     }
 
@@ -2395,13 +2400,13 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     if (dirtyRect.isEmpty())
         return;
 
-    if (!hasInvertibleTransform()) [[unlikely]]
-        return;
-
-    if (options.contains(DidDrawOption::ApplyTransform))
+    if (options.contains(WillUpdateContentsOption::ApplyTransform)) {
+        if (!hasInvertibleTransform()) [[unlikely]]
+            return;
         dirtyRect = state().transform.mapRect(dirtyRect);
+    }
 
-    if (options.contains(DidDrawOption::ApplyShadow) && state().shadowColor.isVisible()) {
+    if (options.contains(WillUpdateContentsOption::ApplyShadow) && state().shadowColor.isVisible()) {
         // The shadow gets applied after transformation
         auto shadowRect = dirtyRect;
         shadowRect.move(state().shadowOffset);
@@ -2412,7 +2417,7 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
 #if !USE(COORDINATED_GRAPHICS)
     // FIXME: This does not apply the clip because we have no way of reading the clip out of the GraphicsContext.
     if (m_dirtyRect.contains(dirtyRect))
-        protect(canvasBase())->didDraw(std::nullopt, shouldApplyPostProcessing);
+        protect(canvasBase())->willUpdateContents(std::nullopt, shouldApplyPostProcessing);
     else
 #endif
     {
@@ -2427,29 +2432,8 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
 #else
         m_dirtyRect.unite(dirtyRect);
 #endif
-        protect(canvasBase())->didDraw(m_dirtyRect, shouldApplyPostProcessing);
+        protect(canvasBase())->willUpdateContents(m_dirtyRect, shouldApplyPostProcessing);
     }
-}
-
-void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, const FloatRect& rect, OptionSet<DidDrawOption> options)
-{
-    return didDraw(entireCanvas, [&] {
-        return rect;
-    }, options);
-}
-
-template<typename RectProvider>
-void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, NOESCAPE const RectProvider& rectProvider, OptionSet<DidDrawOption> options)
-{
-    if (isEntireBackingStoreDirty())
-        didDraw(std::nullopt, options);
-    else if (entireCanvas) {
-        OptionSet<DidDrawOption> didDrawEntireCanvasOptions { DidDrawOption::ApplyClip };
-        if (options.contains(DidDrawOption::ApplyPostProcessing))
-            didDrawEntireCanvasOptions.add(DidDrawOption::ApplyPostProcessing);
-        didDrawEntireCanvas(didDrawEntireCanvasOptions);
-    } else
-        didDraw(rectProvider(), options);
 }
 
 void CanvasRenderingContext2DBase::clearAccumulatedDirtyRect()
@@ -2711,21 +2695,20 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy,
     IntRect destRect { dirtyX, dirtyY, dirtyWidth, dirtyHeight };
     IntRect sourceRect = computeImageDataRect(*buffer, data.size(), destRect, destOffset);
 
-    OptionSet<DidDrawOption> options; // ignore transform, shadow, clip, and post-processing
-    if (!sourceRect.isEmpty()) {
-        RefPtr<PixelBuffer> pixelBuffer = cacheImageDataIfPossible(data, sourceRect, destOffset);
-        if (pixelBuffer)
-            options.add(DidDrawOption::PreserveCachedContents);
-        else
+    if (sourceRect.isEmpty())
+        return;
+    OptionSet<WillUpdateContentsOption> options;
+    RefPtr<PixelBuffer> pixelBuffer = cacheImageDataIfPossible(data, sourceRect, destOffset);
+    if (pixelBuffer)
+        options.add(WillUpdateContentsOption::PreserveCachedContents);
+    else
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-            pixelBuffer = data.pixelBuffer();
+        pixelBuffer = data.pixelBuffer();
 #else
-            pixelBuffer = data.byteArrayPixelBuffer();
+        pixelBuffer = data.byteArrayPixelBuffer();
 #endif
-        buffer->putPixelBuffer(*pixelBuffer, sourceRect, destOffset);
-    }
-
-    didDraw(FloatRect { destRect }, options);
+    willUpdateContents(FloatRect { destRect }, options);
+    buffer->putPixelBuffer(*pixelBuffer, sourceRect, destOffset);
 }
 
 FloatRect CanvasRenderingContext2DBase::inflatedStrokeRect(const FloatRect& rect) const
@@ -2974,6 +2957,8 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     if (drawStyle.canvasGradient() || drawStyle.canvasPattern()) {
         IntRect maskRect = enclosingIntRect(textRect);
 
+        willUpdateContents(FloatRect { maskRect });
+
         // If we have a shadow, we need to draw it before the mask operation.
         // Follow a procedure similar to paintTextWithShadows in TextPainter.
 
@@ -3032,7 +3017,6 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
         else
             c->setFillPattern(drawStyle.canvasPattern()->pattern());
         c->fillRect(maskRect);
-        didDraw(false, FloatRect { maskRect });
         return;
     }
 #endif
@@ -3047,24 +3031,22 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
         location = FloatPoint();
     }
 
-    bool repaintEntireCanvas = false;
     if (isFullCanvasCompositeMode(state().globalComposite)) {
+        willUpdateEntireContents();
         beginCompositeLayer();
         drawText(*c, location);
         endCompositeLayer();
-        repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
+        willUpdateEntireContents();
         clearCanvas();
         drawText(*c, location);
-        repaintEntireCanvas = true;
     } else {
         auto clipBounds = c->clipBounds();
         if ((clipBounds.isEmpty() || (!useMaxWidth && !textRect.isEmpty() && !clipBounds.intersects(enclosingIntRect(textRect)))) && !shouldDrawShadows())
             return;
+        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : textRect);
         drawText(*c, location);
     }
-
-    didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : textRect);
 }
 
 Ref<TextMetrics> CanvasRenderingContext2DBase::measureTextInternal(const String& text)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -363,7 +363,7 @@ protected:
     GraphicsContext* effectiveDrawingContext() const;
     AffineTransform baseTransform() const;
 
-    enum class DidDrawOption {
+    enum class WillUpdateContentsOption {
         ApplyTransform = 1 << 0,
         ApplyShadow = 1 << 1,
         ApplyClip = 1 << 2,
@@ -371,28 +371,26 @@ protected:
         PreserveCachedContents = 1 << 4,
     };
 
-    static constexpr OptionSet<DidDrawOption> defaultDidDrawOptions()
+    static constexpr OptionSet<WillUpdateContentsOption> defaultWillUpdateContentsOptions()
     {
         return {
-            DidDrawOption::ApplyTransform,
-            DidDrawOption::ApplyShadow,
-            DidDrawOption::ApplyClip,
-            DidDrawOption::ApplyPostProcessing,
+            WillUpdateContentsOption::ApplyTransform,
+            WillUpdateContentsOption::ApplyShadow,
+            WillUpdateContentsOption::ApplyClip,
+            WillUpdateContentsOption::ApplyPostProcessing,
         };
     }
 
-    static constexpr OptionSet<DidDrawOption> defaultDidDrawOptionsWithoutPostProcessing()
+    static constexpr OptionSet<WillUpdateContentsOption> defaultWillUpdateContentsOptionsWithoutPostProcessing()
     {
         return {
-            DidDrawOption::ApplyTransform,
-            DidDrawOption::ApplyShadow,
-            DidDrawOption::ApplyClip,
+            WillUpdateContentsOption::ApplyTransform,
+            WillUpdateContentsOption::ApplyShadow,
+            WillUpdateContentsOption::ApplyClip,
         };
     }
-    void didDraw(std::optional<FloatRect>, OptionSet<DidDrawOption> = defaultDidDrawOptions());
-    void didDrawEntireCanvas(OptionSet<DidDrawOption> options = defaultDidDrawOptions());
-    void didDraw(bool entireCanvas, const FloatRect&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
-    template<typename RectProvider> void didDraw(bool entireCanvas, NOESCAPE const RectProvider&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
+    void willUpdateContents(std::optional<FloatRect>, OptionSet<WillUpdateContentsOption> = defaultWillUpdateContentsOptions());
+    void willUpdateEntireContents(OptionSet<WillUpdateContentsOption> options = defaultWillUpdateContentsOptions());
 
     virtual std::optional<Style::Filter> setFilterStringWithoutUpdatingStyle(const String&) { return std::nullopt; }
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
@@ -44,10 +44,10 @@ HTMLCanvasElement* GPUBasedCanvasRenderingContext::htmlCanvas() const
     return dynamicDowncast<HTMLCanvasElement>(canvasBase());
 }
 
-void GPUBasedCanvasRenderingContext::markCanvasChanged()
+void GPUBasedCanvasRenderingContext::willUpdateCanvasContents()
 {
     Ref canvas = canvasBase();
-    canvas->didDraw(FloatRect { { }, canvas->size() }, ShouldApplyPostProcessingToDirtyRect::No);
+    canvas->willUpdateContents(FloatRect { { }, canvas->size() }, ShouldApplyPostProcessingToDirtyRect::No);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -45,7 +45,7 @@ protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);
 
     HTMLCanvasElement* NODELETE htmlCanvas() const;
-    void markCanvasChanged();
+    void willUpdateCanvasContents();
 };
     
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -84,7 +84,7 @@ public:
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&, Document*);
 
-    void markContextChangedAndNotifyCanvasObservers();
+    void willUpdateDisplayBufferContents();
 
     bool isConfigured() const
     {

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -615,7 +615,7 @@ ExceptionOr<Ref<GPUTexture>> GPUCanvasContextCocoa::getCurrentTexture()
     if (currentTexture)
         return currentTexture.releaseNonNull();
 
-    markContextChangedAndNotifyCanvasObservers();
+    willUpdateDisplayBufferContents();
     m_currentTexture = m_presentationContext->getCurrentTexture(m_configuration->frameCount);
     currentTexture = m_currentTexture;
     return currentTexture.releaseNonNull();
@@ -722,14 +722,14 @@ std::optional<FramesPerSecond> GPUCanvasContextCocoa::preferredRenderingUpdateFr
     return m_framePacer.preferredFramesPerSecond(MonotonicTime::now());
 }
 
-void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
+void GPUCanvasContextCocoa::willUpdateDisplayBufferContents()
 {
     m_compositingResultsNeedsUpdating = true;
     if (m_readDisplayBuffer) {
         m_readDisplayBuffer = nullptr;
         updateMemoryCost();
     }
-    markCanvasChanged();
+    willUpdateCanvasContents();
 }
 
 void GPUCanvasContextCocoa::updateMemoryCost() const

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -77,6 +77,7 @@ ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<Im
         return { };
 
     Ref canvasBase = this->canvasBase();
+    canvasBase->willUpdateContents(FloatRect { { }, canvasBase->size() });
     if (originClean)
         canvasBase->setOriginClean();
     else
@@ -90,7 +91,6 @@ ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<Im
         m_buffer = nullptr;
         updateMemoryCost(0);
     }
-    canvasBase->didDraw(FloatRect { { }, canvasBase->size() });
     return { };
 }
 
@@ -100,10 +100,10 @@ RefPtr<ImageBuffer> ImageBitmapRenderingContext::transferToImageBuffer()
     auto size = canvasBase->size();
     if (!m_buffer)
         return ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    canvasBase->willUpdateContents(FloatRect { { }, size });
     RefPtr result = std::exchange(m_buffer, { });
     updateMemoryCost(0);
     canvasBase->setOriginClean();
-    canvasBase->didDraw(FloatRect { { }, size });
     return result;
 }
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -133,17 +133,17 @@ void PlaceholderRenderingContext::setContentsToLayer(GraphicsLayer& layer)
 
 void PlaceholderRenderingContext::setPlaceholderBuffer(Ref<ImageBuffer>&& newBuffer, bool originClean, bool opaque)
 {
-    m_opaque = opaque;
     IntSize newSize = newBuffer->truncatedLogicalSize();
+    Ref canvas = this->canvas();
+    canvas->willUpdateContents(FloatRect { { }, newSize }, ShouldApplyPostProcessingToDirtyRect::No);
+    m_opaque = opaque;
     updateMemoryCost(newBuffer->memoryCost());
     m_buffer = WTF::move(newBuffer);
-    Ref canvas = this->canvas();
     canvas->setSizeForControllingContext(newSize);
     if (originClean)
         canvas->setOriginClean();
     else
         canvas->setOriginTainted();
-    canvas->didDraw(FloatRect { { }, newSize }, ShouldApplyPostProcessingToDirtyRect::No);
 }
 
 PixelFormat PlaceholderRenderingContext::pixelFormat() const

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -666,8 +666,8 @@ void WebGL2RenderingContext::blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLi
 {
     if (isContextLost())
         return;
+    willUpdateDrawingBufferContents(CallerTypeOther);
     protect(graphicsContextGL())->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
-    markContextChangedAndNotifyCanvasObserver(CallerTypeOther);
 }
 
 void WebGL2RenderingContext::deleteFramebuffer(WebGLFramebuffer* framebuffer)
@@ -1598,6 +1598,7 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
     if (m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *protect(m_currentProgram)))
         return;
 
+    willUpdateDrawingBufferContents();
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
@@ -1605,8 +1606,6 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
 
         protect(graphicsContextGL())->drawRangeElements(mode, start, end, count, type, offset);
     }
-
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
@@ -1666,6 +1665,9 @@ void WebGL2RenderingContext::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, 
     if (!data)
         return;
 
+    // This might be used to clear the stencil buffer of the default back buffer.
+    // Notification is required to update the canvas.
+    willUpdateDrawingBufferContents();
     // Flush any pending implicit clears. This cannot be done after the
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);
@@ -1695,15 +1697,14 @@ void WebGL2RenderingContext::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, 
     if (!data)
         return;
 
+    // This might be used to clear the color buffer of the default back buffer.
+    // Notification is required to update the canvas.
+    willUpdateDrawingBufferContents();
     // Flush any pending implicit clears. This cannot be done after the
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);
 
     protect(graphicsContextGL())->clearBufferfv(buffer, drawbuffer, data.value());
-
-    // This might have been used to clear the color buffer of the default
-    // back buffer. Notification is required to update the canvas.
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGL2RenderingContext::clearBufferfi(GCGLenum buffer, GCGLint drawbuffer, GCGLfloat depth, GCGLint stencil)
@@ -1711,6 +1712,9 @@ void WebGL2RenderingContext::clearBufferfi(GCGLenum buffer, GCGLint drawbuffer, 
     if (isContextLost())
         return;
 
+    // This might be used to clear the depth and stencil buffers of the default back buffer.
+    // Notification is required to update the canvas.
+    willUpdateDrawingBufferContents();
     // Flush any pending implicit clears. This cannot be done after the
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
@@ -61,6 +61,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -68,8 +69,6 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
 
         protect(context->graphicsContextGL())->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBaseInstanceWEBGL(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei instanceCount, GCGLint baseVertex, GCGLuint baseInstance)
@@ -84,6 +83,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -91,8 +91,6 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
 
         protect(context->graphicsContextGL())->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -73,6 +73,7 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -80,8 +81,6 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
 
         protect(context->graphicsContextGL())->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), static_cast<size_t>(drawcount) });
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& firstsList, GCGLuint firstsOffset, Int32List&& countsList, GCGLuint countsOffset, Int32List&& instanceCountsList, GCGLuint instanceCountsOffset, GCGLsizei drawcount)
@@ -103,6 +102,7 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -110,8 +110,6 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
 
         protect(context->graphicsContextGL())->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) });
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsList, GCGLuint countsOffset, GCGLenum type, Int32List&& offsetsList, GCGLuint offsetsOffset, GCGLsizei drawcount)
@@ -132,6 +130,7 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -139,8 +138,6 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
 
         protect(context->graphicsContextGL())->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& countsList, GCGLuint countsOffset, GCGLenum type, Int32List&& offsetsList, GCGLuint offsetsOffset, Int32List&& instanceCountsList, GCGLuint instanceCountsOffset, GCGLsizei drawcount)
@@ -162,6 +159,7 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -169,8 +167,6 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
 
         protect(context->graphicsContextGL())->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 bool WebGLMultiDraw::validateDrawcount(WebGLRenderingContextBase& context, ASCIILiteral functionName, GCGLsizei drawcount)

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -74,6 +74,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -81,8 +82,6 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
 
         protect(context->graphicsContextGL())->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) });
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GCGLenum mode, Int32List&& countsList, GCGLuint countsOffset, GCGLenum type, Int32List&& offsetsList, GCGLuint offsetsOffset, Int32List&& instanceCountsList, GCGLuint instanceCountsOffset, Int32List&& baseVerticesList, GCGLuint baseVerticesOffset, Uint32List&& baseInstancesList, GCGLuint baseInstancesOffset, GCGLsizei drawcount)
@@ -106,6 +105,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
     if (RefPtr currentProgram = context->m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(context.get(), *currentProgram))
         return;
 
+    context->willUpdateDrawingBufferContents();
     context->clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
@@ -113,8 +113,6 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
 
         protect(context->graphicsContextGL())->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseVerticesList.span().subspan(baseVerticesOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
-
-    context->markContextChangedAndNotifyCanvasObserver();
 }
 
 bool WebGLMultiDrawInstancedBaseVertexBaseInstance::validateDrawcount(WebGLRenderingContextBase& context, ASCIILiteral functionName, GCGLsizei drawcount)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -678,7 +678,7 @@ void WebGLRenderingContextBase::destroyGraphicsContextGL()
     }
 }
 
-void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLRenderingContextBase::CallerType caller)
+void WebGLRenderingContextBase::willUpdateDrawingBufferContents(WebGLRenderingContextBase::CallerType caller)
 {
     // Draw and clear ops with rasterizer discard enabled do not change the canvas.
     if (caller == CallerTypeDrawOrClear && m_rasterizerDiscardEnabled)
@@ -693,7 +693,7 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
         m_readDrawingBuffer = nullptr;
         updateMemoryCost();
     }
-    markCanvasChanged();
+    willUpdateCanvasContents();
 }
 
 bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::CallerType caller, GCGLbitfield mask)
@@ -1269,9 +1269,10 @@ void WebGLRenderingContextBase::clear(GCGLbitfield mask)
 {
     if (isContextLost())
         return;
-    if (!clearIfComposited(CallerTypeDrawOrClear, mask))
+    willUpdateDrawingBufferContents();
+    bool cleared = clearIfComposited(CallerTypeDrawOrClear, mask);
+    if (!cleared)
         protect(graphicsContextGL())->clear(mask);
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLRenderingContextBase::clearColor(GCGLfloat r, GCGLfloat g, GCGLfloat b, GCGLfloat a)
@@ -1642,14 +1643,13 @@ void WebGLRenderingContextBase::drawArrays(GCGLenum mode, GCGLint first, GCGLsiz
     if (RefPtr currentProgram = m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *currentProgram))
         return;
 
+    willUpdateDrawingBufferContents();
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
         protect(graphicsContextGL())->drawArrays(mode, first, count);
     }
-
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLRenderingContextBase::drawElements(GCGLenum mode, GCGLsizei count, GCGLenum type, long long offset)
@@ -1662,13 +1662,13 @@ void WebGLRenderingContextBase::drawElements(GCGLenum mode, GCGLsizei count, GCG
     if (RefPtr currentProgram = m_currentProgram; currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *currentProgram))
         return;
 
+    willUpdateDrawingBufferContents();
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
         protect(graphicsContextGL())->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
     }
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLRenderingContextBase::enable(GCGLenum cap)
@@ -5461,14 +5461,13 @@ void WebGLRenderingContextBase::drawArraysInstanced(GCGLenum mode, GCGLint first
     if (currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *currentProgram))
         return;
 
+    willUpdateDrawingBufferContents();
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
         protect(graphicsContextGL())->drawArraysInstanced(mode, first, count, primcount);
     }
-
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLRenderingContextBase::drawElementsInstanced(GCGLenum mode, GCGLsizei count, GCGLenum type, long long offset, GCGLsizei primcount)
@@ -5482,14 +5481,13 @@ void WebGLRenderingContextBase::drawElementsInstanced(GCGLenum mode, GCGLsizei c
     if (currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *currentProgram))
         return;
 
+    willUpdateDrawingBufferContents();
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
         protect(graphicsContextGL())->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
     }
-
-    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLRenderingContextBase::vertexAttribDivisor(GCGLuint index, GCGLuint divisor)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -561,7 +561,7 @@ protected:
         CallerTypeOther,
     };
 
-    void markContextChangedAndNotifyCanvasObserver(CallerType = CallerTypeDrawOrClear);
+    void willUpdateDrawingBufferContents(CallerType = CallerTypeDrawOrClear);
 
     void addActivityStateChangeObserverIfNecessary();
     void removeActivityStateChangeObserver();

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -336,7 +336,7 @@ size_t InspectorCanvas::memoryCost() const
     );
 }
 
-void InspectorCanvas::canvasChanged()
+void InspectorCanvas::canvasContentsWillChange()
 {
     Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
     if (!context->hasActiveInspectorCanvasCallTracer())

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -85,7 +85,7 @@ public:
     HashSet<Ref<Element>> cssCanvasClientNodes() const;
     size_t memoryCost() const;
 
-    void canvasChanged();
+    void canvasContentsWillChange();
 
     bool hasActiveInspectorCanvasCallTracer() const;
     void setHasActiveInspectorCanvasCallTracer(bool);

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -457,7 +457,7 @@ void InspectorCanvasAgent::didChangeCanvasMemory(const CanvasRenderingContext& c
     m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->memoryCost());
 }
 
-void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)
+void InspectorCanvasAgent::canvasContentsWillChange(CanvasBase& canvasBase, const FloatRect&)
 {
     RefPtr context = canvasBase.renderingContext();
     if (!context)
@@ -468,7 +468,7 @@ void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect
     if (!inspectorCanvas)
         return;
 
-    inspectorCanvas->canvasChanged();
+    inspectorCanvas->canvasContentsWillChange();
 }
 
 void InspectorCanvasAgent::canvasDestroyed(CanvasBase& canvasBase)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -95,7 +95,7 @@ public:
     void setShaderProgramHighlighted(const Inspector::Protocol::Canvas::ProgramId&, bool highlighted, Ref<SetShaderProgramHighlightedCallback>&&);
 
     // CanvasObserver
-    void canvasChanged(CanvasBase&, const FloatRect&) final;
+    void canvasContentsWillChange(CanvasBase&, const FloatRect&) final;
     void canvasResized(CanvasBase&) final { }
     void canvasDestroyed(CanvasBase&) final;
 

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
@@ -119,12 +119,12 @@ void CanvasImage::didRemoveClient(RenderElement& renderer)
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 
-void CanvasImage::canvasChanged(CanvasBase& canvasBase, const FloatRect& changedRect)
+void CanvasImage::canvasContentsWillChange(CanvasBase& canvasBase, const FloatRect& changingRect)
 {
     ASSERT_UNUSED(canvasBase, is<HTMLCanvasElement>(canvasBase));
     ASSERT_UNUSED(canvasBase, m_element == &downcast<HTMLCanvasElement>(canvasBase));
 
-    auto imageChangeRect = enclosingIntRect(changedRect);
+    auto imageChangeRect = enclosingIntRect(changingRect);
     for (auto entry : clients()) {
         auto& client = entry.key;
         client.imageChanged(static_cast<WrappedImagePtr>(this), &imageChangeRect);

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
@@ -74,7 +74,7 @@ private:
 
     // CanvasObserver.
     bool isStyleCanvasImage() const final { return true; }
-    void canvasChanged(CanvasBase&, const FloatRect&) final;
+    void canvasContentsWillChange(CanvasBase&, const FloatRect&) final;
     void canvasResized(CanvasBase&) final;
     void canvasDestroyed(CanvasBase&) final;
 


### PR DESCRIPTION
#### 4d58ca82d511855cd877e82d432872e7068fa0a3
<pre>
CanvasBase and CanvasRenderingContexts should discard copies before draws
<a href="https://bugs.webkit.org/show_bug.cgi?id=322263">https://bugs.webkit.org/show_bug.cgi?id=322263</a>
<a href="https://rdar.apple.com/185498825">rdar://185498825</a>

Reviewed by Dan Glastonbury.

OffscreenCanvas, HTMLCanvasElement hold copied image of the backing
store. In the future, CanvasRenderingContexts will hold a copy of
the image of the backing store. The copy should be dropped once
we know the drawing buffer will change. This prevents the cached
copy from forcing copy-on-write on contexts such as 2D that support
this.

Rename CanvasBase::didDraw to CanvasBase::willUpdateContents and
call willUpdateContents before doing the update.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::willUpdateContents):
(WebCore::CanvasBase::didDraw): Deleted.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::willUpdateContents):
(WebCore::CanvasBase::didDraw): Deleted.
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::willUpdateContents):
(WebCore::HTMLCanvasElement::didDraw): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::willUpdateContents):
(WebCore::OffscreenCanvas::didDraw): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::drawFocusIfNeededInternal):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::endLayer):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::fillRect):
(WebCore::CanvasRenderingContext2DBase::strokeRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::willUpdateEntireContents):
(WebCore::CanvasRenderingContext2DBase::willUpdateContents):
(WebCore::CanvasRenderingContext2DBase::putImageData):
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
(WebCore::CanvasRenderingContext2DBase::didDrawEntireCanvas): Deleted.
(WebCore::CanvasRenderingContext2DBase::didDraw): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::defaultWillUpdateContentsOptions):
(WebCore::CanvasRenderingContext2DBase::defaultWillUpdateContentsOptionsWithoutPostProcessing):
(WebCore::CanvasRenderingContext2DBase::defaultDidDrawOptions): Deleted.
(WebCore::CanvasRenderingContext2DBase::defaultDidDrawOptionsWithoutPostProcessing): Deleted.
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp:
(WebCore::GPUBasedCanvasRenderingContext::willUpdateCanvasContents):
(WebCore::GPUBasedCanvasRenderingContext::markCanvasChanged): Deleted.
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
(WebCore::GPUCanvasContextCocoa::willUpdateDisplayBufferContents):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
(WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::blitFramebuffer):
(WebCore::WebGL2RenderingContext::drawRangeElements):
(WebCore::WebGL2RenderingContext::clearBufferfv):
* Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::multiDrawArraysWEBGL):
(WebCore::WebGLMultiDraw::multiDrawArraysInstancedWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsInstancedWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::willUpdateDrawingBufferContents):
(WebCore::WebGLRenderingContextBase::clear):
(WebCore::WebGLRenderingContextBase::drawArrays):
(WebCore::WebGLRenderingContextBase::drawElements):
(WebCore::WebGLRenderingContextBase::drawArraysInstanced):
(WebCore::WebGLRenderingContextBase::drawElementsInstanced):
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/319860@main">https://commits.webkit.org/319860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0204c0735554904570aa9e019b26469e38eb403f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146303 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69d5ad1b-b93f-457e-a911-42cd136ed69c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142077 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98643 "3 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/661a685d-209a-4b6b-8ba4-fde0c949e3ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122512 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c06975d-c608-4737-94ed-c1e725e902b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42705 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42335 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3364 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194127 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55592 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151489 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40806 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151193 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45759 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128565 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124367 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54794 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17330 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54175 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->