### PR TITLE
Use copyNativeImage in 2D context drawImage

### DIFF
--- a/LayoutTests/fast/canvas/webgl/lost-context-canvas-image-source-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/lost-context-canvas-image-source-expected.txt
@@ -1,0 +1,29 @@
+Tests that a WebGL canvas with a lost context is a transparent black image source.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS gl.isContextLost() is true
+
+drawImage with globalCompositeOperation 'copy' clears the destination
+PASS pixelAt(25, 25) is "0,0,0,0"
+
+drawImage with globalCompositeOperation 'source-over' leaves the destination intact
+PASS pixelAt(25, 25) is "0,128,0,255"
+
+createPattern paints transparent black
+PASS pattern = context.createPattern(webglCanvas, 'no-repeat') did not throw exception.
+PASS pattern is non-null.
+PASS pixelAt(25, 25) is "0,0,0,0"
+
+createImageBitmap produces a transparent black bitmap
+PASS createImageBitmap(webglCanvas) resolved.
+PASS pixelAt(25, 25) is "0,0,0,0"
+
+texImage2D uploads a transparent black texture
+PASS otherGL.getError() is otherGL.NO_ERROR
+PASS otherGL.checkFramebufferStatus(otherGL.FRAMEBUFFER) is otherGL.FRAMEBUFFER_COMPLETE
+PASS Array.from(pixels).toString() is "0,0,0,0"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/lost-context-canvas-image-source.html
+++ b/LayoutTests/fast/canvas/webgl/lost-context-canvas-image-source.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("Tests that a WebGL canvas with a lost context is a transparent black image source.");
+jsTestIsAsync = true;
+
+var size = 50;
+var webglCanvas;
+var gl;
+var extension;
+var target;
+var context;
+var pattern;
+var bitmap;
+var texture;
+var framebuffer;
+var pixels;
+var otherGL;
+
+function pixelAt(x, y)
+{
+    return Array.from(context.getImageData(x, y, 1, 1).data).toString();
+}
+
+function fillTargetGreen()
+{
+    context.globalCompositeOperation = "source-over";
+    context.fillStyle = "green";
+    context.fillRect(0, 0, size, size);
+}
+
+async function runTest()
+{
+    webglCanvas = document.createElement("canvas");
+    webglCanvas.width = size;
+    webglCanvas.height = size;
+    gl = webglCanvas.getContext("webgl");
+    if (!gl) {
+        testFailed("Could not create a WebGL context.");
+        finishJSTest();
+        return;
+    }
+    extension = gl.getExtension("WEBGL_lose_context");
+    if (!extension) {
+        testFailed("Could not find the WEBGL_lose_context extension.");
+        finishJSTest();
+        return;
+    }
+    target = document.createElement("canvas");
+    target.width = size;
+    target.height = size;
+    context = target.getContext("2d");
+
+    // Draw to the WebGL canvas, so that the drawing buffer has contents that are lost below.
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    extension.loseContext();
+    shouldBeTrue("gl.isContextLost()");
+
+    debug("");
+    debug("drawImage with globalCompositeOperation 'copy' clears the destination");
+    fillTargetGreen();
+    context.globalCompositeOperation = "copy";
+    context.drawImage(webglCanvas, 0, 0);
+    shouldBeEqualToString("pixelAt(25, 25)", "0,0,0,0");
+
+    debug("");
+    debug("drawImage with globalCompositeOperation 'source-over' leaves the destination intact");
+    fillTargetGreen();
+    context.drawImage(webglCanvas, 0, 0);
+    shouldBeEqualToString("pixelAt(25, 25)", "0,128,0,255");
+
+    debug("");
+    debug("createPattern paints transparent black");
+    shouldNotThrow("pattern = context.createPattern(webglCanvas, 'no-repeat')");
+    shouldBeNonNull("pattern");
+    fillTargetGreen();
+    context.globalCompositeOperation = "copy";
+    context.fillStyle = pattern;
+    context.fillRect(0, 0, size, size);
+    shouldBeEqualToString("pixelAt(25, 25)", "0,0,0,0");
+
+    debug("");
+    debug("createImageBitmap produces a transparent black bitmap");
+    try {
+        bitmap = await createImageBitmap(webglCanvas);
+        testPassed("createImageBitmap(webglCanvas) resolved.");
+    } catch (e) {
+        testFailed("createImageBitmap(webglCanvas) rejected with " + e + ".");
+    }
+    if (bitmap) {
+        fillTargetGreen();
+        context.globalCompositeOperation = "copy";
+        context.drawImage(bitmap, 0, 0);
+        shouldBeEqualToString("pixelAt(25, 25)", "0,0,0,0");
+    }
+
+    debug("");
+    debug("texImage2D uploads a transparent black texture");
+    otherGL = document.createElement("canvas").getContext("webgl");
+    texture = otherGL.createTexture();
+    otherGL.bindTexture(otherGL.TEXTURE_2D, texture);
+    otherGL.texImage2D(otherGL.TEXTURE_2D, 0, otherGL.RGBA, otherGL.RGBA, otherGL.UNSIGNED_BYTE, webglCanvas);
+    shouldBe("otherGL.getError()", "otherGL.NO_ERROR");
+    framebuffer = otherGL.createFramebuffer();
+    otherGL.bindFramebuffer(otherGL.FRAMEBUFFER, framebuffer);
+    otherGL.framebufferTexture2D(otherGL.FRAMEBUFFER, otherGL.COLOR_ATTACHMENT0, otherGL.TEXTURE_2D, texture, 0);
+    // With no texture contents defined, the attachment would be incomplete.
+    shouldBe("otherGL.checkFramebufferStatus(otherGL.FRAMEBUFFER)", "otherGL.FRAMEBUFFER_COMPLETE");
+    pixels = new Uint8Array(4);
+    otherGL.readPixels(25, 25, 1, 1, otherGL.RGBA, otherGL.UNSIGNED_BYTE, pixels);
+    shouldBeEqualToString("Array.from(pixels).toString()", "0,0,0,0");
+
+    finishJSTest();
+}
+
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -37,6 +37,7 @@
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
 #include "IntRect.h"
+#include "NativeImage.h"
 #include "NoiseInjectionPolicy.h"
 #include "RenderElementInlines.h"
 #include "ScriptTrackingPrivacyCategory.h"
@@ -97,6 +98,15 @@ RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostPro
         return nullptr;
     // Currently we don't cache transparent black bitmaps of canvases that do not have a context.
     return ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+}
+
+RefPtr<NativeImage> CanvasBase::copyNativeImage() const
+{
+    if (RefPtr context = renderingContext())
+        return context->surfaceBufferToNativeImage(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
+    if (!validateArea())
+        return nullptr;
+    return ImageBuffer::sinkIntoNativeImage(ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8));
 }
 
 static inline size_t NODELETE maxCanvasArea()

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -48,6 +48,7 @@ class GraphicsContext;
 class Image;
 class ImageBuffer;
 class IntRect;
+class NativeImage;
 class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
@@ -75,6 +76,8 @@ public:
     virtual void setSizeForControllingContext(IntSize) = 0;
 
     WEBCORE_EXPORT RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+
+    WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const;
 
     void setOriginClean() { m_originClean = true; }
     void setOriginTainted() { m_originClean = false; }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -860,11 +860,10 @@ SecurityOrigin* HTMLCanvasElement::securityOrigin() const
 
 Image* HTMLCanvasElement::copiedImage() const
 {
-    if (!m_copiedImage) {
-        RefPtr buffer = const_cast<HTMLCanvasElement*>(this)->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-        if (buffer)
-            m_copiedImage = BitmapImage::create(buffer->copyNativeImage());
-    }
+    if (m_copiedImage)
+        return m_copiedImage.get();
+    if (RefPtr image = copyNativeImage())
+        m_copiedImage = BitmapImage::create(WTF::move(image));
     return m_copiedImage.get();
 }
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -359,12 +359,10 @@ Image* OffscreenCanvas::copiedImage() const
 {
     if (m_detached)
         return nullptr;
-
-    if (!m_copiedImage) {
-        RefPtr buffer = const_cast<OffscreenCanvas*>(this)->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-        if (buffer)
-            m_copiedImage = BitmapImage::create(buffer->copyNativeImage());
-    }
+    if (m_copiedImage)
+        return m_copiedImage;
+    if (RefPtr image = const_cast<OffscreenCanvas*>(this)->copyNativeImage())
+        m_copiedImage = BitmapImage::create(WTF::move(image));
     return m_copiedImage.get();
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -49,6 +49,7 @@ class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
 class ImageBitmap;
+class NativeImage;
 class SVGImageElement;
 class WebGLObject;
 enum class PixelFormat : uint8_t;
@@ -98,6 +99,10 @@ public:
 
     // Draws the source buffer to the canvasBase().buffer().
     virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) = 0;
+    // Returns the contents of the source buffer as an image. The image is immutable, so it stays
+    // valid after the context is drawn to again. Returns nullptr only if no image can be produced,
+    // for example because the canvas has no contents or an allocation failed.
+    virtual RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) = 0;
     virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const = 0;
     bool NODELETE delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -68,6 +68,7 @@
 #include "ImageBuffer.h"
 #include "ImageData.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include "PaintRenderingContext2D.h"
 #include "Path2D.h"
@@ -290,6 +291,17 @@ RefPtr<ImageBuffer> CanvasRenderingContext2DBase::surfaceBufferToImageBuffer(Sur
     return buffer();
 }
 
+RefPtr<NativeImage> CanvasRenderingContext2DBase::surfaceBufferToNativeImage(SurfaceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = this->buffer();
+    if (!buffer)
+        return nullptr;
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
+}
+
 bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
 {
     // Before the first draw (or first access to the drawing buffer), the drawing buffer is transparent black.
@@ -337,6 +349,7 @@ void CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties(bool sizeChange
         restore();
     m_stateStack.first() = State();
     m_path.clear();
+    m_bufferNativeImage = nullptr;
     m_cachedContents.emplace<CachedContentsTransparent>();
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();
@@ -1831,8 +1844,8 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     Ref protectedCanvas { sourceCanvas };
     checkOrigin(&sourceCanvas);
 
-    RefPtr buffer = sourceCanvas.makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
-    if (!buffer)
+    RefPtr image = sourceCanvas.copyNativeImage();
+    if (!image)
         return { };
 
     auto shouldUseDrawOptionsWithoutPostProcessing = sourceCanvas.renderingContext() && sourceCanvas.renderingContext()->is2d() && !sourceCanvas.havePendingCanvasNoiseInjection();
@@ -1840,25 +1853,26 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
 
     if (rectContainsCanvas(normalizedDstRect)) {
         willUpdateEntireContents(willUpdateContentsOptions);
-        c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
+        c->drawNativeImage(*image, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
     } else if (isFullCanvasCompositeMode(state().globalComposite)) {
         willUpdateEntireContents(willUpdateContentsOptions);
-        fullCanvasCompositedDrawImage(*buffer, normalizedDstRect, normalizedSrcRect, state().globalComposite);
+        fullCanvasCompositedDrawImage(*image, normalizedDstRect, normalizedSrcRect, state().globalComposite);
     } else if (state().globalComposite == CompositeOperator::Copy) {
         willUpdateEntireContents(willUpdateContentsOptions);
         if (&sourceCanvas == &canvasBase()) {
             if (auto copy = createCompatibleImageBuffer(*c, normalizedSrcRect.size())) {
-                copy->context().drawImageBuffer(*buffer, -normalizedSrcRect.location());
+                copy->context().drawNativeImage(*image, { -normalizedSrcRect.location(), FloatSize { image->size() } }, { { }, FloatSize { image->size() } });
                 clearCanvas();
-                c->drawImageBuffer(*copy, normalizedDstRect, { { }, normalizedSrcRect.size() }, { state().globalComposite, state().globalBlend });
+                if (RefPtr copyImage = ImageBuffer::sinkIntoNativeImage(copy.releaseNonNull()))
+                    c->drawNativeImage(*copyImage, normalizedDstRect, { { }, normalizedSrcRect.size() }, { state().globalComposite, state().globalBlend });
             }
         } else {
             clearCanvas();
-            c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
+            c->drawNativeImage(*image, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
         }
     } else {
         willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, willUpdateContentsOptions);
-        c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
+        c->drawNativeImage(*image, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
     }
 
     return { };
@@ -2062,6 +2076,11 @@ static void drawImageToContext(Image& image, GraphicsContext& context, const Flo
 static void drawImageToContext(ImageBuffer& imageBuffer, GraphicsContext& context, const FloatRect& dest, const FloatRect& src, ImagePaintingOptions options)
 {
     context.drawImageBuffer(imageBuffer, dest, src, options);
+}
+
+static void drawImageToContext(NativeImage& image, GraphicsContext& context, const FloatRect& dest, const FloatRect& src, ImagePaintingOptions options)
+{
+    context.drawNativeImage(image, dest, src, options);
 }
 
 template<class T> void CanvasRenderingContext2DBase::fullCanvasCompositedDrawImage(T& image, const FloatRect& dest, const FloatRect& src, CompositeOperator op)
@@ -2380,6 +2399,7 @@ void CanvasRenderingContext2DBase::willUpdateEntireContents(OptionSet<WillUpdate
 
 void CanvasRenderingContext2DBase::willUpdateContents(std::optional<FloatRect> rect, OptionSet<WillUpdateContentsOption> options)
 {
+    m_bufferNativeImage = nullptr;
     if (!options.contains(WillUpdateContentsOption::PreserveCachedContents))
         m_cachedContents.emplace<CachedContentsUnknown>();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -499,6 +499,7 @@ private:
     template<class T> void fullCanvasCompositedDrawImage(T&, const FloatRect&, const FloatRect&, CompositeOperator);
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
 #if USE(SKIA)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
@@ -518,6 +519,7 @@ private:
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;
     mutable RefPtr<ImageBuffer> m_buffer;
+    RefPtr<NativeImage> m_bufferNativeImage;
 
     // When layers are opened, m_stateStack contains target switchers where the top
     // targetSwitcher on the stack draws to the targetSwitcher under it, ... until

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -65,6 +65,7 @@ public:
     std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond() const override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) override;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     // GPUCanvasContext methods:
@@ -139,7 +140,8 @@ private:
     bool m_suppressEDR { false };
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
-    RefPtr<ImageBuffer> m_readDisplayBuffer;
+    RefPtr<ImageBuffer> m_readDisplayBuffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_readDisplayBufferImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -42,6 +42,7 @@
 #include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "Page.h"
 #include "PlatformCALayerDelegatedContents.h"
 #include "PlatformScreen.h"
@@ -339,6 +340,7 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
         m_currentTexture = nullptr;
     }
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     auto newSize = canvasBase().size();
     auto newWidth = static_cast<GPUIntegerCoordinate>(newSize.width());
@@ -425,6 +427,27 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     return buffer;
 }
 
+RefPtr<NativeImage> GPUCanvasContextCocoa::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    // The inspector reads the last presented frame instead of the current contents, so it does not
+    // use the cached image of the read buffer.
+    bool useCache = sourceBuffer != SurfaceBuffer::DisplayBufferForInspector;
+    if (useCache && m_readDisplayBufferImage)
+        return m_readDisplayBufferImage;
+    RefPtr imageBuffer = surfaceBufferToImageBuffer(sourceBuffer);
+    if (!imageBuffer)
+        return nullptr;
+    // The copy is what GraphicsContext::drawImageBuffer would make for each individual draw of a
+    // deferred context. It is cached here, as the read buffer is discarded whenever the contents
+    // of the canvas change.
+    RefPtr image = imageBuffer->copyNativeImage();
+    if (!useCache)
+        return image;
+    m_readDisplayBufferImage = WTF::move(image);
+    updateMemoryCost();
+    return m_readDisplayBufferImage;
+}
+
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
 {
     RefPtr scriptExecutionContext = protect(canvasBase())->scriptExecutionContext();
@@ -443,6 +466,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
         m_presentationContext->present(m_configuration->frameCount, true);
         m_configuration->lastPresentedFrameIndex = std::nullopt;
         m_readDisplayBuffer = nullptr;
+        m_readDisplayBufferImage = nullptr;
         updateMemoryCost();
     }
     return bufferRef;
@@ -581,6 +605,7 @@ void GPUCanvasContextCocoa::unconfigure()
     auto configuration = std::exchange(m_configuration, std::nullopt);
     m_currentTexture = nullptr;
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     ASSERT(!isConfigured());
 
@@ -669,6 +694,7 @@ void GPUCanvasContextCocoa::prepareForDisplay()
     if (!isConfigured())
         return;
     m_readDisplayBuffer = nullptr;
+    m_readDisplayBufferImage = nullptr;
     updateMemoryCost();
     ASSERT(m_configuration->frameCount < m_configuration->renderBuffers.size());
 
@@ -725,8 +751,9 @@ std::optional<FramesPerSecond> GPUCanvasContextCocoa::preferredRenderingUpdateFr
 void GPUCanvasContextCocoa::willUpdateDisplayBufferContents()
 {
     m_compositingResultsNeedsUpdating = true;
-    if (m_readDisplayBuffer) {
+    if (m_readDisplayBuffer || m_readDisplayBufferImage) {
         m_readDisplayBuffer = nullptr;
+        m_readDisplayBufferImage = nullptr;
         updateMemoryCost();
     }
     willUpdateCanvasContents();
@@ -738,6 +765,8 @@ void GPUCanvasContextCocoa::updateMemoryCost() const
     size_t newMemoryCost = 0;
     if (m_readDisplayBuffer)
         newMemoryCost += m_readDisplayBuffer->memoryCost();
+    if (RefPtr image = m_readDisplayBufferImage)
+        newMemoryCost += image->sizeInBytes();
     if (m_currentTexture)
         newMemoryCost += m_currentTexture->memoryCost();
     CanvasRenderingContext::updateMemoryCost(newMemoryCost);

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -30,6 +30,7 @@
 #include "ImageBitmap.h"
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -91,6 +92,7 @@ ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<Im
         m_buffer = nullptr;
         updateMemoryCost(0);
     }
+    m_bufferNativeImage = nullptr;
     return { };
 }
 
@@ -102,6 +104,7 @@ RefPtr<ImageBuffer> ImageBitmapRenderingContext::transferToImageBuffer()
         return ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     canvasBase->willUpdateContents(FloatRect { { }, size });
     RefPtr result = std::exchange(m_buffer, { });
+    m_bufferNativeImage = nullptr;
     updateMemoryCost(0);
     canvasBase->setOriginClean();
     return result;
@@ -117,6 +120,17 @@ RefPtr<ImageBuffer> ImageBitmapRenderingContext::surfaceBufferToImageBuffer(Surf
         }
     }
     return m_buffer;
+}
+
+RefPtr<NativeImage> ImageBitmapRenderingContext::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = surfaceBufferToImageBuffer(sourceBuffer);
+    if (!buffer)
+        return nullptr;
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
 }
 
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -57,6 +57,7 @@ public:
     bool hasAlpha() { return m_settings.alpha; }
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return !m_buffer; }
     void didUpdateCanvasSizeProperties(bool) final { }
 
@@ -65,7 +66,8 @@ private:
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    RefPtr<ImageBuffer> m_buffer;
+    RefPtr<ImageBuffer> m_buffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_bufferNativeImage;
     ImageBitmapRenderingContextSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -145,6 +145,7 @@ RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
     if (result)
         result->flushDrawingContext();
 #endif
+    willUpdateEntireContents();
     clearCanvas();
     return result;
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsLayer.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "HTMLCanvasElement.h"
+#include "NativeImage.h"
 #include "OffscreenCanvas.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -116,6 +117,8 @@ PlaceholderRenderingContext::PlaceholderRenderingContext(HTMLCanvasElement& canv
 {
 }
 
+PlaceholderRenderingContext::~PlaceholderRenderingContext() = default;
+
 HTMLCanvasElement& PlaceholderRenderingContext::canvas() const
 {
     return downcast<HTMLCanvasElement>(canvasBase());
@@ -139,6 +142,7 @@ void PlaceholderRenderingContext::setPlaceholderBuffer(Ref<ImageBuffer>&& newBuf
     m_opaque = opaque;
     updateMemoryCost(newBuffer->memoryCost());
     m_buffer = WTF::move(newBuffer);
+    m_bufferNativeImage = nullptr;
     canvas->setSizeForControllingContext(newSize);
     if (originClean)
         canvas->setOriginClean();
@@ -156,6 +160,17 @@ PixelFormat PlaceholderRenderingContext::pixelFormat() const
 RefPtr<ImageBuffer> PlaceholderRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
 {
     return m_buffer;
+}
+
+RefPtr<NativeImage> PlaceholderRenderingContext::surfaceBufferToNativeImage(SurfaceBuffer)
+{
+    if (m_bufferNativeImage)
+        return m_bufferNativeImage;
+    RefPtr buffer = m_buffer;
+    if (!buffer)
+        return nullptr;
+    m_bufferNativeImage = buffer->copyNativeImage();
+    return m_bufferNativeImage;
 }
 
 bool PlaceholderRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) const

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -66,6 +66,8 @@ class PlaceholderRenderingContext final : public CanvasRenderingContext {
 public:
     static std::unique_ptr<PlaceholderRenderingContext> create(HTMLCanvasElement&);
 
+    ~PlaceholderRenderingContext();
+
     HTMLCanvasElement& NODELETE canvas() const;
     IntSize NODELETE size() const;
     void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool originClean, bool opaque);
@@ -73,6 +75,7 @@ public:
     PlaceholderRenderingContextSource& source() const { return m_source; }
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final;
     void didUpdateCanvasSizeProperties(bool) final;
 
@@ -83,7 +86,8 @@ private:
     bool isOpaque() const final { return m_opaque; }
 
     const Ref<PlaceholderRenderingContextSource> m_source;
-    RefPtr<ImageBuffer> m_buffer;
+    RefPtr<ImageBuffer> m_buffer; // Temporary until content is provided as NativeImage.
+    RefPtr<NativeImage> m_bufferNativeImage;
     bool m_opaque { false };
 };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -80,6 +80,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "NVShaderNoperspectiveInterpolation.h"
+#include "NativeImage.h"
 #include "NavigatorWebXR.h"
 #include "NotImplemented.h"
 #include "OESDrawBuffersIndexed.h"
@@ -536,8 +537,8 @@ void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> cont
 void WebGLRenderingContextBase::initializeContextState()
 {
     m_errors = { };
-    m_readDisplayBuffer = nullptr;
-    m_readDrawingBuffer = nullptr;
+    m_readDisplayBuffer.clear();
+    m_readDrawingBuffer.clear();
     m_compositingResultsNeedUpdating = false;
     m_activeTextureUnit = 0;
     m_packParameters = { };
@@ -689,8 +690,8 @@ void WebGLRenderingContextBase::willUpdateDrawingBufferContents(WebGLRenderingCo
         return;
 
     m_compositingResultsNeedUpdating = true;
-    if (m_readDrawingBuffer) {
-        m_readDrawingBuffer = nullptr;
+    if (!m_readDrawingBuffer.isEmpty()) {
+        m_readDrawingBuffer.clear();
         updateMemoryCost();
     }
     willUpdateCanvasContents();
@@ -776,6 +777,48 @@ static RefPtr<ImageBuffer> createImageBufferForWebGLContextReads(IntSize size, S
     return ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext.graphicsClient());
 }
 
+void WebGLRenderingContextBase::ReadSurfaceBuffer::clear()
+{
+    image = nullptr;
+    buffer = nullptr;
+}
+
+size_t WebGLRenderingContextBase::ReadSurfaceBuffer::memoryCost() const
+{
+    size_t cost = 0;
+    if (RefPtr image = this->image)
+        cost += image->sizeInBytes();
+    if (buffer)
+        cost += buffer->memoryCost();
+    return cost;
+}
+
+auto WebGLRenderingContextBase::readSurfaceBuffer(SurfaceBuffer sourceBuffer) -> ReadSurfaceBuffer&
+{
+    return sourceBuffer == SurfaceBuffer::DrawingBuffer ? m_readDrawingBuffer : m_readDisplayBuffer;
+}
+
+RefPtr<NativeImage> WebGLRenderingContextBase::surfaceBufferToNativeImage(SurfaceBuffer sourceBuffer)
+{
+    auto size = clampedCanvasSize();
+    if (size.isEmpty())
+        return nullptr;
+    auto& readBuffer = readSurfaceBuffer(sourceBuffer);
+    if (readBuffer.image)
+        return readBuffer.image;
+    if (!isContextLost()) {
+        if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
+            clearIfComposited(CallerTypeOther);
+        readBuffer.image = protect(graphicsContextGL())->copyNativeImage(toGCGLSurfaceBuffer(sourceBuffer));
+    }
+    // A lost context or a failed read is transparent black.
+    if (!readBuffer.image)
+        readBuffer.image = ImageBuffer::sinkIntoNativeImage(ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8));
+    if (readBuffer.image)
+        updateMemoryCost();
+    return readBuffer.image;
+}
+
 RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
@@ -784,33 +827,23 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(Surfac
     auto size = clampedCanvasSize();
     if (size.isEmpty())
         return nullptr;
-    RefPtr<ImageBuffer> buffer;
-    if (sourceBuffer == SurfaceBuffer::DrawingBuffer) {
-        if (m_readDrawingBuffer)
-            return m_readDrawingBuffer;
-        m_readDrawingBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
-        updateMemoryCost();
-        buffer = m_readDrawingBuffer;
-    } else {
-        if (m_readDisplayBuffer)
-            return m_readDisplayBuffer;
-        m_readDisplayBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
-        updateMemoryCost();
-        buffer = m_readDisplayBuffer;
-    }
-    if (isContextLost())
-        return buffer;
+    auto& readBuffer = readSurfaceBuffer(sourceBuffer);
+    if (readBuffer.buffer)
+        return readBuffer.buffer;
+    // Obtain the image before creating the buffer, as obtaining it might invalidate the cache.
+    RefPtr image = surfaceBufferToNativeImage(sourceBuffer);
+    readBuffer.buffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
+    updateMemoryCost();
+    RefPtr buffer = readBuffer.buffer;
     if (!buffer)
+        return nullptr;
+    // A lost context or a failed read is a transparent black buffer.
+    if (!image)
         return buffer;
-    if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
-        clearIfComposited(CallerTypeOther);
     // FIXME: Remote ImageBuffers do not flush the buffers that are drawn to a buffer.
     // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
     // canvas element repeatedly.
     buffer->flushDrawingContext();
-    RefPtr image = protect(graphicsContextGL())->copyNativeImage(toGCGLSurfaceBuffer(sourceBuffer));
-    if (!image)
-        return buffer;
     GraphicsContextGL::paintToCanvas(*image, buffer->backendSize(), buffer->context());
     return buffer;
 }
@@ -893,8 +926,8 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
 {
     if (isContextLost()) {
-        m_readDrawingBuffer = nullptr;
-        m_readDisplayBuffer = nullptr;
+        m_readDrawingBuffer.clear();
+        m_readDisplayBuffer.clear();
         updateMemoryCost();
         return;
     }
@@ -903,8 +936,8 @@ void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
     if (newSize == m_defaultFramebuffer->size())
         return;
 
-    m_readDrawingBuffer = nullptr;
-    m_readDisplayBuffer = nullptr;
+    m_readDrawingBuffer.clear();
+    m_readDisplayBuffer.clear();
 
     m_defaultFramebuffer->reshape(newSize);
     updateMemoryCost();
@@ -5707,8 +5740,8 @@ void WebGLRenderingContextBase::prepareForDisplay()
     m_defaultFramebuffer->markAllUnpreservedBuffersDirty();
 
     m_compositingResultsNeedUpdating = false;
-    m_readDisplayBuffer = nullptr;
-    m_readDrawingBuffer = nullptr;
+    m_readDisplayBuffer.clear();
+    m_readDrawingBuffer.clear();
     updateMemoryCost();
 
     if (hasActiveInspectorCanvasCallTracer()) [[unlikely]]
@@ -5746,10 +5779,8 @@ void WebGLRenderingContextBase::updateMemoryCost() const
 {
     // Computes only a rough ballpark figure to drive garbage collection and Web Inspector.
     size_t newMemoryCost = 0;
-    if (m_readDisplayBuffer)
-        newMemoryCost += m_readDisplayBuffer->memoryCost();
-    if (m_readDrawingBuffer)
-        newMemoryCost += m_readDrawingBuffer->memoryCost();
+    newMemoryCost += m_readDisplayBuffer.memoryCost();
+    newMemoryCost += m_readDrawingBuffer.memoryCost();
     if (!isContextLost()) {
         size_t area = m_defaultFramebuffer->size().unclampedArea();
         size_t bytesPerSample = 4;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -101,6 +101,7 @@ class HTMLImageElement;
 class ImageData;
 class IntSize;
 class KHRParallelShaderCompile;
+class NativeImage;
 class NVShaderNoperspectiveInterpolation;
 class OESDrawBuffersIndexed;
 class OESElementIndexUint;
@@ -444,6 +445,7 @@ public:
     void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    RefPtr<NativeImage> surfaceBufferToNativeImage(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     RefPtr<ByteArrayPixelBuffer> drawingBufferToPixelBuffer();
@@ -724,8 +726,21 @@ protected:
 
     bool m_compositingResultsNeedUpdating { false };
     bool m_memoryCostUpdateScheduled { false };
-    RefPtr<ImageBuffer> m_readDrawingBuffer;
-    RefPtr<ImageBuffer> m_readDisplayBuffer;
+
+    // Temporary holder for both ImageBuffer and NativeImage requests.
+    // Once ImageBuffer requests have been removed, this will be reverted to RefPtr<NativeImage>.
+    struct ReadSurfaceBuffer {
+        RefPtr<NativeImage> image;
+        RefPtr<ImageBuffer> buffer;
+
+        bool isEmpty() const { return !image && !buffer; }
+        void clear();
+        size_t memoryCost() const;
+    };
+    ReadSurfaceBuffer& readSurfaceBuffer(SurfaceBuffer);
+
+    ReadSurfaceBuffer m_readDrawingBuffer;
+    ReadSurfaceBuffer m_readDisplayBuffer;
 
     // Enabled extension objects.
     // FIXME: Move some of these to WebGLRenderingContext, the ones not needed for WebGL2

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -47,6 +47,19 @@ namespace WebCore {
 
 GraphicsContextGLImageExtractor::~GraphicsContextGLImageExtractor() = default;
 
+static std::optional<GraphicsContextGL::DataFormat> dataFormatForColorType(SkColorType colorType)
+{
+    switch (colorType) {
+    case kRGBA_8888_SkColorType:
+        return GraphicsContextGL::DataFormat::RGBA8;
+    case kBGRA_8888_SkColorType:
+        return GraphicsContextGL::DataFormat::BGRA8;
+    default:
+        break;
+    }
+    return std::nullopt;
+}
+
 bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool ignoreGammaAndColorProfile, bool ignoreNativeImageAlphaPremultiplication)
 {
     RefPtr<NativeImage> nativeImage;
@@ -92,39 +105,42 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
     }
 
     unsigned srcUnpackAlignment = 1;
-    size_t bytesPerRow = imageInfo.minRowBytes();
-    size_t bytesPerPixel = imageInfo.bytesPerPixel();
-    unsigned padding = bytesPerRow - bytesPerPixel * m_imageWidth;
-    if (padding) {
-        srcUnpackAlignment = padding + 1;
-        while (bytesPerRow % srcUnpackAlignment)
-            ++srcUnpackAlignment;
-    }
+    size_t bytesPerRow = 0;
 
-    if (platformImage->isTextureBacked()) {
-        auto data = SkData::MakeUninitialized(imageInfo.computeMinByteSize());
-        if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+    // Use the pixels as is when the layout is one the caller understands, otherwise convert to RGBA8.
+    auto sourceFormat = dataFormatForColorType(imageInfo.colorType());
+    auto readInfo = sourceFormat ? imageInfo : imageInfo.makeColorType(kRGBA_8888_SkColorType);
+
+    if (platformImage->isTextureBacked() || !sourceFormat) {
+        auto data = SkData::MakeUninitialized(readInfo.computeMinByteSize());
+        bytesPerRow = readInfo.minRowBytes();
+        if (platformImage->isTextureBacked() && !PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
             return false;
 
         auto* grContext = nativeImage->grContext();
-        if (!platformImage->readPixels(grContext, imageInfo, static_cast<uint8_t*>(data->writable_data()), bytesPerRow, 0, 0))
+        if (!platformImage->readPixels(grContext, readInfo, static_cast<uint8_t*>(data->writable_data()), bytesPerRow, 0, 0))
             return false;
 
         m_pixelData = WTF::move(data);
         m_imagePixelData = span(m_pixelData.get());
-
-        // SkSurfaces backed by textures have RGBA format.
-        m_imageSourceFormat = DataFormat::RGBA8;
+        m_imageSourceFormat = sourceFormat.value_or(DataFormat::RGBA8);
     } else {
         SkPixmap pixmap;
         if (!platformImage->peekPixels(&pixmap))
             return false;
 
+        bytesPerRow = pixmap.rowBytes();
         m_skImage = WTF::move(platformImage);
         m_imagePixelData = span(pixmap);
+        m_imageSourceFormat = *sourceFormat;
+    }
 
-        // Raster SkSurfaces have BGRA format.
-        m_imageSourceFormat = DataFormat::BGRA8;
+    size_t bytesPerPixel = readInfo.bytesPerPixel();
+    unsigned padding = bytesPerRow - bytesPerPixel * m_imageWidth;
+    if (padding) {
+        srcUnpackAlignment = padding + 1;
+        while (bytesPerRow % srcUnpackAlignment)
+            ++srcUnpackAlignment;
     }
 
     m_imageSourceUnpackAlignment = srcUnpackAlignment;


### PR DESCRIPTION
#### ef17f9b10e301dea11025d6d1cb0c8cdb0573328
<pre>
Use copyNativeImage in 2D context drawImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=322254">https://bugs.webkit.org/show_bug.cgi?id=322254</a>
<a href="https://rdar.apple.com/185487825">rdar://185487825</a>

Reviewed by Dan Glastonbury.

Obtain the draw source as NativeImage in
CanvasRenderingContext2DBase::drawImage().  This continues the refactor
to use NativeImages as the only draw source, removing ImageBuffers.

Implements the fast path for WebGL as an example: WebGL provides
the GPUP side NativeImage as the result.

Later commits will modify other canvas rendering contexts to obtain
the image directly as a NativeImage.

Fixes Skia GraphicsContextGLImageExtractor to not assume
NativeImages are BGRA. The below
GraphicsContextGL::createNativeImageFromPixelBuffer already produces
RGBA images.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::copyNativeImage const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::copiedImage const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::copiedImage const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::surfaceBufferToNativeImage):
(WebCore::CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::clearCanvas):
(WebCore::drawImageToContext):
(WebCore::CanvasRenderingContext2DBase::drawSourceImage):
(WebCore::CanvasRenderingContext2DBase::didDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToNativeImage):
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::unconfigure):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
(WebCore::GPUCanvasContextCocoa::updateMemoryCost const):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
(WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
(WebCore::ImageBitmapRenderingContext::surfaceBufferToNativeImage):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
(WebCore::PlaceholderRenderingContext::surfaceBufferToNativeImage):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::clear):
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::memoryCost const):
(WebCore::WebGLRenderingContextBase::readSurfaceBuffer):
(WebCore::WebGLRenderingContextBase::surfaceBufferToNativeImage):
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::didUpdateCanvasSizeProperties):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
(WebCore::WebGLRenderingContextBase::updateMemoryCost const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::ReadSurfaceBuffer::isEmpty const):
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::dataFormatForColorType):
(WebCore::GraphicsContextGLImageExtractor::extractImage):

Canonical link: <a href="https://commits.webkit.org/319967@main">https://commits.webkit.org/319967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08db5bbe44ad73286df56e49123bd174b4135294

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147584 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20367411-0ac9-4638-91a9-12c6d1e33b3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143065 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc05868e-fa3a-4342-b8d8-524a7f6864e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70646c57-fb4d-4a26-b967-a55be646b5ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45499 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43750 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43363 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4686 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195452 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40889 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57590 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152252 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46807 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129870 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18375 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55536 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->