### PR TITLE
[GLIB] Use GRefPtrWrapped for the GTlsCertificate IPC serializer

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -73,6 +73,7 @@ endif ()
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/CoreIPCGByteArray.serialization.in
+    Shared/glib/CoreIPCGTlsCertificate.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -117,6 +117,7 @@ endif ()
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/CoreIPCGByteArray.serialization.in
+    Shared/glib/CoreIPCGTlsCertificate.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -26,87 +26,11 @@
 #include "config.h"
 #include "ArgumentCodersGLib.h"
 
-#include "GeneratedSerializers.h"
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include <wtf/Vector.h>
-#include <wtf/glib/GSpanExtras.h>
-#include <wtf/glib/GUniquePtr.h>
-#include <wtf/text/CString.h>
 
 namespace IPC {
-
-void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRefPtr<GTlsCertificate>& certificate)
-{
-    if (!certificate) {
-        encoder << Vector<std::span<const uint8_t>> { };
-        return;
-    }
-
-    Vector<GRefPtr<GByteArray>> certificatesData;
-    for (auto* nextCertificate = certificate.get(); nextCertificate; nextCertificate = g_tls_certificate_get_issuer(nextCertificate)) {
-        GRefPtr<GByteArray> certificateData;
-        g_object_get(nextCertificate, "certificate", &certificateData.outPtr(), nullptr);
-
-        if (!certificateData) {
-            certificatesData.clear();
-            break;
-        }
-        certificatesData.insert(0, WTF::move(certificateData));
-    }
-
-    if (certificatesData.isEmpty()) {
-        encoder << Vector<std::span<const uint8_t>> { };
-        return;
-    }
-
-    encoder << certificatesData;
-
-    GRefPtr<GByteArray> privateKey;
-    GUniqueOutPtr<char> privateKeyPKCS11Uri;
-    g_object_get(certificate.get(), "private-key", &privateKey.outPtr(), "private-key-pkcs11-uri", &privateKeyPKCS11Uri.outPtr(), nullptr);
-    encoder << privateKey;
-    encoder << CString(privateKeyPKCS11Uri.get());
-}
-
-std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>::decode(Decoder& decoder)
-{
-    auto certificatesData = decoder.decode<WTF::Vector<GRefPtr<GByteArray>>>();
-
-    if (!certificatesData) [[unlikely]]
-        return std::nullopt;
-
-    if (!certificatesData->size())
-        return GRefPtr<GTlsCertificate>();
-
-    std::optional<GRefPtr<GByteArray>> privateKey;
-    decoder >> privateKey;
-    if (!privateKey) [[unlikely]]
-        return std::nullopt;
-
-    std::optional<CString> privateKeyPKCS11Uri;
-    decoder >> privateKeyPKCS11Uri;
-    if (!privateKeyPKCS11Uri) [[unlikely]]
-        return std::nullopt;
-
-    GType certificateType = g_tls_backend_get_certificate_type(g_tls_backend_get_default());
-    GRefPtr<GTlsCertificate> certificate;
-    GTlsCertificate* issuer = nullptr;
-    uint32_t i = 0;
-    for (auto& certificateData : *certificatesData) {
-        certificate = adoptGRef(G_TLS_CERTIFICATE(g_initable_new(
-            certificateType, nullptr, nullptr,
-            "certificate", certificateData.get(),
-            "issuer", issuer,
-            "private-key", i == certificatesData->size() - 1 ? privateKey->get() : nullptr,
-            "private-key-pkcs11-uri", i == certificatesData->size() - 1 ? privateKeyPKCS11Uri->data() : nullptr,
-            nullptr)));
-        issuer = certificate.get();
-        i++;
-    }
-
-    return certificate;
-}
 
 void ArgumentCoder<GTlsCertificateFlags>::encode(Encoder& encoder, GTlsCertificateFlags flags)
 {

--- a/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.cpp
+++ b/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CoreIPCGTlsCertificate.h"
+
+#if USE(GLIB)
+
+#include <gio/gio.h>
+#include <wtf/glib/GUniquePtr.h>
+
+namespace WebKit {
+
+CoreIPCGTlsCertificate::CoreIPCGTlsCertificate(const GRefPtr<GTlsCertificate>& certificate)
+{
+    for (auto* nextCertificate = certificate.get(); nextCertificate; nextCertificate = g_tls_certificate_get_issuer(nextCertificate)) {
+        GRefPtr<GByteArray> certificateData;
+        g_object_get(nextCertificate, "certificate", &certificateData.outPtr(), nullptr);
+
+        if (!certificateData) {
+            m_certificates.clear();
+            break;
+        }
+        m_certificates.insert(0, WTF::move(certificateData));
+    }
+
+    if (m_certificates.isEmpty())
+        return;
+
+    GUniqueOutPtr<char> privateKeyPKCS11Uri;
+    g_object_get(certificate.get(), "private-key", &m_privateKey.outPtr(), "private-key-pkcs11-uri", &privateKeyPKCS11Uri.outPtr(), nullptr);
+    m_privateKeyPKCS11Uri = CString(privateKeyPKCS11Uri.get());
+}
+
+CoreIPCGTlsCertificate::CoreIPCGTlsCertificate(Vector<GRefPtr<GByteArray>>&& certificates, GRefPtr<GByteArray>&& privateKey, CString&& privateKeyPKCS11Uri)
+    : m_certificates(WTF::move(certificates))
+    , m_privateKey(WTF::move(privateKey))
+    , m_privateKeyPKCS11Uri(WTF::move(privateKeyPKCS11Uri))
+{
+}
+
+CoreIPCGTlsCertificate::operator GRefPtr<GTlsCertificate>() const
+{
+    if (m_certificates.isEmpty())
+        return nullptr;
+
+    GType certificateType = g_tls_backend_get_certificate_type(g_tls_backend_get_default());
+    GRefPtr<GTlsCertificate> certificate;
+    GTlsCertificate* issuer = nullptr;
+    for (size_t i = 0; i < m_certificates.size(); ++i) {
+        bool isLeaf = i == m_certificates.size() - 1;
+        certificate = adoptGRef(G_TLS_CERTIFICATE(g_initable_new(
+            certificateType, nullptr, nullptr,
+            "certificate", m_certificates[i].get(),
+            "issuer", issuer,
+            "private-key", isLeaf ? m_privateKey.get() : nullptr,
+            "private-key-pkcs11-uri", isLeaf ? m_privateKeyPKCS11Uri.data() : nullptr,
+            nullptr)));
+        issuer = certificate.get();
+    }
+
+    return certificate;
+}
+
+} // namespace WebKit
+
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.h
+++ b/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,22 +25,34 @@
 
 #pragma once
 
-#include "ArgumentCoders.h"
-#include <gio/gio.h>
+#if USE(GLIB)
+
+#include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/CString.h>
 
-typedef struct _GUnixFDList GUnixFDList;
+typedef struct _GByteArray GByteArray;
+typedef struct _GTlsCertificate GTlsCertificate;
 
-namespace IPC {
+namespace WebKit {
 
-template<> struct ArgumentCoder<GTlsCertificateFlags> {
-    static void encode(Encoder&, GTlsCertificateFlags);
-    static std::optional<GTlsCertificateFlags> decode(Decoder&);
+class CoreIPCGTlsCertificate {
+public:
+    explicit CoreIPCGTlsCertificate(const GRefPtr<GTlsCertificate>&);
+    CoreIPCGTlsCertificate(Vector<GRefPtr<GByteArray>>&&, GRefPtr<GByteArray>&&, CString&&);
+
+    const Vector<GRefPtr<GByteArray>>& certificates() const { return m_certificates; }
+    const GRefPtr<GByteArray>& privateKey() const { return m_privateKey; }
+    CString privateKeyPKCS11Uri() const { return m_privateKeyPKCS11Uri; }
+
+    operator GRefPtr<GTlsCertificate>() const;
+
+private:
+    Vector<GRefPtr<GByteArray>> m_certificates;
+    GRefPtr<GByteArray> m_privateKey;
+    CString m_privateKeyPKCS11Uri;
 };
 
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
-};
+} // namespace WebKit
 
-} // namespace IPC
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.serialization.in
+++ b/Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.serialization.in
@@ -1,0 +1,38 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(GLIB)
+
+header: <gio/gio.h>
+header: "CoreIPCGTlsCertificate.h"
+
+additional_forward_declaration: typedef struct _GByteArray GByteArray
+additional_forward_declaration: typedef struct _GTlsCertificate GTlsCertificate
+
+[GRefPtrWrapped=GTlsCertificate] class WebKit::CoreIPCGTlsCertificate {
+    Vector<GRefPtr<GByteArray>> certificates();
+    GRefPtr<GByteArray> privateKey();
+    CString privateKeyPKCS11Uri();
+}
+
+#endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -84,6 +84,7 @@ Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
 
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/CoreIPCGByteArray.cpp
+Shared/glib/CoreIPCGTlsCertificate.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -82,6 +82,7 @@ Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/CoreIPCGByteArray.cpp
+Shared/glib/CoreIPCGTlsCertificate.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp


### PR DESCRIPTION
#### 12b9f977fe4cc62ab847e52c1968a529ead2b6b8
<pre>
[GLIB] Use GRefPtrWrapped for the GTlsCertificate IPC serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=322269">https://bugs.webkit.org/show_bug.cgi?id=322269</a>

Reviewed by Carlos Garcia Campos.

Migrate ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt; to a generated serializer
using GRefPtrWrapped. The wire format is unchanged: the certificate chain
and private key (de)serialize as GByteArray members, so this builds on the
generated GByteArray coder.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.cpp: Added.
(WebKit::CoreIPCGTlsCertificate::CoreIPCGTlsCertificate):
(WebKit::CoreIPCGTlsCertificate::operator GRefPtr&lt;GTlsCertificate&gt; const):
* Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.h: Added.
* Source/WebKit/Shared/glib/CoreIPCGTlsCertificate.serialization.in: Added.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/319599@main">https://commits.webkit.org/319599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/464e0292468c2599ebdd1429d257b170bad06777

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55930 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184938 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/122522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48561 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55601 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/194136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56292 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27640 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54803 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->