### PR TITLE
[GLIB] Use GRefPtrWrapped for the GUnixFDList IPC serializer

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -74,6 +74,7 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/CoreIPCGByteArray.serialization.in
     Shared/glib/CoreIPCGTlsCertificate.serialization.in
+    Shared/glib/CoreIPCGUnixFDList.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -118,6 +118,7 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/CoreIPCGByteArray.serialization.in
     Shared/glib/CoreIPCGTlsCertificate.serialization.in
+    Shared/glib/CoreIPCGUnixFDList.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -27,20 +27,12 @@
 
 #include "ArgumentCoders.h"
 #include <gio/gio.h>
-#include <wtf/glib/GRefPtr.h>
-
-typedef struct _GUnixFDList GUnixFDList;
 
 namespace IPC {
 
 template<> struct ArgumentCoder<GTlsCertificateFlags> {
     static void encode(Encoder&, GTlsCertificateFlags);
     static std::optional<GTlsCertificateFlags> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.cpp
+++ b/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,23 +24,37 @@
  */
 
 #include "config.h"
-#include "ArgumentCodersGLib.h"
+#include "CoreIPCGUnixFDList.h"
 
-#include <gio/gio.h>
+#if USE(GLIB)
 
-namespace IPC {
+#include <gio/gunixfdlist.h>
 
-void ArgumentCoder<GTlsCertificateFlags>::encode(Encoder& encoder, GTlsCertificateFlags flags)
+namespace WebKit {
+
+CoreIPCGUnixFDList::CoreIPCGUnixFDList(const GRefPtr<GUnixFDList>& fdList)
+    : m_fdList(fdList)
 {
-    encoder << static_cast<uint32_t>(flags);
 }
 
-std::optional<GTlsCertificateFlags> ArgumentCoder<GTlsCertificateFlags>::decode(Decoder& decoder)
+CoreIPCGUnixFDList::CoreIPCGUnixFDList(Vector<WTF::UnixFileDescriptor>&& fileDescriptors)
+    : m_fdList(adoptGRef(g_unix_fd_list_new()))
 {
-    auto flags = decoder.decode<uint32_t>();
-    if (!flags) [[unlikely]]
-        return std::nullopt;
-    return static_cast<GTlsCertificateFlags>(*flags);
+    for (const auto& fileDescriptor : fileDescriptors)
+        g_unix_fd_list_append(m_fdList.get(), fileDescriptor.value(), nullptr);
 }
 
-} // namespace IPC
+Vector<WTF::UnixFileDescriptor> CoreIPCGUnixFDList::fileDescriptors() const
+{
+    unsigned length = std::max(0, m_fdList ? g_unix_fd_list_get_length(m_fdList.get()) : 0);
+    if (!length)
+        return { };
+
+    return Vector<WTF::UnixFileDescriptor>(length, [&](size_t i) {
+        return WTF::UnixFileDescriptor { g_unix_fd_list_get(m_fdList.get(), i, nullptr), WTF::UnixFileDescriptor::Adopt };
+    });
+}
+
+} // namespace WebKit
+
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.h
+++ b/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,24 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "ArgumentCodersGLib.h"
+#pragma once
 
-#include <gio/gio.h>
+#if USE(GLIB)
 
-namespace IPC {
+#include <wtf/Vector.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
-void ArgumentCoder<GTlsCertificateFlags>::encode(Encoder& encoder, GTlsCertificateFlags flags)
-{
-    encoder << static_cast<uint32_t>(flags);
-}
+typedef struct _GUnixFDList GUnixFDList;
 
-std::optional<GTlsCertificateFlags> ArgumentCoder<GTlsCertificateFlags>::decode(Decoder& decoder)
-{
-    auto flags = decoder.decode<uint32_t>();
-    if (!flags) [[unlikely]]
-        return std::nullopt;
-    return static_cast<GTlsCertificateFlags>(*flags);
-}
+namespace WebKit {
 
-} // namespace IPC
+class CoreIPCGUnixFDList {
+public:
+    explicit CoreIPCGUnixFDList(const GRefPtr<GUnixFDList>&);
+    explicit CoreIPCGUnixFDList(Vector<WTF::UnixFileDescriptor>&&);
+
+    Vector<WTF::UnixFileDescriptor> fileDescriptors() const;
+
+    operator GRefPtr<GUnixFDList>() const { return m_fdList; }
+
+private:
+    GRefPtr<GUnixFDList> m_fdList;
+};
+
+} // namespace WebKit
+
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in
+++ b/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(GLIB)
+
+headers: <wtf/unix/UnixFileDescriptor.h> "ArgumentCodersUnix.h"
+header: <gio/gio.h>
+header: "CoreIPCGUnixFDList.h"
+
+additional_forward_declaration: typedef struct _GUnixFDList GUnixFDList
+
+[GRefPtrWrapped=GUnixFDList] class WebKit::CoreIPCGUnixFDList {
+    Vector<WTF::UnixFileDescriptor> fileDescriptors();
+}
+
+#endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -85,6 +85,7 @@ Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/CoreIPCGByteArray.cpp
 Shared/glib/CoreIPCGTlsCertificate.cpp
+Shared/glib/CoreIPCGUnixFDList.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -83,6 +83,7 @@ Shared/API/glib/WebKitUserMessage.cpp @no-unify
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/CoreIPCGByteArray.cpp
 Shared/glib/CoreIPCGTlsCertificate.cpp
+Shared/glib/CoreIPCGUnixFDList.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp


### PR DESCRIPTION
#### 8704a40051233695d3453eb4965b5e6653493b96
<pre>
[GLIB] Use GRefPtrWrapped for the GUnixFDList IPC serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=322270">https://bugs.webkit.org/show_bug.cgi?id=322270</a>

Reviewed by Carlos Garcia Campos.

Migrate ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt; to a generated serializer
using GRefPtrWrapped. The wire format is unchanged: the file descriptors
(de)serialize as a Vector&lt;UnixFileDescriptor&gt;.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/glib/CoreIPCGUnixFDList.cpp: Added.
(WebKit::CoreIPCGUnixFDList::CoreIPCGUnixFDList):
(WebKit::CoreIPCGUnixFDList::fileDescriptors const):
* Source/WebKit/Shared/glib/CoreIPCGUnixFDList.h: Added.
* Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in: Added.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/319623@main">https://commits.webkit.org/319623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fe4e3e0ccf5f1b9c4abb400bf467384235bd5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142092 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44450 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42718 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42348 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3376 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55604 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151500 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56295 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151204 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45773 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128577 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124380 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54806 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->