### PR TITLE
Fix the Swift clang importer on Windows: MSVC STL module visibility and more

### DIFF
--- a/Source/WTF/Scripts/generate-platform-args
+++ b/Source/WTF/Scripts/generate-platform-args
@@ -28,6 +28,7 @@ import sys
 
 DEFINE_RE = re.compile(r'^#define (\w+) (.+)', re.MULTILINE)
 PLATFORM_PREFIX_RE = re.compile(r'^(HAVE_|USE_|ENABLE_|WTF_PLATFORM|ASSERT_)')
+STL_FEATURE_MACRO_RE = re.compile(r'^#define (__cpp_lib_\w+) (.+)', re.MULTILINE)
 
 
 def platform_defines_from_dM(stdout):
@@ -150,7 +151,8 @@ def run_clang_command(command):
 
 
 def run_cmake_mode(args):
-    swift_defines = platform_defines_from_dM(run_clang_command(args.command))
+    dM_output = run_clang_command(args.command)
+    swift_defines = platform_defines_from_dM(dM_output)
 
     cmake_seeds = []
     with open(args.cmakeconfig) as f:
@@ -165,6 +167,11 @@ def run_cmake_mode(args):
     for name, value in cmake_seeds:
         out_lines.append('-Xcc')
         out_lines.append(f'-D{name}={value}')
+    # Windows: define the MSVC STL's __cpp_lib_* feature-test macros
+    # for the clang importer, so that they are visible to modules.
+    for m in re.finditer(STL_FEATURE_MACRO_RE, dM_output):
+        out_lines.append('-Xcc')
+        out_lines.append(f'-D{m.group(1)}={m.group(2)}')
     write_if_changed(args.output, '\n'.join(out_lines) + '\n')
 
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -948,6 +948,9 @@ if (NOT APPLE AND SWIFT_REQUIRED)
     list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -ivfsoverlay")
     list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc ${_vfs_overlay}")
 
+    # Importer flags contributed by the Platform*.cmake file (included above).
+    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS ${WebKit_PLATFORM_SWIFT_CLANG_FLAG_PAIRS})
+
     foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
         target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
     endforeach ()

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -157,3 +157,39 @@ if (USE_CAIRO)
 elseif (USE_SKIA)
     include(Platform/Skia.cmake)
 endif ()
+
+if (SWIFT_REQUIRED)
+    # FIXME(rdar://185507163):
+    # The Swift SDK wraps the MSVC STL in a clang module (SDKROOT/usr/
+    # share/vcruntime.modulemap), but its `std` module names only two of the STL's
+    # __msvc_*.hpp internal headers. Override it to be more complete.
+    cmake_path(CONVERT "$ENV{SDKROOT}" TO_CMAKE_PATH_LIST _swift_sdkroot)
+    cmake_path(CONVERT "$ENV{VCToolsInstallDir}" TO_CMAKE_PATH_LIST _vc_tools_dir)
+    set(_sdk_vcruntime_mm "${_swift_sdkroot}/usr/share/vcruntime.modulemap")
+    if (_swift_sdkroot AND _vc_tools_dir AND EXISTS "${_sdk_vcruntime_mm}")
+        # CONFIGURE_DEPENDS ensures this is rerun if VC changes its header set
+        # (subject to some known limitations of that cmake feature)
+        file(GLOB _msvc_internal_headers CONFIGURE_DEPENDS
+            RELATIVE "${_vc_tools_dir}/include"
+            "${_vc_tools_dir}/include/__msvc_*.hpp")
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} "${WEBKIT_DIR}/Scripts/generate-msvc-stl-modulemap.py"
+                --sdk-modulemap "${_sdk_vcruntime_mm}"
+                --msvc-include-dir "${_vc_tools_dir}/include"
+                --output-dir "${CMAKE_BINARY_DIR}/windows-modulemaps"
+                --headers ${_msvc_internal_headers}
+            OUTPUT_VARIABLE _win_vfs_overlay
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE _win_mm_error
+            RESULT_VARIABLE _win_mm_result)
+    else ()
+        set(_win_mm_result 1)
+        set(_win_mm_error "no readable ${_sdk_vcruntime_mm}")
+    endif ()
+    if (NOT _win_mm_result EQUAL 0)
+        message(WARNING "Could not generate the amended MSVC STL modulemap for the Swift clang importer (SDKROOT='$ENV{SDKROOT}', VCToolsInstallDir='$ENV{VCToolsInstallDir}'); Swift C++ interop will likely fail to import WTF headers.\n${_win_mm_error}")
+    elseif (_win_vfs_overlay)
+        # Single list item to avoid deduplication problems
+        list(APPEND WebKit_PLATFORM_SWIFT_CLANG_FLAG_PAIRS "-Xcc -ivfsoverlay -Xcc ${_win_vfs_overlay}")
+    endif ()
+endif ()

--- a/Source/WebKit/Scripts/generate-msvc-stl-modulemap.py
+++ b/Source/WebKit/Scripts/generate-msvc-stl-modulemap.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# Generates an amended copy of the Swift Windows SDK's vcruntime.modulemap, plus a
+# clang VFS overlay that mounts it over the MSVC include directory as
+# module.modulemap.
+#
+# The additions have to go inside `std._Private` rather than into a separate module
+# of our own: these headers include other STL headers, and STL headers include them,
+# so a separate top-level module would form a cyclic dependency with `std`.
+#
+# Writes <output-dir>/vcruntime.modulemap and <output-dir>/vfs-overlay.yaml, and
+# prints the path of the overlay to stdout for cmake to put on the importer's
+# command line.
+
+# An aggregate that pulls in the whole STL; giving it a module of its own is not useful.
+EXCLUDED_HEADERS = frozenset(['__msvc_all_public_headers.hpp'])
+
+# `module _Private [system] {` inside the `std` module, plus any `requires` lines that
+# open it, so that the additions land after them. Anchoring on the containing submodule
+# rather than on one of its entries keeps this working if the SDK reshuffles which
+# __msvc_*.hpp headers it happens to name.
+PRIVATE_MODULE_RE = re.compile(
+    r'^(?P<indent>[ \t]*)module _Private\b[^\n]*\{[ \t]*\n'
+    r'(?:[ \t]*(?:requires[^\n]*)?\n)*', re.MULTILINE)
+
+
+def declared_headers(modulemap_text):
+    return frozenset(re.findall(r'header\s+"([^"]+)"', modulemap_text))
+
+
+def amend_modulemap(modulemap_text, headers):
+    already_declared = declared_headers(modulemap_text)
+    missing = sorted(h for h in headers if h not in already_declared and h not in EXCLUDED_HEADERS)
+    if not missing:
+        return modulemap_text, []
+
+    match = PRIVATE_MODULE_RE.search(modulemap_text)
+    if not match:
+        raise ValueError("could not find the `module _Private` block to extend")
+
+    indent = match.group('indent') + '  '
+    additions = ''
+    for header in missing:
+        module_name = os.path.splitext(header)[0]
+        additions += '%sexplicit module %s {\n' % (indent, module_name)
+        additions += '%s  header "%s"\n' % (indent, header)
+        additions += '%s  export *\n' % indent
+        additions += '%s}\n\n' % indent
+
+    insertion_point = match.end()
+    return modulemap_text[:insertion_point] + additions + modulemap_text[insertion_point:], missing
+
+
+def write_if_changed(path, contents):
+    try:
+        with open(path, 'r') as f:
+            if f.read() == contents:
+                return False
+    except OSError:
+        pass
+    with open(path, 'w') as f:
+        f.write(contents)
+    return True
+
+
+def vfs_overlay(msvc_include_dir, modulemap_path):
+    return {
+        'version': 0,
+        'case-sensitive': 'false',
+        'roots': [
+            {
+                'name': msvc_include_dir.replace('\\', '/'),
+                'type': 'directory',
+                'contents': [
+                    {
+                        'name': 'module.modulemap',
+                        'type': 'file',
+                        'external-contents': modulemap_path.replace('\\', '/'),
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--sdk-modulemap', required=True,
+                        help='the Swift SDK\'s usr/share/vcruntime.modulemap')
+    parser.add_argument('--msvc-include-dir', required=True,
+                        help='the MSVC include directory to mount the amended map over')
+    parser.add_argument('--output-dir', required=True,
+                        help='where to write vcruntime.modulemap and vfs-overlay.yaml')
+    parser.add_argument('--headers', nargs='*', default=[], metavar='HEADER',
+                        help='__msvc_*.hpp header names, relative to --msvc-include-dir')
+    args = parser.parse_args(argv[1:])
+
+    with open(args.sdk_modulemap, 'r') as f:
+        sdk_modulemap = f.read()
+
+    if not args.headers:
+        raise ValueError('no __msvc_*.hpp headers found in %s' % args.msvc_include_dir)
+
+    amended, added = amend_modulemap(sdk_modulemap, args.headers)
+    if not added:
+        print('%s already declares every internal STL header' % args.sdk_modulemap, file=sys.stderr)
+        return 0
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    modulemap_path = os.path.join(args.output_dir, 'vcruntime.modulemap')
+    overlay_path = os.path.join(args.output_dir, 'vfs-overlay.yaml')
+
+    overlay = json.dumps(vfs_overlay(args.msvc_include_dir, modulemap_path), indent=2) + '\n'
+    wrote = write_if_changed(modulemap_path, amended) | write_if_changed(overlay_path, overlay)
+
+    if wrote:
+        print('declared %d internal STL header(s): %s' % (len(added), ' '.join(added)), file=sys.stderr)
+    print(overlay_path.replace('\\', '/'))
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main(sys.argv))
+    except (OSError, ValueError) as error:
+        print('%s: %s' % (os.path.basename(sys.argv[0]), error), file=sys.stderr)
+        sys.exit(1)

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1134,6 +1134,10 @@ function(_webkit_generate_platform_swift_args _target _resp_path)
     list(APPEND _clang_cmd ${_cxx_defs})
     # -fsanitize=* drives ASAN_ENABLED etc; keep this preprocess in sync with C++.
     list(APPEND _clang_cmd ${ENABLED_COMPILER_SANITIZERS})
+    if (WIN32 AND COMPILER_IS_CLANG_CL)
+        # See explanation in generate-platform-args
+        list(APPEND _clang_cmd -include version)
+    endif ()
     list(APPEND _clang_cmd "${_empty_input}")
 
     set(_script "${CMAKE_SOURCE_DIR}/Source/WTF/Scripts/generate-platform-args")
@@ -1144,6 +1148,7 @@ function(_webkit_generate_platform_swift_args _target _resp_path)
             --cmake
             --output "${_resp_path}"
             --cmakeconfig "${CMAKE_BINARY_DIR}/cmakeconfig.h"
+            ${_stl_feature_macros_arg}
             --
             ${_clang_cmd}
         DEPFILE "${_depfile}"


### PR DESCRIPTION
#### 4e646d190c3faf19195be9e2532318526865044b
<pre>
Fix the Swift clang importer on Windows: MSVC STL module visibility and more
<a href="https://bugs.webkit.org/show_bug.cgi?id=322271">https://bugs.webkit.org/show_bug.cgi?id=322271</a>

Reviewed by Ian Grunert and Elliott Williams.

The Windows Swift build failed in the clang importer for several stacked
reasons:

1. The Swift SDK&apos;s vcruntime.modulemap wraps the MSVC STL in a clang
   module whose yvals_core.h lives in an explicit submodule, so the
   __cpp_lib_* feature-test macros never become visible to headers that
   reach &lt;version&gt; through a module import. WTF/simdutf then mix
   pre-C++20 and C++23 preprocessor paths. Seed the macros through the
   platform-swift-args.resp response file (generate-platform-args
   --stl-feature-macros); they must not go on the command line, which
   already sits near the 32767-char CreateProcess limit that ninja hits
   before swiftc-wrapper can expand its own response file.

2. The same modulemap names only two of the STL&apos;s __msvc_*.hpp internal
   headers, leaving e.g. std::views::transform (__msvc_ranges_to.hpp)
   invisible at use sites. Generate an amended modulemap listing all of
   them and mount it over the MSVC include dir with a VFS overlay.

Alternatives considered:

1. Generate the amened modulemap directly in cmake rather than python.
   This was more concise but was unusually complex cmake code.

2. Do not _generate_ an amended modulemap; instead ship a static one.
   However, the SDK-provided VC modulemap is currently 796 lines which
   would be troublesome to maintain if we forked. A live amendment
   to insert the extra files seems less bad. (Licensing might also
   have made this awkward.)

3. Instead of execute_process, use a add_custom_command such that the
   python script runs in parallel with other build steps instead of
   at each configure time. Architecturally nicer, but the extra
   dependency edges, plus the need to respect CONFIGURE_DEPENDS
   would have made this even more verbose (and it&apos;s only one of
   hundreds of existing python invocations during cmake configure.)

4. List the headers which need to be added, instead of globbing.
   Everyone knows globbing is fragile and bad. However, the list
   of headers may also be fragile, and hopefully the use of
   CONFIGURE_DEPENDS reduces the globbing risk by prompting
   regeneration if the VC runtime header file set changes.

The reference for the limitations of the shipping modulemap is
<a href="https://rdar.apple.com/185507163">rdar://185507163</a>.

Co-Authored-By: Adrian Taylor &lt;adrian_taylor@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/319854@main">https://commits.webkit.org/319854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5849fa0854029e64ba1a2fc4a1e55a1adfe46ba3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36031b36-56a2-4c87-9d95-35ed6118ddce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/003ea10e-aa15-405a-9b8b-47439946a053) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46566 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123271 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04686f7c-dac4-42a1-a227-fc53ce56ba6c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182341 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45258 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12077 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43137 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4405 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44285 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56607 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40802 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57312 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152010 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46570 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125695 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55820 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18148 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55191 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55428 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->