### PR TITLE
[JSC][Wasm] Cover elem kind 6 initialized from global.get

### DIFF
--- a/JSTests/wasm.yaml
+++ b/JSTests/wasm.yaml
@@ -53,6 +53,8 @@
   cmd: runV8WebAssemblySuite(:no_module, "mjsunit.js") unless parseRunCommands
 - path: wasm/branch-hints
   cmd: runWebAssemblySuite unless parseRunCommands
+- path: wasm/extended-const
+  cmd: runWebAssemblySuite unless parseRunCommands
 - path: wasm/threads-spec-tests
   cmd: runWebAssemblyThreadsSpecTest :normal
 

--- a/JSTests/wasm/extended-const/extended-const.js
+++ b/JSTests/wasm/extended-const/extended-const.js
@@ -309,8 +309,7 @@ async function testExtendedConstElement() {
     assert.eq(m.exports.t.get(43), null);
   }
 
-  // FIXME: this requires changing how element segment initialization vectors are parsed.
-  // Test element segment kind 6.with element init expression.
+  // Test element segment kind 6 with element init expression.
   /*
    * (module
    *   (global (import "m" "gi1") externref)
@@ -318,17 +317,17 @@ async function testExtendedConstElement() {
    *   (elem (table 0) (offset (i32.add (i32.const 1) (i32.const 42))) externref (global.get 0))
    *   )
    */
-  //{
-  //  let obj = "hello";
-  //  let m = new WebAssembly.Instance(
-  //    module("\x00\x61\x73\x6d\x01\x00\x00\x00\x02\x8a\x80\x80\x80\x00\x01\x01\x6d\x03\x67\x69\x31\x03\x6f\x00\x04\x84\x80\x80\x80\x00\x01\x6f\x00\x40\x07\x85\x80\x80\x80\x00\x01\x01\x74\x01\x00\x09\x8e\x80\x80\x80\x00\x01\x06\x00\x41\x01\x41\x2a\x6a\x0b\x6f\x01\x23\x00\x0b"),
-  //    { m: { gi1: obj } }
-  //  );
-  //  assert.eq(m.exports.t.get(0), null);
-  //  assert.eq(m.exports.t.get(42), null);
-  //  assert.eq(m.exports.t.get(43), obj);
-  //  assert.eq(m.exports.t.get(44), null);
-  //}
+  {
+    let obj = "hello";
+    let m = new WebAssembly.Instance(
+      module("\x00\x61\x73\x6d\x01\x00\x00\x00\x02\x8a\x80\x80\x80\x00\x01\x01\x6d\x03\x67\x69\x31\x03\x6f\x00\x04\x84\x80\x80\x80\x00\x01\x6f\x00\x40\x07\x85\x80\x80\x80\x00\x01\x01\x74\x01\x00\x09\x8e\x80\x80\x80\x00\x01\x06\x00\x41\x01\x41\x2a\x6a\x0b\x6f\x01\x23\x00\x0b"),
+      { m: { gi1: obj } }
+    );
+    assert.eq(m.exports.t.get(0), null);
+    assert.eq(m.exports.t.get(42), null);
+    assert.eq(m.exports.t.get(43), obj);
+    assert.eq(m.exports.t.get(44), null);
+  }
 }
 
 async function testExtendedConstData() {


### PR DESCRIPTION
#### d95a22ac27020e2a85d22ef67e683de0de274b3e
<pre>
[JSC][Wasm] Cover elem kind 6 initialized from global.get

Reviewed by Yusuke Suzuki.

The parser and table init already support Element::FromGlobal. Enable the
commented kind-6 global.get case and collect wasm/extended-const so EWS
runs it.

* JSTests/wasm/extended-const/extended-const.js:
* JSTests/wasm.yaml:

Canonical link: <a href="https://commits.webkit.org/320062@main">https://commits.webkit.org/320062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dc5f75ee8310ec79ec748843974cadb6871341b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142090 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98656 "8 flakes 36 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122525 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181314 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42721 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4491 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11298 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154854 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42355 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3380 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43273 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194143 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181391 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162326 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40944 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151208 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45776 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128581 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124389 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54810 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17350 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->