### PR TITLE
[list-marker] A list marker's text reaches names and values that asked for text without list markers

### DIFF
--- a/LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt
+++ b/LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt
@@ -1,0 +1,16 @@
+This tests that a marker keeping its text in content renderers does not report that text to callers asking for text without list markers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS nameOf('string-button') is "Reply Item A"
+PASS itemValue('string') is "AXValue: Item A"
+PASS nameOf('counter-button') is "Reply Item B"
+PASS itemValue('counter') is "AXValue: Item B"
+PASS nameOf('decimal-button') is "Reply Item C"
+PASS itemValue('decimal') is "AXValue: Item C"
+PASS nameOf('generated-button') is "Reply radish Item D"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/list-marker-content-renderers-text.html
+++ b/LayoutTests/accessibility/list-marker-content-renderers-text.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<style>
+@counter-style rtl-cyclic { system: cyclic; symbols: "\627"; }
+.rtl-string li { list-style-type: "\627\644\641"; }
+.rtl-counter li { list-style-type: rtl-cyclic; }
+.rtl-list { direction: rtl; }
+.marker-content li::marker { content: "radish "; }
+</style>
+</head>
+<body>
+<div id="content">
+    <ul class="rtl-string"><li id="string">Item A</li></ul>
+    <a role="button" href="#" id="string-button" aria-labelledby="string-button string"><span>Reply</span></a>
+
+    <ul class="rtl-counter"><li id="counter">Item B</li></ul>
+    <a role="button" href="#" id="counter-button" aria-labelledby="counter-button counter"><span>Reply</span></a>
+
+    <ol class="rtl-list"><li id="decimal">Item C</li></ol>
+    <a role="button" href="#" id="decimal-button" aria-labelledby="decimal-button decimal"><span>Reply</span></a>
+
+    <ul class="marker-content"><li id="generated">Item D</li></ul>
+    <a role="button" href="#" id="generated-button" aria-labelledby="generated-button generated"><span>Reply</span></a>
+</div>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description("This tests that a marker keeping its text in content renderers does not report that text to callers asking for text without list markers.");
+
+function nameOf(buttonId) {
+    document.getElementById(buttonId).focus();
+    return platformValueForW3CName(accessibilityController.focusedElement);
+}
+
+function itemValue(itemId) {
+    return accessibilityController.accessibleElementById(itemId).stringValue;
+}
+
+if (window.accessibilityController) {
+    // Each list below gives its marker content renderers to hold the text with: the string and the
+    // counter style symbol are right-to-left, and a right-to-left list makes even decimal need bidi
+    // resolution. aria-labelledby asks for the name without list markers, so none of that text
+    // belongs in these names, nor in the list item's own value.
+    shouldBeEqualToString("nameOf('string-button')", "Reply Item A");
+    shouldBeEqualToString("itemValue('string')", "AXValue: Item A");
+
+    shouldBeEqualToString("nameOf('counter-button')", "Reply Item B");
+    shouldBeEqualToString("itemValue('counter')", "AXValue: Item B");
+
+    shouldBeEqualToString("nameOf('decimal-button')", "Reply Item C");
+    shouldBeEqualToString("itemValue('decimal')", "AXValue: Item C");
+
+    // A `content` marker is the exception: it computes no text of its own, so the renderers holding
+    // its content are the only source and they keep contributing. accname asks for that text in the
+    // name, see accname/name/comp_name_from_pseudo_content_marker.tentative.html.
+    shouldBeEqualToString("nameOf('generated-button')", "Reply radish Item D");
+
+    document.getElementById("content").style.visibility = "hidden";
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -113,6 +113,7 @@
 #include "RenderImage.h"
 #include "RenderListBox.h"
 #include "RenderListItem.h"
+#include "RenderListMarker.h"
 #include "RenderTableCell.h"
 #include "RenderView.h"
 #include "RuleFeature.h"
@@ -917,6 +918,10 @@ bool AccessibilityNodeObject::canHaveChildren() const
     // When <noscript> is not being used (its renderer() == 0), ignore its children
     if (node() && !renderer() && WebCore::elementName(node()) == ElementName::HTML_noscript)
         return false;
+
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderer()))
+        return listMarker->hasContentProperty();
+
     // If this is an AccessibilityRenderObject, then it's okay if this object
     // doesn't have a node - there are some renderers that don't have associated
     // nodes, like scroll areas and css-generated text.

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -432,9 +432,13 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
     if (CheckedPtr fileUpload = dynamicDowncast<RenderFileUploadControl>(*m_renderer))
         return fileUpload->buttonValue();
 
-    if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
-        if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer))
-            return listMarker->textContent();
+    if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer)) {
+        // A `content` marker has no text of its own; the child walk below reads the renderers holding it.
+        if (!listMarker->hasContentProperty()) {
+            if (mode.includeListMarkers == IncludeListMarkerText::Yes)
+                return listMarker->textContent();
+            return { };
+        }
     }
 
     // Reflect when a content author has explicitly marked a line break.


### PR DESCRIPTION
#### 86d27022072df830a2b8749ca4a685fd900677d8
<pre>
[list-marker] A list marker&apos;s text reaches names and values that asked for text without list markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322187">https://bugs.webkit.org/show_bug.cgi?id=322187</a>
&lt;<a href="https://rdar.apple.com/problem/185422271">rdar://problem/185422271</a>&gt;

Reviewed by Antti Koivisto.

  &lt;style&gt;
  li { list-style-type: &quot;\627\644\641&quot; }
  &lt;/style&gt;
  &lt;ul&gt;&lt;li id=item&gt;Item Five
  &lt;a role=button aria-labelledby=&quot;button item&quot; id=button&gt;Reply

Whether a marker&apos;s text belongs in a name is the caller&apos;s to decide, and IncludeListMarkerText is how
it says so: aria-labelledby name computation passes No, and textUnderElement() answers for the marker
only when it is Yes.

A marker whose text needs bidi resolution does not draw that text itself, it keeps it in content
renderers, and those are reachable through AccessibilityRenderObject::firstChild(), which answers from
the render tree before it consults canHaveChildren(). The walk that builds a name reaches them that
way and takes their text, so the flag stops governing what the caller asked about. The name computed
for the button above comes out as &quot;Reply الفItem Five&quot;, and the list item&apos;s own value with it. Neither
the string above nor a right-to-left list of plain decimals is exotic, so this is what any
aria-labelledby pointing at such a list item reports today.

* LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt: Added.
* LayoutTests/accessibility/list-marker-content-renderers-text.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::canHaveChildren const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/319615@main">https://commits.webkit.org/319615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c723515556af11f9a45d124cfe97ca65f448ec7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146323 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55664 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142096 "Found 1 new test failure: accessibility/list-marker-content-renderers-text.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5487b201-79ee-4218-b078-cad9fa133be4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1c87043-6efd-45d0-938d-505184204e05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44457 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42725 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42358 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3384 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162329 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151507 "Found 1 new test failure: accessibility/list-marker-content-renderers-text.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40576 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56303 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151211 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45783 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128585 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124397 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17353 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54195 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->