### PR TITLE
Simplify clamp(none, a, b) to max(a, b) and clamp(a, b, none) to min(a, b)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-partial-serialize.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-partial-serialize.tentative-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL e.style['margin-top'] = "clamp(none, 2px, 3em)" should set the property value assert_equals: serialization should be canonical expected "min(2px, 3em)" but got "clamp(none, 2px, 3em)"
-FAIL e.style['margin-top'] = "calc(clamp(none, 2px, 3em))" should set the property value assert_equals: serialization should be canonical expected "min(2px, 3em)" but got "clamp(none, 2px, 3em)"
-FAIL e.style['margin-top'] = "clamp(1em, 2px, none)" should set the property value assert_equals: serialization should be canonical expected "max(1em, 2px)" but got "clamp(1em, 2px, none)"
-FAIL e.style['margin-top'] = "calc(clamp(1em, 2px, none))" should set the property value assert_equals: serialization should be canonical expected "max(1em, 2px)" but got "clamp(1em, 2px, none)"
-FAIL e.style['margin-top'] = "clamp(1px, 2px, clamp(none, 4px, 5em))" should set the property value assert_equals: serialization should be canonical expected "clamp(1px, 2px, min(4px, 5em))" but got "clamp(1px, 2px, clamp(none, 4px, 5em))"
-FAIL e.style['margin-top'] = "calc(clamp(1px, 2px, clamp(none, 4px, 5em)))" should set the property value assert_equals: serialization should be canonical expected "clamp(1px, 2px, min(4px, 5em))" but got "clamp(1px, 2px, clamp(none, 4px, 5em))"
-FAIL e.style['margin-top'] = "clamp(1px, 2px, clamp(3em, 4px, none))" should set the property value assert_equals: serialization should be canonical expected "clamp(1px, 2px, max(3em, 4px))" but got "clamp(1px, 2px, clamp(3em, 4px, none))"
-FAIL e.style['margin-top'] = "calc(clamp(1px, 2px, clamp(3em, 4px, none)))" should set the property value assert_equals: serialization should be canonical expected "clamp(1px, 2px, max(3em, 4px))" but got "clamp(1px, 2px, clamp(3em, 4px, none))"
-FAIL e.style['margin-top'] = "clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em))" should set the property value assert_equals: serialization should be canonical expected "clamp(min(2em, 3px), 4px, min(6px, 7em))" but got "clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em))"
-FAIL e.style['margin-top'] = "calc(clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em)))" should set the property value assert_equals: serialization should be canonical expected "clamp(min(2em, 3px), 4px, min(6px, 7em))" but got "clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em))"
-FAIL e.style['margin-top'] = "clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em))" should set the property value assert_equals: serialization should be canonical expected "clamp(max(1em, 2px), 4px, min(6px, 7em))" but got "clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em))"
-FAIL e.style['margin-top'] = "calc(clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em)))" should set the property value assert_equals: serialization should be canonical expected "clamp(max(1em, 2px), 4px, min(6px, 7em))" but got "clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em))"
-FAIL e.style['margin-top'] = "clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none))" should set the property value assert_equals: serialization should be canonical expected "clamp(min(2em, 3px), 4px, max(5em, 6px))" but got "clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none))"
-FAIL e.style['margin-top'] = "calc(clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none)))" should set the property value assert_equals: serialization should be canonical expected "clamp(min(2em, 3px), 4px, max(5em, 6px))" but got "clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none))"
+PASS e.style['margin-top'] = "clamp(none, 2px, 3em)" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(none, 2px, 3em))" should set the property value
+PASS e.style['margin-top'] = "clamp(1em, 2px, none)" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(1em, 2px, none))" should set the property value
+PASS e.style['margin-top'] = "clamp(1px, 2px, clamp(none, 4px, 5em))" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(1px, 2px, clamp(none, 4px, 5em)))" should set the property value
+PASS e.style['margin-top'] = "clamp(1px, 2px, clamp(3em, 4px, none))" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(1px, 2px, clamp(3em, 4px, none)))" should set the property value
+PASS e.style['margin-top'] = "clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em))" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(clamp(none, 2em, 3px), 4px, clamp(none, 6px, 7em)))" should set the property value
+PASS e.style['margin-top'] = "clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em))" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(clamp(1em, 2px, none), 4px, clamp(none, 6px, 7em)))" should set the property value
+PASS e.style['margin-top'] = "clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none))" should set the property value
+PASS e.style['margin-top'] = "calc(clamp(clamp(none, 2em, 3px), 4px, clamp(5em, 6px, none)))" should set the property value
 PASS e.style['margin-top'] = "clamp(clamp(none, 2em, none), 4px, clamp(none, 6em, none))" should set the property value
 PASS e.style['margin-top'] = "calc(clamp(clamp(none, 2em, none), 4px, clamp(none, 6em, none)))" should set the property value
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -1009,41 +1009,65 @@ std::optional<Child> simplify(Clamp& root, const SimplificationOptions& options)
         return { WTF::move(root.val) };
     }
 
-    // FIXME: Are any of these transforms kosher?
-    // If only MIN and VAL have matching units, we can transform clamp(MIN, VAL, MAX) aka (max(MIN, min(VAL, MAX)) into a min(newVAL, MAX).
-    // If only VAL and MAX have matching units, we can transform clamp(MIN, VAL, MAX) aka (max(MIN, min(VAL, MAX)) into a max(MIN, newVAL).
+    auto convertToMin = [&] -> std::optional<Child> {
+        Vector<Child> newChildren;
+        newChildren.reserveInitialCapacity(2);
+        newChildren.append(WTF::move(root.val));
+        newChildren.append(get<Child>(WTF::move(root.max)));
+
+        auto min = Min { .children = WTF::move(newChildren) };
+        auto minType = toType(min);
+        if (!minType)
+            return std::nullopt;
+
+        return makeChild(WTF::move(min), *minType);
+    };
+
+    auto convertToMax = [&] -> std::optional<Child> {
+        Vector<Child> newChildren;
+        newChildren.reserveInitialCapacity(2);
+        newChildren.append(get<Child>(WTF::move(root.min)));
+        newChildren.append(WTF::move(root.val));
+
+        auto max = Max { .children = WTF::move(newChildren) };
+        auto maxType = toType(max);
+        if (!maxType)
+            return std::nullopt;
+
+        return makeChild(WTF::move(max), *maxType);
+    };
 
     return WTF::switchOn(root.val,
         [&]<Numeric T>(T& val) -> std::optional<Child> {
             if (minIsNone) {
                 auto& maxChild = get<Child>(root.max);
                 if (!WTF::holdsAlternative<T>(maxChild))
-                    return { };
+                    return convertToMin();
 
                 auto& max = get<T>(maxChild);
 
                 if (!unitsMatch(val, max, options))
-                    return { };
+                    return convertToMin();
 
                 // As units already match, we only have to check that one of the arguments is `magnitudeComparable`.
                 if (!magnitudeComparable(val, options))
-                    return { };
+                    return convertToMin();
 
                 // - clamp(none, VAL, MAX) is equivalent to min(VAL, MAX)
                 return makeChildWithValueBasedOn(executeMathOperation<Min>(val.value, max.value), val);
             } else if (maxIsNone) {
                 auto& minChild = get<Child>(root.min);
                 if (!WTF::holdsAlternative<T>(minChild))
-                    return { };
+                    return convertToMax();
 
                 auto& min = get<T>(minChild);
 
                 if (!unitsMatch(min, val, options))
-                    return { };
+                    return convertToMax();
 
                 // As units already match, we only have to check that one of the arguments is `magnitudeComparable`.
                 if (!magnitudeComparable(val, options))
-                    return { };
+                    return convertToMax();
 
                 // - clamp(MIN, VAL, none) is equivalent to max(MIN, VAL)
                 return makeChildWithValueBasedOn(executeMathOperation<Max>(min.value, val.value), val);


### PR DESCRIPTION
#### 61fc55e15fb67f6df7f4a525568c98123aad3f59
<pre>
Simplify clamp(none, a, b) to max(a, b) and clamp(a, b, none) to min(a, b)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322284">https://bugs.webkit.org/show_bug.cgi?id=322284</a>

Reviewed by Darin Adler.

Add support for additional simplification rules in calc():
  - clamp(none, a, b) -&gt; max(a, b)
  - clamp(a, b, none) -&gt; min(a, b)

This was resolved on by the CSSWG in <a href="https://github.com/w3c/csswg-drafts/issues/13535.">https://github.com/w3c/csswg-drafts/issues/13535.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-partial-serialize.tentative-expected.txt:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:

Canonical link: <a href="https://commits.webkit.org/319614@main">https://commits.webkit.org/319614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d29ca925a3a8839ce4dea2b7b057c09794f2b411

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142103 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42732 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42361 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3392 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55620 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56311 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151219 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45786 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128593 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124412 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54822 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->