### PR TITLE
[webkitbot] Test suite cannot run due to undeclared https-proxy-agent dependency

### DIFF
--- a/Tools/WebKitBot/package-lock.json
+++ b/Tools/WebKitBot/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.15.1",
         "dotenv": "^8.2.0",
         "eslint": "^7.3.1",
+        "https-proxy-agent": "^8.0.0",
         "jest": "^26.1.0",
         "node-persist": "^3.1.0",
         "replaceall": "^0.1.6",
@@ -1384,6 +1385,19 @@
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://npm.apple.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -3081,16 +3095,25 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://npm.apple.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "8.0.0",
+      "resolved": "https://npm.apple.com/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "8.0.0",
+      "resolved": "https://npm.apple.com/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4048,6 +4071,19 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://npm.apple.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jsdom/node_modules/ws": {

--- a/Tools/WebKitBot/package.json
+++ b/Tools/WebKitBot/package.json
@@ -10,6 +10,7 @@
     "axios": "^1.15.1",
     "dotenv": "^8.2.0",
     "eslint": "^7.3.1",
+    "https-proxy-agent": "^8.0.0",
     "jest": "^26.1.0",
     "node-persist": "^3.1.0",
     "replaceall": "^0.1.6",

--- a/Tools/WebKitBot/src/CommandParser.mjs
+++ b/Tools/WebKitBot/src/CommandParser.mjs
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Pure parsing of webkitbot commands. This module deliberately has no imports so that
+// tests can exercise it without pulling in the Slack clients and their dependencies.
+
+export function parseBugId(string)
+{
+    if (!string)
+        return null;
+
+    let match = string.match(/^https?:\/\/webkit\.org\/b\/(\d+)$/m);
+    if (match)
+        return match[1];
+
+    match = string.match(/^https?:\/\/bugs\.webkit\.org\/show_bug\.cgi\?id=(\d+)(?:&ctype=xml|&excludefield=attachmentdata)*$/m);
+    if (match)
+        return match[1];
+
+    return null;
+}
+
+export function parsePRUrl(string)
+{
+    if (!string)
+        return null;
+
+    let match = string.match(/https:\/\/github\.com\/WebKit\/WebKit\/pull\/\d+/im);
+    return match ? match[0] : null;
+}
+
+function extractRevision(text)
+{
+    let revisions = [];
+    for (let candidate of text.split(",")) {
+        candidate = candidate.trim();
+        if (!candidate)
+            continue;
+
+        let match = candidate.match(/^r?(\d{5,6}|\d+@[^:\s]+|[0-9a-f]{6,40}):?$/);
+        if (!match)
+            return null;
+
+        revisions.push(match[1]);
+    }
+    return revisions;
+}
+
+export function buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, issueUrl)
+{
+    let args = [
+        gitWebkitPath,
+        "revert",
+        ...revisions,
+        "--pr",
+        "--defaults",
+        "--no-checks",
+    ];
+
+    if (issueUrl)
+        args.push("--issue", issueUrl);
+    else
+        args.push("--reason", reason);
+
+    return args;
+}
+
+export function extractRevisionsAndReason(args)
+{
+    let revisions = [];
+    let reason = "";
+    for (let i = 0; i < args.length; ++i) {
+        let arg = args[i];
+        let extracted = extractRevision(arg);
+        if (!extracted) {
+            let reasons = [];
+            for (; i < args.length; ++i)
+                reasons.push(args[i]);
+            reason = reasons.join(" ").trim();
+            break;
+        }
+        revisions.push(...extracted);
+    }
+
+    // If reason starts with quote and ends with the same quote, remove them once.
+    if (reason.length >= 2) {
+        let firstCharacterOfReason = reason.charAt(0);
+        if (firstCharacterOfReason === "'" || firstCharacterOfReason === "\"" || firstCharacterOfReason === "`") {
+            if (reason.charAt(reason.length - 1) === firstCharacterOfReason)
+                reason = reason.slice(1, reason.length - 1);
+        }
+    }
+
+    return {revisions, reason};
+}
+
+export function extractCommandAndArgs(text)
+{
+    let args = text.trim().split(/\s+/);
+    let command = args.shift().toLowerCase();
+    return {command, args};
+}
+
+export function extractTextIfMentioned(text, id)
+{
+    let regexp = new RegExp(`<@${id}>`);
+    let globalRegexp = new RegExp(`<@${id}>`, "g");
+    let matched = text.match(regexp);
+    if (!matched)
+        return null;
+
+    text = text.replace(globalRegexp, "");
+
+    // Preprocessing for the text.
+    // 1. Convert smart quotes to normal ASCII quotes because webkit-patch cannot accept non-ASCII text and slack may convert normal quotes to smart quotes.
+    text = text.replace(/[\u2018\u2019]/g, "'");
+    text = text.replace(/[\u201C\u201D]/g, "\"");
+
+    // 2. Convert line-terminators to spaces. It is unlikely that we want to have line-terminators in webkitbot commands.
+    text = text.replace(/(\r\n|\n|\r|\u2028|\u2029)/g, " ");
+
+    // 3. Strip Slack's auto-linked URLs: <https://url> → https://url, <https://url|label> → https://url
+    text = text.replace(/<(https?:\/\/[^|>]+)(?:\|[^>]*)?>/g, "$1");
+
+    return text;
+}

--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -32,6 +32,8 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import LogLevel from "@slack/rtm-api";
 import SlackRTMAPI from "@slack/rtm-api";
 import AsyncTaskQueue from "./AsyncTaskQueue.mjs";
+import {buildGitWebkitRevertCommand, extractCommandAndArgs, extractRevisionsAndReason,
+    extractTextIfMentioned, parseBugId, parsePRUrl} from "./CommandParser.mjs";
 import {dataLogLn, escapeForSlackText, isASCII, rootDirectoryOfWebKit} from "./Utility.mjs";
 
 const defaultTaskLimit = 10;
@@ -41,127 +43,6 @@ const defaultTimeoutForRevert = 60 * 1000 * 10;
 const execFileAsync = util.promisify(execFile);
 const statAsync = util.promisify(stat);
 const unlinkAsync = util.promisify(unlink);
-
-function parseBugId(string)
-{
-    if (!string)
-        return null;
-
-    let match = string.match(/^https?:\/\/webkit\.org\/b\/(\d+)$/m);
-    if (match)
-        return match[1];
-
-    match = string.match(/^https?:\/\/bugs\.webkit\.org\/show_bug\.cgi\?id=(\d+)(?:&ctype=xml|&excludefield=attachmentdata)*$/m);
-    if (match)
-        return match[1];
-
-    return null;
-}
-
-export function parsePRUrl(string)
-{
-    if (!string)
-        return null;
-
-    let match = string.match(/https:\/\/github\.com\/WebKit\/WebKit\/pull\/\d+/im);
-    return match ? match[0] : null;
-}
-
-function extractRevision(text)
-{
-    let revisions = [];
-    for (let candidate of text.split(",")) {
-        candidate = candidate.trim();
-        if (!candidate)
-            continue;
-
-        let match = candidate.match(/^r?(\d{5,6}|\d+\@[^:\s]+|[0-9a-f]{6,40}):?$/);
-        if (!match)
-            return null;
-
-        revisions.push(match[1]);
-    }
-    return revisions;
-}
-
-export function buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, issueUrl)
-{
-    let args = [
-        gitWebkitPath,
-        "revert",
-        ...revisions,
-        "--pr",
-        "--defaults",
-        "--no-checks",
-    ];
-
-    if (issueUrl)
-        args.push("--issue", issueUrl);
-    else
-        args.push("--reason", reason);
-
-    return args;
-}
-
-export function extractRevisionsAndReason(args)
-{
-    let revisions = [];
-    let reason = "";
-    for (let i = 0; i < args.length; ++i) {
-        let arg = args[i];
-        let extracted = extractRevision(arg);
-        if (!extracted) {
-            let reasons = [];
-            for (; i < args.length; ++i)
-                reasons.push(args[i]);
-            reason = reasons.join(" ").trim();
-            break;
-        }
-        revisions.push(...extracted);
-    }
-
-    // If reason starts with quote and ends with the same quote, remove them once.
-    if (reason.length >= 2) {
-        let firstCharacterOfReason = reason.charAt(0);
-        if (firstCharacterOfReason === "'" || firstCharacterOfReason === "\"" || firstCharacterOfReason === "`") {
-            if (reason.charAt(reason.length - 1) === firstCharacterOfReason)
-                reason = reason.slice(1, reason.length - 1);
-        }
-    }
-
-    return {revisions, reason};
-}
-
-export function extractCommandAndArgs(text)
-{
-    let args = text.trim().split(/\s+/);
-    let command = args.shift().toLowerCase();
-    return {command, args};
-}
-
-export function extractTextIfMentioned(text, id)
-{
-    let regexp = new RegExp(`<@${id}>`);
-    let globalRegexp = new RegExp(`<@${id}>`, "g");
-    let matched = text.match(regexp);
-    if (!matched)
-        return null;
-
-    text = text.replace(globalRegexp, "");
-
-    // Preprocessing for the text.
-    // 1. Convert smart quotes to normal ASCII quotes because webkit-patch cannot accept non-ASCII text and slack may convert normal quotes to smart quotes.
-    text = text.replace(/[\u2018\u2019]/g, "'");
-    text = text.replace(/[\u201C\u201D]/g, "\"");
-
-    // 2. Convert line-terminators to spaces. It is unlikely that we want to have line-terminators in webkitbot commands.
-    text = text.replace(/(\r\n|\n|\r|\u2028|\u2029)/g, " ");
-
-    // 3. Strip Slack's auto-linked URLs: <https://url> → https://url, <https://url|label> → https://url
-    text = text.replace(/<(https?:\/\/[^|>]+)(?:\|[^>]*)?>/g, "$1");
-
-    return text;
-}
 
 export default class WebKitBot {
     postMessage(options)

--- a/Tools/WebKitBot/tests/WebKitBot.test.mjs
+++ b/Tools/WebKitBot/tests/WebKitBot.test.mjs
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {buildGitWebkitRevertCommand, extractRevisionsAndReason, extractTextIfMentioned, extractCommandAndArgs} from "../src/WebKitBot.mjs";
+import {buildGitWebkitRevertCommand, extractRevisionsAndReason, extractTextIfMentioned, extractCommandAndArgs} from "../src/CommandParser.mjs";
 const WebKitBotID = 42;
 
 test("buildGitWebkitRevertCommand skips style checks with a reason", () => {


### PR DESCRIPTION
#### 950d24e29c691c014281861b30b28ccddecc96cb
<pre>
[webkitbot] Test suite cannot run due to undeclared https-proxy-agent dependency
<a href="https://bugs.webkit.org/show_bug.cgi?id=322279">https://bugs.webkit.org/show_bug.cgi?id=322279</a>
<a href="https://rdar.apple.com/problem/185518939">rdar://problem/185518939</a>

Reviewed by Aakash Jain.

Running tests/WebKitBot.test.mjs locally fails because src/WebKitBot.mjs imports https-proxy-agent,
which is not declared in package.json. This means that`npm ci` alone resolves only the transitive
v5, and `import { HttpsProxyAgent }` fails against it because v5 is CommonJS with no statically
detectable named export. The deployed bot is unaffected, since the image supplies v8 and Node
resolves it natively.

Along with declaring the dependency, move the pure command parsing out of WebKitBot.mjs into
a new module with no imports at all, so the tests exercise it without loading the Slack clients
or the proxy agent. Other than a drive-by fix to drop an unnecessary escape in the revision
regexp (\@ -&gt; @), this is a straight move.

* Tools/WebKitBot/package.json: Declare https-proxy-agent so `npm ci` matches the deployed image.
* Tools/WebKitBot/package-lock.json: Hoist https-proxy-agent v8, v5 stays nested under axios and jsdom.
* Tools/WebKitBot/src/CommandParser.mjs: Added. Moved from WebKitBot.mjs.
(parseBugId): Moved.
(parsePRUrl): Moved.
(extractRevision): Moved.
(buildGitWebkitRevertCommand): Moved.
(extractRevisionsAndReason): Moved.
(extractCommandAndArgs): Moved.
(extractTextIfMentioned): Moved.
* Tools/WebKitBot/src/WebKitBot.mjs: Import the parsing helpers from CommandParser.mjs.
* Tools/WebKitBot/tests/WebKitBot.test.mjs: Import from CommandParser.mjs.

Canonical link: <a href="https://commits.webkit.org/319804@main">https://commits.webkit.org/319804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40e9889c62379fc8085725979774bf197fd8223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182547 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56494 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192782 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146868 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f86a495d-273a-4f83-a048-85b053a4e226) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184409 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57810 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56217 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192782 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146868 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27082319-b8ec-4c37-bfe6-0280f71b77e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185502 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57810 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192782 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9adc0d5a-15b7-42ff-9444-c1fa2573674f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57810 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56217 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192782 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57810 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3941 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56217 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56165 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/194704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27752 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125155 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54749 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54987 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->