### PR TITLE
canDrawText() refs both the fill and stroke gradient when only one is used

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2836,12 +2836,8 @@ bool CanvasRenderingContext2DBase::canDrawText(double x, double y, bool fill, st
         return false;
 
     // If gradient size is zero, nothing would be painted.
-    RefPtr gradient = c->strokeGradient();
-    if (!fill && gradient && gradient->isZeroSize())
-        return false;
-
-    gradient = c->fillGradient();
-    if (fill && gradient && gradient->isZeroSize())
+    RefPtr gradient = fill ? c->fillGradient() : c->strokeGradient();
+    if (gradient && gradient->isZeroSize())
         return false;
 
     return true;


### PR DESCRIPTION
#### 69387ce22018858ece19528bd2b8255e5ae0db32
<pre>
canDrawText() refs both the fill and stroke gradient when only one is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=322288">https://bugs.webkit.org/show_bug.cgi?id=322288</a>
<a href="https://rdar.apple.com/185524314">rdar://185524314</a>

Reviewed by Gerald Squelart.

canDrawText() rejects text draws whose paint is a zero-size gradient, but which
gradient matters depends on whether the caller is filling or stroking. The check
was written as two unconditional RefPtr assignments with the fill/stroke test
folded into each if-condition, so every fillText() and strokeText() call queried
both GraphicsContext::strokeGradient() and GraphicsContext::fillGradient() and
paid a ref/deref pair for each - both accessors return a raw Gradient*, so the
RefPtr construction is a real refcount round trip - when by construction one of
the two results is discarded unused.

Select the gradient with the fill flag first and take a single reference. No
behavior change: filling still consults only the fill gradient and stroking only
the stroke gradient.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::canDrawText):

Canonical link: <a href="https://commits.webkit.org/319670@main">https://commits.webkit.org/319670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7309e3a909b75134e7eeb467159f99537e330139

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146343 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1b67013-eaee-4483-9a78-a8223afce74b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55684 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98674 "5 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7339ee9-e71a-4309-950b-d8dddc4809b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c6d4611-107d-4344-971f-2a24c3d9ccad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44477 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42744 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42378 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3404 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194167 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55632 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151523 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151227 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45804 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128605 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124425 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17373 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->