### PR TITLE
analyze-safer-cpp: Support upstream clang checkers

### DIFF
--- a/Tools/Scripts/analyze-safer-cpp
+++ b/Tools/Scripts/analyze-safer-cpp
@@ -273,7 +273,18 @@ def rewrite_argv(entry, absSrc, clang, checkers, header_only=False):
     return out, entry['directory']
 
 
-def filter_diagnostics(stderr, requestedPaths, expectations, ignoreExpectations):
+def trace_includes_requested_file(block, requestedPaths):
+    for line in block['lines'][1:]:
+        m = DIAG_RE.match(line)
+        if not m or m.group('kind') != 'note':
+            continue
+        if os.path.realpath(m.group('path')) in requestedPaths:
+            return True
+    return False
+
+
+def filter_diagnostics(stderr, requestedPaths, expectations, ignoreExpectations,
+                       includeReachable):
     lines = stderr.splitlines()
     blocks = []
     current = None
@@ -303,7 +314,11 @@ def filter_diagnostics(stderr, requestedPaths, expectations, ignoreExpectations)
         diagPath = m.group('path')
         diagAbs = os.path.realpath(diagPath)
         if diagAbs not in requestedPaths:
-            continue
+            # This warning came from a file that was not requested to be
+            # analyzed. Hide it unless --include-reachable was passed.
+            if not includeReachable or not trace_includes_requested_file(
+                    block, requestedPaths):
+                continue
         if not ignoreExpectations:
             short = checker.rsplit('.', 1)[-1]
             project, root = project_for_path(diagAbs)
@@ -386,9 +401,15 @@ def normalize_checkers(values, parser):
             result.append(v)
         elif v in shortNames:
             result.append(shortNames[v])
+        elif '.' in v or v.islower():
+            # Not a SaferCPP checker. clang names are either package.Checker
+            # or a bare lowercase package, so pass those through and let clang
+            # reject anything it does not know.
+            result.append(v)
         else:
-            parser.error("unknown checker '{}'; valid names: {}".format(
-                v, ', '.join(sorted(shortNames))))
+            parser.error("unknown checker '{}'; pass a SaferCPP checker ({}) "
+                         'or a fully-qualified upstream checker name such as '
+                         'cplusplus.Move'.format(v, ', '.join(sorted(shortNames))))
     return result
 
 
@@ -492,11 +513,13 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage='%(prog)s [-h] [--base BASE] [--clang CLANG] [--download-toolchain]\n'
               '                         [--cmake-preset CMAKE_PRESET | --compile-commands PATH]\n'
-              '                         [--checker NAME] [--ignore-expectations] [-j N] [-v]\n'
+              '                         [--checker NAME] [--include-reachable]\n'
+              '                         [--ignore-expectations] [-j N] [-v]\n'
               '                         [--changed-files | FILE ...]',
         epilog='examples:\n'
                '  analyze-safer-cpp Source/WebCore/dom/Document.cpp\n'
-               '  analyze-safer-cpp --changed-files -j 12\n')
+               '  analyze-safer-cpp --changed-files -j 12\n'
+               '  analyze-safer-cpp --checker cplusplus.Move --changed-files\n')
     parser.add_argument('files', nargs='*', metavar='FILE',
                         help='source or header files to analyze')
     parser.add_argument('--changed-files', action='store_true',
@@ -515,7 +538,12 @@ def parse_args():
     where.add_argument('--compile-commands', metavar='PATH',
                        help='path to a compile_commands.json file')
     parser.add_argument('--checker', action='append', dest='checkers', metavar='NAME',
-                        help='restrict to one checker (repeatable; short or full name)')
+                        help='restrict to one checker (repeatable). A SaferCPP '
+                             'checker by short or full name, or any upstream '
+                             'checker/package, e.g. cplusplus.Move')
+    parser.add_argument('--include-reachable', action='store_true',
+                        help='also report issues in files you did not list, when '
+                             'their trace reaches one you did')
     parser.add_argument('--ignore-expectations', action='store_true',
                         help='show all checker warnings, ignoring SaferCPPExpectations')
     parser.add_argument('-j', type=int, default=os.cpu_count(), metavar='N',
@@ -605,7 +633,8 @@ def main():
     with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.j)) as pool:
         for tu, stderr, header_only in pool.map(runOne, workItems):
             blocks, unexpected, errors = filter_diagnostics(
-                stderr, requestedPaths, expectations, args.ignore_expectations)
+                stderr, requestedPaths, expectations, args.ignore_expectations,
+                args.include_reachable)
             label = repo_relative(tu) + ' (header-only)' if header_only else repo_relative(tu)
             print('==> {}'.format(label))
             if blocks:


### PR DESCRIPTION
#### 457f36a326b5dc63691677e6b601dcb49f0dbd11
<pre>
analyze-safer-cpp: Support upstream clang checkers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322286">https://bugs.webkit.org/show_bug.cgi?id=322286</a>
<a href="https://rdar.apple.com/185523433">rdar://185523433</a>

Reviewed by NOBODY (OOPS!).

The analyze-safer-cpp script already allows for SaferCPP clang checkers (those
under webkit.* or alpha.webkit.*) to be run on a subset of files instead of the
entire tree.

However, clang offers a large selection of other checkers besides the WebKit
SaferCPP ones. See the full list here:
<a href="https://clang.llvm.org/docs/analyzer/checkers.html">https://clang.llvm.org/docs/analyzer/checkers.html</a>

This patch updates the analyze-safer-cpp script to accept any arbitrary clang
checker and analzye the requested set of files with it.

Now the `--checker` flag will accepts the name of any clang checker (i.e.
cplusplus.Move).

Since some clang checkers can report analyzer warnings in files that weren&apos;t
requested, the output can be noisy if you only want to see warnings in the
requested files. I added a new opt-in flag called --include-reachable which will
show warnings in code that is reachable from the files requested (which may
include files you didn&apos;t request).

* Tools/Scripts/analyze-safer-cpp:
(trace_includes_requested_file):
(filter_diagnostics):
(normalize_checkers):
(parse_args):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/457f36a326b5dc63691677e6b601dcb49f0dbd11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146351 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142117 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98679 "3 flakes 16 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122551 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42750 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42376 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3412 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55640 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151531 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56331 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151235 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45800 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124433 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54842 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17371 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->