### PR TITLE
[DEBUG]REGRESSION(318495@main): 3x TestWebKitAPI.SiteIsolation.BrowsingContext*/CrossOriginPopup* (api-tests) is a constant crash.

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -142,7 +142,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
         previousMainFrame->transferNavigationCallbackToFrame(mainFrame);
     }
 
-    if (isProcessSwappingOnNavigationResponse && previousMainFrame)
+    if (isProcessSwappingOnNavigationResponse && previousMainFrame && !m_shouldReuseMainFrame)
         protect(m_mainFrame)->copyCertificateInfoForProcessSwapOnNavigationResponse(m_provisionalLoadURL, *previousMainFrame);
 
     // Normally, notification of a server redirect comes from the WebContent process.

--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -73,11 +73,6 @@ TestWebKitAPI.WebPageTransferableTests/exportToImage(type:) [ Skip ]
 [ iOS Debug ] TestWebKitAPI.IPCTestingAPI.LockdownModeDetection [ Failure ]
 [ iOS Debug ] TestWebKitAPI.IPCTestingAPI.LockdownModeDisabledAllowsWebGL [ Failure ]
 
-# webkit.org/b/322223 [ DEBUG ]REGRESSION(318495@main): 3x TestWebKitAPI.SiteIsolation.BrowsingContext*/CrossOriginPopup* (api-tests) is a constant crash.
-[ debug ] TestWebKitAPI.SiteIsolation.BrowsingContextGroupSwitchForIncompatibleCrossOriginOpenerPolicy [ Crash ]
-[ debug ] TestWebKitAPI.SiteIsolation.CrossOriginPopupWithCOOPValueSameOrigin [ Crash ]
-[ debug ] TestWebKitAPI.SiteIsolation.CrossOriginPopupWithOpenerCOOPValueSameOrigin [ Crash ]
-
 # webkit.org/b/318742 [ iOS DEBUG ] 3x TestWebKitAPI.WKWebExtensionAPICookies.* (api-tests) are constant crashes/timeout.
 [ iOS Debug ] TestWebKitAPI.WKWebExtensionAPICookies.GetAllAfterNetworkProcessTermination [ Timeout ]
 [ iOS Debug ] TestWebKitAPI.WKWebExtensionAPICookies.RemoveCookie [ Crash ]


### PR DESCRIPTION
#### 81215415fa56d910bd87d807c5b20f5ffd4e2c4b
<pre>
[DEBUG]REGRESSION(318495@main): 3x TestWebKitAPI.SiteIsolation.BrowsingContext*/CrossOriginPopup* (api-tests) is a constant crash.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322223">https://bugs.webkit.org/show_bug.cgi?id=322223</a>
<a href="https://rdar.apple.com/185455432">rdar://185455432</a>

Reviewed by Ben Nham.

No need to copy certificates from a frame to itself.

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* TestExpectations/apitests:

Canonical link: <a href="https://commits.webkit.org/319705@main">https://commits.webkit.org/319705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03aa2859898217a9cfebfee368815ae6cb4fa6da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182029 "60 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49780 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192254 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1e74d82-8af6-4f4f-b205-97b254edb317) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55699 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192254 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98684 "3 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b02d231-b715-4762-8702-fe7133dc77f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162859 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192254 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d1d199c-6a01-46cc-8a9e-c0c73a626bf7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44488 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42756 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192254 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42384 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47011 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194182 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55647 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194182 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39009 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194182 "") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/27709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45807 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128621 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124441 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54849 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17379 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54230 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->