### PR TITLE
[Grid Lanes] Rename remaining references to masonry in the code.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3014,7 +3014,7 @@ rendering/Grid.cpp @header:RenderStyleGetters @cost:5
 rendering/GridBaselineAlignment.cpp @header:RenderStyleGetters @cost:5
 rendering/GridLayoutFunctions.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderGridLayoutState.cpp
-rendering/GridMasonryLayout.cpp @header:RenderStyleGetters @cost:5
+rendering/GridLanesLayout.cpp @header:RenderStyleGetters @cost:5
 rendering/GridTrackSizingAlgorithm.cpp @header:RenderStyleGetters @cost:6
 rendering/HitTestLocation.cpp
 rendering/HitTestRequest.cpp @header:RenderStyleGetters @cost:4

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -17648,8 +17648,8 @@
 		A5071E831C56D079009951BE /* ResourceUsageThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceUsageThread.cpp; sourceTree = "<group>"; };
 		A5071E841C56D079009951BE /* ResourceUsageThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceUsageThread.h; sourceTree = "<group>"; };
 		A5071E881C56D4FA009951BE /* ResourceUsageThreadCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResourceUsageThreadCocoa.mm; sourceTree = "<group>"; };
-		A51324D6290A234D00C0DCFA /* GridMasonryLayout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridMasonryLayout.cpp; sourceTree = "<group>"; };
-		A51324D7290A235900C0DCFA /* GridMasonryLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridMasonryLayout.h; sourceTree = "<group>"; };
+		A51324D6290A234D00C0DCFA /* GridLanesLayout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridLanesLayout.cpp; sourceTree = "<group>"; };
+		A51324D7290A235900C0DCFA /* GridLanesLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridLanesLayout.h; sourceTree = "<group>"; };
 		A51432552DE0CE6E0059FFA1 /* GridSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSpan.h; sourceTree = "<group>"; };
 		A51432562DE0CE6E0059FFA1 /* GridSpan.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridSpan.cpp; sourceTree = "<group>"; };
 		A515729A2F7AD717008975E0 /* SubtreeScrollbarChangesState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubtreeScrollbarChangesState.h; sourceTree = "<group>"; };
@@ -42357,10 +42357,10 @@
 				E112F46F1E3A85D800D6CDFD /* Grid.h */,
 				0FC692EA2585C9670098E3F9 /* GridBaselineAlignment.cpp */,
 				0FC692EC2585C9680098E3F9 /* GridBaselineAlignment.h */,
+				A51324D6290A234D00C0DCFA /* GridLanesLayout.cpp */,
+				A51324D7290A235900C0DCFA /* GridLanesLayout.h */,
 				0FC692ED2585C9690098E3F9 /* GridLayoutFunctions.cpp */,
 				0FC692EE2585C96A0098E3F9 /* GridLayoutFunctions.h */,
-				A51324D6290A234D00C0DCFA /* GridMasonryLayout.cpp */,
-				A51324D7290A235900C0DCFA /* GridMasonryLayout.h */,
 				E12DE7151E4B748700F9ACCF /* GridTrackSizingAlgorithm.cpp */,
 				E12DE7161E4B748700F9ACCF /* GridTrackSizingAlgorithm.h */,
 				4969B0F013D0B33F00DF3521 /* HitTestingTransformState.cpp */,

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1216,7 +1216,7 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
     else if (CheckedPtr renderGrid = dynamicDowncast<RenderGrid>(renderer)) {
         if (renderGrid->isSubgrid())
             layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("subgrid", "subgrid (Inspector Element Selection)", "Inspector element selection tooltip text for Subgrid containers."));
-        else if (renderGrid->isMasonry())
+        else if (renderGrid->isGridLanes())
             layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("grid lanes", "grid lanes (Inspector Element Selection)", "Inspector element selection tooltip text for Grid Lanes containers."));
         else
             layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("grid", "grid (Inspector Element Selection)", "Inspector element selection tooltip text for Grid containers."));
@@ -1573,19 +1573,19 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     if (!columnPositions.size() || !rowPositions.size())
         return { };
 
-    LayoutUnit masonryContentSize = renderGrid->masonryContentSize();
+    LayoutUnit gridLanesContentSize = renderGrid->gridLanesContentSize();
 
-    // There are no actual rows or columns in the masonry axis of a masonry layout.
-    // But we can borrow the concept to draw the two lines at the start and end of the masonry axis.
-    if (renderGrid->areMasonryRows()) {
+    // There are no actual rows or columns in the stacking axis of a grid lanes layout.
+    // But we can borrow the concept to draw the two lines at the start and end of the stacking axis.
+    if (renderGrid->hasStackingAxisRows()) {
         auto firstRowPosition = rowPositions[0];
-        auto lastRowPosition = rowPositions[0] + masonryContentSize;
+        auto lastRowPosition = rowPositions[0] + gridLanesContentSize;
         rowPositions = Vector<LayoutUnit> { firstRowPosition, lastRowPosition };
     }
 
-    if (renderGrid->areMasonryColumns()) {
+    if (renderGrid->hasStackingAxisColumns()) {
         auto firstColumnPosition = columnPositions[0];
-        auto lastColumnPosition = columnPositions[0] + masonryContentSize;
+        auto lastColumnPosition = columnPositions[0] + gridLanesContentSize;
         columnPositions = Vector<LayoutUnit> { firstColumnPosition, lastColumnPosition };
     }
 
@@ -1710,8 +1710,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             gridHighlightOverlay.gridLines.append(columnStartLine);
         }
 
-        // Draw only the bounding lines of the masonry axis.
-        if (renderGrid->areMasonryColumns())
+        // Draw only the bounding lines of the stacking axis.
+        if (renderGrid->hasStackingAxisColumns())
             continue;
         
         FloatLine gapLabelLine = columnStartLine;
@@ -1799,8 +1799,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             gridHighlightOverlay.gridLines.append(rowStartLine);
         }
 
-        // Draw only the bounding lines of the masonry axis.
-        if (renderGrid->areMasonryRows())
+        // Draw only the bounding lines of the stacking axis.
+        if (renderGrid->hasStackingAxisRows())
             continue;
 
         FloatPoint gapLabelPosition = rowStartLine.start();
@@ -1862,7 +1862,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
         }
     }
 
-    if (gridOverlay.config.showAreaNames && !renderGrid->isMasonry()) {
+    if (gridOverlay.config.showAreaNames && !renderGrid->isGridLanes()) {
         for (auto& [name, area] : node->renderStyle()->gridTemplateAreas().map.map) {
             // Named grid areas will always be rectangular per the CSS Grid specification.
             auto columnStartLine = columnLineAt(columnPositions[area.columns.startLine()]);
@@ -1886,8 +1886,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
         }
     }
 
-    // For masonry layouts, draw gaps between items in the masonry axis direction.
-    if (renderGrid->isMasonry()) {
+    // For grid lanes layouts, draw gaps between items in the stacking axis direction.
+    if (renderGrid->isGridLanes()) {
         auto& orderIterator = renderGrid->currentGrid().orderIterator();
 
         struct ItemInfo {
@@ -1910,7 +1910,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             auto maxCorner = localPointToRootPoint(containingView, absoluteRect.maxXMaxYCorner());
             FloatRect rootRect { minCorner, maxCorner - minCorner };
 
-            if (renderGrid->areMasonryRows()) {
+            if (renderGrid->hasStackingAxisRows()) {
                 auto& columnSpan = gridArea.columns;
                 if (!columnSpan.isTranslatedDefinite())
                     continue;
@@ -1923,7 +1923,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             }
         }
 
-        unsigned gridAxisTrackCount = renderGrid->areMasonryRows() ? columnWidths.size() : rowHeights.size();
+        unsigned gridAxisTrackCount = renderGrid->hasStackingAxisRows() ? columnWidths.size() : rowHeights.size();
 
         for (unsigned trackIndex = 0; trackIndex < gridAxisTrackCount; ++trackIndex) {
             Vector<ItemInfo*> itemsInTrack;
@@ -1935,7 +1935,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             if (itemsInTrack.size() < 2)
                 continue;
 
-            if (renderGrid->areMasonryRows()) {
+            if (renderGrid->hasStackingAxisRows()) {
                 std::sort(itemsInTrack.begin(), itemsInTrack.end(), [](ItemInfo* a, ItemInfo* b) {
                     return a->bounds.y() < b->bounds.y();
                 });
@@ -1950,7 +1950,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
                 auto& currentItem = *itemsInTrack[i];
 
                 FloatQuad gapQuad;
-                if (renderGrid->areMasonryRows()) {
+                if (renderGrid->hasStackingAxisRows()) {
                     float gapTop = previousItem.bounds.maxY();
                     float gapBottom = currentItem.bounds.y();
                     if (gapBottom <= gapTop)
@@ -2018,8 +2018,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
         for (CheckedPtr gridItem : gridItemsInGridOrder) {
             FloatQuad itemBounds;
 
-            if (renderGrid->isMasonry()) {
-                // For masonry layouts, use absoluteBoundingBoxRect to get the visual position
+            if (renderGrid->isGridLanes()) {
+                // For grid lanes layouts, use absoluteBoundingBoxRect to get the visual position
                 // accounting for all scroll offsets and transforms including zoom.
                 auto absoluteRect = FloatRect { gridItem->absoluteBoundingBoxRect(true) };
                 auto margins = gridItem->marginBox();

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -857,7 +857,7 @@ static std::optional<InspectorCSSAgent::LayoutFlag> layoutFlagContextType(Render
     if (CheckedPtr renderGrid = dynamicDowncast<RenderGrid>(renderer)) {
         if (renderGrid->isSubgrid())
             return InspectorCSSAgent::LayoutFlag::Subgrid;
-        if (renderGrid->isMasonry())
+        if (renderGrid->isGridLanes())
             return InspectorCSSAgent::LayoutFlag::GridLanes;
         return InspectorCSSAgent::LayoutFlag::Grid;
     }

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -186,7 +186,7 @@ GridSpan Grid::gridItemSpan(const RenderBox& gridItem, Style::GridTrackSizingDir
     return gridItemArea(gridItem).span(direction);
 }
 
-void Grid::setupGridForMasonryLayout()
+void Grid::setupForGridLanesLayout()
 {
     // FIXME(248472): See if we can resize grid instead of clearing it here: https://bugs.webkit.org/show_bug.cgi?id=248472
     m_grid.clear();

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -89,7 +89,7 @@ public:
     void setNeedsItemsPlacement(bool);
     bool needsItemsPlacement() const { return m_needsItemsPlacement; };
 
-    void setupGridForMasonryLayout();
+    void setupForGridLanesLayout();
     unsigned maxRows() const { return m_maxRows; }
     unsigned maxColumns() const { return m_maxColumns; }
 private:

--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "config.h"
-#include "GridMasonryLayout.h"
+#include "GridLanesLayout.h"
 
 #include "GridLayoutFunctions.h"
 #include "RenderBoxInlines.h"
@@ -36,43 +36,42 @@
 
 namespace WebCore {
 
-void GridMasonryLayout::initializeMasonry(unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection)
+void GridLanesLayout::initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection)
 {
-    // Reset global variables as they may contain state from previous runs of Masonry.
-    m_masonryAxisDirection = masonryAxisDirection;
-    m_masonryAxisGridGap = m_renderGrid->gridGap(m_masonryAxisDirection);
+    // Reset global variables as they may contain state from previous runs of grid lanes layout.
+    m_stackingAxisDirection = stackingAxisDirection;
+    m_stackingAxisGridGap = m_renderGrid->gridGap(m_stackingAxisDirection);
     m_gridAxisTracksCount = gridAxisTracks;
     m_gridContentSize = 0;
     m_itemOffsets.clear();
 
-    m_renderGrid->currentGrid().setupGridForMasonryLayout();
+    m_renderGrid->currentGrid().setupForGridLanesLayout();
     m_renderGrid->populateExplicitGridAndOrderIterator();
 
     resizeAndResetRunningPositions();
 }
 
-void GridMasonryLayout::performMasonryPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase layoutPhase)
+void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase layoutPhase)
 {
-    initializeMasonry(gridAxisTracks, masonryAxisDirection);
+    initializeGridLanes(gridAxisTracks, stackingAxisDirection);
 
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns);
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows);
 
-    // 2.3 Masonry Layout Algorithm
-    // https://drafts.csswg.org/css-grid-3/#masonry-layout-algorithm
-    
+    // 4.4 Grid Lanes Layout and Placement Algorithm
+    // https://drafts.csswg.org/css-grid-3/#grid-lanes-layout-algorithm
     // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
     m_autoFlowNextCursor = 0;
 
-    placeMasonryItems(algorithm, layoutPhase);
+    placeGridLanesItems(algorithm, layoutPhase);
 }
 
-void GridMasonryLayout::resizeAndResetRunningPositions()
+void GridLanesLayout::resizeAndResetRunningPositions()
 {
     m_runningPositions.fill(LayoutUnit(), m_gridAxisTracksCount);
 }
 
-void GridMasonryLayout::placeMasonryItems(const GridTrackSizingAlgorithm& algorithm, GridMasonryLayout::MasonryLayoutPhase layoutPhase)
+void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)
 {
     if (!m_gridAxisTracksCount)
         return;
@@ -87,22 +86,22 @@ void GridMasonryLayout::placeMasonryItems(const GridTrackSizingAlgorithm& algori
     }
 }
 
-GridArea GridMasonryLayout::gridAreaForDefiniteGridAxisItem(const RenderBox& gridItem) const
+GridArea GridLanesLayout::gridAreaForDefiniteGridAxisItem(const RenderBox& gridItem) const
 {
     auto itemSpan = m_renderGrid->currentGrid().gridItemSpan(gridItem, gridAxisDirection());
     ASSERT(!itemSpan.isIndefinite());
     itemSpan.translate(m_renderGrid->currentGrid().explicitGridStart(gridAxisDirection()));
-    return masonryGridAreaFromGridAxisSpan(itemSpan);
+    return gridAreaFromGridAxisSpan(itemSpan);
 }
 
-LayoutUnit GridMasonryLayout::calculateMasonryIntrinsicLogicalWidth(RenderBox& gridItem, GridMasonryLayout::MasonryLayoutPhase layoutPhase)
+LayoutUnit GridLanesLayout::calculateGridLanesIntrinsicLogicalWidth(RenderBox& gridItem, Phase layoutPhase)
 {
     switch (layoutPhase) {
-    case MasonryLayoutPhase::MinContentPhase:
+    case Phase::MinContentPhase:
         return gridItem.computeSizingKeywordLogicalWidthUsing(CSS::Keyword::MinContent { }, { }, gridItem.borderAndPaddingLogicalWidth());
-    case MasonryLayoutPhase::MaxContentPhase:
+    case Phase::MaxContentPhase:
         return gridItem.computeSizingKeywordLogicalWidthUsing(CSS::Keyword::MaxContent { }, { }, gridItem.borderAndPaddingLogicalWidth());
-    case MasonryLayoutPhase::LayoutPhase:
+    case Phase::LayoutPhase:
         ASSERT_NOT_REACHED();
         return { };
     }
@@ -110,7 +109,7 @@ LayoutUnit GridMasonryLayout::calculateMasonryIntrinsicLogicalWidth(RenderBox& g
     return { };
 }
 
-void GridMasonryLayout::setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm& algorithm, RenderBox& gridItem)
+void GridLanesLayout::setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm& algorithm, RenderBox& gridItem)
 {
     CheckedPtr<RenderGrid> containingBlock = dynamicDowncast<RenderGrid>(gridItem.containingBlock());
     if (!containingBlock) {
@@ -129,20 +128,20 @@ void GridMasonryLayout::setItemContainingBlockToGridArea(const GridTrackSizingAl
         gridItem.setGridAreaContentLogicalWidth(containingBlock->contentBoxLogicalWidth());
     }
 
-    // FIXME(249230): Try to cache masonry layout sizes
+    // FIXME(249230): Try to cache grid lanes layout sizes
     gridItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
 }
 
-void GridMasonryLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm& algorithm, RenderBox& gridItem, const GridArea& area, GridMasonryLayout::MasonryLayoutPhase layoutPhase)
+void GridLanesLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm& algorithm, RenderBox& gridItem, const GridArea& area, Phase layoutPhase)
 {
-    auto shouldOverrideLogicalWidth = [&](RenderBox& gridItem, GridMasonryLayout::MasonryLayoutPhase layoutPhase) {
-        if (layoutPhase == MasonryLayoutPhase::LayoutPhase)
+    auto shouldOverrideLogicalWidth = [&](RenderBox& gridItem, Phase layoutPhase) {
+        if (layoutPhase == Phase::LayoutPhase)
             return false;
 
         if (!(gridItem.style().logicalWidth().isAuto() || gridItem.style().logicalWidth().isPercent()))
             return false;
 
-        ASSERT(m_renderGrid->isMasonry(Style::GridTrackSizingDirection::Columns));
+        ASSERT(m_renderGrid->isStackingAxis(Style::GridTrackSizingDirection::Columns));
 
         if (gridItem.style().writingMode().isOrthogonal(m_renderGrid->style().writingMode()))
             return false;
@@ -154,7 +153,7 @@ void GridMasonryLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorit
     };
 
     if (shouldOverrideLogicalWidth(gridItem, layoutPhase))
-        gridItem.setOverridingBorderBoxLogicalWidth(calculateMasonryIntrinsicLogicalWidth(gridItem, layoutPhase));
+        gridItem.setOverridingBorderBoxLogicalWidth(calculateGridLanesIntrinsicLogicalWidth(gridItem, layoutPhase));
 
     m_renderGrid->currentGrid().insert(gridItem, area);
     setItemContainingBlockToGridArea(algorithm, gridItem);
@@ -163,10 +162,10 @@ void GridMasonryLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorit
     m_autoFlowNextCursor = gridAxisSpanFromArea(area).endLine() % m_gridAxisTracksCount;
 }
 
-LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& gridItem)
+LayoutUnit GridLanesLayout::stackingAxisMarginBoxForItem(const RenderBox& gridItem)
 {
     LayoutUnit marginBoxSize;
-    if (m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows) {
+    if (m_stackingAxisDirection == Style::GridTrackSizingDirection::Rows) {
         if (GridLayoutFunctions::isOrthogonalGridItem(m_renderGrid, gridItem))
             marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.borderBoxWidth() + gridItem.horizontalMarginExtent() : gridItem.borderBoxHeight() + gridItem.verticalMarginExtent();
         else
@@ -181,7 +180,7 @@ LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& gridI
     return marginBoxSize;
 }
 
-void GridMasonryLayout::updateRunningPositions(const RenderBox& gridItem, const GridArea& area)
+void GridLanesLayout::updateRunningPositions(const RenderBox& gridItem, const GridArea& area)
 {
     auto gridAxisSpan = gridAxisSpanFromArea(area);
     ASSERT(gridAxisSpan.startLine() < m_runningPositions.size() && gridAxisSpan.endLine() <= m_runningPositions.size());
@@ -191,8 +190,8 @@ void GridMasonryLayout::updateRunningPositions(const RenderBox& gridItem, const 
     for (auto line : gridAxisSpan)
         previousRunningPosition = std::max(previousRunningPosition, m_runningPositions[line]);
 
-    auto newRunningPosition = masonryAxisMarginBoxForItem(gridItem) + previousRunningPosition + m_masonryAxisGridGap;
-    m_gridContentSize = std::max(m_gridContentSize, newRunningPosition - m_masonryAxisGridGap);
+    auto newRunningPosition = stackingAxisMarginBoxForItem(gridItem) + previousRunningPosition + m_stackingAxisGridGap;
+    m_gridContentSize = std::max(m_gridContentSize, newRunningPosition - m_stackingAxisGridGap);
 
     for (auto span : gridAxisSpan)
         m_runningPositions[span] = newRunningPosition;
@@ -200,13 +199,13 @@ void GridMasonryLayout::updateRunningPositions(const RenderBox& gridItem, const 
     updateItemOffset(gridItem, previousRunningPosition);
 }
 
-void GridMasonryLayout::updateItemOffset(const RenderBox& gridItem, LayoutUnit offset)
+void GridLanesLayout::updateItemOffset(const RenderBox& gridItem, LayoutUnit offset)
 {
     // We set() and not add() to update the value if the |gridItem| is already inserted
     m_itemOffsets.set(gridItem, offset);
 }
 
-LayoutUnit GridMasonryLayout::maxRunningPositionForSpan(unsigned startLine, unsigned spanLength) const
+LayoutUnit GridLanesLayout::maxRunningPositionForSpan(unsigned startLine, unsigned spanLength) const
 {
     LayoutUnit maxPosition;
     for (unsigned lineOffset = 0; lineOffset < spanLength; lineOffset++)
@@ -214,12 +213,12 @@ LayoutUnit GridMasonryLayout::maxRunningPositionForSpan(unsigned startLine, unsi
     return maxPosition;
 }
 
-GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
+GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
 {
     auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), m_gridAxisTracksCount);
     auto gridAxisLines = m_gridAxisTracksCount + 1;
 
-    // Get flow-tolerance from the masonry container's style
+    // Get flow-tolerance from the grid lanes container's style
     const auto& tolerance = m_renderGrid->style().flowTolerance();
 
     if (tolerance.isInfinite()) {
@@ -232,7 +231,7 @@ GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& i
             startingLine = 0;
 
         auto gridAxisPosition = GridSpan::translatedDefiniteGridSpan(startingLine, startingLine + itemSpanLength);
-        return masonryGridAreaFromGridAxisSpan(gridAxisPosition);
+        return gridAreaFromGridAxisSpan(gridAxisPosition);
     }
 
     // For normal and length-percentage tolerances, find positions within tolerance of the shortest track
@@ -284,10 +283,10 @@ GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& i
     }
 
     auto gridAxisPosition = GridSpan::translatedDefiniteGridSpan(smallestMaxPosLine, smallestMaxPosLine + itemSpanLength);
-    return masonryGridAreaFromGridAxisSpan(gridAxisPosition);
+    return gridAreaFromGridAxisSpan(gridAxisPosition);
 }
 
-LayoutUnit GridMasonryLayout::offsetForGridItem(const RenderBox& gridItem) const
+LayoutUnit GridLanesLayout::offsetForGridItem(const RenderBox& gridItem) const
 {
     const auto& offsetIter = m_itemOffsets.find(gridItem);
     if (offsetIter == m_itemOffsets.end())
@@ -295,27 +294,27 @@ LayoutUnit GridMasonryLayout::offsetForGridItem(const RenderBox& gridItem) const
     return offsetIter->value;
 }
 
-inline Style::GridTrackSizingDirection GridMasonryLayout::gridAxisDirection() const
+inline Style::GridTrackSizingDirection GridLanesLayout::gridAxisDirection() const
 {
-    // The masonry axis and grid axis can never be the same. 
+    // The stacking axis and grid axis can never be the same.
     // They are always perpendicular to each other.
-    return orthogonalDirection(m_masonryAxisDirection);
+    return orthogonalDirection(m_stackingAxisDirection);
 }
 
-bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAxisDirection) const
+bool GridLanesLayout::hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAxisDirection) const
 {
     return !Style::GridPositionsResolver::resolveGridPositionsFromStyle(m_renderGrid, gridItem, gridAxisDirection).isIndefinite();
 }
 
-GridSpan GridMasonryLayout::gridAxisSpanFromArea(const GridArea& gridArea) const
+GridSpan GridLanesLayout::gridAxisSpanFromArea(const GridArea& gridArea) const
 {
     return gridArea.span(gridAxisDirection());
 }
 
-GridArea GridMasonryLayout::masonryGridAreaFromGridAxisSpan(const GridSpan& gridAxisSpan) const
+GridArea GridLanesLayout::gridAreaFromGridAxisSpan(const GridSpan& gridAxisSpan) const
 {
-    return m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows
-        ? GridArea { m_masonryAxisSpan, gridAxisSpan }
-        : GridArea { gridAxisSpan, m_masonryAxisSpan };
+    return m_stackingAxisDirection == Style::GridTrackSizingDirection::Rows
+        ? GridArea { m_stackingAxisSpan, gridAxisSpan }
+        : GridArea { gridAxisSpan, m_stackingAxisSpan };
 }
 } // end namespace WebCore

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -39,43 +39,43 @@ enum class GridTrackSizingDirection : bool;
 
 class RenderGrid;
 
-class GridMasonryLayout {
+class GridLanesLayout {
 public:
-    GridMasonryLayout(RenderGrid& renderGrid)
+    GridLanesLayout(RenderGrid& renderGrid)
         : m_renderGrid(renderGrid)
     {
     }
 
-    enum class MasonryLayoutPhase : uint8_t {
+    enum class Phase : uint8_t {
         LayoutPhase,
         MinContentPhase,
         MaxContentPhase
     };
 
-    void initializeMasonry(unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection);
-    void performMasonryPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase);
+    void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
+    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
-    LayoutUnit gridGap() const { return m_masonryAxisGridGap; };
+    LayoutUnit gridGap() const { return m_stackingAxisGridGap; };
 
 private:
     GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
-    void placeMasonryItems(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
+    void placeGridLanesItems(const GridTrackSizingAlgorithm&, Phase);
     void setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
-    void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, GridMasonryLayout::MasonryLayoutPhase);
-    LayoutUnit calculateMasonryIntrinsicLogicalWidth(RenderBox&, GridMasonryLayout::MasonryLayoutPhase);
+    void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, Phase);
+    LayoutUnit calculateGridLanesIntrinsicLogicalWidth(RenderBox&, Phase);
 
     void resizeAndResetRunningPositions();
-    LayoutUnit masonryAxisMarginBoxForItem(const RenderBox& gridItem);
+    LayoutUnit stackingAxisMarginBoxForItem(const RenderBox& gridItem);
     void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
     void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
     LayoutUnit maxRunningPositionForSpan(unsigned startLine, unsigned spanLength) const;
     inline Style::GridTrackSizingDirection NODELETE gridAxisDirection() const;
 
-    bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection masonryDirection) const;
-    GridArea NODELETE masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
+    bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAxisDirection) const;
+    GridArea NODELETE gridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
 
     unsigned m_gridAxisTracksCount;
@@ -83,11 +83,11 @@ private:
     Vector<LayoutUnit> m_runningPositions;
     HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;
     const CheckedRef<RenderGrid> m_renderGrid;
-    LayoutUnit m_masonryAxisGridGap;
+    LayoutUnit m_stackingAxisGridGap;
     LayoutUnit m_gridContentSize;
 
-    Style::GridTrackSizingDirection m_masonryAxisDirection;
-    const GridSpan m_masonryAxisSpan = GridSpan::masonryAxisTranslatedDefiniteGridSpan();
+    Style::GridTrackSizingDirection m_stackingAxisDirection;
+    const GridSpan m_stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
 
     unsigned m_autoFlowNextCursor;
 };

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -234,8 +234,8 @@ void GridTrackSizingAlgorithm::setAvailableSpace(Style::GridTrackSizingDirection
 
 LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
 {
-    if (isDirectionInMasonryDirection())
-        return m_renderGrid->masonryContentSize();
+    if (isDirectionInStackingAxis())
+        return m_renderGrid->gridLanesContentSize();
 
     WTF::Range<size_t> rangeToIgnore;
     if (m_renderGrid->shouldCheckExplicitIntrinsicInnerLogicalSize(m_direction) && m_renderGrid->autoRepeatType(m_direction) == AutoRepeatType::Fit)
@@ -284,22 +284,22 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::ZoomResolva
     return infinity;
 }
 
-void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSpan& span, MasonryMinMaxTrackSize& masonryIndefiniteItems, GridTrack& track)
+void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanGridLanesGroup(const GridSpan& span, GridLanesMinMaxTrackSize& gridLanesIndefiniteItems, GridTrack& track)
 {
     auto trackPosition = span.startLine();
     const auto& trackSize = tracks(m_direction)[trackPosition]->cachedTrackSize();
 
     if (trackSize.value.hasMinContentMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minContentSize));
+        track.setBaseSize(std::max(track.baseSize(), gridLanesIndefiniteItems.minContentSize));
     else if (trackSize.value.hasMaxContentMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.maxContentSize));
+        track.setBaseSize(std::max(track.baseSize(), gridLanesIndefiniteItems.maxContentSize));
     else if (trackSize.value.hasAutoMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minSize));
+        track.setBaseSize(std::max(track.baseSize(), gridLanesIndefiniteItems.minSize));
 
     if (trackSize.value.hasMinContentMaxTrackBreadth())
-        track.setGrowthLimit(std::max(track.growthLimit(), masonryIndefiniteItems.minContentSize));
+        track.setGrowthLimit(std::max(track.growthLimit(), gridLanesIndefiniteItems.minContentSize));
     else if (trackSize.value.hasMaxContentOrAutoMaxTrackBreadth()) {
-        auto growthLimit = masonryIndefiniteItems.maxContentSize;
+        auto growthLimit = gridLanesIndefiniteItems.maxContentSize;
         if (trackSize.value.isFitContent())
             growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.value.fitContentTrackLength(), availableSpace().value_or(0), trackSize.zoom));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
@@ -384,7 +384,7 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase(TrackS
     return 0;
 }
 
-LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase phase, const MasonryMinMaxTrackSize& trackSize) const
+LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseGridLanes(TrackSizeComputationPhase phase, const GridLanesMinMaxTrackSize& trackSize) const
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
@@ -569,9 +569,9 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(GridItems
 
 
 template <TrackSizeComputationVariant variant>
-void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry(StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes)
+void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsGridLanes(StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>& definiteItemSizes)
 {
-    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizes)
+    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<GridLanesMinMaxTrackSizeWithGridSpan>& definiteItemSizes)
     {
         auto& allTracks = tracks(m_direction);
         for (const auto& trackIndex : m_contentSizedTracksIndex) {
@@ -608,7 +608,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry(St
 
             spanningTracksSize += m_renderGrid->guttersSize(m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
 
-            auto extraSpace = itemSizeForTrackSizeComputationPhaseMasonry(phase, definiteItem.trackSize) - spanningTracksSize;
+            auto extraSpace = itemSizeForTrackSizeComputationPhaseGridLanes(phase, definiteItem.trackSize) - spanningTracksSize;
             extraSpace = std::max<LayoutUnit>(extraSpace, 0);
             auto& tracksToGrowBeyondGrowthLimits = growBeyondGrowthLimitsTracks.isEmpty() ? filteredTracks : growBeyondGrowthLimitsTracks;
             distributeSpaceToTracks<variant, phase>(filteredTracks, &tracksToGrowBeyondGrowthLimits, extraSpace);
@@ -631,9 +631,9 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry(St
 }
 
 template <TrackSizeComputationVariant variant>
-void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWithFlex(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsGridLanesWithFlex(Vector<GridLanesMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
 {
-    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<GridLanesMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
     {
         auto& allTracks = tracks(m_direction);
         for (const auto& trackIndex : m_contentSizedTracksIndex) {
@@ -671,7 +671,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWit
 
             spanningTracksSize += m_renderGrid->guttersSize(m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
 
-            auto extraSpace = itemSizeForTrackSizeComputationPhaseMasonry(phase, item.trackSize) - spanningTracksSize;
+            auto extraSpace = itemSizeForTrackSizeComputationPhaseGridLanes(phase, item.trackSize) - spanningTracksSize;
             extraSpace = std::max<LayoutUnit>(extraSpace, 0);
             auto& tracksToGrowBeyondGrowthLimits = growBeyondGrowthLimitsTracks.isEmpty() ? filteredTracks : growBeyondGrowthLimitsTracks;
             distributeSpaceToTracks<variant, phase>(filteredTracks, &tracksToGrowBeyondGrowthLimits, extraSpace);
@@ -691,7 +691,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWit
     increaseSizes.template operator()<TrackSizeComputationPhase::ResolveMaxContentMaximums>(definiteItemSizesSpanFlexTracks);
 }
 
-void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry(const StdMap<SpanLength, MasonryMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteGridLanes(const StdMap<SpanLength, GridLanesMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<GridLanesMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
 {
     auto& allTracks = tracks(m_direction);
 
@@ -705,10 +705,10 @@ void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry(const Std
 
             // The spec requires items with a span of 1 to be handled earlier.
             if (itemSpan.integerSpan() != 1 && !spanningItemCrossesFlexibleSizedTracks(itemSpan))
-                definiteItemSizes[itemSpan.integerSpan()].append(MasonryMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
+                definiteItemSizes[itemSpan.integerSpan()].append(GridLanesMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
 
             if (spanningItemCrossesFlexibleSizedTracks(itemSpan))
-                definiteItemSizesSpanFlexTracks.append(MasonryMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
+                definiteItemSizesSpanFlexTracks.append(GridLanesMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
         }
     }
 }
@@ -860,10 +860,10 @@ static LayoutUnit computeGridSpanSize(const Vector<UniqueRef<GridTrack>>& tracks
 std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction) const
 {
     // FIXME: These checks only works if we have precomputed logical width/height of the grid, which is not guaranteed.
-    if (m_renderGrid->areMasonryColumns() && direction == Style::GridTrackSizingDirection::Columns)
+    if (m_renderGrid->hasStackingAxisColumns() && direction == Style::GridTrackSizingDirection::Columns)
         return m_renderGrid->contentBoxLogicalWidth();
 
-    if (m_renderGrid->areMasonryRows() && direction == Style::GridTrackSizingDirection::Rows && !GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem))
+    if (m_renderGrid->hasStackingAxisRows() && direction == Style::GridTrackSizingDirection::Rows && !GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem))
         return m_renderGrid->contentBoxLogicalHeight();
 
     bool addContentAlignmentOffset =
@@ -871,7 +871,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(c
     // To determine the column track's size based on an orthogonal grid item we need it's logical
     // height, which may depend on the row track's size. It's possible that the row tracks sizing
     // logic has not been performed yet, so we will need to do an estimation.
-    if (direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::ColumnSizingFirstIteration || m_sizingState == SizingState::ColumnSizingSecondIteration) && !m_renderGrid->areMasonryColumns()) {
+    if (direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::ColumnSizingFirstIteration || m_sizingState == SizingState::ColumnSizingSecondIteration) && !m_renderGrid->hasStackingAxisColumns()) {
         if (m_sizingState == SizingState::ColumnSizingFirstIteration) {
             auto spannedRowsSize = estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
             if (spannedRowsSize) {
@@ -1432,7 +1432,7 @@ private:
     bool isComputingInlineSizeContainment() const override { return renderGrid()->shouldApplyInlineSizeContainment(); }
     bool isComputingSizeOrInlineSizeContainment() const override { return renderGrid()->shouldApplySizeOrInlineSizeContainment(); }
     void accumulateFlexFraction(double& flexFraction, GridIterator&, Style::GridTrackSizingDirection outermostDirection, SingleThreadWeakHashSet<RenderBox>& itemsSet, RenderGridLayoutState&) const;
-    void accumulateFlexFractionMasonry(double& flexFraction, GridIterator&, Style::GridTrackSizingDirection outermostDirection, unsigned flexTrackIndex, SingleThreadWeakHashSet<RenderBox>& itemsSet, Vector<SingleThreadWeakPtr<RenderBox>> indefiniteItems, RenderGridLayoutState&) const;
+    void accumulateFlexFractionGridLanes(double& flexFraction, GridIterator&, Style::GridTrackSizingDirection outermostDirection, unsigned flexTrackIndex, SingleThreadWeakHashSet<RenderBox>& itemsSet, Vector<SingleThreadWeakPtr<RenderBox>> indefiniteItems, RenderGridLayoutState&) const;
 };
 
 void IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& gridItem, bool overrideSizeHasChanged) const
@@ -1456,7 +1456,7 @@ static inline double normalizedFlexFraction(const GridTrack& track)
     return track.baseSize() / std::max<double>(1, flexFactor);
 }
 
-void IndefiniteSizeStrategy::accumulateFlexFractionMasonry(double& flexFraction, GridIterator& iterator, Style::GridTrackSizingDirection direction, unsigned flexTrackIndex, SingleThreadWeakHashSet<RenderBox>& itemsSet, Vector<SingleThreadWeakPtr<RenderBox>> indefiniteItems, RenderGridLayoutState& gridLayoutState) const
+void IndefiniteSizeStrategy::accumulateFlexFractionGridLanes(double& flexFraction, GridIterator& iterator, Style::GridTrackSizingDirection direction, unsigned flexTrackIndex, SingleThreadWeakHashSet<RenderBox>& itemsSet, Vector<SingleThreadWeakPtr<RenderBox>> indefiniteItems, RenderGridLayoutState& gridLayoutState) const
 {
     // Definite Items
     while (auto* gridItem = iterator.nextGridItem()) {
@@ -1534,7 +1534,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
         return flexFraction;
 
     SingleThreadWeakHashSet<RenderBox> itemsSet;
-    if (!m_algorithm.renderGrid()->isMasonry()) {
+    if (!m_algorithm.renderGrid()->isGridLanes()) {
         for (const auto& trackIndex : flexibleSizedTracksIndex) {
             GridIterator iterator(grid, direction, trackIndex);
             accumulateFlexFraction(flexFraction, iterator, direction, itemsSet, gridLayoutState);
@@ -1551,7 +1551,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
 
         for (const auto& trackIndex : flexibleSizedTracksIndex) {
             GridIterator iterator(grid, direction, trackIndex);
-            accumulateFlexFractionMasonry(flexFraction, iterator, direction, trackIndex, itemsSet, indefiniteItems, gridLayoutState);
+            accumulateFlexFractionGridLanes(flexFraction, iterator, direction, trackIndex, itemsSet, indefiniteItems, gridLayoutState);
         }
     }
 
@@ -1848,7 +1848,7 @@ void GridTrackSizingAlgorithm::aggregateGridItemsForIntrinsicSizing(Vector<GridI
     });
 }
 
-void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMap<SpanLength, MasonryMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTrack, RenderGridLayoutState& gridLayoutState)
+void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForGridLanes(StdMap<SpanLength, GridLanesMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<GridLanesMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTrack, RenderGridLayoutState& gridLayoutState)
 {
     auto& allTracks = tracks(m_direction);
     auto trackCount = allTracks.size();
@@ -1862,8 +1862,8 @@ void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMa
             return;
         }
 
-        auto contribution = MasonryMinMaxTrackSizeWithGridSpan {
-            MasonryMinMaxTrackSize {
+        auto contribution = GridLanesMinMaxTrackSizeWithGridSpan {
+            GridLanesMinMaxTrackSize {
                 m_strategy->minContentContributionForGridItem(gridItem, gridLayoutState),
                 m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState),
                 m_strategy->minContributionForGridItem(gridItem, gridLayoutState)
@@ -1892,7 +1892,7 @@ void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMa
     };
 
     traverseSubgridTreeForIntrinsicSizing([&](RenderBox& gridItem, GridSpan gridItemSpan) {
-        // Determine if this item has an indefinite position in the masonry grid-axis.
+        // Determine if this item has an indefinite position in the grid axis.
         // Check against the item's immediate parent grid, using the direction mapped
         // into that parent's coordinate space. The parent is always a RenderGrid since
         // traverseSubgridTreeForIntrinsicSizing only visits children of grid containers.
@@ -1901,13 +1901,13 @@ void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMa
         // For display:grid subgrids (not display:grid-lanes) inside a grid-lanes parent,
         // items have been placed by the grid's auto-placement algorithm, so they should
         // not be considered indefinite even if their CSS style uses auto placement.
-        // We check isMasonry() (no direction argument) to see if the parent uses grid-lanes
-        // display at all, rather than checking the specific direction.
-        bool isIndefinite = parentGrid->isMasonry() && Style::GridPositionsResolver::resolveGridPositionsFromStyle(parentGrid, gridItem, parentDirection).isIndefinite();
-        bool isDirectChildOfMasonryGrid = parentGrid.ptr() == m_renderGrid;
+        // We check isGridLanes() to see if the parent uses grid-lanes display at all,
+        // rather than isStackingAxis() for one specific direction.
+        bool isIndefinite = parentGrid->isGridLanes() && Style::GridPositionsResolver::resolveGridPositionsFromStyle(parentGrid, gridItem, parentDirection).isIndefinite();
+        bool isDirectChildOfGridLanesContainer = parentGrid.ptr() == m_renderGrid;
 
-        if (isIndefinite && !isDirectChildOfMasonryGrid) {
-            // Items inside a masonry subgrid with indefinite placement could land in any
+        if (isIndefinite && !isDirectChildOfGridLanesContainer) {
+            // Items inside a grid-lanes subgrid with indefinite placement could land in any
             // track the subgrid spans. Apply their contribution as a definite single-span
             // item to each content-sized track in the subgrid's span.
             auto subgridSpan = m_renderGrid->gridSpanForGridItem(parentGrid, m_direction);
@@ -1974,17 +1974,17 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes(RenderGridLayoutState&
     handleInfinityGrowthLimit();
 }
 
-void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizesMasonry(RenderGridLayoutState& gridLayoutState)
+void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizesGridLanes(RenderGridLayoutState& gridLayoutState)
 {
     if (m_strategy->isComputingSizeContainment() || !m_grid.hasGridItems()) {
         handleInfinityGrowthLimit();
         return;
     }
-    StdMap<SpanLength, MasonryMinMaxTrackSize> indefiniteSpanSizes;
-    StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>> definiteItemSizes;
-    Vector<MasonryMinMaxTrackSizeWithGridSpan> definiteItemSizesSpanFlexTrack;
+    StdMap<SpanLength, GridLanesMinMaxTrackSize> indefiniteSpanSizes;
+    StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>> definiteItemSizes;
+    Vector<GridLanesMinMaxTrackSizeWithGridSpan> definiteItemSizesSpanFlexTrack;
 
-    computeDefiniteAndIndefiniteItemsForMasonry(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack, gridLayoutState);
+    computeDefiniteAndIndefiniteItemsForGridLanes(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack, gridLayoutState);
 
     // Update intrinsic tracks with single span items that do not cross flex tracks.
     auto& allTracks = tracks(m_direction);
@@ -1998,15 +1998,15 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizesMasonry(RenderGridLayou
             if (spanningItemCrossesFlexibleSizedTracks(itemSpan))
                 continue;
 
-            sizeTrackToFitSingleSpanMasonryGroup(itemSpan, singleTrackSpanSize, track);
+            sizeTrackToFitSingleSpanGridLanesGroup(itemSpan, singleTrackSpanSize, track);
         }
     }
 
-    convertIndefiniteItemsToDefiniteMasonry(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack);
+    convertIndefiniteItemsToDefiniteGridLanes(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack);
 
-    increaseSizesToAccommodateSpanningItemsMasonry<TrackSizeComputationVariant::NotCrossingFlexibleTracks>(definiteItemSizes);
+    increaseSizesToAccommodateSpanningItemsGridLanes<TrackSizeComputationVariant::NotCrossingFlexibleTracks>(definiteItemSizes);
 
-    increaseSizesToAccommodateSpanningItemsMasonryWithFlex<TrackSizeComputationVariant::CrossingFlexibleTracks>(definiteItemSizesSpanFlexTrack);
+    increaseSizesToAccommodateSpanningItemsGridLanesWithFlex<TrackSizeComputationVariant::CrossingFlexibleTracks>(definiteItemSizesSpanFlexTrack);
 
     handleInfinityGrowthLimit();
 }
@@ -2226,7 +2226,7 @@ void GridTrackSizingAlgorithm::run(Style::GridTrackSizingDirection direction, un
 
     StateMachine stateMachine(*this);
 
-    if (m_renderGrid->isMasonry(m_direction))
+    if (m_renderGrid->isStackingAxis(m_direction))
         return;
 
     if (m_renderGrid->isSubgrid(m_direction) && copyUsedTrackSizesForSubgrid())
@@ -2238,7 +2238,7 @@ void GridTrackSizingAlgorithm::run(Style::GridTrackSizingDirection direction, un
 
     // Step 2.
     if (!m_contentSizedTracksIndex.isEmpty())
-        (!m_renderGrid->isMasonry()) ? resolveIntrinsicTrackSizes(gridLayoutState) : resolveIntrinsicTrackSizesMasonry(gridLayoutState);
+        (!m_renderGrid->isGridLanes()) ? resolveIntrinsicTrackSizes(gridLayoutState) : resolveIntrinsicTrackSizesGridLanes(gridLayoutState);
 
     // This is not exactly a step of the track sizing algorithm, but we use the track sizes computed
     // up to this moment (before maximization) to calculate the grid container intrinsic sizes.
@@ -2284,7 +2284,7 @@ bool GridTrackSizingAlgorithm::tracksAreWiderThanMinTrackBreadth() const
     if (m_renderGrid->isSubgrid(m_direction))
         return true;
 
-    if (m_renderGrid->isMasonry(m_direction))
+    if (m_renderGrid->isStackingAxis(m_direction))
         return true;
 
     auto& allTracks = tracks(m_direction);
@@ -2310,9 +2310,9 @@ GridTrackSizingAlgorithm::StateMachine::~StateMachine()
     m_algorithm.m_needsSetup = true;
 }
 
-bool GridTrackSizingAlgorithm::isDirectionInMasonryDirection() const
+bool GridTrackSizingAlgorithm::isDirectionInStackingAxis() const
 {
-    return m_renderGrid->isMasonry(m_direction);
+    return m_renderGrid->isStackingAxis(m_direction);
 }
 
 bool GridTrackSizingAlgorithm::hasAllLengthRowSizes() const

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -166,14 +166,14 @@ private:
     using SpanLength = unsigned;
 
     void setup(Style::GridTrackSizingDirection, unsigned numTracks, SizingOperation, std::optional<LayoutUnit> availableSpace);
-    struct MasonryMinMaxTrackSize {
+    struct GridLanesMinMaxTrackSize {
         LayoutUnit minContentSize;
         LayoutUnit maxContentSize;
         LayoutUnit minSize;
     };
 
-    struct MasonryMinMaxTrackSizeWithGridSpan {
-        MasonryMinMaxTrackSize trackSize;
+    struct GridLanesMinMaxTrackSizeWithGridSpan {
+        GridLanesMinMaxTrackSize trackSize;
         GridSpan gridSpan;
     };
 
@@ -186,7 +186,7 @@ private:
 
     // Helper methods for step 2. resolveIntrinsicTrackSizes().
     void sizeTrackToFitNonSpanningItem(const GridSpan&, RenderBox& gridItem, GridTrack&, RenderGridLayoutState&);
-    void sizeTrackToFitSingleSpanMasonryGroup(const GridSpan&, MasonryMinMaxTrackSize&, GridTrack&);
+    void sizeTrackToFitSingleSpanGridLanesGroup(const GridSpan&, GridLanesMinMaxTrackSize&, GridTrack&);
 
     bool NODELETE spanningItemCrossesFlexibleSizedTracks(const GridSpan&) const;
 
@@ -209,7 +209,7 @@ private:
     // 2. Distribute space to intrinsic tracks
     // This step behaves similar to increaseSizesToAccommodateSpanningItems() where we start at the lowest span length and distribute space to the tracks.
     // Then look at the next smallest span length, and repeat step 2 until we exhaust all grid items.
-    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsMasonry(StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&);
+    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsGridLanes(StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>&);
 
     // 12.5 Resolve Intrinsic Track Sizing : Step 4
     // https://drafts.csswg.org/css-grid-2/#algo-spanning-items
@@ -225,12 +225,12 @@ private:
     //
     // 2. Distribute space to intrinsic tracks
     // This step behaves similar to increaseSizesToAccommodateSpanningItems() where we consider all track items at once instead of per span length.
-    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsMasonryWithFlex(Vector<MasonryMinMaxTrackSizeWithGridSpan>&);
+    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsGridLanesWithFlex(Vector<GridLanesMinMaxTrackSizeWithGridSpan>&);
 
-    void convertIndefiniteItemsToDefiniteMasonry(const StdMap<SpanLength, MasonryMinMaxTrackSize>& gridTrackSpans, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&);
+    void convertIndefiniteItemsToDefiniteGridLanes(const StdMap<SpanLength, GridLanesMinMaxTrackSize>& gridTrackSpans, StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>&, Vector<GridLanesMinMaxTrackSizeWithGridSpan>&);
 
     LayoutUnit itemSizeForTrackSizeComputationPhase(TrackSizeComputationPhase, RenderBox&, RenderGridLayoutState&) const;
-    LayoutUnit NODELETE itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase, const MasonryMinMaxTrackSize&) const;
+    LayoutUnit NODELETE itemSizeForTrackSizeComputationPhaseGridLanes(TrackSizeComputationPhase, const GridLanesMinMaxTrackSize&) const;
 
     template <TrackSizeComputationVariant variant, TrackSizeComputationPhase phase> void distributeSpaceToTracks(Vector<CheckedRef<GridTrack>>& tracks, Vector<CheckedRef<GridTrack>>* growBeyondGrowthLimitsTracks, LayoutUnit& freeSpace) const;
 
@@ -253,7 +253,7 @@ private:
 
     // Build up a map of min/max sizes for each span length for use during resolving intrinsic track sizes.
     // We also need to keep track of definite items separately, since they do not contribute to every track like indefinite items do.
-    void computeDefiniteAndIndefiniteItemsForMasonry(StdMap<SpanLength, MasonryMinMaxTrackSize>&, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&, RenderGridLayoutState&);
+    void computeDefiniteAndIndefiniteItemsForGridLanes(StdMap<SpanLength, GridLanesMinMaxTrackSize>&, StdMap<SpanLength, Vector<GridLanesMinMaxTrackSizeWithGridSpan>>&, Vector<GridLanesMinMaxTrackSizeWithGridSpan>&, RenderGridLayoutState&);
 
     // Track sizing algorithm steps. Note that the "Maximize Tracks" step is done
     // entirely inside the strategies, that's why we don't need an additional
@@ -261,15 +261,15 @@ private:
     void initializeTrackSizes();
     void resolveIntrinsicTrackSizes(RenderGridLayoutState&);
 
-    // Masonry Implementation of https://drafts.csswg.org/css-grid-2/#algo-content.
-    // To implement Masonry performanently, we need to abandon the traditional Grid approach of treating
+    // Grid lanes implementation of https://drafts.csswg.org/css-grid-2/#algo-content.
+    // To implement grid lanes layout performanently, we need to abandon the traditional Grid approach of treating
     // each item individually and start grouping items based on their span. A grid item has 3 major values we care about
     // the minContentSize, maxContentSize, and minSize. These values can be aggregated together and then the max will be chosen.
     // The main three scenarios we need to focus on are items that only span 1 track, items that span multiple tracks without crossing a flex track,
     // and items that span multiple tracks with crossing a flex track.
     //
     // Further details on the optimization can be found at https://fantasai.inkedblade.net/style/specs/masonry/performance.
-    void resolveIntrinsicTrackSizesMasonry(RenderGridLayoutState&);
+    void resolveIntrinsicTrackSizesGridLanes(RenderGridLayoutState&);
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace, RenderGridLayoutState&);
     void stretchAutoTracks();
 
@@ -287,7 +287,7 @@ private:
     void advanceNextState();
     bool NODELETE isValidTransition() const;
 
-    bool isDirectionInMasonryDirection() const;
+    bool isDirectionInStackingAxis() const;
 
     // Data.
     bool wasSetup() const { return !!m_strategy; }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1375,9 +1375,9 @@ bool RenderBlock::establishesIndependentFormattingContext() const
         // https://drafts.csswg.org/css-grid-2/#grid-item-display
         if (!style.gridTemplateColumns().subgrid && !style.gridTemplateRows().subgrid)
             return true;
-        // Masonry makes grid items not subgrids.
+        // Grid lanes layout makes grid items not subgrids.
         if (auto* parentGridBox = dynamicDowncast<RenderGrid>(parent()))
-            return parentGridBox->isMasonry();
+            return parentGridBox->isGridLanes();
     }
 
     return false;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -29,8 +29,8 @@
 
 #include "BaselineAlignmentInlines.h"
 #include "GridArea.h"
+#include "GridLanesLayout.h"
 #include "GridLayoutFunctions.h"
-#include "GridMasonryLayout.h"
 #include "GridTrackSizingAlgorithm.h"
 #include "HitTestLocation.h"
 #include "LayoutIntegrationGridCoverage.h"
@@ -61,7 +61,7 @@ RenderGrid::RenderGrid(Element& element, Style::ComputedStyle&& style)
     : RenderBlock(Type::Grid, element, WTF::move(style), { })
     , m_grid(*this)
     , m_trackSizingAlgorithm(this, currentGrid())
-    , m_masonryLayout(*this)
+    , m_gridLanesLayout(*this)
 {
     ASSERT(isRenderGrid());
     // All of our children must be block level.
@@ -101,7 +101,7 @@ bool RenderGrid::isExtrinsicallySized() const
         || !allTracksAreExtrinsicallySized()
         || gridStyle.aspectRatio().hasRatio()
         || isSubgrid()
-        || isMasonry())
+        || isGridLanes())
         return false;
 
     for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
@@ -116,7 +116,7 @@ bool RenderGrid::isExtrinsicallySized() const
 
 StyleSelfAlignmentData RenderGrid::selfAlignmentForGridItem(const RenderBox& gridItem, LogicalBoxAxis containingAxis, StretchingMode stretchingMode, const Style::ComputedStyle* gridStyle) const
 {
-    if (isMasonry(containingAxis))
+    if (isStackingAxis(containingAxis))
         return { ItemPosition::Start };
 
     if (CheckedPtr renderGrid = dynamicDowncast<RenderGrid>(gridItem); renderGrid && renderGrid->isSubgridInParentDirection(Style::gridTrackSizingDirection(containingAxis)))
@@ -404,13 +404,13 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
     if (relayoutChildren == RelayoutChildren::No && simplifiedLayout())
         return;
 
-    // The layoutBlock was handling the layout of both the grid and masonry implementations.
-    // This caused a huge amount of branching code to handle masonry specific cases. Splitting up the code
+    // The layoutBlock was handling the layout of both the grid and grid lanes implementations.
+    // This caused a huge amount of branching code to handle grid lanes specific cases. Splitting up the code
     // to layout will simplify both implementations.
-    if (!isMasonry())
+    if (!isGridLanes())
         layoutGrid(relayoutChildren);
     else
-        layoutMasonry(relayoutChildren);
+        layoutGridLanes(relayoutChildren);
 }
 
 static void clearGridItemOverridingSizesBeforeLayout(RenderGrid& renderGrid)
@@ -593,7 +593,7 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     return true;
 }
 
-void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
+void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
     LayoutRepainter repainter(*this);
     {
@@ -602,7 +602,7 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
 
         clearGridItemOverridingSizesBeforeLayout(*this);
 
-        // We are committed to a full masonry layout; invalidate the resolved track list now so that a
+        // We are committed to a full grid lanes layout; invalidate the resolved track list now so that a
         // stale read asserts if we fail to repopulate it below (see updateResolvedTrackListsAfterLayout).
         m_resolvedTrackList.invalidate();
 
@@ -652,24 +652,24 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
         } else
             computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection::Rows, availableLogicalHeight(AvailableLogicalHeightType::ExcludeMarginBorderPadding), gridLayoutState);
 
-        auto performMasonryPlacement = [&](const Style::GridTrackSizingDirection masonryAxisDirection) {
-            auto gridAxisDirection = masonryAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
+        auto performGridLanesPlacement = [&](const Style::GridTrackSizingDirection stackingAxisDirection) {
+            auto gridAxisDirection = stackingAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
             unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
 
-            m_masonryLayout.performMasonryPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase::LayoutPhase);
+            m_gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, GridLanesLayout::Phase::LayoutPhase);
         };
 
-        if (areMasonryRows())
-            performMasonryPlacement(Style::GridTrackSizingDirection::Rows);
-        else if (areMasonryColumns())
-            performMasonryPlacement(Style::GridTrackSizingDirection::Columns);
+        if (hasStackingAxisRows())
+            performGridLanesPlacement(Style::GridTrackSizingDirection::Rows);
+        else if (hasStackingAxisColumns())
+            performGridLanesPlacement(Style::GridTrackSizingDirection::Columns);
 
         LayoutUnit trackBasedLogicalHeight = borderAndPaddingLogicalHeight() + scrollbarLogicalHeight();
         if (auto size = explicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection::Rows))
             trackBasedLogicalHeight += size.value();
         else {
-            if (areMasonryRows())
-                trackBasedLogicalHeight += m_masonryLayout.gridContentSize();
+            if (hasStackingAxisRows())
+                trackBasedLogicalHeight += m_gridLanesLayout.gridContentSize();
             else
                 trackBasedLogicalHeight += m_trackSizingAlgorithm.computeTrackBasedSize();
         }
@@ -682,7 +682,7 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
 
         // Once grid's indefinite height is resolved, we can compute the
         // available free space for Content Alignment.
-        if (!hasDefiniteLogicalHeight || areMasonryRows())
+        if (!hasDefiniteLogicalHeight || hasStackingAxisRows())
             m_trackSizingAlgorithm.setFreeSpace(Style::GridTrackSizingDirection::Rows, logicalHeight() - trackBasedLogicalHeight);
 
         // 2.5. Compute Content Distribution offsets for rows tracks
@@ -701,7 +701,7 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
             setLogicalHeight(std::max(logicalHeight(), minHeightForEmptyLine));
         }
 
-        layoutMasonryItems(gridLayoutState);
+        layoutGridLanesItems(gridLayoutState);
 
         updateResolvedTrackListsAfterLayout();
 
@@ -852,19 +852,19 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
 
     auto [minLogicalWidth, maxLogicalWidth] = computeTrackSizesForIndefiniteSize(algorithm, Style::GridTrackSizingDirection::Columns, gridLayoutState);
 
-    if (isMasonry(Style::GridTrackSizingDirection::Columns)) {
-        // The track sizing algorithm will only be run once in this case, since track sizing will not run in the masonry direction.
+    if (isStackingAxis(Style::GridTrackSizingDirection::Columns)) {
+        // The track sizing algorithm will only be run once in this case, since track sizing will not run in the stacking axis.
         std::tie(minLogicalWidth, maxLogicalWidth) = computeTrackSizesForIndefiniteSize(algorithm, Style::GridTrackSizingDirection::Rows, gridLayoutState);
 
         auto gridAxisTracksCountBeforeAutoPlacement = currentGrid().numTracks(Style::GridTrackSizingDirection::Rows);
 
-        // To determine the width of the grid when we have a masonry layout in the column direction we need to perform a layout with the min and max
+        // To determine the width of the grid when we have a grid lanes layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
-        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridMasonryLayout::MasonryLayoutPhase::MinContentPhase);
-        minLogicalWidth = m_masonryLayout.gridContentSize();
+        m_gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MinContentPhase);
+        minLogicalWidth = m_gridLanesLayout.gridContentSize();
 
-        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridMasonryLayout::MasonryLayoutPhase::MaxContentPhase);
-        maxLogicalWidth = m_masonryLayout.gridContentSize();
+        m_gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MaxContentPhase);
+        maxLogicalWidth = m_gridLanesLayout.gridContentSize();
     }
 
     m_grid.resetCurrentGrid();
@@ -1124,33 +1124,42 @@ static GridArea insertIntoGrid(Grid& grid, RenderBox& gridItem, const GridArea& 
     return clamped;
 }
 
-bool RenderGrid::isMasonry() const
+bool RenderGrid::isGridLanes() const
 {
-    return areMasonryRows() || areMasonryColumns();
+    return hasStackingAxisRows() || hasStackingAxisColumns();
 }
 
-// Masonry Spec Section 2
-// "If masonry is specified for both grid-template-columns and grid-template-rows, then the used value for grid-template-columns is none,
-// and thus the inline axis will be the grid axis."
-bool RenderGrid::isMasonry(Style::GridTrackSizingDirection direction) const
+// Grid Lanes Spec Section 2 Grid Lanes Layout Model
+// https://drafts.csswg.org/css-grid-3/#grid-lanes-model
+// The stacking axis is the axis that items are stacked along; the orthogonal axis is
+// the grid axis, which establishes the tracks. Which axis is which is determined per
+// Section 2.3 Orienting Grid Lanes Layout, which we key off grid-auto-flow.
+// https://drafts.csswg.org/css-grid-3/#grid-lanes-orientation
+// Note that a subgrid defers to its parent before we check display, so a display:grid
+// subgrid of a grid lanes container can answer true here.
+bool RenderGrid::isStackingAxis(Style::GridTrackSizingDirection direction) const
 {
-    // isSubgrid will return false if the masonry axis matches. Need to check style if we are a subgrid
+    // isSubgrid will return false if the stacking axis matches. Need to check style if we are a subgrid
     auto& tracks = style().gridTemplateList(direction);
     if (auto* parentGrid = dynamicDowncast<RenderGrid>(parent()); parentGrid && tracks.subgrid)
-        return parentGrid->isMasonry(direction);
+        return parentGrid->isStackingAxis(direction);
     if (style().display() != Style::DisplayType::BlockGridLanes && style().display() != Style::DisplayType::InlineGridLanes)
         return false;
     return (direction == Style::GridTrackSizingDirection::Columns) == style().gridAutoFlow().isColumn();
 }
 
-// Masonry Spec Section 2.3.1 repeat(auto-fit)
-// "repeat(auto-fit) behaves as repeat(auto-fill) when the other axis is a masonry axis."
-// We need to lie here that we are really an auto-fill instead of an auto-fit.
+// Grid Lanes Spec Section 3.3.1 repeat(auto-fit)
+// https://drafts.csswg.org/css-grid-3/#repeat-auto-fit
+// In a grid lanes container placement happens after track sizing, so the spec has
+// auto-fit collapse only those tracks an occupancy heuristic proves to be empty.
+// We do not implement that heuristic and therefore never collapse, so report the
+// repetition as an auto-fill instead of an auto-fit.
+// FIXME: Implement the occupancy heuristic so auto-fit can collapse empty tracks.
 AutoRepeatType RenderGrid::autoRepeatType(Style::GridTrackSizingDirection direction) const
 {
     auto autoRepeatType = style().gridTemplateList(direction).autoRepeatType;
 
-    if (isMasonry(orthogonalDirection(direction)) && autoRepeatType == AutoRepeatType::Fit)
+    if (isStackingAxis(orthogonalDirection(direction)) && autoRepeatType == AutoRepeatType::Fit)
         return AutoRepeatType::Fill;
 
     return autoRepeatType;
@@ -1175,7 +1184,7 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 
     if (autoRepeatColumns != currentGrid().autoRepeatTracks(Style::GridTrackSizingDirection::Columns)
         || autoRepeatRows != currentGrid().autoRepeatTracks(Style::GridTrackSizingDirection::Rows)
-        || isMasonry()) {
+        || isGridLanes()) {
         currentGrid().setNeedsItemsPlacement(true);
         currentGrid().setAutoRepeatTracks(autoRepeatRows, autoRepeatColumns);
     }
@@ -1249,9 +1258,9 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 #endif
 }
 
-LayoutUnit RenderGrid::masonryContentSize() const
+LayoutUnit RenderGrid::gridLanesContentSize() const
 {
-    return m_masonryLayout.gridContentSize();
+    return m_gridLanesLayout.gridContentSize();
 }
 
 void RenderGrid::performPreLayoutForGridItems(const GridTrackSizingAlgorithm& algorithm, const ShouldUpdateGridAreaLogicalSize shouldUpdateGridAreaLogicalSize) const
@@ -1578,10 +1587,10 @@ static bool NODELETE hasRelativeBlockAxisSize(const RenderGrid& grid, const Rend
 
 void RenderGrid::updateGridAreaWithEstimate(RenderBox& gridItem, const GridTrackSizingAlgorithm& algorithm) const
 {
-    auto logicalWidth = isMasonry(Style::GridTrackSizingDirection::Columns)
+    auto logicalWidth = isStackingAxis(Style::GridTrackSizingDirection::Columns)
         ? contentBoxLogicalWidth()
         : algorithm.estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Columns);
-    auto logicalHeight = isMasonry(Style::GridTrackSizingDirection::Rows)
+    auto logicalHeight = isStackingAxis(Style::GridTrackSizingDirection::Rows)
         ? availableLogicalHeightForContentBox()
         : algorithm.estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
     updateGridAreaLogicalSize(gridItem, logicalWidth, logicalHeight);
@@ -1589,10 +1598,10 @@ void RenderGrid::updateGridAreaWithEstimate(RenderBox& gridItem, const GridTrack
 
 void RenderGrid::updateGridAreaIncludingAlignment(RenderBox& gridItem) const
 {
-    auto logicalWidth = isMasonry(Style::GridTrackSizingDirection::Columns)
+    auto logicalWidth = isStackingAxis(Style::GridTrackSizingDirection::Columns)
         ? contentBoxLogicalWidth()
         : gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, Style::GridTrackSizingDirection::Columns);
-    auto logicalHeight = isMasonry(Style::GridTrackSizingDirection::Rows)
+    auto logicalHeight = isStackingAxis(Style::GridTrackSizingDirection::Rows)
         ? contentBoxLogicalHeight()
         : gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, Style::GridTrackSizingDirection::Rows);
     updateGridAreaLogicalSize(gridItem, logicalWidth, logicalHeight);
@@ -1668,7 +1677,7 @@ void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState)
     }
 }
 
-void RenderGrid::layoutMasonryItems(RenderGridLayoutState& gridLayoutState)
+void RenderGrid::layoutGridLanesItems(RenderGridLayoutState& gridLayoutState)
 {
     layoutGridItems(gridLayoutState);
 }
@@ -1759,8 +1768,8 @@ void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorith
             positions[i + 1] = positions[i] + offsetBetweenTracks.distributionOffset + tracks[i]->unclampedBaseSize() + gap;
         positions[lastLine] = positions[nextToLastLine] + tracks[nextToLastLine]->unclampedBaseSize();
 
-        if (isMasonry(direction))
-            positions[lastLine] = m_masonryLayout.gridContentSize() + positions[0];
+        if (isStackingAxis(direction))
+            positions[lastLine] = m_gridLanesLayout.gridContentSize() + positions[0];
 
         // Adjust collapsed gaps. Collapsed tracks cause the surrounding gutters to collapse (they
         // coincide exactly) except on the edges of the grid where they become 0.
@@ -1996,9 +2005,9 @@ const RenderBox* RenderGrid::baselineGridItem(ItemPosition alignment) const
 
 LayoutUnit RenderGrid::columnAxisBaselineOffsetForGridItem(const RenderBox& gridItem) const
 {
-    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
-    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
-    if (isMasonry())
+    // FIXME : CSS Grid Lanes does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is a grid lanes container for now.
+    if (isGridLanes())
         return LayoutUnit { };
 
     if (isSubgridRows()) {
@@ -2012,9 +2021,9 @@ LayoutUnit RenderGrid::columnAxisBaselineOffsetForGridItem(const RenderBox& grid
 
 LayoutUnit RenderGrid::rowAxisBaselineOffsetForGridItem(const RenderBox& gridItem) const
 {
-    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
-    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
-    if (isMasonry())
+    // FIXME : CSS Grid Lanes does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is a grid lanes container for now.
+    if (isGridLanes())
         return LayoutUnit { };
 
     if (isSubgridColumns()) {
@@ -2146,7 +2155,7 @@ LayoutUnit RenderGrid::columnAxisOffsetForGridItem(const RenderBox& gridItem) co
     auto [startOfRow, endOfRow] = gridAreaPositionForInFlowGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
     LayoutUnit startPosition = startOfRow + marginBeforeForChild(gridItem);
     LayoutUnit columnAxisGridItemSize = GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) ? gridItem.logicalWidth() + gridItem.marginLogicalWidth() : gridItem.logicalHeight() + gridItem.marginLogicalHeight();
-    LayoutUnit masonryOffset = areMasonryRows() ? m_masonryLayout.offsetForGridItem(gridItem) : 0_lu;
+    LayoutUnit stackingAxisOffset = hasStackingAxisRows() ? m_gridLanesLayout.offsetForGridItem(gridItem) : 0_lu;
     auto overflow = selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Block).overflow();
     LayoutUnit offsetFromStartPosition = computeOverflowAlignmentOffset(overflow, endOfRow - startOfRow, columnAxisGridItemSize);
     if (GridLayoutFunctions::hasAutoMarginsInColumnAxis(gridItem, writingMode()))
@@ -2154,7 +2163,7 @@ LayoutUnit RenderGrid::columnAxisOffsetForGridItem(const RenderBox& gridItem) co
     GridAxisPosition axisPosition = columnAxisPositionForGridItem(gridItem);
     switch (axisPosition) {
     case GridAxisPosition::GridAxisStart:
-        return startPosition + columnAxisBaselineOffsetForGridItem(gridItem) + masonryOffset;
+        return startPosition + columnAxisBaselineOffsetForGridItem(gridItem) + stackingAxisOffset;
     case GridAxisPosition::GridAxisEnd:
         return (startPosition + offsetFromStartPosition) - columnAxisBaselineOffsetForGridItem(gridItem);
     case GridAxisPosition::GridAxisCenter:
@@ -2169,7 +2178,7 @@ LayoutUnit RenderGrid::rowAxisOffsetForGridItem(const RenderBox& gridItem) const
 {
     auto [startOfColumn, endOfColumn] = gridAreaPositionForInFlowGridItem(gridItem, Style::GridTrackSizingDirection::Columns);
     LayoutUnit startPosition = startOfColumn + marginStartForChild(gridItem);
-    LayoutUnit masonryOffset = areMasonryColumns() ? m_masonryLayout.offsetForGridItem(gridItem) : 0_lu;
+    LayoutUnit stackingAxisOffset = hasStackingAxisColumns() ? m_gridLanesLayout.offsetForGridItem(gridItem) : 0_lu;
     if (GridLayoutFunctions::hasAutoMarginsInRowAxis(gridItem, writingMode()))
         return startPosition;
     LayoutUnit rowAxisGridItemSize = GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) ? gridItem.logicalHeight() + gridItem.marginLogicalHeight() : gridItem.logicalWidth() + gridItem.marginLogicalWidth();
@@ -2179,7 +2188,7 @@ LayoutUnit RenderGrid::rowAxisOffsetForGridItem(const RenderBox& gridItem) const
     GridAxisPosition axisPosition = rowAxisPositionForGridItem(gridItem);
     switch (axisPosition) {
     case GridAxisPosition::GridAxisStart:
-        return startPosition + rowAxisBaselineOffset + masonryOffset;
+        return startPosition + rowAxisBaselineOffset + stackingAxisOffset;
     case GridAxisPosition::GridAxisEnd:
         return startPosition + offsetFromStartPosition - rowAxisBaselineOffset;
     case GridAxisPosition::GridAxisCenter:
@@ -2210,7 +2219,7 @@ bool RenderGrid::isSubgrid(Style::GridTrackSizingDirection direction) const
     auto* renderGrid = dynamicDowncast<RenderGrid>(parent());
     if (!renderGrid)
         return false;
-    return !renderGrid->isMasonry(direction);
+    return !renderGrid->isStackingAxis(direction);
 }
 
 bool RenderGrid::isSubgridInParentDirection(Style::GridTrackSizingDirection parentDirection) const
@@ -2432,8 +2441,8 @@ ContentAlignmentData RenderGrid::computeContentPositionAndDistributionOffset(Sty
 
 LayoutRect RenderGrid::contentOverflowRect() const
 {
-    // FIXME: Handle subgrids and masonry.
-    if (!hasPotentiallyScrollableOverflow() || isMasonry() || isSubgridRows() || isSubgridColumns())
+    // FIXME: Handle subgrids and grid lanes.
+    if (!hasPotentiallyScrollableOverflow() || isGridLanes() || isSubgridRows() || isSubgridColumns())
         return flippedContentBoxRect();
 
     // Get the grid rectangle.
@@ -2668,7 +2677,7 @@ std::optional<GridItemSizeCache>& RenderGrid::intrinsicLogicalHeightsForRowSizin
 
 bool RenderGrid::canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() const
 {
-    if (isMasonry())
+    if (isGridLanes())
         return false;
 
     if (isSubgridRows())

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "Grid.h"
-#include "GridMasonryLayout.h"
+#include "GridLanesLayout.h"
 #include "GridTrackSizingAlgorithm.h"
 #include "RenderBlock.h"
 #include "StyleGridTrackSizingDirection.h"
@@ -111,11 +111,11 @@ public:
     bool willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode = StretchingMode::Normal) const override;
 
     // These functions handle the actual implementation of layoutBlock based on if
-    // the grid is a standard grid or a masonry one. While masonry is an extension of grid,
+    // the grid is a standard grid or a grid lanes one. While grid lanes layout is an extension of grid,
     // keeping the logic in the same function was leading to a messy amount of if statements being added to handle
-    // specific masonry cases.
+    // specific grid lanes cases.
     void layoutGrid(RelayoutChildren);
-    void layoutMasonry(RelayoutChildren);
+    void layoutGridLanes(RelayoutChildren);
 
     // Computes the span relative to this RenderGrid, even if the RenderBox is a grid item
     // of a descendant subgrid.
@@ -132,11 +132,11 @@ public:
     // nested subgrids, where ancestor may not be our direct parent.
     bool isSubgridOf(Style::GridTrackSizingDirection, const RenderGrid& ancestor) const;
 
-    bool NODELETE isMasonry() const;
-    bool isMasonry(Style::GridTrackSizingDirection) const;
-    bool isMasonry(LogicalBoxAxis axis) const { return isMasonry(Style::gridTrackSizingDirection(axis)); }
-    bool areMasonryRows() const { return isMasonry(Style::GridTrackSizingDirection::Rows); }
-    bool areMasonryColumns() const { return isMasonry(Style::GridTrackSizingDirection::Columns); }
+    bool NODELETE isGridLanes() const;
+    bool isStackingAxis(Style::GridTrackSizingDirection) const;
+    bool isStackingAxis(LogicalBoxAxis axis) const { return isStackingAxis(Style::gridTrackSizingDirection(axis)); }
+    bool hasStackingAxisRows() const { return isStackingAxis(Style::GridTrackSizingDirection::Rows); }
+    bool hasStackingAxisColumns() const { return isStackingAxis(Style::GridTrackSizingDirection::Columns); }
 
     const Grid& NODELETE currentGrid() const LIFETIME_BOUND;
     Grid& NODELETE currentGrid() LIFETIME_BOUND;
@@ -149,7 +149,7 @@ public:
     LayoutUnit gridGap(Style::GridTrackSizingDirection) const;
     LayoutUnit gridGap(Style::GridTrackSizingDirection, std::optional<LayoutUnit> availableSize) const;
 
-    LayoutUnit NODELETE masonryContentSize() const;
+    LayoutUnit NODELETE gridLanesContentSize() const;
 
     void updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability();
     std::optional<GridItemSizeCache>& NODELETE intrinsicLogicalHeightsForRowSizingFirstPass() const LIFETIME_BOUND;
@@ -164,7 +164,7 @@ public:
 private:
     friend class GridTrackSizingAlgorithm;
     friend class GridTrackSizingAlgorithmStrategy;
-    friend class GridMasonryLayout;
+    friend class GridLanesLayout;
     friend class PositionedLayoutConstraints;
     friend class LayoutIntegration::GridLayout;
 
@@ -226,7 +226,7 @@ private:
     void updateGridAreaForAspectRatioItems(const Vector<RenderBox*>&, RenderGridLayoutState&);
 
     void layoutGridItems(RenderGridLayoutState&);
-    void layoutMasonryItems(RenderGridLayoutState&);
+    void layoutGridLanesItems(RenderGridLayoutState&);
 
     void populateGridPositionsForDirection(const GridTrackSizingAlgorithm&, Style::GridTrackSizingDirection);
 
@@ -297,7 +297,7 @@ private:
         mutable std::reference_wrapper<Grid> m_currentGrid { std::ref(m_layoutGrid) };
     } m_grid;
 
-    // FIXME: Refactor m_trackSizingAlgorithm to be inside of layoutGrid and layoutMasonry.
+    // FIXME: Refactor m_trackSizingAlgorithm to be inside of layoutGrid and layoutGridLanes.
     // https://bugs.webkit.org/show_bug.cgi?id=277496
     GridTrackSizingAlgorithm m_trackSizingAlgorithm;
 
@@ -325,7 +325,7 @@ private:
         Vector<LayoutUnit>& sizes(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnSizes : rowSizes; }
     } m_resolvedTrackList;
 
-    mutable GridMasonryLayout m_masonryLayout;
+    mutable GridLanesLayout m_gridLanesLayout;
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
 

--- a/Source/WebCore/rendering/style/GridSpan.cpp
+++ b/Source/WebCore/rendering/style/GridSpan.cpp
@@ -45,7 +45,7 @@ GridSpan GridSpan::indefiniteGridSpan()
     return GridSpan(0, 1, Indefinite);
 }
 
-GridSpan GridSpan::masonryAxisTranslatedDefiniteGridSpan()
+GridSpan GridSpan::stackingAxisTranslatedDefiniteGridSpan()
 {
     return GridSpan(0, 1, TranslatedDefinite);
 }

--- a/Source/WebCore/rendering/style/GridSpan.h
+++ b/Source/WebCore/rendering/style/GridSpan.h
@@ -37,7 +37,7 @@ public:
     static GridSpan translatedDefiniteGridSpan(unsigned startLine, unsigned endLine);
     static GridSpan indefiniteGridSpan();
 
-    static GridSpan masonryAxisTranslatedDefiniteGridSpan();
+    static GridSpan stackingAxisTranslatedDefiniteGridSpan();
 
     friend bool operator==(const GridSpan&, const GridSpan&) = default;
 

--- a/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
@@ -285,9 +285,9 @@ NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const Cu
             auto* currentAncestorSubgridParent = downcast<RenderGrid>(currentAncestorSubgrid.parent());
             auto& currentAncestorStyle = currentAncestorSubgrid.style();
 
-            // auto-placed subgrids inside a masonry grid do not inherit any line names
-            if ((currentAncestorSubgridParent->areMasonryRows() && (currentAncestorStyle.gridItemColumnStart().isAuto() || currentAncestorStyle.gridItemColumnStart().isSpan()))
-                || (currentAncestorSubgridParent->areMasonryColumns() && (currentAncestorStyle.gridItemRowStart().isAuto() || currentAncestorStyle.gridItemRowStart().isSpan())))
+            // auto-placed subgrids inside a grid lanes container do not inherit any line names
+            if ((currentAncestorSubgridParent->hasStackingAxisRows() && (currentAncestorStyle.gridItemColumnStart().isAuto() || currentAncestorStyle.gridItemColumnStart().isSpan()))
+                || (currentAncestorSubgridParent->hasStackingAxisColumns() && (currentAncestorStyle.gridItemRowStart().isAuto() || currentAncestorStyle.gridItemRowStart().isSpan())))
                 return;
             // Translate our explicit grid set of lines into the coordinate space of the
             // parent grid, adjusting direction/side as needed.


### PR DESCRIPTION
#### e1e532f4f12ffb9a5afe3b573f4268364d994eb8
<pre>
[Grid Lanes] Rename remaining references to masonry in the code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322291">https://bugs.webkit.org/show_bug.cgi?id=322291</a>
<a href="https://rdar.apple.com/185533476">rdar://185533476</a>

Reviewed by Vitor Roriz and Tim Nguyen.

The CSSWG resolved to rename the &quot;masonry layout&quot; feature to &quot;Grid Lanes&quot;.
Some of the code was already renamed but the layout code was still
referring to the old Masonry name and terms. Some notable changes that
were not a pure masonry -&gt; grid lanes remapping:

- The spec renamed &quot;masonry axis,&quot; to &quot;stacking axis,&quot; so that is
  changed as well.
- Similarly, areMasonryColumns/Rows is changed to hasStackingAxisColumns/Rows
  along with other functions/code with the same idea.
- masonryGridAreaFromGridAxisSpan -&gt; gridAreaFromGridAxisSpan because
  this is a lot more concise and is still accurate and clear.

Also a lot of the comments have been updated with the new terms and
links to the new section in the spec.

Canonical link: <a href="https://commits.webkit.org/319624@main">https://commits.webkit.org/319624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a2ee73249f2f0ee5d51cb9e61765ae6d1a53f96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49789 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192261 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c75a428-b6dd-4710-8abd-3c9b6e33f8c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55706 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192261 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be8d73b8-6e20-42f9-a707-7bf524f80f80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162871 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192261 "") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44497 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42764 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192261 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42396 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194189 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55654 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40578 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56345 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151246 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45820 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128628 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124450 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54856 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17391 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->