### PR TITLE
[WebDriver][WPE] WPEView click count is not reset when needed

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2447,6 +2447,19 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
 }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+
+static bool movedOutOfBounds(const WebCore::IntPoint& origin, const WebCore::IntPoint& position, int maxDistance)
+{
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    // Both WPE and GTK native events compare the double click distance linearly per axis
+    if (!maxDistance)
+        return origin != position;
+    return std::abs(origin.x() - position.x()) >= maxDistance || std::abs(origin.y() - position.y()) >= maxDistance;
+#else
+    return origin.distanceSquaredToPoint(position) > maxDistance;
+#endif
+}
+
 void WebAutomationSession::updateClickCount(MouseButton button, const WebCore::IntPoint& position, Seconds maxTime, int maxDistance)
 {
     if (button != MouseButton::Left) {
@@ -2456,7 +2469,7 @@ void WebAutomationSession::updateClickCount(MouseButton button, const WebCore::I
     }
 
     auto now = MonotonicTime::now();
-    if (!m_lastClickPosition || m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance || now - m_lastClickTime > maxTime) {
+    if (!m_lastClickPosition || movedOutOfBounds(*m_lastClickPosition, position, maxDistance) || now - m_lastClickTime > maxTime) {
         m_lastClickPosition = position;
         m_lastClickTime = now;
         m_clickCount = 1;
@@ -2470,7 +2483,7 @@ void WebAutomationSession::updateClickCount(MouseButton button, const WebCore::I
 void WebAutomationSession::updateLastPosition(const WebCore::IntPoint& position, int maxDistance)
 {
     // Cancel multiple clicks if mouse strays too far:
-    if (m_lastClickPosition && m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance)
+    if (m_lastClickPosition && movedOutOfBounds(*m_lastClickPosition, position, maxDistance))
         m_lastClickPosition.reset();
 
     m_lastPosition = position;

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -33,6 +33,7 @@
 #include "WebEventModifier.h"
 #include "WebPageProxy.h"
 #include <optional>
+#include <tuple>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -124,7 +125,7 @@ static unsigned libWPEStateModifierForWPEButton(unsigned button)
     return state;
 }
 
-static void doMouseEvent(WebPageProxy& page, const WebCore::IntPoint& location, unsigned button, bool isPressed, uint32_t modifiers)
+static void doMouseEvent(WebPageProxy& page, const WebCore::IntPoint& location, unsigned button, bool isPressed, uint32_t modifiers, unsigned pressCount)
 {
     auto* view = page.wpeView();
     auto buttonModifiers =  libWPEStateModifierForWPEButton(button);
@@ -132,7 +133,6 @@ static void doMouseEvent(WebPageProxy& page, const WebCore::IntPoint& location, 
         modifiers |= buttonModifiers;
     else
         modifiers &= ~buttonModifiers;
-    unsigned pressCount = isPressed ? wpe_view_compute_press_count(view, location.x(), location.y(), button, 0) : 0;
     GRefPtr<WPEEvent> event = adoptGRef(wpe_event_pointer_button_new(isPressed ? WPE_EVENT_POINTER_DOWN : WPE_EVENT_POINTER_UP, view, WPE_INPUT_SOURCE_MOUSE,
         0, static_cast<WPEModifiers>(modifiers), button, location.x(), location.y(), pressCount));
     wpe_view_event(view, event.get());
@@ -177,6 +177,29 @@ static unsigned libWPEMouseButtonToWPEButton(MouseButton button)
         return 1;
     }
 }
+
+static std::optional<std::pair<Seconds, int>> getDoubleClickTimeAndDistance(WebPageProxy& page)
+{
+    auto* view = page.wpeView();
+    if (!view)
+        return std::nullopt;
+    auto* display = wpe_view_get_display(view);
+    if (!display)
+        return std::nullopt;
+    auto* settings = wpe_display_get_settings(display);
+    if (!settings)
+        return std::nullopt;
+    GUniqueOutPtr<GError> error;
+    uint32_t doubleClickDistance = wpe_settings_get_uint32(settings, WPE_SETTING_DOUBLE_CLICK_DISTANCE, &error.outPtr());
+    if (error)
+        return std::nullopt;
+    uint32_t doubleClickTime = wpe_settings_get_uint32(settings, WPE_SETTING_DOUBLE_CLICK_TIME, &error.outPtr());
+    if (error)
+        return std::nullopt;
+
+    return std::make_pair(Seconds::fromMilliseconds(doubleClickTime), static_cast<int>(doubleClickDistance));
+}
+
 #endif // ENABLE(WPE_PLATFORM)
 
 void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, MouseInteraction interaction, MouseButton button, const WebCore::IntPoint& locationInView, OptionSet<WebEventModifier> keyModifiers, const String& pointerType)
@@ -196,6 +219,14 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
     unsigned wpeButton = libWPEMouseButtonToWPEButton(button);
     auto modifier = libWPEStateModifierForWPEButton(wpeButton);
     uint32_t state = modifiersToEventState(keyModifiers) | m_currentModifiers;
+    // Fallback defaults from WPESettings.cpp
+    Seconds doubleClickTime = Seconds::fromMilliseconds(400);
+    int doubleClickDistance = 5;
+
+    if (auto doubleClickTimeAndDistance = getDoubleClickTimeAndDistance(page))
+        std::tie(doubleClickTime, doubleClickDistance) = *doubleClickTimeAndDistance;
+    else
+        LOG(Automation, "WebAutomationSession::platformSimulateMouseInteraction: Failed to get double click configuration. Using defaults.");
 
     switch (interaction) {
     case MouseInteraction::Move:
@@ -203,23 +234,27 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
         break;
     case MouseInteraction::Down:
         m_currentModifiers |= modifier;
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
+        updateClickCount(button, location, doubleClickTime, doubleClickDistance);
+        doMouseEvent(page, location, wpeButton, true, state | modifier, m_clickCount);
         break;
     case MouseInteraction::Up:
         m_currentModifiers &= ~modifier;
-        doMouseEvent(page, location, wpeButton, false, state & ~modifier);
+        doMouseEvent(page, location, wpeButton, false, state & ~modifier, 0);
         break;
     case MouseInteraction::SingleClick:
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
+        doMouseEvent(page, location, wpeButton, true, state | modifier, 1);
+        doMouseEvent(page, location, wpeButton, false, state, 0);
         break;
     case MouseInteraction::DoubleClick:
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
+        doMouseEvent(page, location, wpeButton, true, state | modifier, 1);
+        doMouseEvent(page, location, wpeButton, false, state, 0);
+        doMouseEvent(page, location, wpeButton, true, state | modifier, 2);
+        doMouseEvent(page, location, wpeButton, false, state, 0);
         break;
     }
+    // Check whether it should cancel pending multi-clicks when any interaction moves the pointer too much
+    // in-between clicks.
+    updateLastPosition(location, doubleClickDistance);
 #endif // ENABLE(WPE_PLATFORM)
 }
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -845,18 +845,13 @@
     "imported/w3c/webdriver/tests/classic/perform_actions/pointer_contextmenu.py": {
         "subtests": {
             "test_control_click[\\ue051-ctrlKey]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+                "expected": {"wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/184967"}}
             },
             "test_release_control_click": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213060"}}
-            }
-        }
-    },
-
-    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_dblclick.py": {
-        "subtests": {
-            "test_dblclick_at_coordinates[200]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/322119"}}
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/213060"},
+                    "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/213060"}
+                }
             }
         }
     },
@@ -1182,14 +1177,6 @@
             },
             "test_grapheme_cluster[\\u0e01\\u0e33]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            }
-        }
-    },
-
-    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_modifier_click.py": {
-        "subtests": {
-            "test_modifier_click[\\ue052-altKey]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             }
         }
     },


### PR DESCRIPTION
#### d90d95251a5a6f68625c169439af48678cef98a2
<pre>
[WebDriver][WPE] WPEView click count is not reset when needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=322119">https://bugs.webkit.org/show_bug.cgi?id=322119</a>

Reviewed by NOBODY (OOPS!).

Make WPE automation code use WebAutomationSession internal bookkeeping
to track the click count, aligning with GTK and Mac ports. It takes care
both of checking the click distance and interval, alongside resetting
the state between operations like loading frames and finishing
interaction sequences. It also keeps covering the case where the pointer
moves too much between clicks, which was covered by wpe_view_event
before.

The previous behavior used wpe_view_compute_press_count, which relies on
the current and previous timestamps to properly check against the
configured double click interval. The current automation code always
passes the value 0 as the timestamp, so the received click is always
within the interval of the last one, incrementing the count, despite the
actual time elapsed. Note that a 0 timestamp is translated by
WebEventFactoryWPE.cpp to a proper current timestamp when converting
from native to WebEvents, so the events on the page arrive with proper
timestamps, only the misleading click count.

While we could add some sort of platformResetMouseState or
platformResetClickCount to the WebAutomationSession, this approach would
also require to add some kind of wpe_view_reset_click_count to the
WPEView. Given wpe_event_pointer_button_new already accepts a pressCount
parameter, it&apos;s simpler to move to the WebAutomationSession-tracked
click count as mentioned above.

This commit also makes WebAutomationSession use either per-axis distance
(WPE and GTK) or the original radius distance, so the automation session
double click region matches the native event one.

Note that this commit also fixes some tests not directly related to
double click. Two tests issuing single clicks close together in time
might have been accidentally emitting dblclick events on the second
test&apos;s single click as the state was not reset.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::doMouseEvent):
(WebKit::getDoubleClickTimeAndDistance):
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
* WebDriverTests/TestExpectations.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::movedOutOfBounds):
(WebKit::WebAutomationSession::updateClickCount):
(WebKit::WebAutomationSession::updateLastPosition):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d90d95251a5a6f68625c169439af48678cef98a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147424 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142944 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99271 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46668 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163707 "Found 1 new API test failure: TestWebKitAPI.DownloadProgress.PublishProgressAfterDownloadFinished (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43607 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43235 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4526 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56727 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57432 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152114 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46667 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129702 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55940 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->