### PR TITLE
[iOS] MediaPlayerPrivateWirelessPlayback does not correctly issue fast seeks

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/seek-tolerance-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/seek-tolerance-expected.txt
@@ -1,0 +1,28 @@
+
+Test that MediaDeviceRoute requests a precise seek when setting currentTime and an approximate seek for fastSeek().
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+Setting currentTime requests a precise seek.
+RUN(video.currentTime = 30)
+EVENT(seeked)
+EXPECTED (route.lastSeekTolerance == 'precise') OK
+Seeking forward with fastSeek() requests an approximate seek.
+RUN(video.fastSeek(45))
+EVENT(seeked)
+EXPECTED (route.lastSeekTolerance == 'approximate') OK
+Setting currentTime again requests a precise seek.
+RUN(video.currentTime = 50)
+EVENT(seeked)
+EXPECTED (route.lastSeekTolerance == 'precise') OK
+Seeking backward with fastSeek() requests an approximate seek.
+RUN(video.fastSeek(15))
+EVENT(seeked)
+EXPECTED (route.lastSeekTolerance == 'approximate') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/seek-tolerance.html
+++ b/LayoutTests/media/wireless-playback-media-player/seek-tolerance.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                consoleWrite('Setting currentTime requests a precise seek.');
+                run(`video.currentTime = 30`);
+                await waitFor(video, 'seeked');
+                testExpected('route.lastSeekTolerance', 'precise');
+
+                consoleWrite('Seeking forward with fastSeek() requests an approximate seek.');
+                run(`video.fastSeek(45)`);
+                await waitFor(video, 'seeked');
+                testExpected('route.lastSeekTolerance', 'approximate');
+
+                consoleWrite('Setting currentTime again requests a precise seek.');
+                run(`video.currentTime = 50`);
+                await waitFor(video, 'seeked');
+                testExpected('route.lastSeekTolerance', 'precise');
+
+                consoleWrite('Seeking backward with fastSeek() requests an approximate seek.');
+                run(`video.fastSeek(15)`);
+                await waitFor(video, 'seeked');
+                testExpected('route.lastSeekTolerance', 'approximate');
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that MediaDeviceRoute requests a precise seek when setting currentTime and an approximate seek for fastSeek().</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -132,7 +132,8 @@ public:
     bool muted() const;
     float volume() const;
 
-    void setPlaybackPosition(MediaTime);
+    enum class SeekTolerance : bool { Approximate, Precise };
+    void seekToPosition(MediaTime, SeekTolerance);
     void setPlaying(bool);
     void setPlaybackSpeed(float);
     void setScanSpeed(float);

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -243,6 +243,19 @@ static MediaTimeRange convert(CMTimeRange timeRange)
     return { WTF::move(start), start + PAL::toMediaTime(timeRange.duration) };
 }
 
+static CMTime convert(MediaDeviceRoute::SeekTolerance tolerance)
+{
+    switch (tolerance) {
+    case MediaDeviceRoute::SeekTolerance::Precise:
+        return PAL::kCMTimeZero;
+    case MediaDeviceRoute::SeekTolerance::Approximate:
+        return PAL::kCMTimePositiveInfinity;
+    }
+
+    ASSERT_NOT_REACHED();
+    return PAL::kCMTimeZero;
+}
+
 static std::optional<MediaPlaybackSourceError> convert(NSError * _Nullable error)
 {
     if (!error)
@@ -311,10 +324,9 @@ WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
-void MediaDeviceRoute::setPlaybackPosition(MediaTime playbackPosition)
+void MediaDeviceRoute::seekToPosition(MediaTime playbackPosition, SeekTolerance tolerance)
 {
-    // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
-    [[m_playbackControlObserver playbackControl] seekToPosition:convert(WTF::move(playbackPosition)) tolerance:PAL::kCMTimeZero];
+    [[m_playbackControlObserver playbackControl] seekToPosition:convert(WTF::move(playbackPosition)) tolerance:convert(tolerance)];
 }
 
 MediaDeviceRoute::~MediaDeviceRoute()

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -295,6 +295,13 @@ bool MediaPlayerPrivateWirelessPlayback::hasAudio() const
     return false;
 }
 
+static MediaDeviceRoute::SeekTolerance seekTolerance(const SeekTarget& seekTarget)
+{
+    if (!seekTarget.negativeThreshold && !seekTarget.positiveThreshold)
+        return MediaDeviceRoute::SeekTolerance::Precise;
+    return MediaDeviceRoute::SeekTolerance::Approximate;
+}
+
 Ref<MediaTimePromise> MediaPlayerPrivateWirelessPlayback::seekToTarget(const SeekTarget& seekTarget)
 {
     RefPtr route = this->route();
@@ -303,7 +310,8 @@ Ref<MediaTimePromise> MediaPlayerPrivateWirelessPlayback::seekToTarget(const See
 
     ALWAYS_LOG(LOGIDENTIFIER, seekTarget);
     m_seekPromise.emplace(PlatformMediaError::Cancelled);
-    route->setPlaybackPosition(seekTarget.time);
+
+    route->seekToPosition(seekTarget.time, seekTolerance(seekTarget));
     return *m_seekPromise;
 }
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -96,6 +96,8 @@ public:
     bool muted() const;
     void setMuted(bool);
 
+    String lastSeekTolerance() const;
+
 private:
     MockMediaDeviceRoute();
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -43,6 +43,7 @@
     attribute MockMediaDeviceRouteTimeRange timeRange;
     attribute float volume;
     attribute boolean muted;
+    readonly attribute DOMString lastSeekTolerance;
 };
 
 [

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -201,6 +201,18 @@ void MockMediaDeviceRoute::setMuted(bool muted)
     [m_platformRoute setMuted:muted];
 }
 
+String MockMediaDeviceRoute::lastSeekTolerance() const
+{
+    CMTime tolerance = [m_platformRoute lastSeekTolerance];
+    if (CMTIME_IS_INVALID(tolerance))
+        return "none"_s;
+    if (CMTIME_COMPARE_INLINE(tolerance, ==, kCMTimeZero))
+        return "precise"_s;
+    if (CMTIME_IS_POSITIVE_INFINITY(tolerance))
+        return "approximate"_s;
+    return "unexpected"_s;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -56,6 +56,7 @@ extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 @property (nonatomic) CMTimeRange timeRange;
 @property (nonatomic, copy) NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *audioOptions;
 @property (nonatomic, readonly, getter=isConnected) BOOL connected;
+@property (nonatomic, readonly) CMTime lastSeekTolerance;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -49,6 +49,7 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
     RefPtr<WebCore::MockMediaDeviceRouteURLCallback> _urlCallback;
     RefPtr<WebCore::DOMPromise> _urlPromise;
     BOOL _connected;
+    CMTime _lastSeekTolerance;
 }
 
 @synthesize timeRange;
@@ -84,12 +85,19 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
         return nil;
 
     timeRange = CMTimeRangeMake(kCMTimeZero, CMTimeMakeWithSeconds(60, 1000));
+    _lastSeekTolerance = kCMTimeInvalid;
 
     return self;
 }
 
+- (CMTime)lastSeekTolerance
+{
+    return _lastSeekTolerance;
+}
+
 - (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {
+    _lastSeekTolerance = tolerance;
     RetainPtr playbackPosition = adoptNS([allocAVPlaybackUserInterfacePlaybackPositionInstance() initWithPosition:position hostTime:CMClockGetTime(CMClockGetHostTimeClock()) rate:0]);
     self.playbackPosition = playbackPosition.get();
 }


### PR DESCRIPTION
#### d08f00e761db2577ddcc30db998dc5f46424e4a2
<pre>
[iOS] MediaPlayerPrivateWirelessPlayback does not correctly issue fast seeks
<a href="https://bugs.webkit.org/show_bug.cgi?id=322293">https://bugs.webkit.org/show_bug.cgi?id=322293</a>
<a href="https://rdar.apple.com/185535803">rdar://185535803</a>

Reviewed by Jean-Yves Avenard.

-seekToPosition:tolerance: on AVPlaybackUserInterfaceControllable is documented to expect
kCMTimeZero for a precise seek and kCMTimePositiveInfinity for a fast seek. However, WebKit was
always passing kCMTimeZero. Fixed this by using the SeekTarget passed to
MediaPlayerPrivateWirelessPlayback::seekToTarget to compute the appropriate argument.

Test: media/wireless-playback-media-player/seek-tolerance.html

* LayoutTests/media/wireless-playback-media-player/seek-tolerance-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/seek-tolerance.html: Added.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::convert):
(WebCore::MediaDeviceRoute::seekToPosition):
(WebCore::MediaDeviceRoute::setPlaybackPosition): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::seekTolerance):
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::lastSeekTolerance const):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute init]):
(-[WebMockMediaDeviceRoute lastSeekTolerance]):
(-[WebMockMediaDeviceRoute seekToPosition:tolerance:]):

Canonical link: <a href="https://commits.webkit.org/319676@main">https://commits.webkit.org/319676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c6a43402d92d313b77802defbf82e3111f522ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146405 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/931c1fd2-9374-4d49-b466-d778c7f7ae5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98715 "4 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/031a19c2-7d1f-4caa-a893-c1b692b42029) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122586 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f15a097a-587f-4683-973b-e2f7264bdea6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42797 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42420 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3466 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151568 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56385 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151272 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45847 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128668 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124496 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54896 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17416 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->