### PR TITLE
[cleanup] Ask whether a document is fully active rather than whether it has a render tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document-expected.txt
@@ -1,0 +1,5 @@
+
+PASS A DOMParser document exposes the style sheets it was parsed with
+PASS A createHTMLDocument document collects a style sheet inserted after parsing
+PASS Removing a style element from a non-rendered document updates styleSheets
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>styleSheets is populated for a document that never renders</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-documentorshadowroot-stylesheets">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<!--
+  A document created by DOMParser or createHTMLDocument has no browsing context, so it never generates
+  boxes and cannot do a full style update. Its styleSheets collection is still observable and is defined
+  in terms of the style sheets in the document, not in terms of anything being rendered.
+-->
+<script>
+test(() => {
+    const doc = new DOMParser().parseFromString("<style>#a { color: rgb(1, 2, 3) }</style>", "text/html");
+
+    assert_equals(doc.styleSheets.length, 1, "one sheet");
+    assert_equals(doc.styleSheets[0].cssRules.length, 1, "one rule");
+    assert_equals(doc.styleSheets[0].cssRules[0].style.color, "rgb(1, 2, 3)", "the rule is readable");
+}, "A DOMParser document exposes the style sheets it was parsed with");
+
+test(() => {
+    const doc = document.implementation.createHTMLDocument("");
+    assert_equals(doc.styleSheets.length, 0, "no sheets before inserting one");
+
+    const style = doc.createElement("style");
+    style.textContent = "#a { color: rgb(4, 5, 6) }";
+    doc.head.appendChild(style);
+
+    assert_equals(doc.styleSheets.length, 1, "the inserted sheet is collected");
+    assert_equals(doc.styleSheets[0].cssRules[0].style.color, "rgb(4, 5, 6)", "the rule is readable");
+}, "A createHTMLDocument document collects a style sheet inserted after parsing");
+
+test(() => {
+    const doc = document.implementation.createHTMLDocument("");
+    const style = doc.createElement("style");
+    style.textContent = "#a { color: rgb(7, 8, 9) }";
+    doc.head.appendChild(style);
+    assert_equals(doc.styleSheets.length, 1, "collected once");
+
+    style.remove();
+    assert_equals(doc.styleSheets.length, 0, "removing the element removes the sheet");
+}, "Removing a style element from a non-rendered document updates styleSheets");
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4164,6 +4164,11 @@ bool Document::isFullyActive() const
     return frame->isMainFrame() || frame->loader().client().isProvisionalFrame();
 }
 
+bool Document::canEverRender() const
+{
+    return isFullyActive() && !m_isNonRenderedPlaceholder;
+}
+
 // https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention
 // "System focus" here is a property of the top-level traversable (the window), not of this
 // frame's subtree, so it checks FocusController window state rather than Document::hasFocus().

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -846,6 +846,8 @@ public:
     };
     RenderTreeState renderTreeState() const { return m_renderTreeState; }
 
+    WEBCORE_EXPORT bool canEverRender() const;
+
     void updateRenderTree(std::unique_ptr<Style::Update> styleUpdate);
 
     bool updateLayoutIfDimensionsOutOfDate(Element&, OptionSet<DimensionsCheck> = { DimensionsCheck::Width, DimensionsCheck::Height }, OptionSet<LayoutOptions> = { });

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -880,7 +880,7 @@ static Node::Editability NODELETE computeEditabilityFromComputedStyle(const Styl
 
 Node::Editability Node::computeEditabilityWithStyle(const Style::ComputedStyle* incomingStyle, UserSelectAllTreatment treatment, ShouldUpdateStyle shouldUpdateStyle) const
 {
-    if (document().renderTreeState() != Document::RenderTreeState::Built || isPseudoElement())
+    if (!document().canEverRender() || isPseudoElement())
         return Editability::ReadOnly;
 
     Ref document = this->document();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -737,9 +737,10 @@ void FrameLoader::clear(RefPtr<Document>&& newDocument, bool clearWindowProperti
     if (neededClear && document->backForwardCacheState() != Document::InBackForwardCache) {
         document->cancelParsing();
         document->stopActiveDOMObjects();
-        bool hadRenderTree = document->renderTreeState() == Document::RenderTreeState::Built;
+        // Taken before willBeRemovedFromFrame() detaches the document, which makes it no longer fully active.
+        bool shouldAdjustFocus = document->canEverRender();
         document->willBeRemovedFromFrame();
-        if (hadRenderTree)
+        if (shouldAdjustFocus)
             document->adjustFocusedNodeOnNodeRemoval(*document);
     }
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -235,7 +235,7 @@ void HistoryController::saveDocumentState()
 
     ASSERT(m_frame->document());
     Ref document = *m_frame->document();
-    if (item->isCurrentDocument(document) && document->renderTreeState() == Document::RenderTreeState::Built) {
+    if (item->isCurrentDocument(document) && document->canEverRender()) {
         if (RefPtr documentLoader = document->loader())
             item->setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -212,7 +212,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // down the raw HTML parsing case by loading images we don't intend to display.
     Ref element = this->element();
     Ref document = element->document();
-    if (document->renderTreeState() != Document::RenderTreeState::Built)
+    if (!document->canEverRender())
         return;
 
     auto attr = element->imageSourceURL();
@@ -685,7 +685,8 @@ void ImageLoader::dispatchPendingBeforeLoadEvent()
         return;
     if (!m_image)
         return;
-    if (element().document().renderTreeState() != Document::RenderTreeState::Built)
+    Ref document = element().document();
+    if (!document->canEverRender())
         return;
     m_hasPendingBeforeLoadEvent = false;
     if (!element().isConnected())
@@ -700,7 +701,8 @@ void ImageLoader::dispatchPendingLoadEvent()
     if (!m_image)
         return;
     m_hasPendingLoadEvent = false;
-    if (element().document().renderTreeState() == Document::RenderTreeState::Built)
+    Ref document = element().document();
+    if (document->canEverRender())
         dispatchLoadEvent();
 
     // Only consider updating the protection ref-count of the Element immediately before returning
@@ -714,7 +716,8 @@ void ImageLoader::dispatchPendingErrorEvent()
         return;
     m_hasPendingErrorEvent = false;
     loadEventSender().cancelEvent(*this, eventNames().errorEvent);
-    if (element().document().renderTreeState() == Document::RenderTreeState::Built)
+    Ref document = element().document();
+    if (document->canEverRender())
         protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // Only consider updating the protection ref-count of the Element immediately before returning

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -548,7 +548,7 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
     RELEASE_ASSERT(!m_isUpdatingStyleResolver);
     ASSERT(!m_pendingUpdate);
 
-    if (m_document->renderTreeState() != Document::RenderTreeState::Built)
+    if (!m_document->canEverRender())
         return;
 
     if (m_document->inStyleRecalc() || m_document->inRenderTreeUpdate()) {
@@ -817,10 +817,10 @@ void Scope::pendingUpdateTimerFired()
 const Vector<Ref<StyleSheet>>& Scope::styleSheetsForStyleSheetList()
 {
     // FIXME: StyleSheetList content should be updated separately from style resolver updates.
-    if (m_document->renderTreeState() == Document::RenderTreeState::Built)
+    if (m_document->canEverRender())
         flushPendingUpdate();
     else if (m_pendingUpdate) {
-        // Documents without a living render tree (e.g. created by DOMParser) can't do full
+        // Documents that never make renderers (e.g. created by DOMParser) can't do full
         // style updates but should still have an accessible styleSheets collection per spec.
         m_pendingUpdate = { };
         m_styleSheetsForStyleSheetList = collectActiveStyleSheets().styleSheetsForStyleSheetList;


### PR DESCRIPTION
#### 5178278df2e968475df523946dd4caf468069d57
<pre>
[cleanup] Ask whether a document is fully active rather than whether it has a render tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=322292">https://bugs.webkit.org/show_bug.cgi?id=322292</a>
&lt;<a href="https://rdar.apple.com/problem/185534759">rdar://problem/185534759</a>&gt;

Reviewed by Antti Koivisto.

These call sites checked whether a document had a render tree when what they meant was whether it can ever render, which is what separates a
document in a page from one made by DOMParser or held by a template. The spec calls that fully active, and its &quot;Updating the image data&quot;
algorithm names it directly. A non-rendered placeholder is fully active yet never gets a render tree, so Document::canEverRender() asks
both.

<a href="https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data">https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data</a>

Test: imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document.html

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::canEverRender const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::computeEditabilityWithStyle const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clear):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::saveDocumentState):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::dispatchPendingBeforeLoadEvent):
(WebCore::ImageLoader::dispatchPendingLoadEvent):
(WebCore::ImageLoader::dispatchPendingErrorEvent):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateActiveStyleSheets):
(WebCore::Style::Scope::styleSheetsForStyleSheetList):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheets-in-non-rendered-document-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319668@main">https://commits.webkit.org/319668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283818f9db1e79e2ee5cc3c35a6e10ed541d87bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146490 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/580976f7-407c-4d17-9fc4-7b4fd6f4b53b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d4f88e6-2d45-43b8-981e-1f3b79ae9e48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45911 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162957 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.EvictsLoadedSitesOverTheCap (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122628 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f366e48a-730a-4541-b745-c9feebe5b700) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42858 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42482 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3551 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194315 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40624 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151317 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45915 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128753 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54981 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17478 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54601 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->