### PR TITLE
[block] align-content moves a float child twice

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-004-expected.txt
@@ -53,140 +53,20 @@ Show Text
 
 
 PASS .test 1: start
-FAIL .test 2: center assert_equals:
-<div class="test" style="align-content: center" title="center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 3: end assert_equals:
-<div class="test" style="align-content: end" title="end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 2: center
+PASS .test 3: end
 PASS .test 4: baseline
-FAIL .test 5: last baseline assert_equals:
-<div class="test" style="align-content: last baseline" title="last baseline">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">LAST BASELINE</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 5: last baseline
 PASS .test 6: flex-start
-FAIL .test 7: flex-end assert_equals:
-<div class="test" style="align-content: flex-end" title="flex-end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">FLEX-END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
-FAIL .test 12: safe center assert_equals:
-<div class="test" style="align-content: safe center" title="safe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 13: safe end assert_equals:
-<div class="test" style="align-content: safe end" title="safe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">SAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
-FAIL .test 14: space-evenly assert_equals:
-<div class="test" style="align-content: space-evenly" title="space-evenly">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-EVENLY</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 12: safe center
+PASS .test 13: safe end
+PASS .test 14: space-evenly
 PASS .test 15: space-between
-FAIL .test 16: space-around assert_equals:
-<div class="test" style="align-content: space-around" title="space-around">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-AROUND</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 16: space-around
 PASS .test 17: normal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-005-expected.txt
@@ -60,32 +60,8 @@ PASS .test 5: last baseline
 PASS .test 6: flex-start
 PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 15
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got -5
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
 PASS .test 12: safe center
 PASS .test 13: safe end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-006-expected.txt
@@ -53,140 +53,20 @@ Show Text
 
 
 PASS .test 1: start
-FAIL .test 2: center assert_equals:
-<div class="test" style="align-content: center" title="center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 3: end assert_equals:
-<div class="test" style="align-content: end" title="end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 2: center
+PASS .test 3: end
 PASS .test 4: baseline
-FAIL .test 5: last baseline assert_equals:
-<div class="test" style="align-content: last baseline" title="last baseline">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">LAST BASELINE</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 5: last baseline
 PASS .test 6: flex-start
-FAIL .test 7: flex-end assert_equals:
-<div class="test" style="align-content: flex-end" title="flex-end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">FLEX-END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
-FAIL .test 12: safe center assert_equals:
-<div class="test" style="align-content: safe center" title="safe center">
-    <div class="float" "="" data-offset-y="15">FLT</div>
-    <div class="in-flow" "="" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" "="" data-offset-y="25">FLT</div>
-      <span class="label">SAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 13: safe end assert_equals:
-<div class="test" style="align-content: safe end" title="safe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">SAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
-FAIL .test 14: space-evenly assert_equals:
-<div class="test" style="align-content: space-evenly" title="space-evenly">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-EVENLY</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 12: safe center
+PASS .test 13: safe end
+PASS .test 14: space-evenly
 PASS .test 15: space-between
-FAIL .test 16: space-around assert_equals:
-<div class="test" style="align-content: space-around" title="space-around">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-AROUND</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 16: space-around
 PASS .test 17: normal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-007-expected.txt
@@ -60,32 +60,8 @@ PASS .test 5: last baseline
 PASS .test 6: flex-start
 PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 15
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got -5
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
 PASS .test 12: safe center
 PASS .test 13: safe end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-008-expected.txt
@@ -53,140 +53,20 @@ Show Text
 
 
 PASS .test 1: start
-FAIL .test 2: center assert_equals:
-<div class="test" style="align-content: center" title="center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 3: end assert_equals:
-<div class="test" style="align-content: end" title="end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 2: center
+PASS .test 3: end
 PASS .test 4: baseline
-FAIL .test 5: last baseline assert_equals:
-<div class="test" style="align-content: last baseline" title="last baseline">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">LAST BASELINE</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 5: last baseline
 PASS .test 6: flex-start
-FAIL .test 7: flex-end assert_equals:
-<div class="test" style="align-content: flex-end" title="flex-end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">FLEX-END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
-FAIL .test 12: safe center assert_equals:
-<div class="test" style="align-content: safe center" title="safe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 13: safe end assert_equals:
-<div class="test" style="align-content: safe end" title="safe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">SAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
-FAIL .test 14: space-evenly assert_equals:
-<div class="test" style="align-content: space-evenly" title="space-evenly">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-EVENLY</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 12: safe center
+PASS .test 13: safe end
+PASS .test 14: space-evenly
 PASS .test 15: space-between
-FAIL .test 16: space-around assert_equals:
-<div class="test" style="align-content: space-around" title="space-around">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-AROUND</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 16: space-around
 PASS .test 17: normal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-009-expected.txt
@@ -60,32 +60,8 @@ PASS .test 5: last baseline
 PASS .test 6: flex-start
 PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 15
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got -5
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
 PASS .test 12: safe center
 PASS .test 13: safe end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-010-expected.txt
@@ -53,140 +53,20 @@ Show Text
 
 
 PASS .test 1: start
-FAIL .test 2: center assert_equals:
-<div class="test" style="align-content: center" title="center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 3: end assert_equals:
-<div class="test" style="align-content: end" title="end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 2: center
+PASS .test 3: end
 PASS .test 4: baseline
-FAIL .test 5: last baseline assert_equals:
-<div class="test" style="align-content: last baseline" title="last baseline">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">LAST BASELINE</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 5: last baseline
 PASS .test 6: flex-start
-FAIL .test 7: flex-end assert_equals:
-<div class="test" style="align-content: flex-end" title="flex-end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">FLEX-END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
-FAIL .test 12: safe center assert_equals:
-<div class="test" style="align-content: safe center" title="safe center">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
-FAIL .test 13: safe end assert_equals:
-<div class="test" style="align-content: safe end" title="safe end">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">SAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 45
-FAIL .test 14: space-evenly assert_equals:
-<div class="test" style="align-content: space-evenly" title="space-evenly">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-EVENLY</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 12: safe center
+PASS .test 13: safe end
+PASS .test 14: space-evenly
 PASS .test 15: space-between
-FAIL .test 16: space-around assert_equals:
-<div class="test" style="align-content: space-around" title="space-around">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">SPACE-AROUND</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got 25
+PASS .test 16: space-around
 PASS .test 17: normal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-011-expected.txt
@@ -60,32 +60,8 @@ PASS .test 5: last baseline
 PASS .test 6: flex-start
 PASS .test 7: flex-end
 PASS .test 8: unsafe start
-FAIL .test 9: unsafe center assert_equals:
-<div class="test" style="align-content: unsafe center" title="unsafe center">
-    <div class="float" data-offset-y="25">FLT</div>
-    <div class="in-flow" data-offset-y="35"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="35">FLT</div>
-      <span class="label">UNSAFE CENTER</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 25 but got 15
-FAIL .test 10: unsafe end assert_equals:
-<div class="test" style="align-content: unsafe end" title="unsafe end">
-    <div class="float" data-offset-y="15">FLT</div>
-    <div class="in-flow" data-offset-y="25"></div>
-    <div class="in-flow">
-      <div class="float" data-offset-y="25">FLT</div>
-      <span class="label">UNSAFE END</span>
-      <span class="abspos">ABS</span>
-      <span class="relpos">REL</span>
-      <div class="overflow">OVERFLOW</div>
-    </div>
-  </div>
-offsetTop expected 15 but got -5
+PASS .test 9: unsafe center
+PASS .test 10: unsafe end
 PASS .test 11: safe start
 PASS .test 12: safe center
 PASS .test 13: safe end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001-expected.txt
@@ -1,0 +1,6 @@
+
+PASS .box 1: start
+PASS .box 2: center
+PASS .box 3: end
+PASS .box 4: space-around
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment: align-content moves a float with the content it starts</title>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#distribution-block">
+<meta name="assert" content="align-content on a block container moves the container's content, floats included, so a float at the start of the content stays level with the block that follows it.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<style>
+  html, body { margin: 0; padding: 0; }
+
+  /* 50px of container for 20px of content leaves 30px to distribute. The float is shorter than the block, so
+     it never decides the content's height. */
+  /* relative so that the offsets below are measured from the container */
+  .box { width: 100px; height: 50px; margin-bottom: 10px; position: relative; }
+  .float { float: right; width: 10px; height: 10px; background: orange; }
+  .block { height: 20px; background: green; }
+</style>
+
+<div class="box" style="align-content: start" title="start">
+  <div class="float" data-offset-y="0"></div>
+  <div class="block" data-offset-y="0"></div>
+</div>
+<div class="box" style="align-content: center" title="center">
+  <div class="float" data-offset-y="15"></div>
+  <div class="block" data-offset-y="15"></div>
+</div>
+<div class="box" style="align-content: end" title="end">
+  <div class="float" data-offset-y="30"></div>
+  <div class="block" data-offset-y="30"></div>
+</div>
+<div class="box" style="align-content: space-around" title="space-around">
+  <div class="float" data-offset-y="15"></div>
+  <div class="block" data-offset-y="15"></div>
+</div>
+
+<script>
+checkLayout(".box");
+</script>

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -444,7 +444,9 @@ void FloatingObjects::shiftFloatsBy(LayoutUnit blockShift)
             removePlacedObject(floatBox.get());
 
         floatBox->m_frameRect.move(shiftX, shiftY);
-        floatBox->renderer()->move(shiftX, shiftY);
+        // Only a float this container lays out moves with this container's content. Anything else in the list is a copy of an entry in another box's list.
+        if (floatBox->renderer()->containingBlock() == &renderer())
+            floatBox->renderer()->move(shiftX, shiftY);
 
         if (isPlaced)
             addPlacedObject(floatBox.get());

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -180,7 +180,7 @@ public:
     LayoutUnit findNextFloatLogicalBottomBelow(LayoutUnit logicalHeight);
     LayoutUnit findNextFloatLogicalBottomBelowForBlock(LayoutUnit logicalHeight);
 
-    void NODELETE shiftFloatsBy(LayoutUnit blockShift);
+    void shiftFloatsBy(LayoutUnit blockShift);
 
 private:
     const RenderBlockFlow& renderer() const { ASSERT(m_renderer); return *m_renderer; }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -874,6 +874,9 @@ LayoutUnit RenderBlockFlow::shiftForAlignContent(LayoutUnit intrinsicLogicalHeig
             svgTextLayout->shiftLineBy(-space, 0);
     } else {
         for (CheckedPtr child = firstChildBox(); child; child = child->nextSiblingBox()) {
+            // A float is in our float list too and moves with it below, so leave it alone here.
+            if (child->isFloating())
+                continue;
             setLogicalTopForChild(*child, logicalTopForChild(*child) + space);
             if (child->isOutOfFlowPositioned() && child->style().hasStaticBlockPosition(isHorizontalWritingMode())) {
                 ASSERT(child->layer());


### PR DESCRIPTION
#### 8c4fd56347648a238656e54d696b308dca674fe8
<pre>
[block] align-content moves a float child twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=322298">https://bugs.webkit.org/show_bug.cgi?id=322298</a>
&lt;<a href="https://rdar.apple.com/problem/185536955">rdar://problem/185536955</a>&gt;

Reviewed by Antti Koivisto.

align-content distributes a block container&apos;s extra space by moving its content. shiftForAlignContent moves
every child box and FloatingObjects::shiftFloatsBy then moves the float renderers again, so a float that is a
child of the container travels twice as far as the content it sits with.

A float taken from a child&apos;s float list moves twice as well: the child moves with the rest of the content and
shiftFloatsBy then moves the float&apos;s renderer, which belongs to that child. Only the FloatingObject&apos;s frame
rect needs the shift there, since that rect is in this container&apos;s coordinate space.

* Source/WebCore/rendering/FloatingObjects.cpp:
(WebCore::FloatingObjects::shiftFloatsBy):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::shiftForAlignContent):
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-float-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-011-expected.txt:
* Source/WebCore/rendering/FloatingObjects.h:

Canonical link: <a href="https://commits.webkit.org/319665@main">https://commits.webkit.org/319665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/912d37469138cf8159dd9de5a192e43baada9f27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146492 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142189 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f96d7c35-fb5c-4ac0-9093-2db3758ebb8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e812cbfa-98c6-4470-9ed9-5772f44a5ca8) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181488 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42859 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42477 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3553 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151618 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56472 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151313 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45910 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128755 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17473 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54431 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->