### PR TITLE
[WPE] Add API to show what events the webview processed

### DIFF
--- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
@@ -46,6 +46,7 @@ typedef union _GdkEvent GdkEvent;
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include <wpe/GRefPtrWPE.h>
 typedef struct _WPEEvent WPEEvent;
 #endif
 
@@ -100,6 +101,8 @@ public:
     GdkEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(IOS_FAMILY)
     ::WebEvent* nativeEvent() const { return m_nativeEvent.get(); }
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    WPEEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(WIN)
     const MSG* nativeEvent() const LIFETIME_BOUND { return &m_nativeEvent; }
     const Vector<MSG>& pendingCharEvents() const LIFETIME_BOUND { return m_pendingCharEvents; }
@@ -116,6 +119,8 @@ private:
     GUniquePtr<GdkEvent> m_nativeEvent;
 #elif PLATFORM(IOS_FAMILY)
     RetainPtr<::WebEvent> m_nativeEvent;
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    GRefPtr<WPEEvent> m_nativeEvent;
 #elif PLATFORM(WIN)
     MSG m_nativeEvent;
     Vector<MSG> m_pendingCharEvents;

--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -44,6 +44,7 @@ typedef union _GdkEvent GdkEvent;
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include <wpe/GRefPtrWPE.h>
 typedef struct _WPEEvent WPEEvent;
 #endif
 
@@ -83,6 +84,8 @@ public:
     NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(GTK)
     GdkEvent* nativeEvent() const { return m_nativeEvent.get(); }
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    WPEEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(WIN)
     const MSG* nativeEvent() const LIFETIME_BOUND { return &m_nativeEvent; }
 #else
@@ -96,6 +99,8 @@ private:
     GRefPtr<GdkEvent> m_nativeEvent;
 #elif PLATFORM(GTK)
     GUniquePtr<GdkEvent> m_nativeEvent;
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    GRefPtr<WPEEvent> m_nativeEvent;
 #elif PLATFORM(WIN)
     MSG m_nativeEvent;
 #endif

--- a/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp
+++ b/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp
@@ -34,6 +34,7 @@ namespace WebKit {
 
 NativeWebKeyboardEvent::NativeWebKeyboardEvent(WPEEvent* event, const String& text, bool isAutorepeat)
     : WebKeyboardEvent(WebEventFactory::createWebKeyboardEvent(event, text, isAutorepeat))
+    , m_nativeEvent(event)
 {
 }
 

--- a/Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp
+++ b/Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp
@@ -34,11 +34,13 @@ namespace WebKit {
 
 NativeWebWheelEvent::NativeWebWheelEvent(WPEEvent* event)
     : WebWheelEvent(WebEventFactory::createWebWheelEvent(event))
+    , m_nativeEvent(event)
 {
 }
 
 NativeWebWheelEvent::NativeWebWheelEvent(WPEEvent* event, WebWheelEvent::Phase phase)
     : WebWheelEvent(WebEventFactory::createWebWheelEvent(event, phase))
+    , m_nativeEvent(event)
 {
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -28,6 +28,7 @@
 
 #include "APIViewClient.h"
 #include "DrawingAreaProxyCoordinatedGraphics.h"
+#include "NativeWebKeyboardEvent.h"
 #include "NativeWebMouseEvent.h"
 #include "NativeWebTouchEvent.h"
 #include "NativeWebWheelEvent.h"
@@ -243,13 +244,34 @@ WebCore::IntRect PageClientImpl::rootViewToAccessibilityScreen(const WebCore::In
     return rootViewToScreen(rect);    
 }
 
-void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent&, bool)
+void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool wasEventHandled)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = m_view.wpeView()) {
+        // Events synthesized by the input method filter carry no native event.
+        if (auto* wpeEvent = event.nativeEvent()) {
+            wpe_view_event_processed(view, wpeEvent, wasEventHandled);
+            return;
+        }
+    }
+#else
+    UNUSED_PARAM(event);
+    UNUSED_PARAM(wasEventHandled);
+#endif
 }
 
 #if ENABLE(TOUCH_EVENTS)
 void PageClientImpl::doneWithTouchEvent(const WebTouchEvent& touchEvent, bool wasEventHandled)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = m_view.wpeView()) {
+        if (touchEvent.isNativeWebTouchEvent()) {
+            if (auto* wpeEvent = static_cast<const NativeWebTouchEvent&>(touchEvent).nativeEvent())
+                wpe_view_event_processed(view, wpeEvent, wasEventHandled);
+        }
+    }
+#endif
+
     if (wasEventHandled) {
 #if ENABLE(WPE_PLATFORM)
         // If the touch event was handled, we must interrupt any gesture detection sequence ongoing so that gestures
@@ -312,6 +334,21 @@ void PageClientImpl::doneWithTouchEvent(const WebTouchEvent& touchEvent, bool wa
 
 void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&)
 {
+}
+
+void PageClientImpl::doneWithWheelEvent(const NativeWebWheelEvent& event, bool wasEventHandled)
+{
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = m_view.wpeView()) {
+        if (auto* wpeEvent = event.nativeEvent()) {
+            wpe_view_event_processed(view, wpeEvent, wasEventHandled);
+            return;
+        }
+    }
+#else
+    UNUSED_PARAM(event);
+    UNUSED_PARAM(wasEventHandled);
+#endif
 }
 
 RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -127,6 +127,7 @@ private:
     void doneWithTouchEvent(const WebTouchEvent&, bool) override;
 #endif
     void wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&) override;
+    void doneWithWheelEvent(const NativeWebWheelEvent&, bool) override;
 
     RefPtr<WebPopupMenuProxy> createPopupMenuProxy(WebPageProxy&) override;
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -478,6 +478,7 @@ public:
 #endif
 
     virtual void doneWithKeyEvent(const NativeWebKeyboardEvent&, bool wasEventHandled) = 0;
+    virtual void doneWithWheelEvent(const NativeWebWheelEvent&, bool wasEventHandled) { }
 #if ENABLE(TOUCH_EVENTS)
     virtual void doneWithTouchEvent(const WebTouchEvent&, bool wasEventHandled) = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5009,11 +5009,16 @@ void WebPageProxy::wheelEventHandlingCompleted(bool wasHandled)
     else
         LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::wheelEventHandlingCompleted - no event, handled " << wasHandled);
 
-    if (oldestProcessedEvent && !wasHandled) {
-        CheckedRef event = *oldestProcessedEvent;
-        m_uiClient->didNotHandleWheelEvent(this, event.get());
-        if (RefPtr pageClient = m_pageClient.get())
-            pageClient->wheelEventWasNotHandledByWebCore(event.get());
+    if (oldestProcessedEvent) {
+        CheckedRef event = *oldestProcessedEvent;\
+        RefPtr pageClient = m_pageClient.get();
+        if (!wasHandled) {
+            m_uiClient->didNotHandleWheelEvent(this, event.get());
+            if (pageClient)
+                pageClient->wheelEventWasNotHandledByWebCore(event.get());
+        }
+        if (pageClient)
+            pageClient->doneWithWheelEvent(event.get(), wasHandled);
     }
 
     if (auto eventToSend = wheelEventCoalescer().nextEventToDispatch()) {

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -123,6 +123,7 @@ enum {
     BUFFER_RENDERED,
     BUFFER_RELEASED,
     EVENT,
+    EVENT_PROCESSED,
     TOPLEVEL_STATE_CHANGED,
     PREFERRED_BUFFER_FORMATS_CHANGED,
 
@@ -470,6 +471,38 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         g_cclosure_marshal_generic,
         G_TYPE_BOOLEAN, 1,
         WPE_TYPE_EVENT);
+
+    /**
+     * WPEView::event-processed:
+     * @view: a #WPEView
+     * @event: the #WPEEvent that was delivered with wpe_view_event()
+     * @handled: whether the web engine handled @event
+     *
+     * Emitted when the web view has finished processing @event, which happens
+     * asynchronously, always after [signal@WPEView::event] returned, because the
+     * web content only gets to decide once the event reached it.
+     *
+     * An event the web content did not take reports %FALSE, which lets a
+     * platform implementation, or the application embedding it, treat the event
+     * as unclaimed and act on it, without it ever being injected back into the
+     * toolkit.
+     *
+     * Not every event is reported. Keyboard, scroll and touch events are, since
+     * the web view tells the UI process what became of them. Others, pointer
+     * events in particular, are not. An event the web engine never got to decide
+     * on is not reported either, which is the case for a key an input method
+     * consumed.
+     *
+     * Since: 2.56
+     */
+    signals[EVENT_PROCESSED] = g_signal_new(
+        "event-processed",
+        G_TYPE_FROM_CLASS(viewClass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 2,
+        WPE_TYPE_EVENT, G_TYPE_BOOLEAN);
 
     /**
      * WPEView::toplevel-state-changed:
@@ -1028,6 +1061,26 @@ void wpe_view_event(WPEView* view, WPEEvent* event)
         if (std::abs(x - priv->lastButtonPress.x) >= doubleClickDistance || std::abs(y - priv->lastButtonPress.y) >= doubleClickDistance)
             priv->lastButtonPress.pressCount = 0;
     }
+}
+
+/**
+ * wpe_view_event_processed:
+ * @view: a #WPEView
+ * @event: a #WPEEvent previously delivered with wpe_view_event()
+ * @handled: whether the web engine handled @event
+ *
+ * Emit [signal@WPEView::event-processed] signal to report the result of
+ * processing @event. This is called by the web engine once processing completed,
+ * which for events forwarded to the web process happens asynchronously.
+ *
+ * Since: 2.56
+ */
+void wpe_view_event_processed(WPEView* view, WPEEvent* event, gboolean handled)
+{
+    g_return_if_fail(WPE_IS_VIEW(view));
+    g_return_if_fail(event);
+
+    g_signal_emit(view, signals[EVENT_PROCESSED], 0, event, handled);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -139,6 +139,9 @@ WPE_API void                  wpe_view_buffer_released              (WPEView    
                                                                      WPEBuffer          *buffer);
 WPE_API void                  wpe_view_event                        (WPEView            *view,
                                                                      WPEEvent           *event);
+WPE_API void                  wpe_view_event_processed              (WPEView            *view,
+                                                                     WPEEvent           *event,
+                                                                     gboolean            handled);
 WPE_API guint                 wpe_view_compute_press_count          (WPEView            *view,
                                                                      gdouble             x,
                                                                      gdouble             y,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewInputEvents.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewInputEvents.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, WA 02110-1301  USA
+ */
+
+#include "config.h"
+#include "WebViewTest.h"
+
+#include <wpe/GRefPtrWPE.h>
+#include <wpe/wpe-platform.h>
+#include <wtf/glib/GUniquePtr.h>
+
+// WPEView::event-processed reports what the web content did with an input event
+// it was given. A browser needs it to decide whether a shortcut the page did not
+// take should be handled by the application instead, and whether a scroll or a
+// tap the page ignored should be used for something else.
+class EventProcessedTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(EventProcessedTest);
+
+    ~EventProcessedTest()
+    {
+        if (m_signalID)
+            g_signal_handler_disconnect(view(), m_signalID);
+    }
+
+    WPEView* view() const
+    {
+        auto* view = webkit_web_view_get_wpe_view(m_webView.get());
+        g_assert_true(WPE_IS_VIEW(view));
+        return view;
+    }
+
+    void loadContentsAndWait(const char* html, int width = 0, int height = 0)
+    {
+        if (!m_signalID)
+            m_signalID = g_signal_connect(view(), "event-processed", G_CALLBACK(eventProcessedCallback), this);
+
+        showInWindow(width, height);
+        loadHtml(html, nullptr);
+        waitUntilLoadFinished();
+    }
+
+    enum class Verdict { Pending, Handled, Declined };
+
+    // Every key the web engine processes is reported, so this can wait for the
+    // answer rather than guess at how long one might take to arrive.
+    Verdict keyDownVerdict(unsigned keyVal, OptionSet<Modifiers> modifiers = OptionSet<Modifiers>())
+    {
+        m_verdict = Verdict::Pending;
+        m_keyval = 0;
+        keyStroke(keyVal, modifiers);
+
+        unsigned triesCount = 100;
+        while (m_verdict == Verdict::Pending && triesCount--)
+            wait(0.05);
+
+        return m_verdict;
+    }
+
+    unsigned reportedKeyval() const { return m_keyval; }
+
+    Verdict touchDownVerdict(double x, double y)
+    {
+        m_verdict = Verdict::Pending;
+        GRefPtr<WPEEvent> event = adoptGRef(wpe_event_touch_new(WPE_EVENT_TOUCH_DOWN, view(),
+            WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), 0, x, y));
+        wpe_view_event(view(), event.get());
+
+        unsigned triesCount = 100;
+        while (m_verdict == Verdict::Pending && triesCount--)
+            wait(0.05);
+
+        return m_verdict;
+    }
+
+private:
+    static void eventProcessedCallback(WPEView*, WPEEvent* event, gboolean handled, EventProcessedTest* test)
+    {
+        if (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_DOWN) {
+            test->m_verdict = handled ? Verdict::Handled : Verdict::Declined;
+            return;
+        }
+
+        // The key up follows every key down, and only the key down decides
+        // whether an accelerator should run.
+        if (wpe_event_get_event_type(event) != WPE_EVENT_KEYBOARD_KEY_DOWN)
+            return;
+
+        // Reading the event here is what requires the UI process to keep it
+        // alive: whoever delivered it dropped its reference long ago.
+        test->m_keyval = wpe_event_keyboard_get_keyval(event);
+        test->m_verdict = handled ? Verdict::Handled : Verdict::Declined;
+    }
+
+    unsigned long m_signalID { 0 };
+    Verdict m_verdict { Verdict::Pending };
+    unsigned m_keyval { 0 };
+};
+
+static const char* plainHTML = "<html><body>All work and no play.</body></html>";
+
+static const char* indifferentListenerHTML =
+    "<html><body>All work and no play."
+    "<script>window.addEventListener('keydown', () => { window.seen = true; });</script>"
+    "</body></html>";
+
+static const char* preventDefaultHTML =
+    "<html><body>All work and no play."
+    "<script>window.addEventListener('keydown', e => {"
+    "  if (e.ctrlKey && e.key === 'f') e.preventDefault();"
+    "});</script></body></html>";
+
+static void testKeyboardEventDeclinedByPage(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait(plainHTML);
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_f, { WebViewTest::Modifiers::Control }) == EventProcessedTest::Verdict::Declined);
+    g_assert_cmpuint(test->reportedKeyval(), ==, WPE_KEY_f);
+}
+
+// A page that merely listens for a key has not claimed it. If this were
+// reported as handled, no application could tell the two cases apart.
+static void testKeyboardEventListenerAloneDoesNotClaimKey(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait(indifferentListenerHTML);
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_f, { WebViewTest::Modifiers::Control }) == EventProcessedTest::Verdict::Declined);
+    test->assertJavaScriptBecomesTrue("window.seen === true");
+}
+
+static void testKeyboardEventHandledByPage(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait(preventDefaultHTML);
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_f, { WebViewTest::Modifiers::Control }) == EventProcessedTest::Verdict::Handled);
+    g_assert_cmpuint(test->reportedKeyval(), ==, WPE_KEY_f);
+
+    // The same page leaves every other key alone.
+    g_assert_true(test->keyDownVerdict(WPE_KEY_g, { WebViewTest::Modifiers::Control }) == EventProcessedTest::Verdict::Declined);
+    g_assert_cmpuint(test->reportedKeyval(), ==, WPE_KEY_g);
+}
+
+// Modifier presses are reported like any other key. Under the event
+// reinjection this API replaces, these were the ones that looped forever.
+static void testKeyboardEventModifierAlone(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait(plainHTML);
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_Control_L) == EventProcessedTest::Verdict::Declined);
+    g_assert_cmpuint(test->reportedKeyval(), ==, WPE_KEY_Control_L);
+}
+
+// A key the engine acts on itself is handled, so it never reaches an
+// application shortcut. Scrolling and editing commands both work this way.
+static void testKeyboardEventHandledByEngine(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait("<html><body style=\"height: 5000px\">All work and no play.</body></html>", 200, 200);
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_Down) == EventProcessedTest::Verdict::Handled);
+    test->assertJavaScriptBecomesTrue("window.scrollY > 0");
+
+    g_assert_true(test->keyDownVerdict(WPE_KEY_a, { WebViewTest::Modifiers::Control }) == EventProcessedTest::Verdict::Handled);
+}
+
+// The same signal reports touch, which is how a platform learns that a tap
+// went unused. This is the path WebDriver drives for pointerType "touch".
+static void testTouchEventDeclinedByPage(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait(plainHTML, 200, 200);
+
+    g_assert_true(test->touchDownVerdict(20, 20) == EventProcessedTest::Verdict::Declined);
+}
+
+static void testTouchEventHandledByPage(EventProcessedTest* test, gconstpointer)
+{
+    test->loadContentsAndWait("<html><body>All work and no play."
+        "<script>window.seen = false;"
+        "window.addEventListener('touchstart', e => { window.seen = true; e.preventDefault(); }, { passive: false });"
+        "</script></body></html>", 200, 200);
+
+    // On the GLib ports touch events take the coordinated path, where the
+    // scrolling thread answers from the scrolling tree's touch event regions.
+    // Those only exist once a rendering update has pushed them there, so a
+    // touch sent before that is answered declined without the page ever
+    // seeing it.
+    test->wait(1);
+
+    auto verdict = test->touchDownVerdict(20, 20);
+    test->assertJavaScriptBecomesTrue("window.seen === true");
+    g_assert_true(verdict == EventProcessedTest::Verdict::Handled);
+}
+
+void beforeAll()
+{
+    EventProcessedTest::add("WebKitWebView", "keyboard-event-declined-by-page", testKeyboardEventDeclinedByPage);
+    EventProcessedTest::add("WebKitWebView", "keyboard-event-listener-alone-does-not-claim-key", testKeyboardEventListenerAloneDoesNotClaimKey);
+    EventProcessedTest::add("WebKitWebView", "keyboard-event-handled-by-page", testKeyboardEventHandledByPage);
+    EventProcessedTest::add("WebKitWebView", "keyboard-event-modifier-alone", testKeyboardEventModifierAlone);
+    EventProcessedTest::add("WebKitWebView", "keyboard-event-handled-by-engine", testKeyboardEventHandledByEngine);
+    EventProcessedTest::add("WebKitWebView", "touch-event-declined-by-page", testTouchEventDeclinedByPage);
+    EventProcessedTest::add("WebKitWebView", "touch-event-handled-by-page", testTouchEventHandledByPage);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestView.cpp
@@ -30,6 +30,7 @@
 #include "WPEScreenMock.h"
 #include "WPEToplevelMock.h"
 #include "WPEViewMock.h"
+#include <wpe/GRefPtrWPE.h>
 
 namespace TestWebKitAPI {
 
@@ -185,12 +186,138 @@ static void testViewToplevelState(WPEMockViewTest* test, gconstpointer)
     g_signal_handler_disconnect(test->view(), viewResizedID);
 }
 
+static GRefPtr<WPEEvent> createKeyEvent(WPEView* view, WPEEventType type)
+{
+    return adoptGRef(wpe_event_keyboard_new(type, view, WPE_INPUT_SOURCE_KEYBOARD, 0, WPE_MODIFIER_KEYBOARD_CONTROL, 41, WPE_KEY_f));
+}
+
+struct ProcessedResult {
+    unsigned count { 0 };
+    WPEEvent* event { nullptr };
+    gboolean handled { FALSE };
+    const char* userData { nullptr };
+};
+
+static void testViewKeyboardEventProcessed(WPEMockViewTest* test, gconstpointer)
+{
+    ProcessedResult result;
+    auto signalID = g_signal_connect(test->view(), "event-processed", G_CALLBACK(+[](WPEView*, WPEEvent* event, gboolean handled, ProcessedResult* result) {
+        result->count++;
+        result->event = event;
+        result->handled = handled;
+        result->userData = static_cast<const char*>(wpe_event_get_user_data(event));
+    }), &result);
+
+    auto event = createKeyEvent(test->view(), WPE_EVENT_KEYBOARD_KEY_DOWN);
+
+    // A platform implementation recognizes the event it sent by the data it
+    // attached to it, so that has to survive the round trip.
+    static const char* platformData = "platform-data";
+    wpe_event_set_user_data(event.get(), const_cast<char*>(platformData), nullptr);
+
+    wpe_view_event_processed(test->view(), event.get(), FALSE);
+    g_assert_cmpuint(result.count, ==, 1);
+    g_assert_true(result.event == event.get());
+    g_assert_false(result.handled);
+    g_assert_cmpstr(result.userData, ==, platformData);
+    g_assert_cmpuint(wpe_event_get_event_type(result.event), ==, WPE_EVENT_KEYBOARD_KEY_DOWN);
+    g_assert_cmpuint(wpe_event_keyboard_get_keyval(result.event), ==, WPE_KEY_f);
+    g_assert_true(wpe_event_get_view(result.event) == test->view());
+
+    // Every processed event is reported, so a consumer can always tell a key
+    // the web content took from one it never got to decide on.
+    wpe_view_event_processed(test->view(), event.get(), TRUE);
+    g_assert_cmpuint(result.count, ==, 2);
+    g_assert_true(result.event == event.get());
+    g_assert_true(result.handled);
+
+    auto keyUpEvent = createKeyEvent(test->view(), WPE_EVENT_KEYBOARD_KEY_UP);
+    wpe_view_event_processed(test->view(), keyUpEvent.get(), FALSE);
+    g_assert_cmpuint(result.count, ==, 3);
+    g_assert_true(result.event == keyUpEvent.get());
+    g_assert_null(result.userData);
+
+    g_signal_handler_disconnect(test->view(), signalID);
+
+    // Reporting a result nobody listens for is not an error.
+    wpe_view_event_processed(test->view(), event.get(), TRUE);
+    g_assert_cmpuint(result.count, ==, 3);
+}
+
+struct EventCounts {
+    unsigned event { 0 };
+    unsigned processed { 0 };
+};
+
+static void testViewKeyboardEventProcessedIsSeparateFromEvent(WPEMockViewTest* test, gconstpointer)
+{
+    EventCounts counts;
+    auto eventID = g_signal_connect(test->view(), "event", G_CALLBACK(+[](WPEView*, WPEEvent*, EventCounts* counts) -> gboolean {
+        counts->event++;
+        return TRUE;
+    }), &counts);
+    auto processedID = g_signal_connect(test->view(), "event-processed", G_CALLBACK(+[](WPEView*, WPEEvent*, gboolean, EventCounts* counts) {
+        counts->processed++;
+    }), &counts);
+
+    auto event = createKeyEvent(test->view(), WPE_EVENT_KEYBOARD_KEY_DOWN);
+
+    // Delivering an event says nothing about what became of it, which is the
+    // whole reason the second signal exists.
+    wpe_view_event(test->view(), event.get());
+    g_assert_cmpuint(counts.event, ==, 1);
+    g_assert_cmpuint(counts.processed, ==, 0);
+
+    wpe_view_event_processed(test->view(), event.get(), FALSE);
+    g_assert_cmpuint(counts.event, ==, 1);
+    g_assert_cmpuint(counts.processed, ==, 1);
+
+    g_signal_handler_disconnect(test->view(), eventID);
+    g_signal_handler_disconnect(test->view(), processedID);
+}
+
+static void testViewEventProcessedScroll(WPEMockViewTest* test, gconstpointer)
+{
+    ProcessedResult result;
+    auto signalID = g_signal_connect(test->view(), "event-processed", G_CALLBACK(+[](WPEView*, WPEEvent* event, gboolean handled, ProcessedResult* result) {
+        result->count++;
+        result->event = event;
+        result->handled = handled;
+    }), &result);
+
+    GRefPtr<WPEEvent> event = adoptGRef(wpe_event_scroll_new(test->view(), WPE_INPUT_SOURCE_MOUSE, 0, WPE_MODIFIER_KEYBOARD_CONTROL,
+        0., -3., FALSE, FALSE, 10., 20.));
+
+    wpe_view_event_processed(test->view(), event.get(), FALSE);
+    g_assert_cmpuint(result.count, ==, 1);
+    g_assert_true(result.event == event.get());
+    g_assert_false(result.handled);
+    g_assert_cmpuint(wpe_event_get_event_type(result.event), ==, WPE_EVENT_SCROLL);
+    g_assert_true(wpe_event_get_modifiers(result.event) & WPE_MODIFIER_KEYBOARD_CONTROL);
+
+    // The deltas have to survive, since what to do with an unused scroll
+    // depends on them.
+    double deltaX, deltaY;
+    wpe_event_scroll_get_deltas(result.event, &deltaX, &deltaY);
+    g_assert_cmpfloat(deltaX, ==, 0.);
+    g_assert_cmpfloat(deltaY, ==, -3.);
+
+    wpe_view_event_processed(test->view(), event.get(), TRUE);
+    g_assert_cmpuint(result.count, ==, 2);
+    g_assert_true(result.handled);
+
+    g_signal_handler_disconnect(test->view(), signalID);
+}
+
 void beforeAll()
 {
     WPEMockViewTest::add("View", "toplevel", testViewToplevel);
     WPEMockViewTest::add("View", "size", testViewSize);
     WPEMockViewTest::add("View", "scale", testViewScale);
     WPEMockViewTest::add("View", "toplevel-state", testViewToplevelState);
+    WPEMockViewTest::add("View", "event-processed", testViewKeyboardEventProcessed);
+    WPEMockViewTest::add("View", "event-processed-is-separate-from-event", testViewKeyboardEventProcessedIsSeparateFromEvent);
+    WPEMockViewTest::add("View", "event-processed-scroll", testViewEventProcessedScroll);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
@@ -27,6 +27,7 @@ if (ENABLE_WPE_PLATFORM)
     add_subdirectory(WPEPlatform)
 
     ADD_WK2_TEST(TestWebViewEditor ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewEditor.cpp)
+    ADD_WK2_TEST(TestWebViewInputEvents ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewInputEvents.cpp)
 endif ()
 
 if (ENABLE_2022_GLIB_API)


### PR DESCRIPTION
#### bfc67a150cfc33c2b934ef57d71356943a31e621
<pre>
[WPE] Add API to show what events the webview processed
<a href="https://bugs.webkit.org/show_bug.cgi?id=322302">https://bugs.webkit.org/show_bug.cgi?id=322302</a>

Reviewed by NOBODY (OOPS!).

Web content is allowed to handle some events, key down, scroll wheel, touch,
and prevent them from being processed by the application. To support this
we need to wire up the missing PageClient methods and signal these events.

* Source/WebKit/Shared/NativeWebKeyboardEvent.h:
(WebKit::NativeWebKeyboardEvent::nativeEvent const):
* Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp:
(WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithKeyEvent):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpe_view_keyboard_event_processed):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewKeyEvents.cpp: Added.
(KeyboardEventProcessedTest::~KeyboardEventProcessedTest):
(KeyboardEventProcessedTest::view const):
(KeyboardEventProcessedTest::loadContentsAndWait):
(KeyboardEventProcessedTest::keyDownVerdict):
(KeyboardEventProcessedTest::reportedKeyval const):
(KeyboardEventProcessedTest::keyboardEventProcessedCallback):
(testKeyboardEventDeclinedByPage):
(testKeyboardEventListenerAloneDoesNotClaimKey):
(testKeyboardEventHandledByPage):
(testKeyboardEventModifierAlone):
(testKeyboardEventHandledByEngine):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestView.cpp:
(TestWebKitAPI::createKeyEvent):
(TestWebKitAPI::testViewKeyboardEventProcessed):
(TestWebKitAPI::testViewKeyboardEventProcessedIsSeparateFromEvent):
(TestWebKitAPI::beforeAll):
* Tools/TestWebKitAPI/glib/PlatformWPE.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc67a150cfc33c2b934ef57d71356943a31e621

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98812 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162999 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122667 "Found 1 new API test failure: TestWebKitWebView:/webkit/WebKitWebView/fullscreen (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42897 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42524 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3607 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55835 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45951 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128810 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55037 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->