### PR TITLE
Use a normal UUID for the `FileSystemHandleGlobalIdentifier` type

### DIFF
--- a/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
@@ -71,7 +71,7 @@ void FileSystemHandle::close()
 
 void FileSystemHandle::markAsUnresolved(ClientOrigin&& origin, Ref<FileSystemStorageConnection>&& connection)
 {
-    ASSERT(m_globalIdentifier.toRawValue());
+    ASSERT(!!m_globalIdentifier);
     m_isUnresolved = true;
     m_origin = WTF::move(origin);
     connection->addGlobalIdentifierReference(ClientOrigin { m_origin }, m_globalIdentifier);

--- a/Source/WebCore/Modules/filesystem/FileSystemHandleGlobalIdentifier.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandleGlobalIdentifier.h
@@ -25,11 +25,10 @@
 
 #pragma once
 
-#include <wtf/ObjectIdentifier.h>
+#include <wtf/UUID.h>
 
 namespace WebCore {
 
-struct FileSystemHandleGlobalIdentifierType;
-using FileSystemHandleGlobalIdentifier = UUIDObjectIdentifier<FileSystemHandleGlobalIdentifierType>;
+using FileSystemHandleGlobalIdentifier = WTF::UUID;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2153,7 +2153,7 @@ IDBError SQLiteIDBBackingStore::addFileSystemHandleRecordsForObjectStoreRecord(i
     for (auto& record : records) {
         auto sql = cachedStatement(SQL::AddFileSystemHandleRecord, "INSERT INTO FileSystemHandleRecords VALUES (?, ?, ?, ?, ?);"_s);
         CheckedPtr statement = sql.get();
-        auto rawIdentifier = record.identifier.toRawValue();
+        auto rawIdentifier = record.identifier;
         if (!statement
             || statement->bindInt64(1, recordID) != SQLITE_OK
             || statement->bindBlob(2, rawIdentifier.span()) != SQLITE_OK

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1482,7 +1482,7 @@ public:
             write(FileSystemHandleTag);
             write(std::to_underlying(handle.kind()));
             write(handle.name());
-            write(std::span<const uint8_t> { handle.globalIdentifier().toRawValue().span() });
+            write(std::span<const uint8_t> { handle.globalIdentifier().span() });
             ASSERT(!context->securityOrigin()->isOpaque());
             write(context->securityOrigin()->toString());
             if (RefPtr connection = fileSystemStorageConnectionForContext(*context)) {

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -104,7 +104,7 @@ Expected<std::pair<WebCore::FileSystemHandleGlobalIdentifier, WebCore::FileSyste
     if (!newHandle)
         return makeUnexpected(FileSystemStorageError::Unknown);
 
-    auto globalIdentifier = WebCore::FileSystemHandleGlobalIdentifier::generate();
+    auto globalIdentifier = WTF::UUID::createVersion4();
     newHandle->setGlobalIdentifier(globalIdentifier);
 
     auto newHandleIdentifier = newHandle->identifier();

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -355,11 +355,6 @@ def message_to_struct_declaration(receiver, message):
 
 def atomic_object_identifier(type):
     # FIXME: This can be derived from *.serialization.in files.
-    uuid_object_identifiers = [
-        'WebCore::FileSystemHandleGlobalIdentifier',
-    ]
-    if type in uuid_object_identifiers:
-        return 'UUID'
     atomic_object_identifiers = [
         'WebCore::FileSystemHandleIdentifier',
         'WebCore::FileSystemSyncAccessHandleIdentifier',
@@ -446,7 +441,6 @@ def serialized_identifiers():
         'WebCore::DictationContext',
         'WebCore::NodeIdentifier',
         'WebCore::FetchIdentifier',
-        'WebCore::FileSystemHandleGlobalIdentifier',
         'WebCore::FileSystemHandleIdentifier',
         'WebCore::FileSystemSyncAccessHandleIdentifier',
         'WebCore::FileSystemWritableFileStreamIdentifier',
@@ -624,6 +618,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::DictationContext',
         'WebCore::DragApplicationFlags',
         'WebCore::DragEventTargetData',
+        'WebCore::FileSystemHandleGlobalIdentifier',
         'WebCore::FloatBoxExtent',
         'WebCore::GCGLExtension',
         'WebCore::GlyphBufferAdvance',
@@ -1275,6 +1270,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::FontInternalAttributes': ['<WebCore/Font.h>'],
         'WebCore::FileChooserSettings': ['<WebCore/FileChooser.h>'],
         'WebCore::FillLightMode': ['<WebCore/FillLightMode.h>'],
+        'WebCore::FileSystemHandleGlobalIdentifier': ['<WebCore/FileSystemHandleGlobalIdentifier.h>'],
         'WebCore::FirstPartyWebsiteDataRemovalMode': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::FontChanges': ['<WebCore/FontAttributeChanges.h>'],
         'WebCore::FontPlatformDataAttributes': ['<WebCore/FontPlatformData.h>'],

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -507,7 +507,6 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::DictationContext"_s,
         "WebCore::NodeIdentifier"_s,
         "WebCore::FetchIdentifier"_s,
-        "WebCore::FileSystemHandleGlobalIdentifier"_s,
         "WebCore::FileSystemHandleIdentifier"_s,
         "WebCore::FileSystemSyncAccessHandleIdentifier"_s,
         "WebCore::FileSystemWritableFileStreamIdentifier"_s,

--- a/Source/WebKit/Shared/FileSystemHandleInfo.serialization.in
+++ b/Source/WebKit/Shared/FileSystemHandleInfo.serialization.in
@@ -22,6 +22,8 @@
 
 enum class WebCore::FileSystemHandleKind : bool;
 
+using WebCore::FileSystemHandleGlobalIdentifier = WTF::UUID;
+
 struct WebCore::FileSystemHandleInfo {
     WebCore::FileSystemHandleGlobalIdentifier globalIdentifier;
     WebCore::FileSystemHandleIdentifier identifier;

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -247,11 +247,6 @@ template: struct WebKit::WebTransportSessionIdentifierType
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 
-template: struct WebCore::FileSystemHandleGlobalIdentifierType
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::UUIDObjectIdentifier {
-    [Validator='WTF::ObjectIdentifierGenericBase<WTF::UUID>::isValidIdentifier(*toRawValue)'] WTF::UUID toRawValue()
-}
-
 #if OS(WINDOWS)
 using WTF::ProcessID = int;
 #else


### PR DESCRIPTION
#### 22fbd8510ca81ff8d8cc2e03f50a5dbb186dbb9d
<pre>
Use a normal UUID for the `FileSystemHandleGlobalIdentifier` type
<a href="https://bugs.webkit.org/show_bug.cgi?id=322301">https://bugs.webkit.org/show_bug.cgi?id=322301</a>
<a href="https://rdar.apple.com/185540297">rdar://185540297</a>

Reviewed by Abrar Rahman Protyasha.

The `FileSystemHandleGlobalIdentifier` type is the only type across the entire codebase that
used a UUID-based ObjectIdentifier. Switch to just a normal UUID to be consistent with everything else.

This also unblocks being able to remove the UUID version of ObjectIdentifier, a mistake introduced
by a less pragmatic version of myself several years ago.

* Source/WebCore/Modules/filesystem/FileSystemHandle.cpp:
(WebCore::FileSystemHandle::markAsUnresolved):
* Source/WebCore/Modules/filesystem/FileSystemHandleGlobalIdentifier.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::addFileSystemHandleRecordsForObjectStoreRecord):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpDerivedTerminal):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::createHandle):
* Source/WebKit/Scripts/webkit/messages.py:
(atomic_object_identifier):
(serialized_identifiers):
(types_that_cannot_be_forward_declared):
(headers_for_type):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/319641@main">https://commits.webkit.org/319641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47d13396202af712381259ffcd1543fbe40a7a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49862 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192338 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb7bf1b7-02d9-4559-8e68-59ed17c783db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55779 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192338 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12264491-dff3-4cfc-8f11-cec0abffb6b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162920 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192338 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b48dbbc-7725-4345-b59a-ad95231bf00e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181434 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44555 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192338 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42445 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3499 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47078 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194263 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55727 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194263 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40587 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56418 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194263 "") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45877 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128701 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54929 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17441 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->