### PR TITLE
[WTF] Align PriorityQueue to std::priority_queue and fix WasmWorklist

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -448,9 +448,11 @@ public:
         out.print("<", m_tmp, ", ", WTF::RawHex(m_priority), ">");
     }
 
-    static bool NODELETE isHigherPriority(const TmpPriority& left, const TmpPriority& right)
+    // The packed priority is built so that a numerically greater value is more urgent, which is the
+    // order PriorityQueue serves.
+    friend bool NODELETE operator<(const TmpPriority& left, const TmpPriority& right)
     {
-        return left.m_priority > right.m_priority;
+        return left.m_priority < right.m_priority;
     }
 
 private:
@@ -3641,7 +3643,7 @@ private:
     Vector<StackSlot*> m_spillSlotTable;
     IndexMap<Reg, RegisterRange> m_regRanges;
     GenerationalSet<uint8_t, SaVector> m_visited;
-    PriorityQueue<TmpPriority, TmpPriority::isHigherPriority> m_queue;
+    PriorityQueue<TmpPriority> m_queue;
     IndexMap<BasicBlock*, PhaseInsertionSet> m_insertionSets;
     BlockWorklist m_fastBlocks;
     UseCounts m_useCounts;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -338,12 +338,15 @@ void InliningPlan::surveyCallSites(Site& parent, CodeBlock* codeBlock, unsigned 
     }
 }
 
-static bool isHigherPriorityInliningCandidate(InliningPlan::Site* const& left, InliningPlan::Site* const& right)
-{
-    if (left->score != right->score)
-        return left->score > right->score;
-    return left->surveyIndex < right->surveyIndex;
-}
+// Served first is the highest score, then the earliest surveyed site.
+struct InliningCandidateIsLowerPriority {
+    bool operator()(InliningPlan::Site* left, InliningPlan::Site* right) const
+    {
+        if (left->score != right->score)
+            return left->score < right->score;
+        return left->surveyIndex > right->surveyIndex;
+    }
+};
 
 void InliningPlan::build(CodeBlock* rootCodeBlock, JITType jitType)
 {
@@ -359,7 +362,7 @@ void InliningPlan::build(CodeBlock* rootCodeBlock, JITType jitType)
 
     surveyCallSites(m_root, rootCodeBlock, m_root.depth + 1);
 
-    PriorityQueue<InliningPlan::Site*, isHigherPriorityInliningCandidate> queue;
+    PriorityQueue<InliningPlan::Site*, InliningCandidateIsLowerPriority> queue;
 
     auto makeAdmissible = [&](const auto& sites) {
         for (Site* site : sites)

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
@@ -187,15 +187,17 @@ MergedProfile* InliningDecision::profileForCallee(const IPIntCallee& callee)
     }).iterator->value.get();
 }
 
-static bool isHigherPriority(InliningNode* const& lhs, InliningNode* const& rhs)
-{
-    // The ordering is, higher score, lower index, lower pointer.
-    return std::tuple { lhs->score(), rhs->callee().index(), rhs } > std::tuple { rhs->score(), lhs->callee().index(), lhs };
-}
+struct InliningNodeIsLowerPriority {
+    bool operator()(InliningNode* lhs, InliningNode* rhs) const
+    {
+        // Served first is the highest score, then the lowest callee index, then the lowest pointer.
+        return std::tuple { lhs->score(), rhs->callee().index(), rhs } < std::tuple { rhs->score(), lhs->callee().index(), lhs };
+    }
+};
 
 void InliningDecision::expand()
 {
-    PriorityQueue<InliningNode*, isHigherPriority> queue;
+    PriorityQueue<InliningNode*, InliningNodeIsLowerPriority> queue;
 
     auto addChildrenToQueue = [&](InliningNode* target) {
         if (target->depth() >= Options::wasmInliningMaximumDepth()) {

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -175,7 +175,7 @@ void Worklist::completePlanSynchronously(Plan& plan)
 {
     {
         Locker locker { *m_lock };
-        m_queue.decreaseKey([&] (QueueElement& element) {
+        m_queue.increaseKey([&] (QueueElement& element) {
             if (element.plan == &plan) {
                 element.priority = Priority::Synchronous;
                 return true;

--- a/Source/JavaScriptCore/wasm/WasmWorklist.h
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.h
@@ -29,8 +29,6 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include <queue>
-
 #include <wtf/AutomaticThread.h>
 #include <wtf/PrintStream.h>
 #include <wtf/PriorityQueue.h>
@@ -56,11 +54,12 @@ public:
 
     JS_EXPORT_PRIVATE void completePlanSynchronously(Plan&);
 
+    // The queue serves its greatest element, so a greater Priority is more urgent.
     enum class Priority {
-        Shutdown,
-        Synchronous,
+        Preparation,
         Compilation,
-        Preparation
+        Synchronous,
+        Shutdown
     };
 
     void dump(PrintStream&) const;
@@ -80,19 +79,23 @@ private:
         void NODELETE setToNextPriority();
     };
 
-    static bool isHigherPriority(const QueueElement& left, const QueueElement& right)
-    {
-        if (left.priority == right.priority)
-            return left.ticket > right.ticket;
-        return left.priority > right.priority;
-    }
+    struct QueueElementIsLowerPriority {
+        bool NODELETE operator()(const QueueElement& left, const QueueElement& right) const
+        {
+            // Within one Priority, the earliest ticket is served first.
+            if (left.priority == right.priority)
+                return left.ticket > right.ticket;
+
+            return left.priority < right.priority;
+        }
+    };
 
     Box<Lock> m_lock;
     const Ref<AutomaticThreadCondition> m_planEnqueued;
     // Technically, this could overflow but that's unlikely. Even if it did, we will just compile things of the same
-    // Priority it the wrong order, which isn't wrong, just suboptimal.
+    // Priority in the wrong order, which isn't wrong, just suboptimal.
     Ticket m_lastGrantedTicket { 0 };
-    PriorityQueue<QueueElement, isHigherPriority, 10> m_queue;
+    PriorityQueue<QueueElement, QueueElementIsLowerPriority, 10> m_queue;
     Vector<Ref<Thread>> m_threads;
 };
 

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -428,10 +428,6 @@ constexpr bool isMultipleOf(unsigned factor, T value)
     return factor && !(value % factor);
 }
 
-template<typename T> constexpr bool isLessThan(const T& a, const T& b) { return a < b; }
-template<typename T> constexpr bool isLessThanEqual(const T& a, const T& b) { return a <= b; }
-template<typename T> constexpr bool isGreaterThan(const T& a, const T& b) { return a > b; }
-template<typename T> constexpr bool isGreaterThanEqual(const T& a, const T& b) { return a >= b; }
 template<typename T> constexpr bool isInRange(const T& a, const T& min, const T& max) { return a >= min && a <= max; }
 
 // decompose 'number' to its sign, exponent, and mantissa components.

--- a/Source/WTF/wtf/PriorityQueue.h
+++ b/Source/WTF/wtf/PriorityQueue.h
@@ -25,24 +25,30 @@
 
 #pragma once
 
-#include <wtf/MathExtras.h>
+#include <functional>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
 
-// This class implements a basic priority queue. The class is backed as a binary heap, like std::priority_queue.
+// This class implements a basic priority queue. The class is backed as a binary heap and follows the
+// conventions of std::priority_queue: Compare is a less-than ordering, and peek() and dequeue() serve
+// the element that is greatest under it.
+//
 // PriorityQueue has a couple of advantages over std::priority_queue:
 //
 // 1) The backing vector is fastMalloced.
 // 2) You can iterate the elements.
 // 3) It has in-place decrease/increaseKey methods, although they are still O(n) rather than O(log(n)).
 
-template<typename T, bool (*isHigherPriority)(const T&, const T&) = &isLessThan<T>, size_t inlineCapacity = 0>
+template<typename T, typename Compare = std::less<T>, size_t inlineCapacity = 0>
 class PriorityQueue final {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PriorityQueue);
     using BufferType = Vector<T, inlineCapacity>;
     using const_iterator = typename BufferType::const_iterator;
+    // Compare is default-constructed on each use, which a function pointer type survives as a null
+    // one, so reject those instead of calling through them.
+    static_assert(!std::is_pointer_v<Compare>, "Compare must be a functor type, not a function pointer.");
 public:
     size_t size() const { return m_buffer.size(); }
     bool isEmpty() const { return m_buffer.isEmpty(); }
@@ -63,12 +69,15 @@ public:
         return result;
     }
 
+    // Call decreaseKey after making the accepted element compare less than it did, and increaseKey
+    // after making it compare greater. The greatest element is served first, so increaseKey is the
+    // one that moves an element towards the front of the queue.
     void decreaseKey(NOESCAPE const Invocable<bool(T&)> auto& desiredElement)
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
                 siftDown(i);
-                return;
+                break;
             }
         }
         ASSERT(isValidHeap());
@@ -79,7 +88,7 @@ public:
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
                 siftUp(i);
-                return;
+                break;
             }
         }
         ASSERT(isValidHeap());
@@ -91,15 +100,17 @@ public:
     bool isValidHeap() const
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
-            if (leftChildOf(i) < m_buffer.size() && !isHigherPriority(m_buffer[i], m_buffer[leftChildOf(i)]))
+            if (leftChildOf(i) < m_buffer.size() && isLessThan(m_buffer[i], m_buffer[leftChildOf(i)]))
                 return false;
-            if (rightChildOf(i) < m_buffer.size() && !isHigherPriority(m_buffer[i], m_buffer[rightChildOf(i)]))
+            if (rightChildOf(i) < m_buffer.size() && isLessThan(m_buffer[i], m_buffer[rightChildOf(i)]))
                 return false;
         }
         return true;
     }
 
 protected:
+    static bool isLessThan(const T& a, const T& b) { return Compare { }(a, b); }
+
     static inline size_t parentOf(size_t location) { ASSERT(location); return (location - 1) / 2; }
     static constexpr size_t leftChildOf(size_t location) { return location * 2 + 1; }
     static constexpr size_t rightChildOf(size_t location) { return leftChildOf(location) + 1; }
@@ -108,7 +119,7 @@ protected:
     {
         while (location) {
             auto parent = parentOf(location);
-            if (isHigherPriority(m_buffer[parent], m_buffer[location]))
+            if (!isLessThan(m_buffer[parent], m_buffer[location]))
                 return;
 
             std::swap(m_buffer[parent], m_buffer[location]);
@@ -119,17 +130,17 @@ protected:
     void siftDown(size_t location)
     {
         while (leftChildOf(location) < m_buffer.size()) {
-            size_t higherPriorityChild;
+            size_t greatestChild;
             if (rightChildOf(location) < m_buffer.size()) [[likely]]
-                higherPriorityChild = isHigherPriority(m_buffer[leftChildOf(location)], m_buffer[rightChildOf(location)]) ? leftChildOf(location) : rightChildOf(location);
+                greatestChild = isLessThan(m_buffer[leftChildOf(location)], m_buffer[rightChildOf(location)]) ? rightChildOf(location) : leftChildOf(location);
             else
-                higherPriorityChild = leftChildOf(location);
+                greatestChild = leftChildOf(location);
 
-            if (isHigherPriority(m_buffer[location], m_buffer[higherPriorityChild]))
+            if (!isLessThan(m_buffer[location], m_buffer[greatestChild]))
                 return;
 
-            std::swap(m_buffer[location], m_buffer[higherPriorityChild]);
-            location = higherPriorityChild;
+            std::swap(m_buffer[location], m_buffer[greatestChild]);
+            location = greatestChild;
         }
     }
 

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -76,7 +76,7 @@ private:
     private:
         void removeExpired(ContinuousApproximateTime);
 
-        PriorityQueue<ContinuousApproximateTime> m_accessTimes;
+        PriorityQueue<ContinuousApproximateTime, std::greater<ContinuousApproximateTime>> m_accessTimes;
         ContinuousApproximateTime m_newestAccessTime { -ContinuousApproximateTime::infinity() };
     };
 

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -84,27 +84,30 @@ private:
         unsigned taskNumber { 0 };
     };
 
-    static bool firstIsHigherPriority(const Task&, const Task&);
+    // The queue serves its greatest element, so High compares greater than Low and, within one
+    // priority, an earlier task number compares greater.
+    struct TaskIsLowerPriority {
+        bool operator()(const Task& first, const Task& second) const
+        {
+            if (first.priority != second.priority)
+                return first.priority == Priority::Low;
+
+            return first.taskNumber > second.taskNumber;
+        }
+    };
+
     unsigned nextTaskNumber() { return ++m_currentTaskNumber; }
 
     ImageTranslationLanguageIdentifiers m_languageIdentifiers;
     WeakPtr<Page> m_page;
     Timer m_resumeProcessingTimer;
     WeakHashMap<HTMLImageElement, URL, WeakPtrImplWithEventTargetData> m_queuedElements;
-    PriorityQueue<Task, firstIsHigherPriority> m_queue;
+    PriorityQueue<Task, TaskIsLowerPriority> m_queue;
     unsigned m_pendingRequestCount { 0 };
     unsigned m_currentTaskNumber { 0 };
     std::unique_ptr<PAL::HysteresisActivity> m_imageQueueEmptyHysteresis;
     bool m_analysisOfAllImagesOnPageHasStarted { false };
 };
-
-inline bool ImageAnalysisQueue::firstIsHigherPriority(const Task& first, const Task& second)
-{
-    if (first.priority != second.priority)
-        return first.priority == Priority::High;
-
-    return first.taskNumber < second.taskNumber;
-}
 
 } // namespace WebCore
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -108,12 +108,12 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Storage::ReadOperation);
 
-bool Storage::isHigherPriority(const std::unique_ptr<ReadOperation>& a, const std::unique_ptr<ReadOperation>& b)
+bool Storage::ReadOperationIsLowerPriority::operator()(const std::unique_ptr<ReadOperation>& a, const std::unique_ptr<ReadOperation>& b) const
 {
     if (a->priority() == b->priority())
-        return a->identifier() < b->identifier();
+        return a->identifier() > b->identifier();
 
-    return a->priority() > b->priority();
+    return a->priority() < b->priority();
 }
 
 void Storage::ReadOperation::updateForStart(size_t readOperationDispatchCount)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -190,7 +190,9 @@ private:
     void addToRecordFilter(const Key&);
     void deleteFiles(const Key&);
 
-    static bool NODELETE isHigherPriority(const std::unique_ptr<ReadOperation>&, const std::unique_ptr<ReadOperation>&);
+    struct ReadOperationIsLowerPriority {
+        bool NODELETE operator()(const std::unique_ptr<ReadOperation>&, const std::unique_ptr<ReadOperation>&) const;
+    };
 
     size_t estimateRecordsSize(unsigned recordCount, unsigned blobCount) const;
     uint32_t volumeBlockSize() const;
@@ -217,7 +219,7 @@ private:
     Vector<Key::HashType> m_recordFilterHashesAddedDuringSynchronization;
     Vector<Key::HashType> m_blobFilterHashesAddedDuringSynchronization;
 
-    PriorityQueue<std::unique_ptr<ReadOperation>, &isHigherPriority> m_pendingReadOperations;
+    PriorityQueue<std::unique_ptr<ReadOperation>, ReadOperationIsLowerPriority> m_pendingReadOperations;
     HashMap<ReadOperationIdentifier, std::unique_ptr<ReadOperation>> m_activeReadOperations;
     WebCore::Timer m_readOperationTimeoutTimer;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
@@ -34,8 +34,8 @@
 
 constexpr std::size_t operator""_z(unsigned long long n) { return n; }
 
-template<typename T, bool (*isHigherPriority)(const T&, const T&)>
-static void enqueue(PriorityQueue<T, isHigherPriority>& queue, T element)
+template<typename T, typename Compare, size_t inlineCapacity>
+static void enqueue(PriorityQueue<T, Compare, inlineCapacity>& queue, T element)
 {
     size_t sizeBefore = queue.size();
     queue.enqueue(WTF::move(element));
@@ -43,8 +43,8 @@ static void enqueue(PriorityQueue<T, isHigherPriority>& queue, T element)
     EXPECT_FALSE(queue.isEmpty());
 }
 
-template<typename T, bool (*isHigherPriority)(const T&, const T&)>
-static T dequeue(PriorityQueue<T, isHigherPriority>& queue)
+template<typename T, typename Compare, size_t inlineCapacity>
+static T dequeue(PriorityQueue<T, Compare, inlineCapacity>& queue)
 {
     EXPECT_FALSE(queue.isEmpty());
     size_t sizeBefore = queue.size();
@@ -65,19 +65,21 @@ TEST(WTF_PriorityQueue, Basic)
     for (unsigned i = 0; i < numElements; ++i)
         enqueue(queue, i);
 
+    // The default std::less serves the greatest element first, like std::priority_queue.
     for (unsigned i = 0; i < numElements; ++i) {
-        EXPECT_EQ(i, queue.peek());
-        EXPECT_EQ(i, dequeue(queue));
-        EXPECT_EQ(numElements - i - 1, queue.size());
+        unsigned expected = numElements - i - 1;
+        EXPECT_EQ(expected, queue.peek());
+        EXPECT_EQ(expected, dequeue(queue));
+        EXPECT_EQ(expected, queue.size());
     }
 
     EXPECT_TRUE(queue.isEmpty());
 }
 
-TEST(WTF_PriorityQueue, CustomPriorityFunction)
+TEST(WTF_PriorityQueue, ReversedComparator)
 {
     const unsigned numElements = 10;
-    PriorityQueue<unsigned, &isGreaterThan<unsigned>> queue;
+    PriorityQueue<unsigned, std::greater<unsigned>> queue;
 
     EXPECT_EQ(0_z, queue.size());
     EXPECT_TRUE(queue.isEmpty());
@@ -89,29 +91,29 @@ TEST(WTF_PriorityQueue, CustomPriorityFunction)
     }
 
     for (unsigned i = 0; i < numElements; ++i) {
-        EXPECT_EQ(numElements - i - 1, queue.peek());
-        EXPECT_EQ(numElements - i - 1, dequeue(queue));
+        EXPECT_EQ(i, queue.peek());
+        EXPECT_EQ(i, dequeue(queue));
         EXPECT_EQ(numElements - i - 1, queue.size());
     }
 
     EXPECT_TRUE(queue.isEmpty());
 }
 
-template<bool (*isHigherPriority)(const unsigned&, const unsigned&)>
-struct CompareMove {
-    static bool compare(const MoveOnly& m1, const MoveOnly& m2)
-    {
-        return isHigherPriority(m1.value(), m2.value());
-    }
+struct MoveOnlyIsLessThan {
+    bool operator()(const MoveOnly& a, const MoveOnly& b) const { return a.value() < b.value(); }
+};
+
+struct MoveOnlyIsGreaterThan {
+    bool operator()(const MoveOnly& a, const MoveOnly& b) const { return a.value() > b.value(); }
 };
 
 TEST(WTF_PriorityQueue, MoveOnly)
 {
-    PriorityQueue<MoveOnly, &CompareMove<&isLessThan<unsigned>>::compare> queue;
+    PriorityQueue<MoveOnly, MoveOnlyIsLessThan> queue;
 
     Vector<unsigned> values = { 23, 54, 4, 8, 1, 2, 4, 0 };
     Vector<unsigned> sorted = values;
-    std::ranges::sort(sorted);
+    std::ranges::sort(sorted, std::greater<unsigned>());
 
     for (auto value : values)
         queue.enqueue(MoveOnly(value));
@@ -124,19 +126,19 @@ TEST(WTF_PriorityQueue, MoveOnly)
 
 TEST(WTF_PriorityQueue, DecreaseKey)
 {
-    PriorityQueue<MoveOnly, &CompareMove<&isLessThan<unsigned>>::compare> queue;
+    PriorityQueue<MoveOnly, MoveOnlyIsLessThan> queue;
 
     Vector<unsigned> values = { 23, 54, 4, 8, 1, 2, 4, 0 };
     Vector<unsigned> sorted = values;
-    sorted[3] = 12;
-    std::ranges::sort(sorted);
+    sorted[3] = 3;
+    std::ranges::sort(sorted, std::greater<unsigned>());
 
     for (auto value : values)
         queue.enqueue(MoveOnly(value));
 
     queue.decreaseKey([] (MoveOnly& m) {
         if (m.value() == 8) {
-            m = MoveOnly(12);
+            m = MoveOnly(3);
             return true;
         }
         return false;
@@ -150,7 +152,7 @@ TEST(WTF_PriorityQueue, DecreaseKey)
 
 TEST(WTF_PriorityQueue, IncreaseKey)
 {
-    PriorityQueue<MoveOnly, &CompareMove<&isGreaterThan<unsigned>>::compare> queue;
+    PriorityQueue<MoveOnly, MoveOnlyIsLessThan> queue;
 
     Vector<unsigned> values = { 23, 54, 4, 8, 1, 2, 4, 0 };
     Vector<unsigned> sorted = values;
@@ -174,9 +176,36 @@ TEST(WTF_PriorityQueue, IncreaseKey)
     }
 }
 
+// Under a reversed comparator a smaller value compares greater, so shrinking a value increases its key.
+TEST(WTF_PriorityQueue, IncreaseKeyWithAReversedComparator)
+{
+    PriorityQueue<MoveOnly, MoveOnlyIsGreaterThan> queue;
+
+    Vector<unsigned> values = { 23, 54, 4, 8, 1, 2, 4, 0 };
+    Vector<unsigned> sorted = values;
+    sorted[3] = 3;
+    std::ranges::sort(sorted);
+
+    for (auto value : values)
+        queue.enqueue(MoveOnly(value));
+
+    queue.increaseKey([] (MoveOnly& m) {
+        if (m.value() == 8) {
+            m = MoveOnly(3);
+            return true;
+        }
+        return false;
+    });
+
+    for (auto sortedValue : sorted) {
+        auto value = queue.dequeue();
+        EXPECT_EQ(sortedValue, value.value());
+    }
+}
+
 TEST(WTF_PriorityQueue, Iteration)
 {
-    PriorityQueue<MoveOnly, &CompareMove<&isGreaterThan<unsigned>>::compare> queue;
+    PriorityQueue<MoveOnly, MoveOnlyIsGreaterThan> queue;
 
     Vector<unsigned> values = { 23, 54, 4, 8, 1, 2, 4, 0 };
     Vector<unsigned> sorted = values;
@@ -194,6 +223,99 @@ TEST(WTF_PriorityQueue, Iteration)
     if (values.size() == sorted.size()) {
         for (size_t i = 0; i < values.size(); ++i)
             EXPECT_EQ(sorted[i], values[i]);
+    }
+}
+
+TEST(WTF_PriorityQueue, EqualElementsAreAValidHeap)
+{
+    PriorityQueue<unsigned> queue;
+
+    for (unsigned value : { 4u, 1u, 4u, 1u, 4u })
+        enqueue(queue, value);
+
+    EXPECT_TRUE(queue.isValidHeap());
+
+    // Finding nothing still validates the heap, so a queue holding equal elements must not trip it.
+    auto matchNothing = [] (unsigned&) {
+        return false;
+    };
+    queue.decreaseKey(matchNothing);
+    queue.increaseKey(matchNothing);
+
+    EXPECT_EQ(4u, dequeue(queue));
+    EXPECT_EQ(4u, dequeue(queue));
+    EXPECT_EQ(4u, dequeue(queue));
+    EXPECT_EQ(1u, dequeue(queue));
+    EXPECT_EQ(1u, dequeue(queue));
+    EXPECT_TRUE(queue.isEmpty());
+}
+
+static bool comparatorIsReversed { false };
+
+struct ReversibleComparator {
+    bool operator()(const unsigned& left, const unsigned& right) const
+    {
+        return comparatorIsReversed ? left > right : left < right;
+    }
+};
+
+TEST(WTF_PriorityQueue, IsValidHeapDetectsAGreaterChild)
+{
+    PriorityQueue<unsigned, ReversibleComparator> queue;
+
+    comparatorIsReversed = false;
+    for (unsigned i = 0; i < 8; ++i)
+        enqueue(queue, i);
+    EXPECT_TRUE(queue.isValidHeap());
+
+    // Reversing the order the elements were sifted with leaves every child greater than its parent.
+    comparatorIsReversed = true;
+    EXPECT_FALSE(queue.isValidHeap());
+
+    comparatorIsReversed = false;
+}
+
+struct PrioritizedTask {
+    unsigned priority { 0 };
+    unsigned ticket { 0 };
+};
+
+// Shaped like the real clients: a greater priority is served first and equal priorities are served FIFO.
+struct PrioritizedTaskIsLowerPriority {
+    bool operator()(const PrioritizedTask& left, const PrioritizedTask& right) const
+    {
+        if (left.priority == right.priority)
+            return left.ticket > right.ticket;
+        return left.priority < right.priority;
+    }
+};
+
+TEST(WTF_PriorityQueue, IncreaseKeyMovesTowardsTheFront)
+{
+    PriorityQueue<PrioritizedTask, PrioritizedTaskIsLowerPriority> queue;
+
+    unsigned ticket = 0;
+    for (unsigned priority : { 3u, 2u, 3u, 2u, 3u })
+        queue.enqueue({ priority, ticket++ });
+
+    queue.increaseKey([] (PrioritizedTask& task) {
+        if (task.ticket != 4)
+            return false;
+        task.priority = 5;
+        return true;
+    });
+
+    EXPECT_TRUE(queue.isValidHeap());
+
+    Vector<unsigned> served;
+    while (!queue.isEmpty())
+        served.append(queue.dequeue().ticket);
+
+    Vector<unsigned> expected = { 4, 0, 2, 1, 3 };
+    EXPECT_EQ(expected.size(), served.size());
+    if (expected.size() == served.size()) {
+        for (size_t i = 0; i < expected.size(); ++i)
+            EXPECT_EQ(expected[i], served[i]);
     }
 }
 
@@ -244,8 +366,8 @@ TEST(WTF_PriorityQueue, RandomActions)
             if (!values.size())
                 continue;
 
-            // Sort with greater so the last element should be the one we dequeue.
-            std::ranges::sort(values, std::greater<uint64_t>());
+            // Sort ascending so the last element is the greatest, which is the one we dequeue.
+            std::ranges::sort(values);
             EXPECT_EQ(values.takeLast(), queue.dequeue());
 
             continue;


### PR DESCRIPTION
#### cffd5ed032c478c1dee5311a89b91e64909e8b90
<pre>
[WTF] Align PriorityQueue to std::priority_queue and fix WasmWorklist
<a href="https://bugs.webkit.org/show_bug.cgi?id=322303">https://bugs.webkit.org/show_bug.cgi?id=322303</a>
<a href="https://rdar.apple.com/185541345">rdar://185541345</a>

Reviewed by Dan Hecht.

We found that WasmWorklist&apos;s PriorityQueue&apos;s ordering is opposite and
not correct. The reason is that PriorityQueue and std::priority_queue&apos;s
comparator is opposite and when changing std::priority_queue to
PriorityQueue, we didn&apos;t change the comparator. But this is error-prone.
This patch fixes that issue and also change PriorityQueue&apos;s comparator
to align it to std::priority_queue&apos;s one. So by default, taking
std::less, and populating the greatest value first. Doing the same in
PriorityQueue.

Test: Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::TmpPriority::operator&lt;):
(JSC::B3::Air::Greedy::TmpPriority::isHigherPriority): Deleted.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::InliningCandidateIsLowerPriority::operator() const):
(JSC::DFG::InliningPlan::build):
(JSC::DFG::isHigherPriorityInliningCandidate): Deleted.
* Source/JavaScriptCore/wasm/WasmInliningDecision.cpp:
(JSC::Wasm::InliningNodeIsLowerPriority::operator() const):
(JSC::Wasm::InliningDecision::expand):
(JSC::Wasm::isHigherPriority): Deleted.
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::completePlanSynchronously):
* Source/JavaScriptCore/wasm/WasmWorklist.h:
(JSC::Wasm::Worklist::QueueElementIsLowerPriority::operator() const):
(JSC::Wasm::Worklist::isHigherPriority): Deleted.
* Source/WTF/wtf/MathExtras.h:
(isLessThan): Deleted.
(isLessThanEqual): Deleted.
(isGreaterThan): Deleted.
(isGreaterThanEqual): Deleted.
* Source/WTF/wtf/PriorityQueue.h:
* Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/page/ImageAnalysisQueue.h:
(WebCore::ImageAnalysisQueue::firstIsHigherPriority): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::ReadOperationIsLowerPriority::operator() const):
(WebKit::NetworkCache::Storage::isHigherPriority): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp:
(enqueue):
(dequeue):
(TEST(WTF_PriorityQueue, Basic)):
(TEST(WTF_PriorityQueue, ReversedComparator)):
(MoveOnlyIsLessThan::operator() const):
(MoveOnlyIsGreaterThan::operator() const):
(TEST(WTF_PriorityQueue, MoveOnly)):
(TEST(WTF_PriorityQueue, DecreaseKey)):
(TEST(WTF_PriorityQueue, IncreaseKey)):
(TEST(WTF_PriorityQueue, IncreaseKeyWithAReversedComparator)):
(TEST(WTF_PriorityQueue, Iteration)):
(TEST(WTF_PriorityQueue, EqualElementsAreAValidHeap)):
(ReversibleComparator::operator() const):
(TEST(WTF_PriorityQueue, IsValidHeapDetectsAGreaterChild)):
(PrioritizedTaskIsLowerPriority::operator() const):
(TEST(WTF_PriorityQueue, IncreaseKeyMovesTowardsTheFront)):
(TEST(WTF_PriorityQueue, RandomActions)):
(isHigherPriority): Deleted.
(TEST(WTF_PriorityQueue, CustomPriorityFunction)): Deleted.

Canonical link: <a href="https://commits.webkit.org/319634@main">https://commits.webkit.org/319634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93965b050c20880580d6164e55d45e8ac1c00df8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49824 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192297 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146400 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2d692c6-71bf-46c6-83ab-a625c58413e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55741 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192297 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/700f49c4-a2b4-4479-8354-5d3e71529587) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45845 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192297 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fb6612e-ddea-48e6-8cef-908444ec7f40) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44529 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192297 "") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11365 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42422 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3461 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43354 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48649 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55689 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151569 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56380 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151273 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45851 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124491 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54891 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17418 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->