### PR TITLE
Extension background service worker can't find other extension pages using clients.matchAll

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11600,7 +11600,8 @@ void Document::updateServiceWorkerClientData()
     if (!serviceWorkerConnection)
         return;
 
-    if (!Ref { topOrigin() }->isHTTPFamily() && !(page() && page()->isServiceWorkerPage()))
+    Ref topOrigin = this->topOrigin();
+    if (!topOrigin->isHTTPFamily() && !LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients(topOrigin->protocol()) && !(page() && page()->isServiceWorkerPage()))
         return;
 
     auto controllingServiceWorkerRegistrationIdentifier = activeServiceWorker() ? std::make_optional<ServiceWorkerRegistrationIdentifier>(activeServiceWorker()->registrationIdentifier()) : std::nullopt;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -614,7 +614,8 @@ bool DocumentLoader::setControllingServiceWorkerRegistration(ServiceWorkerRegist
 
 void DocumentLoader::matchRegistration(const URL& url, SWClientConnection::RegistrationCallback&& callback)
 {
-    bool shouldTryLoadingThroughServiceWorker = m_canUseServiceWorkers && !frameLoader()->isReloadingFromOrigin() && m_frame->page() && url.protocolIsInHTTPFamily();
+    bool shouldTryLoadingThroughServiceWorker = m_canUseServiceWorkers && !frameLoader()->isReloadingFromOrigin() && m_frame->page()
+        && (url.protocolIsInHTTPFamily() || LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients(url.protocol()));
     if (!shouldTryLoadingThroughServiceWorker) {
         callback(std::nullopt);
         return;
@@ -1359,7 +1360,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
                     document->createNewIdentifier();
             }
 
-            if (m_frame->document()->activeServiceWorker() || document->url().protocolIsInHTTPFamily() || (document->page() && document->page()->isServiceWorkerPage()) || (document->parentDocument() && shouldUseActiveServiceWorkerFromParent(document, *protect(document->parentDocument()))))
+            if (m_frame->document()->activeServiceWorker() || document->url().protocolIsInHTTPFamily() || LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients(document->url().protocol()) || (document->page() && document->page()->isServiceWorkerPage()) || (document->parentDocument() && shouldUseActiveServiceWorkerFromParent(document, *protect(document->parentDocument()))))
                 document->setServiceWorkerConnection(&ServiceWorkerProvider::singleton().serviceWorkerConnection());
 
             if (m_resultingClientId) {
@@ -2230,7 +2231,7 @@ void DocumentLoader::startLoadingMainResource()
 
         DOCUMENTLOADER_RELEASE_LOG_FORWARDABLE(DocumentLoaderStartLoadingMainResourceStartingLoad);
 
-        if (m_substituteData.isValid()) {
+        if (m_substituteData.isValid() || LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients(request.url().protocol())) {
             auto url = request.url();
             matchRegistration(url, [request = WTF::move(request), protectedThis = Ref { *this }, this] (auto&& registrationData) mutable {
                 if (!m_mainDocumentError.isNull()) {

--- a/Source/WebCore/platform/LegacySchemeRegistry.cpp
+++ b/Source/WebCore/platform/LegacySchemeRegistry.cpp
@@ -161,6 +161,13 @@ static URLSchemesMap& secureSchemes() WTF_REQUIRES_LOCK(schemeRegistryLock)
     return secureSchemes;
 }
 
+static URLSchemesMap& NODELETE schemesAllowingServiceWorkerClients()
+{
+    ASSERT(isMainThread());
+    static NeverDestroyed<URLSchemesMap> schemesAllowingServiceWorkerClients;
+    return schemesAllowingServiceWorkerClients;
+}
+
 static std::span<const ASCIILiteral> builtinSchemesWithUniqueOrigins()
 {
     static constexpr std::array schemes {
@@ -376,6 +383,24 @@ bool LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(StringView scheme)
 
     Locker locker { schemeRegistryLock };
     return secureSchemes().contains<StringViewHashTranslator>(scheme);
+}
+
+void LegacySchemeRegistry::registerURLSchemeAsAllowingServiceWorkerClients(const String& scheme)
+{
+    ASSERT(isMainThread());
+    if (scheme.isNull())
+        return;
+
+    schemesAllowingServiceWorkerClients().add(scheme);
+}
+
+bool LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients(StringView scheme)
+{
+    ASSERT(isMainThread());
+    if (scheme.isNull())
+        return false;
+
+    return schemesAllowingServiceWorkerClients().contains<StringViewHashTranslator>(scheme);
 }
 
 void LegacySchemeRegistry::registerURLSchemeAsEmptyDocument(const String& scheme)

--- a/Source/WebCore/platform/LegacySchemeRegistry.h
+++ b/Source/WebCore/platform/LegacySchemeRegistry.h
@@ -52,6 +52,9 @@ public:
     WEBCORE_EXPORT static void registerURLSchemeAsNoAccess(const String&); // Thread safe.
     static bool shouldTreatURLSchemeAsNoAccess(StringView); // Thread safe.
 
+    WEBCORE_EXPORT static void registerURLSchemeAsAllowingServiceWorkerClients(const String&); // Must be called on the main thread.
+    static bool shouldTreatURLSchemeAsAllowingServiceWorkerClients(StringView); // Must be called on the main thread.
+
     // Display-isolated schemes can only be displayed (in the sense of
     // SecurityOrigin::canDisplay) by documents from the same scheme.
     WEBCORE_EXPORT static void registerURLSchemeAsDisplayIsolated(const String&); // Thread safe.

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -935,6 +935,11 @@ void SWServer::matchAll(SWServerWorker& worker, const ServiceWorkerClientQueryOp
         if (m_clientsToBeCreatedById.contains(clientData.identifier))
             return;
 
+        // The worker's own hosting page (e.g. an extension's service worker page) is an implementation
+        // detail, not a real client, and should not be exposed to matchAll().
+        if (worker.serviceWorkerPageIdentifier() == clientData.identifier)
+            return;
+
         if (!options.includeUncontrolled) {
             auto registrationIdentifier = m_clientToControllingRegistration.get(clientData.identifier);
             if (worker.data().registrationIdentifier != registrationIdentifier)

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -180,8 +180,10 @@ void SWServerWorker::terminationTimerFired()
 
 const ClientOrigin& SWServerWorker::origin() const
 {
+    ASSERT(!SecurityOriginData::shouldTreatAsOpaqueOrigin(m_data.scriptURL) || !m_registration || !!m_registration->serviceWorkerPageIdentifier());
+
     if (!m_origin)
-        m_origin = ClientOrigin { m_registrationKey.topOrigin(), SecurityOriginData::fromURL(m_data.scriptURL) };
+        m_origin = ClientOrigin { m_registrationKey.topOrigin(), SecurityOriginData::fromURLWithoutStrictOpaqueness(m_data.scriptURL) };
 
     return *m_origin;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -30,6 +30,7 @@
 
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
+#include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/LocalizedStrings.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <wtf/HashMap.h>
@@ -99,6 +100,8 @@ void WebExtensionMatchPattern::registerCustomURLScheme(String urlScheme)
     extensionSchemes().addVoid(canonicalScheme.value());
     validSchemes().addVoid(canonicalScheme.value());
     supportedSchemes().addVoid(canonicalScheme.value());
+
+    LegacySchemeRegistry::registerURLSchemeAsAllowingServiceWorkerClients(canonicalScheme.value());
 
     for (auto& pool : WebProcessPool::allProcessPools())
         pool->sendToAllProcesses(Messages::WebProcess::RegisterURLSchemeAsWebExtension(urlScheme));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
@@ -241,6 +241,7 @@ TEST_F(WKWebExtensionAPIOffscreen, DocumentContentLoads)
     ];
 
     auto *offscreenScript = @[
+        @"browser.test.assertFalse(navigator.serviceWorker.controller === undefined)",
         @"browser.test.notifyPass()"
     ];
 
@@ -301,6 +302,120 @@ TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentAPIAvailability)
         @"background.js": Util::constructScript(script),
         @"offscreen.html": @"<script type='module' src='offscreen.js'></script>",
         @"offscreen.js": Util::constructScript(offscreenScript),
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentVisibleToClientsMatchAll)
+{
+    auto *script = @[
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+
+        @"const offscreenURL = browser.runtime.getURL('offscreen.html')",
+
+        @"const controlledClients = await self.clients.matchAll()",
+        @"browser.test.assertEq(controlledClients.length, 1)",
+        @"browser.test.assertTrue(controlledClients.some((client) => client.url === offscreenURL), 'The offscreen document should be a controlled window client of the background service worker')",
+
+        @"const allClients = await self.clients.matchAll({ includeUncontrolled: true })",
+        @"browser.test.assertEq(allClients.length, 1)",
+        @"browser.test.assertTrue(allClients.some((client) => client.url === offscreenURL), 'The offscreen document should also appear when including uncontrolled clients')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentRemovedFromClientsMatchAllAfterClose)
+{
+    auto *script = @[
+        @"const offscreenURL = browser.runtime.getURL('offscreen.html')",
+        @"const isOffscreenAClient = async () => (await self.clients.matchAll()).some((client) => client.url === offscreenURL)",
+
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"browser.test.assertTrue(await isOffscreenAClient(), 'The offscreen document should be a client while it is open')",
+
+        @"await browser.offscreen.closeDocument()",
+
+        // After closing the document, give the client time to tear down and unregister itself as a client.
+        @"let stillAClient = true",
+        @"for (let attempt = 0; attempt < 50 && stillAClient; ++attempt) {",
+        @"  stillAClient = await isOffscreenAClient()",
+        @"  if (stillAClient)",
+        @"    await new Promise((resolve) => setTimeout(resolve, 50))",
+        @"}",
+
+        @"browser.test.assertFalse(stillAClient, 'The offscreen document should stop being a client after it is closed')",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, ClientsMatchAllUsedAsHasDocumentGuard)
+{
+    auto *script = @[
+        @"const offscreenURL = browser.runtime.getURL('offscreen.html')",
+        @"const hasDocument = async () => (await self.clients.matchAll()).some((client) => client.url === offscreenURL)",
+
+        @"const ensureDocument = async () => {",
+        @"  if (await hasDocument())",
+        @"    return",
+        @"  await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"}",
+
+        @"await ensureDocument()",
+
+        @"browser.test.assertTrue(await browser.offscreen.hasDocument(), 'A single offscreen document should still be open')",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, TabAndOffscreenDocumentVisibleToClientsMatchAll)
+{
+    auto *script = @[
+        @"const offscreenURL = browser.runtime.getURL('offscreen.html')",
+        @"const tabURL = browser.runtime.getURL('tab.html')",
+
+        @"const tabReady = new Promise((resolve) => {",
+        @"  browser.runtime.onMessage.addListener((message) => {",
+        @"    if (message === 'tab ready')",
+        @"      resolve()",
+        @"  })",
+        @"})",
+
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"await browser.tabs.create({ url: 'tab.html' })",
+        @"await tabReady",
+
+        @"const clients = await self.clients.matchAll({ includeUncontrolled: true })",
+        @"browser.test.assertEq(clients.length, 2)",
+        @"browser.test.assertTrue(clients.some((client) => client.url === offscreenURL), 'The offscreen document should be a service worker client')",
+        @"browser.test.assertTrue(clients.some((client) => client.url === tabURL), 'The tab should be a service worker client')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *tabScript = @[
+        @"browser.runtime.sendMessage('tab ready')",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+        @"tab.html": @"<script type='module' src='tab.js'></script>",
+        @"tab.js": Util::constructScript(tabScript),
     }, offscreenConfig);
 }
 


### PR DESCRIPTION
#### 86ddc7a7a759e3741432f7dac824120cb7de5e58
<pre>
Extension background service worker can&apos;t find other extension pages using clients.matchAll
<a href="https://bugs.webkit.org/show_bug.cgi?id=322306">https://bugs.webkit.org/show_bug.cgi?id=322306</a>
<a href="https://rdar.apple.com/185462954">rdar://185462954</a>

Reviewed by Youenn Fablet.

This PR allows custom extension schemes to be found as clients of the service worker if they are
from the same scheme/host.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateServiceWorkerClientData): Don&apos;t return early if the scheme is in the list
of schemes allowed to be service worker clients.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::matchRegistration): Ditto.
(WebCore::DocumentLoader::commitData): Ditto.
(WebCore::DocumentLoader::startLoadingMainResource): Main resources served by a URL scheme handler never create
a NetworkResourceLoader, so the fetch-interception path that normally assigns a controlling service worker
registration cannot run for them. Make sure that we register these.
* Source/WebCore/platform/LegacySchemeRegistry.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::LegacySchemeRegistry::registerURLSchemeAsAllowingServiceWorkerClients):
(WebCore::LegacySchemeRegistry::shouldTreatURLSchemeAsAllowingServiceWorkerClients):
(WebCore::schemesAllowingServiceWorkerClients):
* Source/WebCore/platform/LegacySchemeRegistry.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::origin const): Use the non-strict variant to match how clients are keyed.
SecurityOriginData::fromURL() consults LegacySchemeRegistry::schemeIsHandledBySchemeHandler(), which is only
populated in a web content process, so it would yield an opaque origin here for any non-special scheme served
by a URL scheme handler. This matches the code in validateClientOrigin.
could stall due to the completion handler not being called. This could have been a standalone PR, but the bug
was only brought forward from the rest of this change.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp:
(WebKit::WebExtensionMatchPattern::registerCustomURLScheme): Add the custom scheme to the schemes for service
worker registration.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentVisibleToClientsMatchAll)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentRemovedFromClientsMatchAllAfterClose)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, ClientsMatchAllUsedAsHasDocumentGuard)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, DocumentContentLoads)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, TabAndOffscreenDocumentVisibleToClientsMatchAll)):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::matchAll):

Canonical link: <a href="https://commits.webkit.org/319898@main">https://commits.webkit.org/319898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e33b3117a6f942b9b78d5bb01e6ca8e2a74fa9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147205 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7852eea3-7643-4e2a-aae8-6c3f0b40a8dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d234fb48-1be3-4e4b-bb93-7b44d5794b89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123193 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43428 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43057 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4307 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56509 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40837 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57214 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151926 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46487 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129483 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125571 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18067 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55093 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->