### PR TITLE
[JSC] Procedure::usesSIMD() not set when OMG inlines a SIMD callee into a non-SIMD root

### DIFF
--- a/JSTests/wasm/stress/inline-wasm-simd-into-non-simd.js
+++ b/JSTests/wasm/stress/inline-wasm-simd-into-non-simd.js
@@ -1,0 +1,54 @@
+load("../libwabt.js");
+
+const NUM_REFS = 49;
+
+let wabt = await WabtModule();
+
+let refParams = "", refResults = "", pushResults = "";
+
+for (let i = 1; i <= NUM_REFS; i++) {
+    refParams  += " externref";
+    refResults += " externref";
+    pushResults += `(local.get ${i})\n`;
+}
+
+const wat = `
+(module
+  (tag $T (param i64 i64 i64 v128))
+  (func $B (param i64)
+    (throw $T (i64.const 0) (i64.const 0) (i64.const 0)
+              (i64x2.splat (local.get 0))))
+  (func $A (export "A") (param i64${refParams}) (result${refResults})
+    (try
+      (do (call $B (local.get 0)))
+      (catch_all))
+    ${pushResults}
+  )
+)`;
+
+const bin = wabt.parseWat("filenamesAreCool", wat, { simd: true, exceptions: true, reference_types: true, multi_value: true }).toBinary({}).buffer;
+const inst = new WebAssembly.Instance(new WebAssembly.Module(bin), {});
+const A = inst.exports.A;
+
+const sentinel = { marker: "SENTINEL" };
+const args = [0xan];
+for (let i = 0; i < NUM_REFS; i++)
+    args.push(sentinel);
+
+// Tier $A up to OMG.
+let last;
+for (let i = 0; i < testLoopCount; i++)
+    last = A.apply(null, args);
+
+let bad = -1;
+
+for (let k = 0; k < NUM_REFS; k++) {
+    if (last[k] !== sentinel) {
+        bad = k;
+        break;
+    }
+}
+
+if (bad >= 0) {
+    throw new Error("usesSIMD desync");
+}

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -58,7 +58,7 @@ Procedure::Procedure(bool usesSIMD)
     , m_heaps(makeUniqueRef<AbstractHeapRepository>())
 {
     if (usesSIMD)
-        setUsessSIMD();
+        setUsesSIMD();
     // Initialize all our fields before constructing Air::Code since
     // it looks into our fields.
     m_code = std::unique_ptr<Air::Code>(new Air::Code(*this));

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -292,7 +292,7 @@ public:
     bool shouldDumpIR() const { return m_shouldDumpIR; }
     JS_EXPORT_PRIVATE void NODELETE setShouldDumpIR();
 
-    void setUsessSIMD()
+    void setUsesSIMD()
     { 
         RELEASE_ASSERT(Options::useWasmSIMD());
         m_usesSIMD = true;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -497,7 +497,13 @@ public:
     }
 
     // SIMD
-    void NODELETE notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
+    bool NODELETE usesSIMD() const { return m_info.usesSIMD(m_functionIndex); }
+    void NODELETE notifyFunctionUsesSIMD()
+    {
+        ASSERT(m_info.usesSIMD(m_functionIndex));
+        m_proc.setUsesSIMD();
+    }
+
     [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint64_t offset, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);


### PR DESCRIPTION
#### 9a17cd1100ad6cd41afa7aa1f0a2fa5a2e797a10
<pre>
[JSC] Procedure::usesSIMD() not set when OMG inlines a SIMD callee into a non-SIMD root
<a href="https://bugs.webkit.org/show_bug.cgi?id=316918">https://bugs.webkit.org/show_bug.cgi?id=316918</a>
<a href="https://rdar.apple.com/177938898">rdar://177938898</a>

Reviewed by Yusuke Suzuki and Dan Hecht.

This patch makes OMGIRGenerator mark the procedure as using SIMD when the parser
detects SIMD instructions.

Test: JSTests/wasm/stress/inline-wasm-simd-into-non-simd.js

* JSTests/wasm/stress/inline-wasm-simd-into-non-simd.js: Added.
(try.call.B.local.0):
(const.inst.new.WebAssembly.Instance.new.WebAssembly.Module):
* Source/JavaScriptCore/b3/B3Procedure.cpp:
(JSC::B3::Procedure::Procedure):
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setUsesSIMD):
(JSC::B3::Procedure::setUsessSIMD): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::notifyFunctionUsesSIMD):

Originally-landed-as: 305413.976@safari-7624.5-branch (cdf687829ac6). <a href="https://rdar.apple.com/185368152">rdar://185368152</a>
Canonical link: <a href="https://commits.webkit.org/319839@main">https://commits.webkit.org/319839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617de4344f16c6bb9a91f58020457521bce6df92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43392 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5137 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11966 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43026 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4265 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44145 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56467 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152193 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57172 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46454 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129441 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55680 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55051 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->