### PR TITLE
dialog close() restores focus unconditionally instead of only when focus is inside the dialog or it was modal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
@@ -5,7 +5,7 @@ PASS Clicking outside, when focusin removes and reinserts, modeless
 PASS Pressing escape, when focusin closes dialog, modeless
 PASS Clicking outside, when focusin closes dialog, modeless
 FAIL Pressing escape, when focusin calls showModal, modeless assert_equals: Dialog should respond to ESC expected true but got false
-FAIL Clicking outside, when focusin calls showModal, modeless assert_equals: Dialog respond to light dismiss expected true but got false
+PASS Clicking outside, when focusin calls showModal, modeless
 PASS Pressing escape, when beforetoggle closes dialog, modeless
 PASS Clicking outside, when beforetoggle closes dialog, modeless
 PASS Pressing escape, when beforetoggle calls showModal, modeless

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
@@ -1,9 +1,7 @@
 button 1 button 2
 
-FAIL Focus should not be restored if the currently focused element is not inside the dialog. assert_equals: expected Element node <button id="b2">button 2</button> but got Element node <button id="b1">button 1</button>
-FAIL Focus restore should not occur when the focused element is in a shadowroot outside of the dialog. assert_equals: document.activeElement should point at the shadow host. expected Element node <div id="host">
-
-</div> but got Element node <button id="b2">button 2</button>
+PASS Focus should not be restored if the currently focused element is not inside the dialog.
+PASS Focus restore should not occur when the focused element is in a shadowroot outside of the dialog.
 PASS Focus restore should occur when the focused element is in a shadowroot inside the dialog.
 PASS Focus restore should occur when the focused element is slotted into a dialog.
 PASS Focus restore should always occur for modal dialogs.

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -252,7 +252,9 @@ void HTMLDialogElement::close(const String& result, Element* source)
 
     removeAttribute(openAttr);
 
-    if (isModal())
+    bool wasModal = isModal();
+
+    if (wasModal)
         removeFromTopLayer();
 
     setIsModal(false);
@@ -260,15 +262,14 @@ void HTMLDialogElement::close(const String& result, Element* source)
     if (!result.isNull())
         m_returnValue = result;
 
-    // FIXME: Focus should only be restored when the document's focused element is still inside
-    // this dialog, or when the dialog was modal. Adding that condition requires show() to run the
-    // dialog focusing steps reliably first: focusability is determined from a possibly stale
-    // computed style, so for a dialog that was previously shown and closed no candidate looks
-    // focusable and focus never enters the dialog. See webkit.org/b/321623.
     if (RefPtr element = std::exchange(m_previouslyFocusedElement, nullptr).get()) {
-        FocusOptions options;
-        options.preventScroll = true;
-        element->focus(options);
+        RefPtr focusedElement = document().focusedElement();
+        bool focusIsInsideDialog = focusedElement == this || (focusedElement && focusedElement->isComposedTreeDescendantOf(*this));
+        if (wasModal || focusIsInsideDialog) {
+            FocusOptions options;
+            options.preventScroll = true;
+            element->focus(options);
+        }
     }
 
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));


### PR DESCRIPTION
#### baf4a9a7ec0b8436f3dec8cb8c4b418f0795a308
<pre>
dialog close() restores focus unconditionally instead of only when focus is inside the dialog or it was modal
<a href="https://bugs.webkit.org/show_bug.cgi?id=322310">https://bugs.webkit.org/show_bug.cgi?id=322310</a>
<a href="https://rdar.apple.com/185549474">rdar://185549474</a>

Reviewed by Tim Nguyen.

The close the dialog steps gate the focus restore [1]:

    If subject&apos;s node document&apos;s focused area of the document&apos;s DOM anchor is a
    shadow-including inclusive descendant of subject, or wasModal is true, then
    run the focusing steps for element; the viewport should not be scrolled by
    doing this step.

We ran that unconditionally, so closing a non-modal dialog yanked focus back
even when the author had moved it elsewhere. The stray focus change is
observable: it fires focusin, letting a listener re-enter the dialog&apos;s own state
machine. Capture wasModal after removing the open attribute, matching the spec&apos;s
step order, and gate on it.

The check uses the composed tree, not the shadow-including tree: a node slotted
into a dialog inside a shadow root is not a shadow-including descendant, yet
focus restore is expected for it. See whatwg/html#8904 [2], cited by
dialog-focus-previous-outside.html for that case.

This removes the FIXME from 319173@main and fixes the bug by handling focus
properly.

[1] <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#close-the-dialog">https://html.spec.whatwg.org/multipage/interactive-elements.html#close-the-dialog</a>
[2] <a href="https://github.com/whatwg/html/issues/8904">https://github.com/whatwg/html/issues/8904</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt: Ditto
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::close):

Canonical link: <a href="https://commits.webkit.org/319640@main">https://commits.webkit.org/319640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea4dd7265f4134f3777efdd1fde8b1a92293d6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146406 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aff4ea17-e194-48a9-abb2-e2d991bd4525) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea5cd55e-1346-469e-b128-f421b9350e5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122585 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42799 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42421 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194231 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55695 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151571 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40588 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56386 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151274 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45850 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128669 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54897 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17417 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->