### PR TITLE
[JSC] Make Air::padInference faster by avoiding visiting args twice

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirInst.cpp
+++ b/Source/JavaScriptCore/b3/air/AirInst.cpp
@@ -57,10 +57,21 @@ bool Inst::hasLateUseOrDef()
     return result;
 }
 
-bool Inst::needsPadding(Inst* prevInst, Inst* nextInst)
+Inst::PaddingSummary Inst::paddingSummary()
 {
-    bool result = prevInst && nextInst && prevInst->hasLateUseOrDef() && nextInst->hasEarlyDef();
-    return result;
+    PaddingSummary summary;
+    if (kind.opcode == Patch) {
+        summary.hasEarlyDef = !extraEarlyClobberedRegs().isEmpty();
+        summary.hasLateUseOrDef = !extraClobberedRegs().isEmpty();
+        if (summary.hasEarlyDef && summary.hasLateUseOrDef)
+            return summary;
+    }
+    forEachArg(
+        [&] (Arg&, Arg::Role role, Bank, Width) {
+            summary.hasEarlyDef |= Arg::isEarlyDef(role);
+            summary.hasLateUseOrDef |= Arg::isLateUse(role) || Arg::isLateDef(role);
+        });
+    return summary;
 }
 
 bool Inst::hasArgEffects()

--- a/Source/JavaScriptCore/b3/air/AirInst.h
+++ b/Source/JavaScriptCore/b3/air/AirInst.h
@@ -194,12 +194,15 @@ struct Inst {
     template<typename Thing, typename Functor>
     static void forEachUse(Inst* prevInst, Inst* nextInst, const Functor&);
 
-    // Some summaries about all arguments. These are useful for needsPadding().
+    struct PaddingSummary {
+        bool hasEarlyDef { false };
+        bool hasLateUseOrDef { false };
+    };
+    PaddingSummary paddingSummary();
+
     bool hasEarlyDef();
     bool hasLateUseOrDef();
 
-    static bool needsPadding(Inst* prevInst, Inst* nextInst);
-    
     // Use this to report which registers are live. This should be done just before codegen. Note
     // that for efficiency, reportUsedRegisters() only works for the Patch opcode.
     void reportUsedRegisters(const RegisterSet&);

--- a/Source/JavaScriptCore/b3/air/AirPadInterference.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPadInterference.cpp
@@ -30,6 +30,8 @@
 
 #include "AirCode.h"
 #include "AirInsertionSet.h"
+#include "AirInstInlines.h"
+#include "Options.h"
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -37,10 +39,16 @@ void padInterference(Code& code)
 {
     InsertionSet insertionSet(code);
     for (BasicBlock* block : code) {
+        if (block->size() < 2)
+            continue;
+
+        bool prevHasLateUseOrDef = block->at(0).paddingSummary().hasLateUseOrDef;
         for (unsigned instIndex = 1; instIndex < block->size(); ++instIndex) {
             Inst& inst = block->at(instIndex);
-            if (Inst::needsPadding(&block->at(instIndex - 1), &inst))
+            Inst::PaddingSummary summary = inst.paddingSummary();
+            if (prevHasLateUseOrDef && summary.hasEarlyDef)
                 insertionSet.insert(instIndex, Padding, inst.origin);
+            prevHasLateUseOrDef = summary.hasLateUseOrDef;
         }
         insertionSet.execute(block);
     }


### PR DESCRIPTION
#### 2cba6521075d9a3a968a4a00f5e352f6e578c61f
<pre>
[JSC] Make Air::padInference faster by avoiding visiting args twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=322311">https://bugs.webkit.org/show_bug.cgi?id=322311</a>
<a href="https://rdar.apple.com/185549590">rdar://185549590</a>

Reviewed by Dan Hecht.

Avoiding calling forEachArg twice and collecting hasEarlyDef /
hasLateUseOrDef at once via paddingSummary.

* Source/JavaScriptCore/b3/air/AirInst.cpp:
(JSC::B3::Air::Inst::paddingSummary):
(JSC::B3::Air::Inst::needsPadding): Deleted.
* Source/JavaScriptCore/b3/air/AirInst.h:
* Source/JavaScriptCore/b3/air/AirPadInterference.cpp:
(JSC::B3::Air::padInterference):

Canonical link: <a href="https://commits.webkit.org/319642@main">https://commits.webkit.org/319642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a12fa66a679c88f0d57f672067c7b017ab4c0fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146445 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25a6c6f6-b19a-4fad-80ef-f0a5a244f9e9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55786 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44a364e8-cc5c-45ac-b214-65a8d13fd562) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122592 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5243ea53-2839-4818-8de7-4925a6ba1358) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44562 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4558 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11394 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42451 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43399 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48694 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194270 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55734 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194270 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56425 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194270 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45879 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128708 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124544 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54936 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17447 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54317 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->