### PR TITLE
Cherry-pick 305413.951@safari-7624.4-branch (3cbf2f5adfe0). https://bugs.webkit.org/show_bug.cgi?id=311800

### DIFF
--- a/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
+++ b/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
@@ -1,0 +1,40 @@
+//@ runDefault("--forceEagerCompilation=1")
+
+let total = 0;
+function check(v3) {
+    if (++total > 10000)
+        quit(0);
+    transferArrayBuffer(v3);
+}
+noInline(check);
+
+function main() {
+    function v2(v3) {
+        for (let v9 = 0; v9 < 1024; v9 = v9 + 1) {
+            try {
+                check(v3);
+            } catch {
+                const x = (() => {
+                    const a = new Array(8);
+                    a[0] = {}, a[1] = {}, a[2] = {}, a[3] = {}, a[0] = {}, a[5] = {}, a[6] = {}, a[7] = {};
+                    return a;
+                })();
+                const y = (() => {
+                    const r = [];
+                    for (let i = 0; i < 16; i++) { }
+                })();
+                try {
+                    for (let i = 0; i < 16; i++) {
+                        const o = {};
+                        try {
+                            main(o);
+                            x.__proto__ = Math.LN2;
+                        } catch { }
+                    }
+                } catch { }
+            }
+        }
+    }
+    const v11 = v2();
+}
+main();

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -81,7 +81,8 @@ static void reboxAccordingToFormat(
         break;
     }
 
-    case DataFormatJS: {
+    case DataFormatJS:
+    case DataFormatStorage: {
         // Done already!
         break;
     }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -58,6 +58,7 @@
 #include "SourceBufferPrivate.h"
 #include "TextTrackList.h"
 #include "TimeRanges.h"
+#include "TrackOpaqueRoot.h"
 #include "VideoTrack.h"
 #include "VideoTrackList.h"
 #include "VideoTrackPrivate.h"
@@ -179,7 +180,7 @@ SourceBuffer::SourceBuffer(Ref<SourceBufferPrivate>&& sourceBufferPrivate, Media
     , m_private(WTF::move(sourceBufferPrivate))
     , m_client(SourceBufferClientImpl::create(*this))
     , m_source(&source)
-    , m_opaqueRootProvider(Observer<WebCoreOpaqueRoot()>::create([opaqueRoot = WebCoreOpaqueRoot { this }] { return opaqueRoot; }))
+    , m_trackOpaqueRoot(TrackOpaqueRoot::create(opaqueRoot()))
     , m_appendWindowStart(MediaTime::zeroTime())
     , m_appendWindowEnd(MediaTime::positiveInfiniteTime())
     , m_appendState(WaitingForSegment)
@@ -199,6 +200,7 @@ SourceBuffer::~SourceBuffer()
 {
     ASSERT(isRemoved());
     ALWAYS_LOG(LOGIDENTIFIER);
+    m_trackOpaqueRoot->clear();
 }
 
 ExceptionOr<Ref<TimeRanges>> SourceBuffer::buffered()
@@ -732,7 +734,7 @@ VideoTrackList& SourceBuffer::videoTracks()
     if (!m_videoTracks) {
         Ref videoTracks = VideoTrackList::create(protect(scriptExecutionContext()).get());
         m_videoTracks = videoTracks.copyRef();
-        videoTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        videoTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_videoTracks;
 }
@@ -742,7 +744,7 @@ AudioTrackList& SourceBuffer::audioTracks()
     if (!m_audioTracks) {
         Ref audioTracks = AudioTrackList::create(protect(scriptExecutionContext()).get());
         m_audioTracks = audioTracks.copyRef();
-        audioTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        audioTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_audioTracks;
 }
@@ -752,7 +754,7 @@ TextTrackList& SourceBuffer::textTracks()
     if (!m_textTracks) {
         Ref textTracks = TextTrackList::create(protect(scriptExecutionContext()).get());
         m_textTracks = textTracks.copyRef();
-        textTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        textTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_textTracks;
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -56,6 +56,7 @@ class PlatformTimeRanges;
 class SourceBufferPrivate;
 class TextTrackList;
 class TimeRanges;
+class TrackOpaqueRoot;
 class VideoTrackList;
 class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
@@ -227,7 +228,7 @@ private:
     WeakPtr<MediaSource> m_source;
     AppendMode m_mode { AppendMode::Segments };
 
-    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
+    const Ref<TrackOpaqueRoot> m_trackOpaqueRoot;
 
     RefPtr<SharedBuffer> m_pendingAppendData;
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -737,6 +737,7 @@ bindings/js/JSFetchEventCustom.cpp
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp @cost:3
+bindings/js/JSHTMLMediaElementCustom.cpp
 bindings/js/JSHTMLTemplateElementCustom.cpp
 bindings/js/JSHistoryCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -16982,6 +16982,8 @@
 		9B56C9A81C89312800C456DF /* CustomElementReactionQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomElementReactionQueue.h; sourceTree = "<group>"; };
 		9B56C9A91C89329A00C456DF /* CustomElementReactionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CustomElementReactionQueue.cpp; sourceTree = "<group>"; };
 		9B6116491F6A593300E923B8 /* WebContentReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebContentReader.cpp; sourceTree = "<group>"; };
+		9B672EC52FDC971500D9F683 /* JSHTMLMediaElementCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLMediaElementCustom.cpp; sourceTree = "<group>"; };
+		9B672EC62FDC98BF00D9F683 /* TrackOpaqueRoot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackOpaqueRoot.h; sourceTree = "<group>"; };
 		9B69D3B11B98FF0A00E3512B /* HTMLSlotElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HTMLSlotElement.idl; sourceTree = "<group>"; };
 		9B69D3B21B98FFE900E3512B /* HTMLSlotElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLSlotElement.cpp; sourceTree = "<group>"; };
 		9B69D3B31B98FFE900E3512B /* HTMLSlotElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTMLSlotElement.h; sourceTree = "<group>"; };
@@ -32355,6 +32357,7 @@
 				4131F3B11F9552810059995A /* JSFetchEventCustom.cpp */,
 				84BBE5482597E7F100AA8F28 /* JSHTMLAllCollectionCustom.cpp */,
 				6E576BC324EB509C0094D4AA /* JSHTMLCanvasElementCustom.cpp */,
+				9B672EC52FDC971500D9F683 /* JSHTMLMediaElementCustom.cpp */,
 				D6F7960C166FFECE0076DD18 /* JSHTMLTemplateElementCustom.cpp */,
 				511EF2CE17F0FDF100E4FA16 /* JSIDBObjectStoreCustom.cpp */,
 				51E269321DD3BC43006B6A58 /* JSIDBTransactionCustom.cpp */,
@@ -36003,6 +36006,7 @@
 				070334D21459FFAC008D8D45 /* TrackEvent.idl */,
 				BE88E0BF1715CE2600658D98 /* TrackListBase.cpp */,
 				BE88E0C01715CE2600658D98 /* TrackListBase.h */,
+				9B672EC62FDC98BF00D9F683 /* TrackOpaqueRoot.h */,
 				BE88E0D21715D2A200658D98 /* VideoTrack.cpp */,
 				BE88E0D31715D2A200658D98 /* VideoTrack.h */,
 				BE88E0D41715D2A200658D98 /* VideoTrack.idl */,

--- a/Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSHTMLMediaElement.h"
+
+#include "TrackOpaqueRoot.h"
+#include "WebCoreOpaqueRootInlines.h"
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSHTMLMediaElement::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    addWebCoreOpaqueRoot(visitor, wrapped().trackOpaqueRoot().opaqueRoot());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSHTMLMediaElement);
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -143,6 +143,7 @@
 #include "TextTrackRepresentation.h"
 #include "ThreadableBlobRegistry.h"
 #include "TimeRanges.h"
+#include "TrackOpaqueRoot.h"
 #include "UserContentController.h"
 #include "UserGestureIndicator.h"
 #include "VideoPlaybackQuality.h"
@@ -649,10 +650,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_haveVisibleTextTrack(false)
     , m_processingPreferenceChange(false)
     , m_volumeLocked(defaultVolumeLocked())
-    , m_opaqueRootProvider(WTF::Observer<WebCoreOpaqueRoot()>::create([weakThis = WeakPtr { *this }] {
-        // This gets called on a GC thread so we cannot ref `this`.
-        return weakThis->opaqueRoot();
-    }))
+    , m_trackOpaqueRoot(TrackOpaqueRoot::create(WebCoreOpaqueRoot { this }))
 #if USE(AUDIO_SESSION)
     , m_categoryAtMostRecentPlayback(AudioSessionCategory::None)
     , m_modeAtMostRecentPlayback(AudioSessionMode::Default)
@@ -786,6 +784,8 @@ HTMLMediaElement::~HTMLMediaElement()
     invalidateBufferingStopwatch();
 
     beginIgnoringTrackDisplayUpdateRequests();
+
+    m_trackOpaqueRoot->clear();
 
     if (m_textTracks) {
         for (unsigned i = 0; i < m_textTracks->length(); ++i) {
@@ -5422,7 +5422,7 @@ AudioTrackList& HTMLMediaElement::ensureAudioTracks()
 {
     if (!m_audioTracks) {
         lazyInitialize(m_audioTracks, AudioTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
-        m_audioTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_audioTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
 
     return *m_audioTracks;
@@ -5432,7 +5432,7 @@ TextTrackList& HTMLMediaElement::ensureTextTracks()
 {
     if (!m_textTracks) {
         lazyInitialize(m_textTracks, TextTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
-        m_textTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_textTracks->setOpaqueRoot(m_trackOpaqueRoot);
         m_textTracks->setDuration(durationMediaTime());
     }
 
@@ -5443,7 +5443,7 @@ VideoTrackList& HTMLMediaElement::ensureVideoTracks()
 {
     if (!m_videoTracks) {
         lazyInitialize(m_videoTracks, VideoTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
-        m_videoTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_videoTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
 
     return *m_videoTracks;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -114,6 +114,7 @@ class SleepDisabler;
 class SourceBuffer;
 class SpeechSynthesis;
 class TextTrackList;
+class TrackOpaqueRoot;
 class TimeRanges;
 class VideoPlaybackQuality;
 class VideoTrackList;
@@ -194,6 +195,8 @@ public:
     // ActiveDOMObject, AudioSessionConfigurationChangeObserver.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
+
+    TrackOpaqueRoot& trackOpaqueRoot() { return m_trackOpaqueRoot; }
 
     MediaPlayer* player() const { return m_player.get(); }
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;
@@ -1386,6 +1389,7 @@ private:
 
     std::optional<CaptionUserPreferences::CaptionDisplayMode> m_captionDisplayMode;
 
+    Ref<TrackOpaqueRoot> m_trackOpaqueRoot;
     const RefPtr<AudioTrackList> m_audioTracks;
     const RefPtr<TextTrackList> m_textTracks;
     const RefPtr<VideoTrackList> m_videoTracks;
@@ -1421,7 +1425,6 @@ private:
     RefPtr<Blob> m_blob;
     URLKeepingBlobAlive m_blobURLForReading;
     std::optional<MediaProvider> m_mediaProvider;
-    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RefPtr<WebKitMediaKeys> m_webKitMediaKeys;

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -43,6 +43,7 @@ typedef (
     ActiveDOMObject,
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
+    JSCustomMarkFunction,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface HTMLMediaElement : HTMLElement {

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -46,6 +46,15 @@ TextTrackList::TextTrackList(ScriptExecutionContext* context)
 
 TextTrackList::~TextTrackList() = default;
 
+void TextTrackList::setOpaqueRoot(TrackOpaqueRoot& trackOpaqueRoot)
+{
+    TrackListBase::setOpaqueRoot(trackOpaqueRoot);
+    for (Ref track : m_addTrackTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+    for (Ref track : m_elementTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+}
+
 unsigned TextTrackList::length() const
 {
     return m_addTrackTracks.size() + m_elementTracks.size() + m_inbandTracks.size();

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -46,6 +46,8 @@ public:
     }
     virtual ~TextTrackList();
 
+    void setOpaqueRoot(TrackOpaqueRoot&) final;
+
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const final;
     int getTrackIndex(TextTrack&);

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Logging.h"
 #include "TrackListBase.h"
+#include "TrackOpaqueRoot.h"
 #include "TrackPrivateBase.h"
 #include "TrackPrivateBaseClient.h"
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -92,6 +93,18 @@ void TrackBase::didMoveToNewDocument(Document& newDocument)
     observeContext(protect(newDocument.contextDocument()).ptr());
 }
 
+void TrackBase::setOpaqueRoot(TrackOpaqueRoot& opaqueRoot)
+{
+    m_trackOpaqueRoot = opaqueRoot;
+}
+
+WebCoreOpaqueRoot TrackBase::opaqueRoot() const
+{
+    if (RefPtr trackOpaqueRoot = m_trackOpaqueRoot)
+        return trackOpaqueRoot->opaqueRoot();
+    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
+}
+
 #if ENABLE(MEDIA_SOURCE)
 SourceBuffer* TrackBase::sourceBuffer() const
 {
@@ -107,24 +120,18 @@ void TrackBase::setSourceBuffer(SourceBuffer* buffer)
 void TrackBase::setTrackList(TrackListBase& trackList)
 {
     m_trackList = trackList;
+    m_trackOpaqueRoot = trackList.trackOpaqueRoot();
 }
 
 void TrackBase::clearTrackList()
 {
     m_trackList = nullptr;
+    m_trackOpaqueRoot = nullptr;
 }
 
 TrackListBase* TrackBase::trackList() const
 {
     return m_trackList.get();
-}
-
-WebCoreOpaqueRoot TrackBase::opaqueRoot() const
-{
-    // Runs on GC thread.
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* trackList = this->trackList())
-        return trackList->opaqueRoot();
-    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
 }
 
 // See: https://tools.ietf.org/html/bcp47#section-2.1

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/WebCoreOpaqueRoot.h>
+#include <atomic>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -40,6 +41,7 @@ class Document;
 class SourceBuffer;
 class TrackListBase;
 class WeakPtrImplWithEventTargetData;
+class TrackOpaqueRoot;
 class TrackPrivateBase;
 class TrackPrivateBaseClient;
 using TrackID = uint64_t;
@@ -80,6 +82,7 @@ public:
     void setTrackList(TrackListBase&);
     void clearTrackList();
     TrackListBase* NODELETE trackList() const;
+    void setOpaqueRoot(TrackOpaqueRoot&);
     WebCoreOpaqueRoot NODELETE opaqueRoot() const;
 
     virtual bool enabled() const = 0;
@@ -122,6 +125,7 @@ private:
     uint64_t m_logIdentifier { 0 };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
+    RefPtr<TrackOpaqueRoot> m_trackOpaqueRoot;
     size_t m_clientRegistrationId { 0 };
 };
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -33,6 +33,7 @@
 #include "EventNames.h"
 #include "ScriptExecutionContext.h"
 #include "TrackEvent.h"
+#include "TrackOpaqueRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -58,11 +59,17 @@ void TrackListBase::didMoveToNewDocument(Document& newDocument)
         track->didMoveToNewDocument(newDocument);
 }
 
+void TrackListBase::setOpaqueRoot(TrackOpaqueRoot& trackOpaqueRoot)
+{
+    m_trackOpaqueRoot = &trackOpaqueRoot;
+    for (Ref track : m_inbandTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+}
+
 WebCoreOpaqueRoot TrackListBase::opaqueRoot() const
 {
-    // Cannot ref the observer as this gets called on a GC thread.
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* rootObserver = m_opaqueRootObserver.get())
-        return (*rootObserver)();
+    if (RefPtr trackOpaqueRoot = m_trackOpaqueRoot)
+        return trackOpaqueRoot->opaqueRoot();
     return WebCoreOpaqueRoot { const_cast<TrackListBase*>(this) };
 }
 

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class TrackBase;
+class TrackOpaqueRoot;
 using TrackID = uint64_t;
 
 class TrackListBase : public RefCounted<TrackListBase>, public EventTarget, public ActiveDOMObject {
@@ -64,8 +65,8 @@ public:
 
     void didMoveToNewDocument(Document&);
 
-    using OpaqueRootObserver = WTF::Observer<WebCoreOpaqueRoot()>;
-    void setOpaqueRootObserver(const OpaqueRootObserver& observer) { m_opaqueRootObserver = observer; };
+    TrackOpaqueRoot* trackOpaqueRoot() { return m_trackOpaqueRoot.get(); }
+    virtual void setOpaqueRoot(TrackOpaqueRoot&);
 
     // Needs to be public so tracks can call it
     void scheduleChangeEvent();
@@ -88,7 +89,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    WeakPtr<OpaqueRootObserver> m_opaqueRootObserver;
+    RefPtr<TrackOpaqueRoot> m_trackOpaqueRoot;
     bool m_isChangeEventScheduled { false };
 };
 

--- a/Source/WebCore/html/track/TrackOpaqueRoot.h
+++ b/Source/WebCore/html/track/TrackOpaqueRoot.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebCoreOpaqueRoot.h"
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class TrackOpaqueRoot : public ThreadSafeRefCounted<TrackOpaqueRoot> {
+public:
+    static Ref<TrackOpaqueRoot> create(const WebCoreOpaqueRoot& root)
+    {
+        return adoptRef(*new TrackOpaqueRoot(root));
+    }
+
+    WebCoreOpaqueRoot opaqueRoot() const { return m_opaqueRoot; }
+    void clear() { m_opaqueRoot = nullptr; }
+
+private:
+    TrackOpaqueRoot(const WebCoreOpaqueRoot& root)
+        : m_opaqueRoot(root)
+    { }
+
+    WebCoreOpaqueRoot m_opaqueRoot;
+};
+
+}


### PR DESCRIPTION
#### 8b15b7ea86363a8cac72bfee3b661090864b633d
<pre>
Cherry-pick 305413.951@safari-7624.4-branch (3cbf2f5adfe0). <a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>

    Data race in TrackBase::opaqueRoot during GC leading to use-after-free
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>
    <a href="https://rdar.apple.com/176058579">rdar://176058579</a>

    Reviewed by Geoffrey Garen.

    To fix the data race, we introduce SourceBuffer and HTMLMediaElement as opaque roots for Track* classes
    and *TrackList classes instead of using the root node of HTMLMediaElement which can change over time.

    We introduce TrackOpaqueRoot, which is a thin ThreadSafeRefCounted wrapper around WebCoreOpaqueRoot,
    and initialize it with WebCoreOpaqueRoot pointing to SourceBuffer or HTMLMediaElement.

    Each Track and TrackList class will have RefPtr&lt;TrackOpaqueRoot&gt; and reads the opaque root directly
    from a GC thread without relying on any pointer indirections.

    No new tests since there is no reliable way to test this data race.

    * Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
    (WebCore::SourceBuffer::SourceBuffer):
    (WebCore::SourceBuffer::~SourceBuffer):
    (WebCore::SourceBuffer::videoTracks):
    (WebCore::SourceBuffer::audioTracks):
    (WebCore::SourceBuffer::textTracks):
    (WebCore::m_logIdentifier): Deleted.
    * Source/WebCore/Modules/mediasource/SourceBuffer.h:
    * Source/WebCore/Sources.txt:
    * Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    * Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp: Added.
    (WebCore::JSHTMLMediaElement::visitAdditionalChildren):
    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::m_trackOpaqueRoot):
    (WebCore::HTMLMediaElement::~HTMLMediaElement):
    (WebCore::HTMLMediaElement::ensureAudioTracks):
    (WebCore::HTMLMediaElement::ensureTextTracks):
    (WebCore::HTMLMediaElement::ensureVideoTracks):
    (WebCore::m_opaqueRootProvider): Deleted.
    * Source/WebCore/html/HTMLMediaElement.h:
    (WebCore::HTMLMediaElement::trackOpaqueRoot):
    * Source/WebCore/html/HTMLMediaElement.idl:
    * Source/WebCore/html/track/TextTrackList.cpp:
    (WebCore::TextTrackList::setOpaqueRoot):
    * Source/WebCore/html/track/TextTrackList.h:
    * Source/WebCore/html/track/TrackBase.cpp:
    (WebCore::TrackBase::setOpaqueRoot):
    (WebCore::TrackBase::opaqueRoot):
    (WebCore::TrackBase::setTrackList):
    (WebCore::TrackBase::clearTrackList):
    * Source/WebCore/html/track/TrackBase.h:
    * Source/WebCore/html/track/TrackListBase.cpp:
    (WebCore::TrackListBase::setOpaqueRoot):
    (WebCore::TrackListBase::opaqueRoot):
    * Source/WebCore/html/track/TrackListBase.h:
    (WebCore::TrackListBase::trackOpaqueRoot):
    (WebCore::TrackListBase::setOpaqueRootObserver): Deleted.
    * Source/WebCore/html/track/TrackOpaqueRoot.h: Added.
    (WebCore::TrackOpaqueRoot::create):
    (WebCore::TrackOpaqueRoot::opaqueRoot const):
    (WebCore::TrackOpaqueRoot::clear):
    (WebCore::TrackOpaqueRoot::TrackOpaqueRoot):

    Identifier: 305413.951@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/317695.137@webkitglib/2.54">https://commits.webkit.org/317695.137@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 5d96a4934eed0228239c55f399969dd18859840a
<pre>
Cherry-pick 305413.922@safari-7624.4-branch (883cc7576689). <a href="https://bugs.webkit.org/show_bug.cgi?id=314579">https://bugs.webkit.org/show_bug.cgi?id=314579</a>

    [JSC] FTL OSR exit: handle DataFormatStorage in reboxAccordingToFormat
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314579">https://bugs.webkit.org/show_bug.cgi?id=314579</a>
    <a href="https://rdar.apple.com/176131036">rdar://176131036</a>

    Reviewed by Marcus Plutowski.

    300523@main relaxed validation so that PhantomNewArrayWithButterfly may
    reference a non-phantom NewButterflyWithSize, and taught
    FTLLowerDFGToB3::exitValueForNode to emit an ExitArgument with
    DataFormatStorage for the live butterfly. However, the FTL OSR exit
    compiler&apos;s reboxAccordingToFormat() was never updated, so when such an
    exit is compiled it falls into RELEASE_ASSERT_NOT_REACHED().

    The recovered storage value is the raw butterfly pointer that
    operationMaterializeObjectInOSR(PhantomNewArrayWithButterfly) consumes
    via std::bit_cast&lt;Butterfly*&gt;, so no boxing is required; treat it the
    same as DataFormatJS and pass it through unchanged.

    Test: JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js

    * JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js: Added.
    (check):
    (main.v2):
    (main):
    * Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
    (JSC::FTL::reboxAccordingToFormat):

    Identifier: 305413.922@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/317695.136@webkitglib/2.54">https://commits.webkit.org/317695.136@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da5c9beaa7f9237aa3a9daa6304bdb5fbbb9d6ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182143 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56090 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146472 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184005 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57406 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55813 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142175 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146472 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185098 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57406 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122608 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57406 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55813 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4574 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57406 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3533 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/43427 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48721 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55813 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194297 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55761 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151595 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56452 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151297 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27663 "") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56452 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128735 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124582 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54963 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49896 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54344 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54583 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54411 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->