### PR TITLE
[webkitbugspy] Cannot remove a relation between two issues

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(0, 15, 4)
+version = Version(0, 15, 5)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -596,54 +596,57 @@ class Tracker(GenericTracker):
 
         return result
 
+    RELATIONS = ('depends_on', 'blocks', 'regressed_by', 'regressions')
+
     def related_issue_id(self, issue):
         if isinstance(issue.tracker, Tracker):
             return issue.id
         else:
             raise TypeError('Cannot relate issues of different types.')
 
-    def relate(self, issue, depends_on=None, blocks=None, regressed_by=None, regressions=None, **relations):
-        if relations:
-            raise TypeError("'{}' is an invalid relation".format(list(relations.keys())[0]))
+    def _modify_relations(self, issue, action, relations):
+        if invalid := [relation for relation in relations if relation not in self.RELATIONS]:
+            raise TypeError(f"'{invalid[0]}' is an invalid relation")
 
-        update_dict = dict()
-        update_dict['ids'] = [issue.id]
-        if depends_on:
-            update_dict['depends_on'] = {'add': [self.related_issue_id(depends_on)]}
-        if blocks:
-            update_dict['blocks'] = {'add': [self.related_issue_id(blocks)]}
-        if regressed_by:
-            update_dict['regressed_by'] = {'add': [self.related_issue_id(regressed_by)]}
-        if regressions:
-            update_dict['regressions'] = {'add': [self.related_issue_id(regressions)]}
+        update_dict = {'ids': [issue.id]}
+        for relation, related in relations.items():
+            if related:
+                update_dict[relation] = {action: [self.related_issue_id(related)]}
 
         response = None
         try:
             response = self.session.put(
-                '{}/rest/bug/{}{}'.format(self.url, issue.id, self._login_arguments(required=True)),
+                f'{self.url}/rest/bug/{issue.id}{self._login_arguments(required=True)}',
                 json=update_dict,
                 timeout=self.timeout,
             )
         except requests.exceptions.RequestException as e:
-            sys.stderr.write('Request Error: {}\n'.format(e))
+            sys.stderr.write(f'Request Error: {e}\n')
         if response is not None and response.status_code // 100 == 4 and self._logins_left:
             self._logins_left -= 1
         if response is None or response.status_code // 100 != 2:
-            sys.stderr.write("Failed to modify '{}'\n".format(issue))
+            sys.stderr.write(f"Failed to modify '{issue}'\n")
             return None
 
         if not issue._related:
             self.populate(issue, 'related')
-        else:
-            if depends_on:
-                issue._related['depends_on'].append(depends_on)
-            if blocks:
-                issue._related['blocks'].append(blocks)
-            if regressed_by:
-                issue._related['regressed_by'].append(regressed_by)
-            if regressions:
-                issue._related['regressions'].append(regressions)
+            return issue
+
+        for relation, related in relations.items():
+            if not related:
+                continue
+            existing = issue._related.setdefault(relation, [])
+            if action == 'add' and related not in existing:
+                existing.append(related)
+            elif action == 'remove' and related in existing:
+                existing.remove(related)
         return issue
+
+    def relate(self, issue, **relations):
+        return self._modify_relations(issue, 'add', relations)
+
+    def unrelate(self, issue, **relations):
+        return self._modify_relations(issue, 'remove', relations)
 
     @property
     @webkitcorepy.decorators.Memoize()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -206,6 +206,9 @@ class Issue(object):
     def relate(self, **relations):
         return self.tracker.relate(self, **relations)
 
+    def unrelate(self, **relations):
+        return self.tracker.unrelate(self, **relations)
+
     @property
     def assignee(self):
         if self._assignee is None:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -158,17 +158,36 @@ class Bugzilla(Base, mocks.Requests):
                 issue['component'] = data['component']
             if data.get('version'):
                 issue['version'] = data['version']
-            issue['related'] = {'blocks': [], 'depends_on': [], 'regressions': [], 'regressed_by': []}
-            if data.get('depends_on'):
-                issue['related']['depends_on'] = data['depends_on']
-            if data.get('blocks'):
-                issue['related']['blocks'] = data['blocks']
-            if data.get('regressed_by'):
-                issue['related']['regressed_by'] = data['regressed_by']
-            if data.get('regressions'):
-                issue['related']['regressions'] = data['regressions']
             if data.get('see_also'):
                 issue['related_links'] = data['see_also']['add']
+
+            # A dependency is one edge, so recording it on this issue also records it on the other
+            INVERSE = {
+                'depends_on': 'blocks',
+                'blocks': 'depends_on',
+                'regressed_by': 'regressions',
+                'regressions': 'regressed_by',
+            }
+
+            def related_for(number, relation):
+                related = self.issues[number].setdefault('related', {key: [] for key in INVERSE})
+                return related.setdefault(relation, [])
+
+            for relation, inverse in INVERSE.items():
+                if not (change := data.get(relation)):
+                    continue
+                for other in change.get('add') or []:
+                    forward, reverse = related_for(id, relation), related_for(other, inverse)
+                    if other not in forward:
+                        forward.append(other)
+                    if id not in reverse:
+                        reverse.append(id)
+                for other in change.get('remove') or []:
+                    forward, reverse = related_for(id, relation), related_for(other, inverse)
+                    if other in forward:
+                        forward.remove(other)
+                    if id in reverse:
+                        reverse.remove(id)
 
             keywords = data.get('keywords', {})
             if keywords:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -176,6 +176,7 @@ class RadarModel(object):
             self.state = 'Analyze' if issue['opened'] else 'Verify'
         self.duplicateOfProblemID = issue['original']['id'] if issue.get('original', None) else None
         self.related = list()
+        self.unrelated = list()
         if issue.get('substate'):
             self.substate = issue['substate']
         else:
@@ -288,6 +289,17 @@ class RadarModel(object):
                 self.client.parent.issues[r.related_radar_id]['related'] = list()
             self.client.parent.issues[r.related_radar_id]['related'].append(inverse_r_dict)
 
+        for r in list(self.unrelated):
+            r_dict = {'relationship': r.type, 'related_radar': r.related_radar_id}
+            entries = self.client.parent.issues[self.id].get('related') or []
+            if r_dict in entries:
+                entries.remove(r_dict)
+
+            inverse_r_dict = {'relationship': Radar.Relationship.inverse_map[r.type], 'related_radar': self.id}
+            entries = self.client.parent.issues[r.related_radar_id].get('related') or []
+            if inverse_r_dict in entries:
+                entries.remove(inverse_r_dict)
+
         if getattr(self, 'sourceChanges', None):
             self.client.parent.issues[self.id]['sourceChanges'] = self.sourceChanges
 
@@ -313,6 +325,9 @@ class RadarModel(object):
 
     def add_relationship(self, relationship):
         self.related.append(relationship)
+
+    def delete_relationship(self, relationship):
+        self.unrelated.append(relationship)
 
     def remove_keyword(self, keyword):
         if keyword.name in self._issue.get('keywords') or []:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -612,6 +612,61 @@ class Tracker(GenericTracker):
         return None
 
     @handle_access_exception
+    def remove_relationship(self, issue, issue2, relationship):
+        if relationship not in self.RELATIONSHIP_TYPES:
+            sys.stderr.write(f'{relationship} is not a valid relationship type.')
+            return None
+        if relationship in (
+            self.radarclient().Relationship.TYPE_DUPLICATE_OF,
+            self.radarclient().Relationship.TYPE_ORIGINAL_OF,
+        ):
+            raise NotImplementedError(f'Cannot remove a {relationship} relationship')
+
+        radar = self.client.radar_for_id(issue.id)
+        if not radar:
+            sys.stderr.write(f"Failed to fetch '{issue.link}'\n")
+            return None
+
+        # 'delete_relationship' only accepts a relationship the radar already has
+        existing = next((
+            candidate for candidate in radar.relationships() or []
+            if candidate.type == relationship and candidate.related_radar_id == issue2.id
+        ), None)
+        if not existing:
+            return issue
+
+        radar.delete_relationship(existing)
+        radar.commit_changes()
+
+        if not issue._related:
+            self.populate(issue, 'related')
+        else:
+            issue._related[relationship] = [
+                candidate for candidate in issue._related[relationship] if candidate.id != issue2.id
+            ]
+        return issue
+
+    @handle_access_exception
+    def unrelate(self, issue, related_to=None, blocked_by=None, blocking=None, parent_of=None, subtask_of=None,
+                 cause_of=None, caused_by=None, duplicate_of=None, original_of=None, **relations):
+        if relations:
+            raise TypeError(f"'{list(relations.keys())[0]}' is an invalid relation")
+
+        for related, relationship in (
+            (related_to, self.radarclient().Relationship.TYPE_RELATED_TO),
+            (blocked_by, self.radarclient().Relationship.TYPE_BLOCKED_BY),
+            (blocking, self.radarclient().Relationship.TYPE_BLOCKING),
+            (parent_of, self.radarclient().Relationship.TYPE_PARENT_OF),
+            (subtask_of, self.radarclient().Relationship.TYPE_SUBTASK_OF),
+            (cause_of, self.radarclient().Relationship.TYPE_CAUSE_OF),
+            (caused_by, self.radarclient().Relationship.TYPE_CAUSED_BY),
+            (duplicate_of, self.radarclient().Relationship.TYPE_DUPLICATE_OF),
+            (original_of, self.radarclient().Relationship.TYPE_ORIGINAL_OF),
+        ):
+            if related:
+                self.remove_relationship(issue, related, relationship)
+        return issue
+
     def relate(self, issue, related_to=None, blocked_by=None, blocking=None, parent_of=None, subtask_of=None,
                cause_of=None, caused_by=None, duplicate_of=None, original_of=None, **relations):
         if relations:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -1135,6 +1135,13 @@ What component in 'WebKit' should the bug be associated with?:
             self.assertEqual(issue.related['depends_on'], [tracker.issue(2)])
             self.assertEqual(issue.related['blocks'], [])
 
+            # The edge runs both ways
+            self.assertEqual(tracker.issue(2).related['blocks'], [issue])
+
+            issue.unrelate(depends_on=tracker.issue(2))
+            self.assertEqual(issue.related['depends_on'], [])
+            self.assertEqual(tracker.issue(2).related['blocks'], [])
+
     def test_relate(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
                 BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -596,6 +596,11 @@ What version of 'WebKit Text' should the bug be associated with?:
             self.assertEqual(tracker.issue(1).related['blocking'], [tracker.issue(2)])
             self.assertEqual(tracker.issue(2).related['blocked-by'], [tracker.issue(1)])
 
+            # Removing it removes both ends, as adding it added both
+            tracker.issue(2).unrelate(blocked_by=tracker.issue(1))
+            self.assertEqual(tracker.issue(2).related['blocked-by'], [])
+            self.assertEqual(tracker.issue(1).related['blocking'], [])
+
             tracker.issue(2).relate(parent_of=tracker.issue(3))
             self.assertEqual(tracker.issue(2).related['parent-of'], [tracker.issue(3)])
             self.assertEqual(tracker.issue(3).related['subtask-of'], [tracker.issue(2)])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -183,6 +183,9 @@ class Tracker(object):
     def relate(self, issue, **relations):
         raise NotImplementedError()
 
+    def unrelate(self, issue, **relations):
+        raise NotImplementedError()
+
     def add_comment(self, issue, text):
         raise NotImplementedError()
 


### PR DESCRIPTION
#### 92e0ba83201799cf2b06703b37758746c091eeea
<pre>
[webkitbugspy] Cannot remove a relation between two issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=322308">https://bugs.webkit.org/show_bug.cgi?id=322308</a>
<a href="https://rdar.apple.com/problem/185553192">rdar://problem/185553192</a>

Reviewed by Sam Sneddon.

Relations could only be added. Bugzilla&apos;s &apos;relate&apos; sent &apos;{&quot;add&quot;: [...]}&apos; and
radar&apos;s created a relationship, with no way to undo either, so a tool which
records a dependency between two issues cannot later forget it and a stale
relation has to be removed by hand.

Add &apos;unrelate&apos;, which Bugzilla implements by sending &apos;{&quot;remove&quot;: [...]}&apos;
through the request &apos;relate&apos; already builds and radar by deleting a
relationship the radar already holds. &apos;duplicate-of&apos; and &apos;original-of&apos; are not
removable this way, since they are recorded as a resolution rather than as a
relationship.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker):

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker):
(Tracker._modify_relations):
(Tracker.relate):
(Tracker.unrelate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.unrelate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue):
(Bugzilla._issue.related_for):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.__init__):
(RadarModel.commit_changes):
(RadarModel.delete_relationship):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.remove_relationship):
(Tracker):
(Tracker.unrelate):
(Tracker.relation_key):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(test_relate_simple):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.unrelate):
(Tracker):
(Tracker.relation_key):

Canonical link: <a href="https://commits.webkit.org/320010@main">https://commits.webkit.org/320010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d152e88a303b8e6bfd92e997c7944ac851e7f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57418 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57153 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46972 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182822 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/4893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195654 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40917 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57792 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152418 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46965 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56300 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55910 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->