### PR TITLE
Add --exit-after-n-failures option to run-api-tests

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -215,6 +215,8 @@ def parse_args(args):
                              help='Run all tests, even DISABLED tests'),
         optparse.make_option('-f', '--fully-parallel', action='store_true', default=False,
                              help='Force all tests to run in parallel (without grouping shards)'),
+        optparse.make_option('--exit-after-n-failures', type='int', default=None,
+                             help='Exit after the first N failures instead of running all tests'),
         optparse.make_option('--additional-env-var', type='string', action='append', default=[],
                              help='Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)'),
         optparse.make_option('--test-parallel-safety', type='string', action='append', default=[],

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -26,7 +26,7 @@ import os
 import re
 import time
 
-from webkitpy.api_tests.runner import Runner
+from webkitpy.api_tests.runner import EarlyExitException, Runner
 from webkitpy.api_tests.test_expectations import (
     APITestExpectations, PASS, FAIL, CRASH, TIMEOUT,
     runner_status_to_expectation,
@@ -360,9 +360,12 @@ class Manager(object):
         try:
             _log.info('Running tests')
             runner = Runner(self._port, self._stream, expectations=self._expectations)
+            runner.exit_after_n_failures = getattr(self._options, 'exit_after_n_failures', None)
             for i in range(self._options.iterations):
                 _log.debug(f'\nIteration {i + 1}')
                 runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else None)
+        except EarlyExitException as e:
+            self._stream.writeln(f'\nExiting early after {e.failure_count} failures.')
         except KeyboardInterrupt:
             # If we receive a KeyboardInterrupt, print results.
             self._stream.writeln('')

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -77,6 +77,13 @@ def run_test_parallel_safety_single_iteration(test_name):
         _log.error(f'Error in test-parallel-safety iteration for {test_name}: {e}')
         raise  # Re-raise so TaskPool can handle the error appropriately
 
+
+class EarlyExitException(Exception):
+    def __init__(self, failure_count):
+        self.failure_count = failure_count
+        super().__init__(f'Exiting early after {failure_count} failures.')
+
+
 def report_result(worker, test, status, output, elapsed=None):
     if elapsed < Runner.ELAPSED_THRESHOLD and status == Runner.STATUS_PASSED and (not output or Runner.instance.port.get_option('quiet')):
         Runner.instance.printer.write_update(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}')
@@ -89,6 +96,11 @@ def report_result(worker, test, status, output, elapsed=None):
             Runner.instance.results[test] = status, output, elapsed
     else:
         Runner.instance.results[test] = status, output, elapsed
+
+    if status in (Runner.STATUS_FAILED, Runner.STATUS_CRASHED, Runner.STATUS_TIMEOUT):
+        Runner.instance._failure_count += 1
+        if Runner.instance.exit_after_n_failures and Runner.instance._failure_count >= Runner.instance.exit_after_n_failures:
+            raise EarlyExitException(Runner.instance._failure_count)
 
 
 def teardown_shard():
@@ -124,6 +136,8 @@ class Runner(object):
         self._has_logged_for_test = True  # Suppress an empty line between "Running tests" and the first test's output.
         self.results = {}
         self.expectations = expectations
+        self.exit_after_n_failures = None
+        self._failure_count = 0
 
     # FIXME API tests should run as an app, we won't need this function <https://bugs.webkit.org/show_bug.cgi?id=175204>
     @staticmethod

--- a/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
@@ -23,8 +23,9 @@
 """Unit tests for runner.py."""
 
 import unittest
+from unittest.mock import MagicMock
 
-from webkitpy.api_tests.runner import Runner
+from webkitpy.api_tests.runner import EarlyExitException, Runner, report_result
 
 
 class RunnerTest(unittest.TestCase):
@@ -59,6 +60,53 @@ class RunnerTest(unittest.TestCase):
         runnable, disabled = Runner._partition_parallel_safety_tests(supplied)
         self.assertEqual(runnable, supplied)
         self.assertEqual(disabled, [])
+
+
+class ReportResultEarlyExitTest(unittest.TestCase):
+    def setUp(self):
+        self._saved_instance = Runner.instance
+        fake = MagicMock()
+        fake.port.get_option.return_value = False
+        fake.results = {}
+        fake.exit_after_n_failures = None
+        fake._failure_count = 0
+        Runner.instance = fake
+        self.fake = fake
+
+    def tearDown(self):
+        Runner.instance = self._saved_instance
+
+    def _fail(self, name):
+        report_result('worker', name, Runner.STATUS_FAILED, output='err', elapsed=0.1)
+
+    def test_no_early_exit_when_disabled(self):
+        self.fake.exit_after_n_failures = None
+        for i in range(20):
+            self._fail(f'T{i}')
+        self.assertEqual(self.fake._failure_count, 20)
+
+    def test_raises_when_threshold_reached(self):
+        self.fake.exit_after_n_failures = 3
+        self._fail('T1')
+        self._fail('T2')
+        with self.assertRaises(EarlyExitException) as ctx:
+            self._fail('T3')
+        self.assertEqual(ctx.exception.failure_count, 3)
+        self.assertEqual(self.fake._failure_count, 3)
+
+    def test_crash_and_timeout_count_as_failures(self):
+        self.fake.exit_after_n_failures = 3
+        report_result('w', 'T1', Runner.STATUS_CRASHED, output='c', elapsed=0.1)
+        report_result('w', 'T2', Runner.STATUS_TIMEOUT, output='t', elapsed=0.1)
+        with self.assertRaises(EarlyExitException):
+            report_result('w', 'T3', Runner.STATUS_FAILED, output='f', elapsed=0.1)
+
+    def test_pass_and_disabled_do_not_count(self):
+        self.fake.exit_after_n_failures = 2
+        report_result('w', 'P1', Runner.STATUS_PASSED, output='', elapsed=0.1)
+        report_result('w', 'D1', Runner.STATUS_DISABLED, output='', elapsed=0.1)
+        report_result('w', 'P2', Runner.STATUS_PASSED, output='', elapsed=0.1)
+        self.assertEqual(self.fake._failure_count, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 2a77f5e5eb97e190d708ca2ae6fc4cb3b7a27679
<pre>
Add --exit-after-n-failures option to run-api-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321046">https://bugs.webkit.org/show_bug.cgi?id=321046</a>
<a href="https://rdar.apple.com/176804299">rdar://176804299</a>

Reviewed by Aakash Jain.

run-api-tests currently runs to completion, which lets API test EWS
steps run for hours when a change breaks many tests. Add
--exit-after-n-failures N so callers can bound the run. Enabling it on
EWS is a separate follow-up to Tools/CISupport/ews-build/steps.py.

Manager.run() catches EarlyExitException from report_result once the
failure count reaches the cap, then falls through to the normal
summary/JSON path so the &quot;Ran N tests of M ...&quot; line still reaches
stdout - filter-test-logs and buildbot&apos;s parseOutputLine observer both
depend on it.

* Tools/Scripts/run-api-tests:
(parse_args):
Add --exit-after-n-failures N option.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(EarlyExitException):
(report_result):
(Runner.__init__):
Track a failure counter on the Runner. When report_result records a
FAILED/CRASHED/TIMEOUT status and the count reaches the cap, raise
EarlyExitException.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run):
Wire the option onto the Runner. Catch EarlyExitException and fall
through to the normal summary/JSON path.

* Tools/Scripts/webkitpy/api_tests/runner_unittest.py:
(ReportResultEarlyExitTest):
Cover report_result&apos;s early-exit behavior.

Canonical link: <a href="https://commits.webkit.org/319704@main">https://commits.webkit.org/319704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8199ebe7fecb6f2d5484f93bd7aea5b4ff00c205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146422 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/670e3fff-485e-4099-a596-b7169beb8abd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55763 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142156 "15 flakes 2 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98723 "6 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46b18889-9fa2-458f-94e7-de908be03994) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122590 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9162ba4-5eac-4ea6-9044-766c0fc03d8d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181418 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42810 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42433 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3483 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194247 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55711 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151576 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56402 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151279 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45866 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124513 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54913 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17429 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54294 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54533 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->