### PR TITLE
[Quirks] Move element fullscreen and simulated mouse events quirks into the table

### DIFF
--- a/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
@@ -14,12 +14,16 @@ https://www.airindiaexpress.com/
     NeedsAirIndiaExpressLayeringQuirk
 https://www.amazon.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://sub.amazon.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://www.amazon.co.uk/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://amazon.design/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://www.apple.com/
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture
 https://as.com/
@@ -75,6 +79,7 @@ https://www.espn.com/
 https://www.facebook.com/
     NeedsFacebookRemoveNotSupportedQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
     ShouldEnableCameraAndMicrophonePermissionStateQuirk
     ShouldEnableEnumerateDeviceQuirk
     ShouldEnableFacebookFlagQuirk
@@ -91,9 +96,11 @@ https://www.google.com/
 https://www.google.com/maps/
     MaybeBypassBackForwardCache
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://maps.google.com/maps/
     MaybeBypassBackForwardCache
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://docs.google.com/
     InputMethodUsesCorrectKeyEventOrder
     MaybeBypassBackForwardCache
@@ -226,6 +233,7 @@ https://www.sharepoint.com/
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
 https://soundcloud.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
     ShouldExposeShowModalDialog
 https://soylent.com/
     ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick
@@ -251,6 +259,7 @@ https://www.thesaurus.com/
 https://www.tiktok.com/
     NeedsTikTokOverflowingContentQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://trix-editor.org/
     (none)
 https://www.twitch.tv/

--- a/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
@@ -14,17 +14,21 @@ https://www.airindiaexpress.com/
     NeedsAirIndiaExpressLayeringQuirk
 https://www.amazon.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://sub.amazon.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://www.amazon.co.uk/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://amazon.design/
     NeedsAmazonDesignMenuViewportUnitQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://www.apple.com/
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture
 https://as.com/
-    (none)
+    ShouldDisableElementFullscreenQuirk
 https://www.att.com/
     ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk
 https://www.bbc.co.uk/
@@ -53,7 +57,7 @@ https://www.cnn.com/
     NeedsFullscreenObjectFitQuirk
     ShouldDisableThreadedAnimationsQuirk
 https://www.digitaltrends.com/
-    (none)
+    ShouldDisableElementFullscreenQuirk
 https://discord.com/
     ShouldUseLayoutViewportForClientRectsQuirk
 https://store.steampowered.com/
@@ -82,6 +86,7 @@ https://www.facebook.com/
     NeedsFacebookRemoveNotSupportedQuirk
     RequiresUserGestureToPauseInPictureInPictureQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
     ShouldEnableCameraAndMicrophonePermissionStateQuirk
     ShouldEnableEnumerateDeviceQuirk
     ShouldEnableFacebookFlagQuirk
@@ -100,11 +105,13 @@ https://www.google.com/maps/
     MaybeBypassBackForwardCache
     NeedsGoogleMapsScrollingQuirk
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://maps.google.com/maps/
     MayNeedToIgnoreContentObservation
     MaybeBypassBackForwardCache
     NeedsGoogleMapsScrollingQuirk
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://docs.google.com/
     InputMethodUsesCorrectKeyEventOrder
     MaybeBypassBackForwardCache
@@ -171,6 +178,7 @@ https://www.imdb.com/
     NeedsZeroMaxTouchPointsQuirk
 https://www.instagram.com/
     NeedsInstagramResizingReelsQuirk
+    ShouldDisableElementFullscreenQuirk
     ShouldSendFakeTouchForceChangeEvent
 https://invideo.io/
     NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
@@ -250,6 +258,7 @@ https://www.sharepoint.com/
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
 https://soundcloud.com/
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
     ShouldExposeShowModalDialog
 https://soylent.com/
     (none)
@@ -277,6 +286,7 @@ https://www.thesaurus.com/
 https://www.tiktok.com/
     NeedsTikTokOverflowingContentQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
 https://trix-editor.org/
     (none)
 https://www.twitch.tv/
@@ -290,6 +300,7 @@ https://vimeo.com/
     BlocksReturnToFullscreenFromPictureInPictureQuirk
     MaybeBypassBackForwardCache
     NeedsPreloadAutoQuirk
+    ShouldDisableElementFullscreenQuirk
     ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk
 https://www.walmart.com/
     MayNeedToIgnoreContentObservation
@@ -327,6 +338,7 @@ https://www.youtube.com/
     NeedsYouTubeCaptionQuirk
     NeedsYouTubeMouseOutQuirk
     NeedsYouTubeOverflowScrollQuirk
+    ShouldDisableElementFullscreenQuirk
     ShouldSilenceResizeObservers
 https://www.youtube-nocookie.com/
     (none)

--- a/Source/WebCore/page/QuirkMatch.h
+++ b/Source/WebCore/page/QuirkMatch.h
@@ -50,15 +50,20 @@ enum class QuirkCondition : uint8_t {
 
 WEBCORE_EXPORT bool evaluateQuirkCondition(QuirkCondition);
 
+enum class IsTopDocument : bool { No, Yes };
+
 class QuirkMatchContext {
 public:
-    QuirkMatchContext(URL topURL, URL documentURL)
+    QuirkMatchContext(URL topURL, URL documentURL, IsTopDocument isTopDocument = IsTopDocument::Yes)
         : m_topURL(WTF::move(topURL))
         , m_documentURL(WTF::move(documentURL))
+        , m_isTopDocument(isTopDocument)
     {
     }
 
     const URL& topURL() const LIFETIME_BOUND { return m_topURL; }
+
+    bool isTopDocument() const { return m_isTopDocument == IsTopDocument::Yes; }
 
     StringView host() const LIFETIME_BOUND { return m_topURL.host(); }
 
@@ -86,6 +91,7 @@ public:
 private:
     const URL m_topURL;
     const URL m_documentURL;
+    const IsTopDocument m_isTopDocument;
     mutable std::optional<String> m_registrableDomain;
     mutable std::optional<String> m_domainWithoutPublicSuffix;
     mutable std::optional<String> m_documentDomain;
@@ -132,6 +138,11 @@ public:
         return QuirkMatch { Kind::AnyTopLevelDomain, name };
     }
 
+    static constexpr QuirkMatch anySite()
+    {
+        return QuirkMatch { Kind::AnySite };
+    }
+
     constexpr QuirkMatch&& pathContains(ASCIILiteral substring) &&
     {
         return WTF::move(*this).setPathConstraint(PathConstraintKind::PathContains, substring);
@@ -149,14 +160,39 @@ public:
 
     constexpr QuirkMatch&& onlyIf(QuirkCondition condition) &&
     {
-        m_condition = condition;
+        currentRefinements().condition = condition;
+        return WTF::move(*this);
+    }
+
+    constexpr QuirkMatch&& documentDomainIs(ASCIILiteral pattern) &&
+    {
+        currentRefinements().documentDomains = PatternList { pattern };
         return WTF::move(*this);
     }
 
     template<const auto& patterns> constexpr QuirkMatch&& documentDomainIsOneOf() &&
     {
         static_assert(std::size(patterns), "A quirk must match at least one document domain.");
-        m_documentDomains = std::span<const ASCIILiteral> { patterns };
+        currentRefinements().documentDomains = PatternList { std::span<const ASCIILiteral> { patterns } };
+        return WTF::move(*this);
+    }
+
+    template<const auto& patterns> constexpr QuirkMatch&& hostIsOneOf() &&
+    {
+        static_assert(std::size(patterns), "A quirk must match at least one host.");
+        currentRefinements().hosts = std::span<const ASCIILiteral> { patterns };
+        return WTF::move(*this);
+    }
+
+    constexpr QuirkMatch&& onlyIfEmbedded() &&
+    {
+        currentRefinements().requiresEmbeddedDocument = true;
+        return WTF::move(*this);
+    }
+
+    constexpr QuirkMatch&& exceptWhen() &&
+    {
+        m_refiningException = true;
         return WTF::move(*this);
     }
 
@@ -165,13 +201,10 @@ public:
         if (!matchesSite(context)) [[likely]]
             return false;
 
-        if (m_pathConstraint && !matchesPathConstraint(context.topURL()))
+        if (!matchesRefinements(m_refinements, context))
             return false;
 
-        if (m_condition && !evaluateQuirkCondition(*m_condition))
-            return false;
-
-        if (!m_documentDomains.empty() && !matchesDocumentDomain(context))
+        if (!m_exception.isEmpty() && matchesRefinements(m_exception, context))
             return false;
 
         return true;
@@ -184,6 +217,7 @@ private:
         HostOrSubdomainOf,
         HostEndingWith,
         AnyTopLevelDomain,
+        AnySite,
     };
 
     enum class PathConstraintKind : uint8_t {
@@ -194,6 +228,8 @@ private:
 
     class PatternList {
     public:
+        constexpr PatternList() = default;
+
         constexpr explicit PatternList(ASCIILiteral pattern)
             : m_single(pattern)
         {
@@ -208,13 +244,38 @@ private:
 
         std::span<const ASCIILiteral> span() const LIFETIME_BOUND
         {
-            return m_multiple.empty() ? singleElementSpan(m_single) : m_multiple;
+            if (!m_multiple.empty())
+                return m_multiple;
+            if (m_single.isNull())
+                return { };
+            return singleElementSpan(m_single);
         }
+
+        constexpr bool isEmpty() const { return m_multiple.empty() && m_single.isNull(); }
 
     private:
         ASCIILiteral m_single;
         std::span<const ASCIILiteral> m_multiple;
     };
+
+    struct Refinements {
+        PathConstraintKind pathConstraintKind { PathConstraintKind::PathContains };
+        ASCIILiteral pathConstraint;
+        std::optional<QuirkCondition> condition;
+        PatternList documentDomains;
+        std::span<const ASCIILiteral> hosts;
+        bool requiresEmbeddedDocument { false };
+
+        constexpr bool isEmpty() const
+        {
+            return !requiresEmbeddedDocument && pathConstraint.isNull() && !condition && documentDomains.isEmpty() && hosts.empty();
+        }
+    };
+
+    constexpr explicit QuirkMatch(Kind kind)
+        : m_kind(kind)
+    {
+    }
 
     constexpr QuirkMatch(Kind kind, ASCIILiteral pattern)
         : m_kind(kind)
@@ -228,10 +289,16 @@ private:
     {
     }
 
+    constexpr Refinements& currentRefinements() LIFETIME_BOUND
+    {
+        return m_refiningException ? m_exception : m_refinements;
+    }
+
     constexpr QuirkMatch&& setPathConstraint(PathConstraintKind kind, ASCIILiteral value) &&
     {
-        m_pathConstraintKind = kind;
-        m_pathConstraint = value;
+        auto& refinements = currentRefinements();
+        refinements.pathConstraintKind = kind;
+        refinements.pathConstraint = value;
         return WTF::move(*this);
     }
 
@@ -253,42 +320,59 @@ private:
             return anyPattern([&](ASCIILiteral pattern) { return context.host().endsWithIgnoringASCIICase(pattern); });
         case Kind::AnyTopLevelDomain:
             return anyPattern([&](ASCIILiteral pattern) { return context.domainWithoutPublicSuffix() == pattern; });
+        case Kind::AnySite:
+            return !context.host().isEmpty();
         }
 
         ASSERT_NOT_REACHED();
         return false;
     }
 
-    bool matchesPathConstraint(const URL& topURL) const
+    bool matchesRefinements(const Refinements& refinements, const QuirkMatchContext& context) const
     {
-        switch (m_pathConstraintKind) {
+        if (!refinements.pathConstraint.isNull() && !matchesPathConstraint(refinements, context.topURL()))
+            return false;
+
+        if (refinements.condition && !evaluateQuirkCondition(*refinements.condition))
+            return false;
+
+        if (refinements.requiresEmbeddedDocument && context.isTopDocument())
+            return false;
+
+        if (!refinements.documentDomains.isEmpty() && !anyOf(refinements.documentDomains.span(), context.documentDomain()))
+            return false;
+
+        if (!refinements.hosts.empty() && !anyOf(refinements.hosts, context.host()))
+            return false;
+
+        return true;
+    }
+
+    template<typename StringType> static bool anyOf(std::span<const ASCIILiteral> patterns, const StringType& value)
+    {
+        return std::ranges::any_of(patterns, [&](ASCIILiteral pattern) { return value == pattern; });
+    }
+
+    bool matchesPathConstraint(const Refinements& refinements, const URL& topURL) const
+    {
+        switch (refinements.pathConstraintKind) {
         case PathConstraintKind::PathContains:
-            return topURL.path().contains(m_pathConstraint);
+            return topURL.path().contains(refinements.pathConstraint);
         case PathConstraintKind::PathStartsWith:
-            return startsWithLettersIgnoringASCIICase(topURL.path(), m_pathConstraint);
+            return startsWithLettersIgnoringASCIICase(topURL.path(), refinements.pathConstraint);
         case PathConstraintKind::PathOrFragmentContains:
-            return topURL.path().contains(m_pathConstraint) || topURL.fragmentIdentifier().contains(m_pathConstraint);
+            return topURL.path().contains(refinements.pathConstraint) || topURL.fragmentIdentifier().contains(refinements.pathConstraint);
         }
 
         ASSERT_NOT_REACHED();
-        return false;
-    }
-
-    bool matchesDocumentDomain(const QuirkMatchContext& context) const
-    {
-        for (auto pattern : m_documentDomains) {
-            if (context.documentDomain() == pattern)
-                return true;
-        }
         return false;
     }
 
     Kind m_kind;
-    PathConstraintKind m_pathConstraintKind { PathConstraintKind::PathContains };
     PatternList m_patterns;
-    ASCIILiteral m_pathConstraint;
-    std::span<const ASCIILiteral> m_documentDomains;
-    std::optional<QuirkCondition> m_condition;
+    Refinements m_refinements;
+    Refinements m_exception;
+    bool m_refiningException { false };
 };
 
 consteval QuirksData::QuirkBitSet quirkBehaviors(std::initializer_list<QuirksData::SiteSpecificQuirk> quirks)
@@ -303,7 +387,6 @@ struct Quirk {
     QuirkMatch match;
     QuirksData::QuirkBitSet behaviors { };
     std::optional<QuirkSite> site { };
-    bool disablesElementFullscreen { false };
 
     void apply(QuirksData& quirksData) const
     {
@@ -311,10 +394,9 @@ struct Quirk {
 
         if (site)
             quirksData.addSite(*site);
-
-        if (disablesElementFullscreen)
-            quirksData.shouldDisableElementFullscreen = true;
     }
 };
+
+WEBCORE_EXPORT QuirksData resolveSiteSpecificQuirks(const QuirkMatchContext&);
 
 } // namespace WebCore

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -501,14 +501,7 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     // (Ref: rdar://121473410)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
-    if (m_quirksData.shouldDisableElementFullscreen)
-        return true;
-
-    if (protect(m_document)->isTopDocument())
-        return false;
-
-    return isEmbedDomain("x.com"_s)
-        || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isYoutubeEmbedDomain());
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableElementFullscreenQuirk);
 #else
     return false;
 #endif
@@ -521,6 +514,15 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
 // soundcloud.com rdar://52915981
 // naver.com rdar://48068610
 // mybinder.org rdar://51770057
+template<typename Predicate> static bool targetOrAncestorMatches(const EventTarget* target, NOESCAPE Predicate&& predicate)
+{
+    for (RefPtr node = dynamicDowncast<Node>(target); node; node = node->parentNode()) {
+        if (auto* element = dynamicDowncast<Element>(*node); element && predicate(*element))
+            return true;
+    }
+    return false;
+}
+
 bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
 {
     if (m_document->settings().mouseEventsSimulationEnabled())
@@ -528,91 +530,29 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
 
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    auto doShouldDispatchChecks = [this] () -> QuirksData::ShouldDispatchSimulatedMouseEvents {
-        auto* loader = m_document->loader();
-        if (!loader || loader->simulatedMouseEventsDispatchPolicy() != SimulatedMouseEventsDispatchPolicy::Allow)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
-
-        if (m_quirksData.isSite(QuirkSite::Amazon))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (m_quirksData.isSite(QuirkSite::GoogleMaps))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (m_quirksData.isSite(QuirkSite::SoundCloud))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        // facebook.com rdar://174179871
-        if (m_quirksData.isSite(QuirkSite::Facebook))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole;
-        // tiktok.com rdar://174179805
-        if (m_quirksData.isSite(QuirkSite::TikTok))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole;
-
-        const URL& topDocumentURL = this->topDocumentURL();
-        const auto registrableDomainString = RegistrableDomain(topDocumentURL).string();
-
-        if (registrableDomainString == "wix.com"_s) {
-            // Disable simulated mouse dispatching for template selection.
-            return startsWithLettersIgnoringASCIICase(topDocumentURL.path(), "/website/templates/"_s) ? QuirksData::ShouldDispatchSimulatedMouseEvents::No : QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        }
-
-        if (registrableDomainString == "airtable.com"_s)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (registrableDomainString == "flipkart.com"_s)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (registrableDomainString == "mybinder.org"_s)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetFor_mybinder_org;
-
-        auto host = topDocumentURL.host();
-        if (host == "naver.com"_s)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (host.endsWith(".naver.com"_s)) {
-            // Disable the quirk for tv.naver.com subdomain to be able to simulate hover on videos.
-            if (host == "tv.naver.com"_s)
-                return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
-            // Disable the quirk for mail.naver.com subdomain to be able to tap on mail subjects.
-            if (host == "mail.naver.com"_s)
-                return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
-            // Disable the quirk on the mobile site.
-            // FIXME: Maybe this quirk should be disabled for "m." subdomains on all sites? These are generally mobile sites that don't need mouse events.
-            if (host == "m.naver.com"_s)
-                return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        }
-
-        return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
-    };
-
-    if (m_quirksData.shouldDispatchSimulatedMouseEventsQuirk == QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown)
-        m_quirksData.shouldDispatchSimulatedMouseEventsQuirk = doShouldDispatchChecks();
-
-    switch (m_quirksData.shouldDispatchSimulatedMouseEventsQuirk) {
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown:
-        ASSERT_NOT_REACHED();
+    if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDispatchSimulatedMouseEventsQuirk))
         return false;
 
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::No:
+    auto* loader = m_document->loader();
+    if (!loader || loader->simulatedMouseEventsDispatchPolicy() != SimulatedMouseEventsDispatchPolicy::Allow)
         return false;
 
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole:
-        for (RefPtr node = dynamicDowncast<Node>(target); node; node = node->parentNode()) {
-            if (RefPtr element = dynamicDowncast<Element>(*node); element && element->attributeWithoutSynchronization(HTMLNames::roleAttr) == "slider"_s)
-                return true;
-        }
-        return false;
-
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetFor_mybinder_org:
-        for (RefPtr node = dynamicDowncast<Node>(target); node; node = node->parentNode()) {
-            // This uses auto* instead of RefPtr as otherwise GCC does not compile.
-            if (auto* element = dynamicDowncast<Element>(*node); element && element->hasClassName("lm-DockPanel-tabBar"_s))
-                return true;
-        }
-        return false;
-
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::Yes:
-        return true;
+    // facebook.com rdar://174179871
+    // tiktok.com rdar://174179805
+    if (m_quirksData.isSite(QuirkSite::Facebook) || m_quirksData.isSite(QuirkSite::TikTok)) {
+        return targetOrAncestorMatches(target, [](auto& element) {
+            return element.attributeWithoutSynchronization(HTMLNames::roleAttr) == "slider"_s;
+        });
     }
 
-    ASSERT_NOT_REACHED();
-    return false;
+    // mybinder.org rdar://51770057
+    if (m_quirksData.isSite(QuirkSite::MyBinder)) {
+        return targetOrAncestorMatches(target, [](auto& element) {
+            return element.hasClassName("lm-DockPanel-tabBar"_s);
+        });
+    }
+
+    return true;
 }
 
 bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType, EventTarget* target) const
@@ -1944,10 +1884,7 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (m_quirksData.needsDisableDOMPasteAccessQuirk)
-        return *m_quirksData.needsDisableDOMPasteAccessQuirk;
-
-    m_quirksData.needsDisableDOMPasteAccessQuirk = [&] {
+    return quirkIsEnabledAfterProbing(QuirksData::SiteSpecificQuirk::NeedsDisableDOMPasteAccessQuirk, [&] {
         RefPtr document = m_document.get();
         if (!document)
             return false;
@@ -1959,9 +1896,7 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
         JSC::JSLockHolder lock(vm);
         auto tableauPrepProperty = JSC::Identifier::fromString(vm, "tableauPrep"_s);
         return globalObject->hasProperty(globalObject, tableauPrepProperty);
-    }();
-
-    return *m_quirksData.needsDisableDOMPasteAccessQuirk;
+    });
 }
 
 // rdar://133423460
@@ -2942,6 +2877,9 @@ static constexpr std::array expediaGroupDomains {
     "hotels.com"_s, "mrjet.se"_s, "orbitz.com"_s, "travelocity.ca"_s,
     "travelocity.com"_s, "wotif.co.nz"_s, "wotif.com"_s
 };
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+static constexpr std::array naverHostsWithoutSimulatedMouseEvents { "tv.naver.com"_s, "mail.naver.com"_s, "m.naver.com"_s };
+#endif
 #if PLATFORM(IOS_FAMILY)
 static constexpr std::array claudeDomains { "claude.ai"_s, "claude.com"_s };
 static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
@@ -2968,6 +2906,12 @@ static constexpr Quirk table[] = {
         .behaviors = quirkBehaviors({ NeedsAirIndiaExpressLayeringQuirk }) },
 
     // Note: There is a userAgent override for rdar://117771731, see needsCustomUserAgentOverride()
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    // airtable.com rdar://49124313
+    { .match = QuirkMatch::domain("airtable.com"_s),
+        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+#endif
+
     { .match = QuirkMatch::anyTopLevelDomain("amazon"_s),
         .behaviors = quirkBehaviors({
             // amazon.com rdar://49124529
@@ -2975,6 +2919,10 @@ static constexpr Quirk table[] = {
 #if PLATFORM(MAC)
             // amazon.com rdar://128962002
             NeedsPrimeVideoUserSelectNoneQuirk,
+#endif
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+            // amazon.com rdar://49124313
+            ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
         }),
         .site = QuirkSite::Amazon },
@@ -2996,7 +2944,7 @@ static constexpr Quirk table[] = {
 #if PLATFORM(IOS_FAMILY)
     // as.com: rdar://121014613
     { .match = QuirkMatch::domain("as.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .disablesElementFullscreen = true },
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
 
     // att.com rdar://55185021
     { .match = QuirkMatch::domain("att.com"_s),
@@ -3124,7 +3072,7 @@ static constexpr Quirk table[] = {
 #if PLATFORM(IOS_FAMILY)
     // digitaltrends.com rdar://121014613
     { .match = QuirkMatch::domain("digitaltrends.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .disablesElementFullscreen = true },
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
 
     // discord.com rdar://162719481
     { .match = QuirkMatch::domain("discord.com"_s),
@@ -3191,8 +3139,18 @@ static constexpr Quirk table[] = {
             // facebook.com rdar://158736355
             ShouldEnableRTCEncodedStreamsQuirk,
 #endif
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+            // facebook.com rdar://174179871
+            ShouldDispatchSimulatedMouseEventsQuirk,
+#endif
         }),
         .site = QuirkSite::Facebook },
+
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    // flipkart.com rdar://49648520
+    { .match = QuirkMatch::domain("flipkart.com"_s),
+        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+#endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // forbes.com rdar://67273166
@@ -3228,6 +3186,10 @@ static constexpr Quirk table[] = {
 #endif
             // maps.google.com https://bugs.webkit.org/show_bug.cgi?id=214945
             ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+            // maps.google.com rdar://49124313
+            ShouldDispatchSimulatedMouseEventsQuirk,
+#endif
         }),
         .site = QuirkSite::GoogleMaps },
 
@@ -3343,7 +3305,7 @@ static constexpr Quirk table[] = {
 #if PLATFORM(IOS_FAMILY)
     // instagram.com rdar://121014613
     { .match = QuirkMatch::domain("instagram.com"_s),
-        .disablesElementFullscreen = true },
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
 #endif
 
     // invideo.io rdar://171741842 https://webkit.org/b/311602
@@ -3455,6 +3417,17 @@ static constexpr Quirk table[] = {
 #endif
 #endif
 
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    // mybinder.org rdar://51770057
+    { .match = QuirkMatch::domain("mybinder.org"_s),
+        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }),
+        .site = QuirkSite::MyBinder },
+
+    // naver.com rdar://48068610
+    { .match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen().hostIsOneOf<naverHostsWithoutSimulatedMouseEvents>(),
+        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+#endif
+
     { .match = QuirkMatch::domain("netflix.com"_s),
         .behaviors = quirkBehaviors({
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
@@ -3551,6 +3524,10 @@ static constexpr Quirk table[] = {
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
             // Soundcloud: rdar://102913500
             ShouldExposeShowModalDialog,
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+            // soundcloud.com rdar://52915981
+            ShouldDispatchSimulatedMouseEventsQuirk,
+#endif
         }),
         .site = QuirkSite::SoundCloud },
 
@@ -3605,6 +3582,10 @@ static constexpr Quirk table[] = {
             NeedsTikTokOverflowingContentQuirk,
             // tiktok.com rdar://174179805
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+            // tiktok.com rdar://174179805
+            ShouldDispatchSimulatedMouseEventsQuirk,
+#endif
         }),
         .site = QuirkSite::TikTok },
 
@@ -3652,7 +3633,7 @@ static constexpr Quirk table[] = {
 #if PLATFORM(IOS_FAMILY)
     // rdar://116531089
     { .match = QuirkMatch::domain("vimeo.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .disablesElementFullscreen = true },
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
@@ -3693,6 +3674,12 @@ static constexpr Quirk table[] = {
         }) },
 
     // rdar://170412045, https://bugs.webkit.org/show_bug.cgi?id=307933
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    // wix.com rdar://49124313, except while picking a template.
+    { .match = QuirkMatch::domain("wix.com"_s).exceptWhen().pathStartsWith("/website/templates/"_s),
+        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+#endif
+
     { .match = QuirkMatch::domain("workspaces.xyz"_s),
         .behaviors = quirkBehaviors({ ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions }) },
 
@@ -3761,7 +3748,14 @@ static constexpr Quirk table[] = {
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
     { .match = QuirkMatch::domain("youtube.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .disablesElementFullscreen = true },
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+
+    // tiny. (Ref: rdar://121471373, rdar://121473410)
+    { .match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIsOneOf<youTubeEmbedDomains>().onlyIf(QuirkCondition::SmallScreen),
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+
+    { .match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIs("x.com"_s),
+        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
 
     // youtube.com rdar://49582231
     { .match = QuirkMatch::host("www.youtube.com"_s),
@@ -3812,10 +3806,20 @@ static constexpr Quirk table[] = {
 
 } // namespace SiteSpecificQuirks
 
+QuirksData resolveSiteSpecificQuirks(const QuirkMatchContext& context)
+{
+    QuirksData quirksData;
+    for (auto& quirk : SiteSpecificQuirks::table)
+        if (quirk.match.matches(context))
+            quirk.apply(quirksData);
+    return quirksData;
+}
+
 void Quirks::determineRelevantQuirks()
 {
     RELEASE_ASSERT(m_document);
     m_quirksData = { };
+    m_probedQuirks = { };
 
 #if PLATFORM(IOS_FAMILY)
     static const bool shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
@@ -3846,16 +3850,9 @@ void Quirks::determineRelevantQuirks()
     if (quirksURL.isEmpty())
         return;
 
-    QuirkMatchContext context { quirksURL, protect(m_document)->url() };
-    for (auto& quirk : SiteSpecificQuirks::table) {
-        if (quirk.match.matches(context))
-            quirk.apply(m_quirksData);
-    }
+    Ref document = *protect(m_document);
+    m_quirksData.merge(resolveSiteSpecificQuirks({ quirksURL, document->url(), document->isTopDocument() ? IsTopDocument::Yes : IsTopDocument::No }));
 
-    // Note: `needsDisableDOMPasteAccessQuirk` needs a live document to assess
-    // Note: `shouldDisableElementFullscreen` needs a live document for embedded sites
-
-    // FIXME: The below quirks should be handled more efficiently in a
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
     // rdar://133423460
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldFlipScreenDimensionsQuirk, shouldFlipScreenDimensionsInternal(quirksURL));

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -403,6 +403,19 @@ private:
 
     mutable QuirksData m_quirksData;
 
+    mutable QuirksData::QuirkBitSet m_probedQuirks;
+
+    template<typename Probe>
+    bool quirkIsEnabledAfterProbing(QuirksData::SiteSpecificQuirk quirk, NOESCAPE Probe&& probe) const
+    {
+        auto index = static_cast<size_t>(quirk);
+        if (!m_probedQuirks.get(index)) {
+            m_probedQuirks.set(index);
+            m_quirksData.setQuirkState(quirk, probe());
+        }
+        return m_quirksData.quirkIsEnabled(quirk);
+    }
+
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
     bool m_needsToCopyUserSelectNoneQuirk { false };
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -47,6 +47,7 @@ enum class QuirkSite : uint8_t {
     IHeart,
     InVideo,
     LinkedIn,
+    MyBinder,
     NBA,
     Netflix,
     Outlook,
@@ -99,6 +100,7 @@ struct QuirksData {
 #if PLATFORM(IOS_FAMILY)
         NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk,
 #endif
+        NeedsDisableDOMPasteAccessQuirk,
         NeedsFacebookRemoveNotSupportedQuirk,
 #if PLATFORM(COCOA)
         NeedsAnchorToBeMouseFocusableQuirk,
@@ -176,6 +178,9 @@ struct QuirksData {
 #endif
         ShouldDisableDataURLPaddingValidation,
         ShouldDisableDOMAudioSession,
+#if PLATFORM(IOS_FAMILY)
+        ShouldDisableElementFullscreenQuirk,
+#endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
         ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk,
 #endif
@@ -204,6 +209,9 @@ struct QuirksData {
 #endif
         ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk,
         ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
+#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+        ShouldDispatchSimulatedMouseEventsQuirk,
+#endif
 #if ENABLE(MEDIA_STREAM)
         ShouldEnableCameraAndMicrophonePermissionStateQuirk,
         ShouldEnableCameraBackgroundPlayback,
@@ -334,20 +342,12 @@ struct QuirksData {
         return activeQuirks.set(static_cast<size_t>(quirk), state);
     }
 
-    // Requires check at moment of use
-    std::optional<bool> needsDisableDOMPasteAccessQuirk;
-    bool shouldDisableElementFullscreen { false };
-
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
-    enum class ShouldDispatchSimulatedMouseEvents : uint8_t {
-        Unknown,
-        No,
-        DependingOnTargetWithSliderRole,
-        DependingOnTargetFor_mybinder_org,
-        Yes,
-    };
-    ShouldDispatchSimulatedMouseEvents shouldDispatchSimulatedMouseEventsQuirk { ShouldDispatchSimulatedMouseEvents::Unknown };
-#endif
+    constexpr void merge(const QuirksData& other)
+    {
+        auto& [otherActiveQuirks, otherSites] = other;
+        activeQuirks.merge(otherActiveQuirks);
+        sites.merge(otherSites);
+    }
 };
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
@@ -43,11 +43,13 @@ static bool matchesURL(const QuirkMatch& match, ASCIILiteral urlString)
 
 static bool matchesEmbeddedURL(const QuirkMatch& match, ASCIILiteral topURLString, ASCIILiteral documentURLString)
 {
-    return match.matches(QuirkMatchContext { URL { topURLString }, URL { documentURLString } });
+    return match.matches(QuirkMatchContext { URL { topURLString }, URL { documentURLString }, WebCore::IsTopDocument::No });
 }
 
 static constexpr std::array expediaGroupDomains { "hotels.com"_s, "orbitz.com"_s, "wotif.co.nz"_s };
 static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
+static constexpr std::array vimeoDomains { "vimeo.com"_s };
+static constexpr std::array excludedNaverHosts { "tv.naver.com"_s, "mail.naver.com"_s, "m.naver.com"_s };
 
 TEST(QuirkMatchTest, DomainMatchesRegistrableDomain)
 {
@@ -221,6 +223,94 @@ TEST(QuirkMatchTest, DocumentDomainIsOneOfMatchesEmbeddedDocuments)
 
     EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://www.youtube.com/embed/abc"_s));
     EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.youtube.com/"_s, "https://www.theguardian.com/film"_s));
+}
+
+TEST(QuirkMatchTest, DocumentDomainIsMatchesASingleEmbeddedDomain)
+{
+    auto match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIs("x.com"_s);
+
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://x.com/i/status/123"_s));
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://platform.x.com/embed/Tweet.html"_s));
+
+    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://vimeo.com/12345"_s));
+    EXPECT_FALSE(matchesURL(match, "https://x.com/i/status/123"_s));
+}
+
+TEST(QuirkMatchTest, AnySiteWithOnlyIfEmbeddedMatchesEmbedsAnywhereButNeverTheTopDocument)
+{
+    auto match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIsOneOf<youTubeEmbedDomains>();
+
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
+
+    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://vimeo.com/12345"_s));
+    // youtube.com at the top level, and youtube.com embedded in itself, are both the top document.
+    EXPECT_FALSE(matchesURL(match, "https://www.youtube.com/watch?v=abc"_s));
+}
+
+TEST(QuirkMatchTest, AnySiteMatchesEverySiteWithoutFurtherRefinement)
+{
+    auto match = QuirkMatch::anySite();
+
+    EXPECT_TRUE(matchesURL(match, "https://www.example.com/"_s));
+    EXPECT_TRUE(matchesURL(match, "https://webkit.org/"_s));
+    EXPECT_FALSE(matchesURL(match, "about:blank"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenCarvesOutPagesOfAMatchedSite)
+{
+    auto match = QuirkMatch::domain("wix.com"_s).exceptWhen().pathStartsWith("/website/templates/"_s);
+
+    EXPECT_TRUE(matchesURL(match, "https://www.wix.com/"_s));
+    EXPECT_TRUE(matchesURL(match, "https://www.wix.com/website/other"_s));
+    // The exception reuses pathStartsWith(), so it is anchored the same way.
+    EXPECT_TRUE(matchesURL(match, "https://www.wix.com/x/website/templates/blank"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://www.wix.com/website/templates/"_s));
+    EXPECT_FALSE(matchesURL(match, "https://www.wix.com/website/templates/blank"_s));
+
+    // The exception only ever narrows: a page it describes on another site is still no match.
+    EXPECT_FALSE(matchesURL(match, "https://www.example.com/website/other"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenCarvesOutHostsOfAMatchedSite)
+{
+    auto match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen().hostIsOneOf<excludedNaverHosts>();
+
+    EXPECT_TRUE(matchesURL(match, "https://naver.com/"_s));
+    EXPECT_TRUE(matchesURL(match, "https://news.naver.com/"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://tv.naver.com/"_s));
+    EXPECT_FALSE(matchesURL(match, "https://m.naver.com/"_s));
+    // hostIsOneOf() names exact hosts, so subdomains of an excluded host are not excluded.
+    EXPECT_TRUE(matchesURL(match, "https://sub.tv.naver.com/"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)
+{
+    auto match = QuirkMatch::domain("theguardian.com"_s).exceptWhen().onlyIfEmbedded().documentDomainIsOneOf<vimeoDomains>();
+
+    EXPECT_TRUE(matchesURL(match, "https://www.theguardian.com/film"_s));
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
+
+    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://vimeo.com/12345"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)
+{
+    auto match = QuirkMatch::domain("example.com"_s).pathStartsWith("/app"_s).exceptWhen().pathStartsWith("/app/legacy"_s);
+
+    EXPECT_TRUE(matchesURL(match, "https://www.example.com/app/main"_s));
+    EXPECT_FALSE(matchesURL(match, "https://www.example.com/other"_s));
+    EXPECT_FALSE(matchesURL(match, "https://www.example.com/app/legacy/page"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenWithNothingChainedIsANoOp)
+{
+    auto match = QuirkMatch::domain("example.com"_s).exceptWhen();
+
+    EXPECT_TRUE(matchesURL(match, "https://www.example.com/"_s));
+    EXPECT_FALSE(matchesURL(match, "https://webkit.org/"_s));
 }
 
 TEST(QuirkMatchTest, MatchesIgnoreTheDocumentURLByDefault)

--- a/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <WebCore/QuirkMatch.h>
 #include <WebCore/Quirks.h>
 #include <wtf/MainThread.h>
 #include <wtf/URL.h>
@@ -43,6 +44,25 @@ public:
 static std::optional<String> customUserAgentFor(ASCIILiteral urlString)
 {
     return WebCore::Quirks::needsCustomUserAgentOverride(URL { urlString }, "TestApp"_s, "TestBase/1.0 (KHTML, like Gecko) Trailer/1.0"_s);
+}
+
+static WebCore::QuirksData resolveQuirksForTopURL(ASCIILiteral urlString)
+{
+    return WebCore::resolveSiteSpecificQuirks({ URL { urlString }, URL { urlString } });
+}
+
+TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)
+{
+    using SiteSpecificQuirk = WebCore::QuirksData::SiteSpecificQuirk;
+
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.airindiaexpress.com/"_s).quirkIsEnabled(SiteSpecificQuirk::NeedsAirIndiaExpressLayeringQuirk));
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.scribd.com/"_s).quirkIsEnabled(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk));
+
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.iheart.com/"_s).isSite(WebCore::QuirkSite::IHeart));
+
+    auto unrelatedSiteQuirks = resolveQuirksForTopURL("https://www.example.com/"_s);
+    EXPECT_TRUE(unrelatedSiteQuirks.activeQuirks.isEmpty());
+    EXPECT_FALSE(unrelatedSiteQuirks.isSite(WebCore::QuirkSite::IHeart));
 }
 
 TEST_F(QuirksTest, NeedsIPadMiniUserAgent)


### PR DESCRIPTION
#### 11b32a9eb61ff839e2fbfb3c58fc54df3b3813c3
<pre>
[Quirks] Move element fullscreen and simulated mouse events quirks into the table
<a href="https://bugs.webkit.org/show_bug.cgi?id=322315">https://bugs.webkit.org/show_bug.cgi?id=322315</a>
<a href="https://rdar.apple.com/185554722">rdar://185554722</a>

Reviewed by Brent Fulgham.

I have moved the element fullscreen quirk and the simulated mouse events quirks to follow
the new paradigm. Adding these quirks to the table explicitly names the quirks, which will
help us later when we want to turn quirks on and off individually.

I needed to extend the QuirkMatch API to do this correctly. I have added the following
functions to the API:
QuirkMatch::anySite()
QuirkMatch::hostIsOneOf()
QuirkMatch::onlyIfEmbedded()
QuirkMatch::exceptWhen()

Tests: Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
       Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp

* Source/WebCore/page/QuirkMatch.h:
(WebCore::QuirkMatchContext::QuirkMatchContext):
(WebCore::QuirkMatchContext::isTopDocument const):
(WebCore::QuirkMatch::anySite):
(WebCore::QuirkMatch::onlyIf):
(WebCore::QuirkMatch::documentDomainIsOneOf):
(WebCore::QuirkMatch::hostIsOneOf):
(WebCore::QuirkMatch::onlyIfEmbedded):
(WebCore::QuirkMatch::exceptWhen):
(WebCore::QuirkMatch::matches const):
(WebCore::QuirkMatch::Refinements::isEmpty const):
(WebCore::QuirkMatch::setPathConstraint):
(WebCore::QuirkMatch::matchesSite const):
(WebCore::QuirkMatch::matchesRefinements const):
(WebCore::QuirkMatch::anyOf):
(WebCore::QuirkMatch::matchesPathConstraint const):
(WebCore::Quirk::apply const):
(WebCore::QuirkMatch::matchesDocumentDomain const): Deleted.
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
(WebCore::Quirks::quirkIsEnabledAfterProbing const):
* Source/WebCore/page/QuirksData.h:
(WebCore::QuirksData::merge):
(): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp:
(TestWebKitAPI::matchesEmbeddedURL):
(TestWebKitAPI::TEST(QuirkMatchTest, AnySiteWithOnlyIfEmbeddedMatchesEmbedsAnywhereButNeverTheTopDocument)):
(TestWebKitAPI::TEST(QuirkMatchTest, AnySiteMatchesEverySiteWithoutFurtherRefinement)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenCarvesOutPagesOfAMatchedSite)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenCarvesOutHostsOfAMatchedSite)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenWithNothingChainedIsANoOp)):
* Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp:
(TestWebKitAPI::resolveQuirksForTopURL):
(TestWebKitAPI::TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)):

Canonical link: <a href="https://commits.webkit.org/319832@main">https://commits.webkit.org/319832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfb7ac394cd2a11cf95b3934ccee27ac95542d55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182851 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0154ec8-7350-4da4-85e7-a3cf596909e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142713 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c323b62-d938-4966-8ac4-9332d78e22c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123141 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/048b3ae7-6d0f-46ea-886e-e30683acfd96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45121 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43373 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43002 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4241 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195009 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56443 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57148 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151872 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46431 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129417 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125499 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55656 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18012 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55027 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->