### PR TITLE
[Grid Lanes] GridLanesLayout does not need to live on RenderGrid.

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1573,7 +1573,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     if (!columnPositions.size() || !rowPositions.size())
         return { };
 
-    LayoutUnit gridLanesContentSize = renderGrid->gridLanesContentSize();
+    LayoutUnit gridLanesContentSize = renderGrid->gridLanesContentSizeForWebInspectorOverlay();
 
     // There are no actual rows or columns in the stacking axis of a grid lanes layout.
     // But we can borrow the concept to draw the two lines at the start and end of the stacking axis.

--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -55,8 +55,8 @@ void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& 
 {
     initializeGridLanes(gridAxisTracks, stackingAxisDirection);
 
-    m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns);
-    m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows);
+    m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns, std::cref(*this));
+    m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows, std::cref(*this));
 
     // 4.4 Grid Lanes Layout and Placement Algorithm
     // https://drafts.csswg.org/css-grid-3/#grid-lanes-layout-algorithm

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -52,13 +52,13 @@ public:
         MaxContent
     };
 
-    void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
     void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
-    LayoutUnit gridGap() const { return m_stackingAxisGridGap; };
 
 private:
+    void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
+
     GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
@@ -78,7 +78,7 @@ private:
     GridArea NODELETE gridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
 
-    unsigned m_gridAxisTracksCount;
+    unsigned m_gridAxisTracksCount { 0 };
 
     Vector<LayoutUnit> m_runningPositions;
     HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;
@@ -86,10 +86,10 @@ private:
     LayoutUnit m_stackingAxisGridGap;
     LayoutUnit m_gridContentSize;
 
-    Style::GridTrackSizingDirection m_stackingAxisDirection;
+    Style::GridTrackSizingDirection m_stackingAxisDirection { };
     const GridSpan m_stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
 
-    unsigned m_autoFlowNextCursor;
+    unsigned m_autoFlowNextCursor { 0 };
 };
 
 } // end namespace WebCore

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -234,8 +234,10 @@ void GridTrackSizingAlgorithm::setAvailableSpace(Style::GridTrackSizingDirection
 
 LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
 {
-    if (isDirectionInStackingAxis())
-        return m_renderGrid->gridLanesContentSize();
+    // A grid lanes container's content size in the stacking axis comes from placement rather than from
+    // track sizing, and run() returns early for the stacking axis, so no caller reaches this in that
+    // direction. The callers which need the placed size read it from the GridLanesLayout directly.
+    ASSERT(!isDirectionInStackingAxis());
 
     WTF::Range<size_t> rangeToIgnore;
     if (m_renderGrid->shouldCheckExplicitIntrinsicInnerLogicalSize(m_direction) && m_renderGrid->autoRepeatType(m_direction) == AutoRepeatType::Fit)

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -61,7 +61,6 @@ RenderGrid::RenderGrid(Element& element, Style::ComputedStyle&& style)
     : RenderBlock(Type::Grid, element, WTF::move(style), { })
     , m_grid(*this)
     , m_trackSizingAlgorithm(this, currentGrid())
-    , m_gridLanesLayout(*this)
 {
     ASSERT(isRenderGrid());
     // All of our children must be block level.
@@ -293,7 +292,7 @@ void RenderGrid::repeatTracksSizingIfNeeded(LayoutUnit availableSpaceForColumns,
     // it is applicable for the case of percent-sized rows with indefinite height as well.
     if (gridLayoutState.needsSecondTrackSizingPass() || m_trackSizingAlgorithm.hasAnyPercentSizedRowsIndefiniteHeight() || (m_trackSizingAlgorithm.hasAnyFlexibleMaxTrackBreadth() && !m_trackSizingAlgorithm.hasAnyBaselineAlignmentItem()) || gridLayoutState.hasAspectRatioBlockSizeDependentItem()) {
 
-        populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows);
+        populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows, { });
         computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection::Columns, availableSpaceForColumns, gridLayoutState);
         m_offsetBetweenColumns = computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection::Columns, m_trackSizingAlgorithm.freeSpace(Style::GridTrackSizingDirection::Columns).value(), nonCollapsedTracks(Style::GridTrackSizingDirection::Columns));
 
@@ -529,7 +528,7 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         m_offsetBetweenRows = computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection::Rows, m_trackSizingAlgorithm.freeSpace(Style::GridTrackSizingDirection::Rows).value(), nonCollapsedTracks(Style::GridTrackSizingDirection::Rows));
 
         if (!aspectRatioBlockSizeDependentGridItems.isEmpty()) {
-            updateGridAreaForAspectRatioItems(aspectRatioBlockSizeDependentGridItems, gridLayoutState);
+            updateGridAreaForAspectRatioItems(aspectRatioBlockSizeDependentGridItems, gridLayoutState, { });
             updateLogicalWidth();
         }
 
@@ -546,7 +545,7 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
             setLogicalHeight(std::max(logicalHeight(), minHeightForEmptyLine));
         }
 
-        layoutGridItems(gridLayoutState);
+        layoutGridItems(gridLayoutState, { });
 
         updateResolvedTrackListsAfterLayout();
 
@@ -652,11 +651,18 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
         } else
             computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection::Rows, availableLogicalHeight(AvailableLogicalHeightType::ExcludeMarginBorderPadding), gridLayoutState);
 
+        auto gridLanesLayout = GridLanesLayout { *this };
+
         auto performGridLanesPlacement = [&](const Style::GridTrackSizingDirection stackingAxisDirection) {
             auto gridAxisDirection = stackingAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
             unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
 
-            m_gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, GridLanesLayout::Phase::Layout);
+            gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, GridLanesLayout::Phase::Layout);
+
+            // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
+            // placement, but its min-content and max-content results are not what the overlay should
+            // be drawing.
+            m_gridLanesContentSizeForWebInspectorOverlay = gridLanesLayout.gridContentSize();
         };
 
         if (hasStackingAxisRows())
@@ -669,7 +675,7 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
             trackBasedLogicalHeight += size.value();
         else {
             if (hasStackingAxisRows())
-                trackBasedLogicalHeight += m_gridLanesLayout.gridContentSize();
+                trackBasedLogicalHeight += gridLanesLayout.gridContentSize();
             else
                 trackBasedLogicalHeight += m_trackSizingAlgorithm.computeTrackBasedSize();
         }
@@ -689,7 +695,7 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
         m_offsetBetweenRows = computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection::Rows, m_trackSizingAlgorithm.freeSpace(Style::GridTrackSizingDirection::Rows).value(), nonCollapsedTracks(Style::GridTrackSizingDirection::Rows));
 
         if (!aspectRatioBlockSizeDependentGridItems.isEmpty()) {
-            updateGridAreaForAspectRatioItems(aspectRatioBlockSizeDependentGridItems, gridLayoutState);
+            updateGridAreaForAspectRatioItems(aspectRatioBlockSizeDependentGridItems, gridLayoutState, gridLanesLayout);
             updateLogicalWidth();
         }
 
@@ -701,7 +707,7 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
             setLogicalHeight(std::max(logicalHeight(), minHeightForEmptyLine));
         }
 
-        layoutGridLanesItems(gridLayoutState);
+        layoutGridLanesItems(gridLayoutState, gridLanesLayout);
 
         updateResolvedTrackListsAfterLayout();
 
@@ -860,11 +866,13 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
 
         // To determine the width of the grid when we have a grid lanes layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
-        m_gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MinContent);
-        minLogicalWidth = m_gridLanesLayout.gridContentSize();
+        auto gridLanesLayout = GridLanesLayout { const_cast<RenderGrid&>(*this) };
 
-        m_gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MaxContent);
-        maxLogicalWidth = m_gridLanesLayout.gridContentSize();
+        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MinContent);
+        minLogicalWidth = gridLanesLayout.gridContentSize();
+
+        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MaxContent);
+        maxLogicalWidth = gridLanesLayout.gridContentSize();
     }
 
     m_grid.resetCurrentGrid();
@@ -1258,11 +1266,6 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 #endif
 }
 
-LayoutUnit RenderGrid::gridLanesContentSize() const
-{
-    return m_gridLanesLayout.gridContentSize();
-}
-
 void RenderGrid::performPreLayoutForGridItems(const GridTrackSizingAlgorithm& algorithm, const ShouldUpdateGridAreaLogicalSize shouldUpdateGridAreaLogicalSize) const
 {
     ASSERT(!algorithm.grid().needsItemsPlacement());
@@ -1620,10 +1623,10 @@ void RenderGrid::updateGridAreaLogicalSize(RenderBox& gridItem, std::optional<La
     gridItem.setGridAreaContentLogicalHeight(height);
 }
 
-void RenderGrid::updateGridAreaForAspectRatioItems(const Vector<RenderBox*>& autoGridItems, RenderGridLayoutState& gridLayoutState)
+void RenderGrid::updateGridAreaForAspectRatioItems(const Vector<RenderBox*>& autoGridItems, RenderGridLayoutState& gridLayoutState, GridLanesLayoutRef gridLanesLayout)
 {
-    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Columns);
-    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows);
+    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Columns, gridLanesLayout);
+    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows, gridLanesLayout);
 
     for (auto& autoGridItem : autoGridItems) {
         updateGridAreaIncludingAlignment(*autoGridItem);
@@ -1633,10 +1636,10 @@ void RenderGrid::updateGridAreaForAspectRatioItems(const Vector<RenderBox*>& aut
     }
 }
 
-void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState)
+void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState, GridLanesLayoutRef gridLanesLayout)
 {
-    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Columns);
-    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows);
+    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Columns, gridLanesLayout);
+    populateGridPositionsForDirection(m_trackSizingAlgorithm, Style::GridTrackSizingDirection::Rows, gridLanesLayout);
 
     for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
         if (currentGrid().orderIterator().shouldSkipChild(gridItem)) {
@@ -1667,7 +1670,7 @@ void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState)
         // We need pending layouts to be done in order to compute auto-margins properly.
         GridLayoutFunctions::updateAutoMarginsIfNeeded(gridItem, writingMode());
 
-        setLogicalPositionForGridItem(gridItem);
+        setLogicalPositionForGridItem(gridItem, gridLanesLayout);
 
         // If the grid item moved, we have to repaint it as well as any floating/positioned
         // descendants. An exception is if we need a layout. In this case, we know we're going to
@@ -1677,9 +1680,9 @@ void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState)
     }
 }
 
-void RenderGrid::layoutGridLanesItems(RenderGridLayoutState& gridLayoutState)
+void RenderGrid::layoutGridLanesItems(RenderGridLayoutState& gridLayoutState, const GridLanesLayout& gridLanesLayout)
 {
-    layoutGridItems(gridLayoutState);
+    layoutGridItems(gridLayoutState, gridLanesLayout);
 }
 
 void RenderGrid::prepareGridItemForPositionedLayout(RenderBox& gridItem)
@@ -1735,7 +1738,7 @@ LayoutUnit RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets(const
     return finalTrackPosition - initialTrackPosition + tracks[span.endLine() - 1]->unclampedBaseSize();
 }
 
-void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction)
+void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction, GridLanesLayoutRef gridLanesLayout)
 {
     // Since we add alignment offsets and track gutters, grid lines are not always adjacent. Hence, we will have to
     // assume from now on that we just store positions of the initial grid lines of each track,
@@ -1769,7 +1772,7 @@ void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorith
         positions[lastLine] = positions[nextToLastLine] + tracks[nextToLastLine]->unclampedBaseSize();
 
         if (isStackingAxis(direction))
-            positions[lastLine] = m_gridLanesLayout.gridContentSize() + positions[0];
+            positions[lastLine] = gridLanesLayout->get().gridContentSize() + positions[0];
 
         // Adjust collapsed gaps. Collapsed tracks cause the surrounding gutters to collapse (they
         // coincide exactly) except on the edges of the grid where they become 0.
@@ -2150,12 +2153,12 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     return GridAxisPosition::GridAxisStart;
 }
 
-LayoutUnit RenderGrid::columnAxisOffsetForGridItem(const RenderBox& gridItem) const
+LayoutUnit RenderGrid::columnAxisOffsetForGridItem(const RenderBox& gridItem, GridLanesLayoutRef gridLanesLayout) const
 {
     auto [startOfRow, endOfRow] = gridAreaPositionForInFlowGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
     LayoutUnit startPosition = startOfRow + marginBeforeForChild(gridItem);
     LayoutUnit columnAxisGridItemSize = GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) ? gridItem.logicalWidth() + gridItem.marginLogicalWidth() : gridItem.logicalHeight() + gridItem.marginLogicalHeight();
-    LayoutUnit stackingAxisOffset = hasStackingAxisRows() ? m_gridLanesLayout.offsetForGridItem(gridItem) : 0_lu;
+    LayoutUnit stackingAxisOffset = hasStackingAxisRows() ? gridLanesLayout->get().offsetForGridItem(gridItem) : 0_lu;
     auto overflow = selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Block).overflow();
     LayoutUnit offsetFromStartPosition = computeOverflowAlignmentOffset(overflow, endOfRow - startOfRow, columnAxisGridItemSize);
     if (GridLayoutFunctions::hasAutoMarginsInColumnAxis(gridItem, writingMode()))
@@ -2174,11 +2177,11 @@ LayoutUnit RenderGrid::columnAxisOffsetForGridItem(const RenderBox& gridItem) co
     return 0;
 }
 
-LayoutUnit RenderGrid::rowAxisOffsetForGridItem(const RenderBox& gridItem) const
+LayoutUnit RenderGrid::rowAxisOffsetForGridItem(const RenderBox& gridItem, GridLanesLayoutRef gridLanesLayout) const
 {
     auto [startOfColumn, endOfColumn] = gridAreaPositionForInFlowGridItem(gridItem, Style::GridTrackSizingDirection::Columns);
     LayoutUnit startPosition = startOfColumn + marginStartForChild(gridItem);
-    LayoutUnit stackingAxisOffset = hasStackingAxisColumns() ? m_gridLanesLayout.offsetForGridItem(gridItem) : 0_lu;
+    LayoutUnit stackingAxisOffset = hasStackingAxisColumns() ? gridLanesLayout->get().offsetForGridItem(gridItem) : 0_lu;
     if (GridLayoutFunctions::hasAutoMarginsInRowAxis(gridItem, writingMode()))
         return startPosition;
     LayoutUnit rowAxisGridItemSize = GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) ? gridItem.logicalHeight() + gridItem.marginLogicalHeight() : gridItem.logicalWidth() + gridItem.marginLogicalWidth();
@@ -2497,19 +2500,19 @@ LayoutUnit RenderGrid::translateRTLCoordinate(LayoutUnit coordinate) const
 }
 
 // FIXME: SetLogicalPositionForGridItem has only one caller, consider its refactoring in the future.
-void RenderGrid::setLogicalPositionForGridItem(RenderBox& gridItem) const
+void RenderGrid::setLogicalPositionForGridItem(RenderBox& gridItem, GridLanesLayoutRef gridLanesLayout) const
 {
     // "In the positioning phase [...] calculations are performed according to the writing mode of the containing block of the box establishing the
     // orthogonal flow." However, 'setLogicalLocation' will only take into account the grid item's writing-mode, so the position may need to be transposed.
-    LayoutPoint gridItemLocation(logicalOffsetForGridItem(gridItem, Style::GridTrackSizingDirection::Columns), logicalOffsetForGridItem(gridItem, Style::GridTrackSizingDirection::Rows));
+    LayoutPoint gridItemLocation(logicalOffsetForGridItem(gridItem, Style::GridTrackSizingDirection::Columns, gridLanesLayout), logicalOffsetForGridItem(gridItem, Style::GridTrackSizingDirection::Rows, gridLanesLayout));
     gridItem.setLogicalLocation(GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) ? gridItemLocation.transposedPoint() : gridItemLocation);
 }
 
-LayoutUnit RenderGrid::logicalOffsetForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction) const
+LayoutUnit RenderGrid::logicalOffsetForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction, GridLanesLayoutRef gridLanesLayout) const
 {
     if (direction == Style::GridTrackSizingDirection::Rows)
-        return columnAxisOffsetForGridItem(gridItem);
-    LayoutUnit rowAxisOffset = rowAxisOffsetForGridItem(gridItem);
+        return columnAxisOffsetForGridItem(gridItem, gridLanesLayout);
+    LayoutUnit rowAxisOffset = rowAxisOffsetForGridItem(gridItem, gridLanesLayout);
     // We stored m_columnPositions's data ignoring the direction, hence we might need now
     // to translate positions from RTL to LTR, as it's more convenient for painting.
     if (writingMode().isInlineFlipped())

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "Grid.h"
-#include "GridLanesLayout.h"
 #include "GridTrackSizingAlgorithm.h"
 #include "RenderBlock.h"
 #include "StyleGridTrackSizingDirection.h"
@@ -46,8 +45,15 @@ class GridLayout;
 
 class GridArea;
 class RenderGridLayoutState;
+class GridLanesLayout;
 class GridSpan;
 class LayoutRange;
+
+// A grid lanes layout only exists for the duration of a single layout (or intrinsic width
+// computation) of a grid lanes container, so it is threaded through the layout call chain as a
+// non-owning observer rather than living on the renderer. It is std::nullopt for grids which are
+// not performing a grid lanes layout.
+using GridLanesLayoutRef = std::optional<std::reference_wrapper<const GridLanesLayout>>;
 
 struct ContentAlignmentData {
     LayoutUnit positionOffset;
@@ -149,7 +155,11 @@ public:
     LayoutUnit gridGap(Style::GridTrackSizingDirection) const;
     LayoutUnit gridGap(Style::GridTrackSizingDirection, std::optional<LayoutUnit> availableSize) const;
 
-    LayoutUnit NODELETE gridLanesContentSize() const;
+    // The stacking axis content size produced by the most recent grid lanes layout. Unlike the rest of
+    // the GridLanesLayout state this has to outlive layout, because the web inspector's grid overlay
+    // reads it at paint time. Nothing in layout should use this; layout threads the GridLanesLayout
+    // itself through as a GridLanesLayoutRef instead.
+    LayoutUnit NODELETE gridLanesContentSizeForWebInspectorOverlay() const { return m_gridLanesContentSizeForWebInspectorOverlay; }
 
     void updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability();
     std::optional<GridItemSizeCache>& NODELETE intrinsicLogicalHeightsForRowSizingFirstPass() const LIFETIME_BOUND;
@@ -223,23 +233,23 @@ private:
 
     void repeatTracksSizingIfNeeded(LayoutUnit availableSpaceForColumns, LayoutUnit availableSpaceForRows, RenderGridLayoutState&);
 
-    void updateGridAreaForAspectRatioItems(const Vector<RenderBox*>&, RenderGridLayoutState&);
+    void updateGridAreaForAspectRatioItems(const Vector<RenderBox*>&, RenderGridLayoutState&, GridLanesLayoutRef);
 
-    void layoutGridItems(RenderGridLayoutState&);
-    void layoutGridLanesItems(RenderGridLayoutState&);
+    void layoutGridItems(RenderGridLayoutState&, GridLanesLayoutRef);
+    void layoutGridLanesItems(RenderGridLayoutState&, const GridLanesLayout&);
 
-    void populateGridPositionsForDirection(const GridTrackSizingAlgorithm&, Style::GridTrackSizingDirection);
+    void populateGridPositionsForDirection(const GridTrackSizingAlgorithm&, Style::GridTrackSizingDirection, GridLanesLayoutRef);
 
     LayoutRange gridAreaRangeForOutOfFlow(const RenderBox&, Style::GridTrackSizingDirection) const;
     std::pair<LayoutUnit, LayoutUnit> gridAreaPositionForInFlowGridItem(const RenderBox&, Style::GridTrackSizingDirection) const;
 
     GridAxisPosition columnAxisPositionForGridItem(const RenderBox&) const;
     GridAxisPosition rowAxisPositionForGridItem(const RenderBox&) const;
-    LayoutUnit columnAxisOffsetForGridItem(const RenderBox&) const;
-    LayoutUnit rowAxisOffsetForGridItem(const RenderBox&) const;
+    LayoutUnit columnAxisOffsetForGridItem(const RenderBox&, GridLanesLayoutRef) const;
+    LayoutUnit rowAxisOffsetForGridItem(const RenderBox&, GridLanesLayoutRef) const;
     ContentAlignmentData computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection, const LayoutUnit& availableFreeSpace, unsigned numberOfGridTracks) const;
-    void setLogicalPositionForGridItem(RenderBox&) const;
-    LayoutUnit logicalOffsetForGridItem(const RenderBox&, Style::GridTrackSizingDirection) const;
+    void setLogicalPositionForGridItem(RenderBox&, GridLanesLayoutRef) const;
+    LayoutUnit logicalOffsetForGridItem(const RenderBox&, Style::GridTrackSizingDirection, GridLanesLayoutRef) const;
 
     LayoutUnit gridAreaBreadthForGridItemIncludingAlignmentOffsets(const RenderBox&, Style::GridTrackSizingDirection) const;
 
@@ -305,6 +315,7 @@ private:
     Vector<LayoutUnit> m_rowPositions;
     ContentAlignmentData m_offsetBetweenColumns;
     ContentAlignmentData m_offsetBetweenRows;
+    LayoutUnit m_gridLanesContentSizeForWebInspectorOverlay;
 
     // Cached resolved value of grid-template-columns / grid-template-rows (see computeResolvedTrackList).
     // Invalidated when a full (non-simplified) layout begins and repopulated at the end of that layout,
@@ -324,8 +335,6 @@ private:
         const Vector<LayoutUnit>& sizes(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnSizes : rowSizes; }
         Vector<LayoutUnit>& sizes(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnSizes : rowSizes; }
     } m_resolvedTrackList;
-
-    mutable GridLanesLayout m_gridLanesLayout;
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
 


### PR DESCRIPTION
#### efff72a3b9ffcf15c4af0b28648a7c209a5d8eb6
<pre>
[Grid Lanes] GridLanesLayout does not need to live on RenderGrid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322316">https://bugs.webkit.org/show_bug.cgi?id=322316</a>
<a href="https://rdar.apple.com/problem/185555283">rdar://problem/185555283</a>

Reviewed by Alan Baradlay.

RenderGrid held onto a GridLanesLayout object as a member and generally
we want to avoid having items live on the renderer unless they are
needed for some reason after layout. There are a couple of grid lanes
related information that is needed for the web inspector but there is no
need to hold onto the whole object so in the patch we change it to be a
local stack variable that is alive during the duration of layout.

This is mostly a mechanical change where we create the GridLanesLayout
object on the stack and then thread it through different areas of the
code where it is needed. There are some bits of RenderGrid code that
seem to need access to this object so we thread it through as an
optional std::ref to appease both the Grid and Grid Lanes situations.

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::buildGridOverlay):
This is the only piece of information that is needed outside of layout.
The web inspector overlay needs to know the grid content size so we will
keep that one piece of information on the renderer and label it so it is
clear what it is being used for.

* Source/WebCore/rendering/GridLanesLayout.cpp:
(WebCore::GridLanesLayout::performGridLanesPlacement):
populateGridPositionsForDirection needs access to a GridLanesLayout
object in this case so we wrap it in a optional std::ref so that it can
use it.

* Source/WebCore/rendering/GridLanesLayout.h:
Need to initialize some of these members as well!

(WebCore::GridLanesLayout::gridGap const): Deleted.
Unused.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
This one is a little interesting because all callers of this function
could not actually trigger the if (isDirectionInStackingAxis()) logic.
So I remove that code and replace it with a debug assert instead.

Canonical link: <a href="https://commits.webkit.org/319810@main">https://commits.webkit.org/319810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28257820654cff55625197041113536e07f5873e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49853 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192328 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146429 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31338d18-c281-41f8-90c5-481d1c2ab379) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55770 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192328 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98728 "3 flakes 17 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb38dadf-ffd3-487a-ad04-1c88034b5d5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162914 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192328 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4d140ce-6027-4530-87d3-03f22e141bc6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181425 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42816 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192328 "") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11382 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42439 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3490 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43383 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47071 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194254 "") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181501 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162410 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194254 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40766 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56409 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39064 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194254 "") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45869 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128692 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124522 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54920 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17435 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54301 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->