### PR TITLE
CanvasRenderingContext2DBase::drawTextUnchecked: don't re-use pointer returned by fontProxy()

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/canvas/canvas-filter-fillText-crash.html
+++ b/LayoutTests/fast/canvas/canvas-filter-fillText-crash.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ CanvasFiltersEnabled=true ] -->
+
+<!DOCTYPE html>
+
+<p>This test passes if it does not crash.</p>
+<canvas id="c" width="200" height="100"></canvas>
+
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  const ctx = document.getElementById('c').getContext('2d');
+  ctx.font = '20px serif';
+
+  for (let i = 0; i < 15; ++i)
+    ctx.save();
+
+  ctx.filter = 'blur(5px)';
+  ctx.fillText('hello', 10, 50);
+</script>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -10,7 +10,6 @@ dom/Position.cpp
 editing/Editing.cpp
 [ iOS ] editing/cocoa/EditorCocoa.mm
 [ macOS ] html/HTMLMediaElement.cpp
-html/canvas/CanvasRenderingContext2DBase.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/InspectorDOMAgent.cpp
 layout/formattingContexts/FormattingGeometry.cpp

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2902,18 +2902,17 @@ static bool canUseCachedShapedText(const TextRun& textRun)
 
 void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, double x, double y, bool fill, std::optional<double> maxWidth)
 {
-    auto& fontCascade = this->fontProxy()->fontCascade();
-    auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
-
     auto* cachedShapedText = [&]() -> TextShapingResultAndDisplayList* {
         if (!canUseCachedShapedText(textRun))
             return nullptr;
-        RefPtr fonts = fontCascade.fonts();
+
+        CheckedRef fontCascade = fontProxy()->fontCascade();
+        RefPtr fonts = fontCascade->fonts();
         ASSERT(fonts);
         return fonts->getOrCreateCachedShapedText(textRun, fontCascade, 0, std::nullopt, ForTextEmphasis::No);
     }();
 
-    float fontWidth = cachedShapedText ? cachedShapedText->textShapingResult.width : fontCascade.width(textRun);
+    float fontWidth = cachedShapedText ? cachedShapedText->textShapingResult.width : protect(fontProxy()->fontCascade())->width(textRun);
 
     bool useMaxWidth = maxWidth && maxWidth.value() < fontWidth;
     float width = useMaxWidth ? maxWidth.value() : fontWidth;
@@ -2921,22 +2920,26 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     location += textOffset(width, textRun.direction());
 
     // The slop built in to this mask rect matches the heuristic used in FontCGWin.cpp for GDI text.
-    FloatRect textRect = FloatRect(location.x() - fontMetrics.intHeight() / 2, location.y() - fontMetrics.intAscent() - fontMetrics.intLineGap(),
-        width + fontMetrics.intHeight(), fontMetrics.intLineSpacing());
+    FloatRect textRect = [&] () {
+        const auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
+        return FloatRect(
+            location.x() - fontMetrics.intHeight() / 2,
+            location.y() - fontMetrics.intAscent() - fontMetrics.intLineGap(),
+            width + fontMetrics.intHeight(),
+            fontMetrics.intLineSpacing()
+        );
+    }();
     if (!fill)
         textRect = inflatedStrokeRect(textRect);
 
     auto targetSwitcher = CanvasFilterContextSwitcher::create(*this, textRect);
 
-    // FIXME: Need to refetch fontProxy. CanvasFilterContextSwitcher might have called save().
-    // https://bugs.webkit.org/show_bug.cgi?id=193077.
     auto* c = effectiveDrawingContext();
-    auto& fontProxy = *this->fontProxy();
 
     bool cachedDisplayListNeedsStateSave = false;
     // Any shadow could add display list items to draw glyphs a 2nd time with different context attributes.
     if (cachedShapedText && !cachedShapedText->displayList && !cachedShapedText->textShapingResult.glyphBuffer.isEmpty() && !c->dropShadow()) {
-        cachedShapedText->displayList = fontCascade.displayListForGlyphBuffer(*c, cachedShapedText->textShapingResult.glyphBuffer, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        cachedShapedText->displayList = protect(fontProxy()->fontCascade())->displayListForGlyphBuffer(*c, cachedShapedText->textShapingResult.glyphBuffer, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
 
         if (cachedShapedText->displayList) {
             for (auto& item : cachedShapedText->displayList->items()) {
@@ -2965,11 +2968,11 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
                     }
                 } else {
                     FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
-                    fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+                    protect(fontProxy()->fontCascade())->drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
                 }
             }
         } else
-            fontProxy.drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            fontProxy()->drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
     };
 
 #if USE(CG)


### PR DESCRIPTION
#### f0d5be8210e3d8c5ac5fd6c86e86195b64cf7bb9
<pre>
CanvasRenderingContext2DBase::drawTextUnchecked: don&apos;t re-use pointer returned by fontProxy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318372">https://bugs.webkit.org/show_bug.cgi?id=318372</a>
<a href="https://rdar.apple.com/175759731">rdar://175759731</a>

Reviewed by Simon Fraser.

CanvasRenderingContext2D::fontProxy() returns the pointer to State::font
(a FontProxy) of the top State in the state stack. State stores the
FontProxy by value, so the FontProxy goes away when the State is deallocated.
This could happen when the state stack (a Vector&lt;State, 1&gt;) grows beyond
the storage buffer: a new buffer is created, existing State objects are
copied/moved to the new buffer and the old copies deallocated. Hence,
pointers returned by fontProxy() aren&apos;t safe to be re-used, because
between the time when the pointer is obtained and when it&apos;s used, some
operations might&apos;ve manipulated the state stack and caused the FontProxy
to go away.

CanvasRenderingContext2DBase::drawTextUnchecked is one place where it happens:
it (1) holds on to the font cascade from the FontProxy returned by fontProxy(),
(2) creates a CanvasFilterContextSwitcher, whose constructor calls save() which
manipulates the state stack, then (3) uses the saved font cascade from the
FontProxy which might have been deallocated:

void CanvasRenderingContext2DBase::drawTextUnchecked(...)
{
    auto&amp; fontCascade = this-&gt;fontProxy()-&gt;fontCascade();       &lt;-- (1)

    [...]
    auto targetSwitcher = CanvasFilterContextSwitcher::create(*this, textRect);     &lt;-- (2)

    [...]
    auto drawText = [&amp;](...) {
        [...]
        fontCascade.drawGlyphBuffer(...);    &lt;-- (3)

(actually, 317546@main indirectly fixes this by avoiding saving state when
creating CanvasFilterContextSwitcher. But as explained above, re-using fontCascade
is unsafe, so this patch still has merits, even though it&apos;s not fixing anything)

Fix this by not holding onto pointers returned by fontProxy(). Instead, whenever
the FontProxy is needed, call fontProxy() so we&apos;re guaranteed to have a pointer
to a live FontProxy. Additionally, FontCascade can be made CheckedPtr, so wrap
it in CheckedPtr/CheckedRef whenever possible.

Future patches could improve on this by making FontProxy ref-counted, so the
pointer returned by fontProxy() is guaranteed to be alive no matter how the
State object storing it is copied/moved around.

Test: fast/canvas/canvas-filter-fillText-crash.html

* LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-filter-fillText-crash.html: Added.
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

Originally-landed-as: 305413.1097@safari-7624.5-branch (1d58c6a24867). <a href="https://rdar.apple.com/175759731">rdar://175759731</a>
Canonical link: <a href="https://commits.webkit.org/320073@main">https://commits.webkit.org/320073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f18ea084b9c36bb83e02f993b05b1fa43d2c9e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143214 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99440 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45677 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43908 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43503 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4888 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40955 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152412 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46963 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130067 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126366 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56296 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18512 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->