### PR TITLE
marketwatch.com: "Subscribe now" drop-down does not render anything

### DIFF
--- a/LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html
+++ b/LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html
@@ -1,1 +1,1 @@
-<iframe style="border: none;" srcdoc="some content"></iframe><pre>40</pre>
+<iframe style="border: none;" srcdoc="some content"></iframe><pre>0</pre>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS Changing an ancestor's display type does not restart animations inside a subframe
+PASS Hiding and showing an ancestor does not restart animations inside a subframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Changing an ancestor's display does not restart animations inside a subframe</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#animations">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 70px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  A subframe's content lives in its own document, so its animations are not applied to a descendant of
+  anything in this document. Changing the display of an ancestor here must not terminate them, whether
+  the ancestor merely changes display type or is hidden outright. Compare
+  display-none-prevents-starting-in-subtree.html, which covers the same rule within one document.
+-->
+<div class="wrapper" id="displayTypeWrapper">
+  <iframe id="displayTypeFrame" srcdoc="
+    <style>
+      @keyframes slide {
+        from { transform: translateX(0px) }
+        to { transform: translateX(240px) }
+      }
+      #animated {
+        width: 50px;
+        height: 50px;
+        background: green;
+        animation: slide 10s linear infinite;
+      }
+      body { margin: 0 }
+    </style>
+    <div id='animated'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="hiddenWrapper">
+  <iframe id="hiddenFrame" srcdoc="
+    <style>
+      @keyframes slide {
+        from { transform: translateX(0px) }
+        to { transform: translateX(240px) }
+      }
+      #animated {
+        width: 50px;
+        height: 50px;
+        background: green;
+        animation: slide 10s linear infinite;
+      }
+      body { margin: 0 }
+    </style>
+    <div id='animated'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+
+// Seek far enough into the animation that a restart is unmistakable.
+const seekTime = 500;
+
+function seekAnimationIn(frameId) {
+  const contentDocument = document.getElementById(frameId).contentDocument;
+  const animations = contentDocument.getAnimations();
+  assert_equals(animations.length, 1, "subframe should have exactly one animation");
+  animations[0].currentTime = seekTime;
+  return animations[0];
+}
+
+// Reading a layout property flushes style and the render tree update, which is where a subframe's
+// render tree would be torn down.
+function flushRenderTreeUpdate() {
+  document.body.offsetHeight;
+}
+
+promise_test(async () => {
+  await loaded;
+  const animation = seekAnimationIn("displayTypeFrame");
+
+  document.getElementById("displayTypeWrapper").style.display = "inline-block";
+  flushRenderTreeUpdate();
+
+  assert_not_equals(animation.playState, "idle", "animation must not be canceled");
+  assert_greater_than_equal(animation.currentTime, seekTime, "animation must not restart");
+}, "Changing an ancestor's display type does not restart animations inside a subframe");
+
+promise_test(async () => {
+  await loaded;
+  const animation = seekAnimationIn("hiddenFrame");
+
+  const wrapper = document.getElementById("hiddenWrapper");
+  wrapper.style.display = "none";
+  flushRenderTreeUpdate();
+  wrapper.style.display = "block";
+  flushRenderTreeUpdate();
+
+  assert_not_equals(animation.playState, "idle", "animation must not be canceled");
+  assert_greater_than_equal(animation.currentTime, seekTime, "animation must not restart");
+}, "Hiding and showing an ancestor does not restart animations inside a subframe");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Hiding an ancestor of the frame is reflected in a resolved value read from inside it
+PASS Displaying an ancestor of the frame is reflected in a resolved value read from inside it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A resolved value in a subframe reflects a pending display change in the owner document</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper { width: 320px; }
+.wrapper iframe { width: 300px; height: 100px; border: 0; }
+#toShowWrapper { display: none; }
+</style>
+<body>
+<!--
+  Whether a subframe's contents generate boxes depends on the frame's owner element in the parent
+  document, so a resolved value read from the subframe depends on style the parent has not resolved yet.
+  #box has no width of its own, so its computed value is "auto" while its used value is a length, which
+  is what makes it possible to tell which one was returned.
+
+  Each test asserts that a value read straight after the mutation matches the one read once everything
+  has settled, rather than asserting particular values, so nothing here depends on scrollbar widths or
+  on which fallback an implementation reports.
+-->
+<div class="wrapper" id="toHideWrapper"><iframe></iframe></div>
+<div class="wrapper" id="toShowWrapper"><iframe></iframe></div>
+
+<script>
+const frameMarkup = "<style>body { margin: 0 }</style><div id='box' style='height: 40px'></div>";
+
+function boxIn(wrapperId)
+{
+    return document.getElementById(wrapperId).querySelector("iframe").contentDocument.getElementById("box");
+}
+
+function widthOf(wrapperId)
+{
+    return getComputedStyle(boxIn(wrapperId)).width;
+}
+
+// Resolves style and layout in this document, which is what settles whether the frame's owner element
+// generates a box.
+function settleThisDocument()
+{
+    document.documentElement.offsetHeight;
+}
+
+function loadFrames()
+{
+    return Promise.all(Array.from(document.querySelectorAll("iframe"), frame => {
+        return new Promise(resolve => {
+            frame.addEventListener("load", resolve, { once: true });
+            frame.srcdoc = frameMarkup;
+        });
+    }));
+}
+
+promise_setup(loadFrames);
+
+promise_test(async () => {
+    // Displayed, everything settled: a used value, so a length rather than "auto".
+    const beforeHiding = widthOf("toHideWrapper");
+    assert_not_equals(beforeHiding, "auto", "a displayed frame should report a used value");
+
+    document.getElementById("toHideWrapper").style.display = "none";
+    const unsettled = widthOf("toHideWrapper");
+
+    settleThisDocument();
+    assert_equals(unsettled, widthOf("toHideWrapper"),
+        "value read straight after hiding the ancestor should match the settled value");
+}, "Hiding an ancestor of the frame is reflected in a resolved value read from inside it");
+
+promise_test(async () => {
+    document.getElementById("toShowWrapper").style.display = "block";
+    const unsettled = widthOf("toShowWrapper");
+
+    settleThisDocument();
+    const settled = widthOf("toShowWrapper");
+
+    assert_not_equals(settled, "auto", "a displayed frame should report a used value");
+    assert_equals(unsettled, settled,
+        "value read straight after displaying the ancestor should match the settled value");
+}, "Displaying an ancestor of the frame is reflected in a resolved value read from inside it");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Subframe content is not laid out when the frame's own display animates to none
+PASS Subframe content is not laid out when an ancestor's display animates to none
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Subframe content is not laid out when display reaches none through an animation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 80px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  Reaching display:none through an animation must suppress the subframe's content the same way a plain
+  display:none does. An implementation that decides this from the kind of render tree teardown in
+  progress can miss it, because an animated removal is indistinguishable from a renderer being
+  replaced.
+-->
+<div class="wrapper">
+  <iframe id="selfFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #box {
+        width: 250px;
+        height: 40px;
+      }
+    </style>
+    <div id='box'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="ancestorWrapper">
+  <iframe id="ancestorFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #box {
+        width: 250px;
+        height: 40px;
+      }
+    </style>
+    <div id='box'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+
+function boxRectIn(frameId) {
+  const contentDocument = document.getElementById(frameId).contentDocument;
+  return contentDocument.getElementById("box").getBoundingClientRect();
+}
+
+// Reaching display:none through an animation, jumped to its end so no time passes. The forwards fill
+// keeps the animation affecting display after it has finished.
+function hideByAnimatingDisplay(element) {
+  element.animate([{ display: "block" }, { display: "none" }],
+    { duration: 1000, fill: "forwards" }).finish();
+}
+
+// Reading a layout property flushes style and the render tree update.
+function flushParent() {
+  document.body.offsetHeight;
+}
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("selfFrame");
+  assert_equals(boxRectIn("selfFrame").width, 250, "subframe content should start out laid out");
+
+  hideByAnimatingDisplay(frame);
+  flushParent();
+
+  const rect = boxRectIn("selfFrame");
+  assert_equals(rect.width, 0, "width once the frame's display animates to none");
+  assert_equals(rect.height, 0, "height once the frame's display animates to none");
+}, "Subframe content is not laid out when the frame's own display animates to none");
+
+promise_test(async () => {
+  await loaded;
+  assert_equals(boxRectIn("ancestorFrame").width, 250, "subframe content should start out laid out");
+
+  hideByAnimatingDisplay(document.getElementById("ancestorWrapper"));
+  flushParent();
+
+  const rect = boxRectIn("ancestorFrame");
+  assert_equals(rect.width, 0, "width once the ancestor's display animates to none");
+  assert_equals(rect.height, 0, "height once the ancestor's display animates to none");
+}, "Subframe content is not laid out when an ancestor's display animates to none");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Subframe content inside a display:none ancestor reports no geometry until displayed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-while-parent-restyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-while-parent-restyles-expected.txt
@@ -1,0 +1,6 @@
+no relation to any of the frames
+
+PASS A display:none iframe loaded with the parent settled does not lay out its contents
+PASS srcdoc set while the parent has an unrelated pending restyle does not lay out the contents
+PASS srcdoc set while the parent is kept pending throughout the load does not lay out the contents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-while-parent-restyles.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-while-parent-restyles.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Content of a display:none iframe loaded while the parent has pending style is not laid out</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.hidden { display: none; width: 300px; }
+.hidden iframe { width: 300px; height: 100px; border: 0; }
+.restyled { color: rgb(1, 2, 3); }
+</style>
+<body>
+<!--
+  Whether a frame's contents generate boxes depends on the owner element in the parent document, so it is
+  decided by the parent's style update rather than the frame's own. A frame whose document arrives before
+  that update has happened must still not lay out its contents while it is display:none, however the parent's
+  pending style happens to be timed.
+-->
+<div class="hidden" id="settled"><iframe></iframe></div>
+<div class="hidden" id="srcdocCase"><iframe></iframe></div>
+<div class="hidden" id="keptPendingCase"><iframe></iframe></div>
+<div id="unrelated">no relation to any of the frames</div>
+
+<script>
+const markup = "<body style='margin: 0'><div id='box' style='width: 250px; height: 169px'></div></body>";
+const unrelated = document.getElementById("unrelated");
+
+function load(wrapperId)
+{
+    const frame = document.getElementById(wrapperId).querySelector("iframe");
+    return new Promise(resolve => {
+        frame.addEventListener("load", () => resolve(frame), { once: true });
+        frame.srcdoc = markup;
+    });
+}
+
+// Resolving style and layout here is what settles whether the frames' owner elements generate boxes.
+function settleThisDocument()
+{
+    document.documentElement.offsetHeight;
+}
+
+function assertNotLaidOut(frame, description)
+{
+    const box = frame.contentDocument.getElementById("box");
+    assert_equals(box.offsetWidth, 0, description + ", width");
+    assert_equals(box.offsetHeight, 0, description + ", height");
+}
+
+promise_test(async () => {
+    settleThisDocument();
+    const frame = await load("settled");
+    assertNotLaidOut(frame, "loaded with the parent settled");
+}, "A display:none iframe loaded with the parent settled does not lay out its contents");
+
+promise_test(async () => {
+    settleThisDocument();
+    unrelated.className = "restyled";
+    const frame = await load("srcdocCase");
+    assertNotLaidOut(frame, "srcdoc set with an unrelated restyle pending");
+}, "srcdoc set while the parent has an unrelated pending restyle does not lay out the contents");
+
+promise_test(async t => {
+    settleThisDocument();
+
+    // Keeps the parent restyled for the whole load, so the new document cannot arrive at a moment when the
+    // parent happens to be up to date. A timer rather than a microtask, so the load is not starved.
+    let keepPending = true;
+    let flip = false;
+    (function restyle() {
+        if (!keepPending)
+            return;
+        unrelated.style.color = (flip = !flip) ? "rgb(4, 5, 6)" : "rgb(7, 8, 9)";
+        t.step_timeout(restyle, 0);
+    })();
+
+    const frame = await load("keptPendingCase");
+    keepPending = false;
+    assertNotLaidOut(frame, "srcdoc set with the parent kept pending throughout");
+}, "srcdoc set while the parent is kept pending throughout the load does not lay out the contents");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Content of a display:none iframe is not laid out until the frame is displayed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+#hidden {
+  display: none;
+  width: 300px;
+}
+#hidden iframe {
+  width: 0;
+  height: 0;
+  border: 0;
+}
+</style>
+<body>
+<div id="hidden">
+  <iframe id="frame" srcdoc="<!doctype html><body style='margin: 0'><div id='box' style='font: 20px/1 Ahem; width: 100px; height: 40px'>X</div></body>"></iframe>
+</div>
+<script>
+function boxRect() {
+  const contentDocument = document.getElementById("frame").contentDocument;
+  return contentDocument.getElementById("box").getBoundingClientRect();
+}
+
+promise_test(async () => {
+  await new Promise(resolve => addEventListener("load", resolve));
+
+  const whileHidden = boxRect();
+  assert_equals(whileHidden.width, 0, "width while the ancestor is display:none");
+  assert_equals(whileHidden.height, 0, "height while the ancestor is display:none");
+
+  document.getElementById("hidden").style.display = "block";
+
+  const whenShown = boxRect();
+  assert_equals(whenShown.width, 100, "width once the ancestor is displayed");
+  assert_equals(whenShown.height, 40, "height once the ancestor is displayed");
+}, "Subframe content inside a display:none ancestor reports no geometry until displayed");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS Hiding and showing an ancestor preserves a subframe's scroll offset
+PASS Reading a subframe's scroll offset while an ancestor is hidden does not reset it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Hiding and showing an ancestor preserves a subframe's scroll offset</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 100px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  Tentative: no specification says what happens to a subframe's scroll offset while its frame is not
+  rendered. An implementation that drops the content render tree while the frame is hidden must not let
+  the resulting empty layout clamp the offset away, otherwise showing the frame again silently scrolls
+  its content back to the top.
+-->
+<div class="wrapper" id="delayedWrapper">
+  <iframe id="delayedFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #tall {
+        width: 100px;
+        height: 2000px;
+      }
+    </style>
+    <div id='tall'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="probedWrapper">
+  <iframe id="probedFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #tall {
+        width: 100px;
+        height: 2000px;
+      }
+    </style>
+    <div id='tall'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+const targetOffset = 500;
+
+// Reading a layout property flushes style and the render tree update, which is where a subframe's
+// render tree is torn down or rebuilt.
+function flushParent() {
+  document.body.offsetHeight;
+}
+
+function flushSubframe(frame) {
+  frame.contentDocument.documentElement.offsetHeight;
+}
+
+function scrollSubframeToTarget(frame) {
+  flushSubframe(frame);
+  frame.contentWindow.scrollTo(0, targetOffset);
+  flushSubframe(frame);
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "subframe should start out scrolled");
+}
+
+function nextFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("delayedFrame");
+  scrollSubframeToTarget(frame);
+
+  const wrapper = document.getElementById("delayedWrapper");
+  wrapper.style.display = "none";
+  flushParent();
+
+  // Give any layout scheduled by hiding the frame a chance to run.
+  await nextFrame();
+  await nextFrame();
+
+  wrapper.style.display = "block";
+  flushParent();
+  flushSubframe(frame);
+
+  assert_equals(frame.contentWindow.scrollY, targetOffset);
+}, "Hiding and showing an ancestor preserves a subframe's scroll offset");
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("probedFrame");
+  scrollSubframeToTarget(frame);
+
+  const wrapper = document.getElementById("probedWrapper");
+  wrapper.style.display = "none";
+  flushParent();
+
+  // Reading the offset while the frame is hidden runs layout in the content document, which is the
+  // synchronous version of the same hazard.
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "offset while the ancestor is hidden");
+
+  wrapper.style.display = "block";
+  flushParent();
+  flushSubframe(frame);
+
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "offset once the ancestor is shown again");
+}, "Reading a subframe's scroll offset while an ancestor is hidden does not reset it");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-content-stays-editable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-content-stays-editable-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS isContentEditable is true inside a display:none iframe
+PASS isContentEditable does not change as the frame is hidden and shown
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-content-stays-editable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-content-stays-editable.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>contenteditable inside a display:none iframe is still editable</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#contenteditable">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<!--
+  Whether content is editable is a property of the document, not of whether it is on screen right now, so a
+  display:none iframe's content does not become read-only while the frame is hidden.
+-->
+<div id="hidden" style="display: none"><iframe id="hiddenFrame"></iframe></div>
+<div><iframe id="shownFrame"></iframe></div>
+
+<script>
+const markup = "<div id='editable' contenteditable>text</div>";
+
+function loadFrame(frame) {
+    return new Promise(resolve => {
+        frame.addEventListener("load", resolve, { once: true });
+        frame.srcdoc = markup;
+    });
+}
+
+function editableIn(frameId) {
+    return document.getElementById(frameId).contentDocument.getElementById("editable");
+}
+
+promise_setup(() => Promise.all([
+    loadFrame(document.getElementById("hiddenFrame")),
+    loadFrame(document.getElementById("shownFrame")),
+]));
+
+promise_test(async () => {
+    assert_true(editableIn("shownFrame").isContentEditable, "control: a rendered frame");
+    assert_true(editableIn("hiddenFrame").isContentEditable, "a display:none frame");
+}, "isContentEditable is true inside a display:none iframe");
+
+promise_test(async () => {
+    const hidden = document.getElementById("hidden");
+    assert_true(editableIn("hiddenFrame").isContentEditable, "while display:none");
+
+    hidden.style.display = "block";
+    assert_true(editableIn("hiddenFrame").isContentEditable, "once displayed");
+
+    hidden.style.display = "none";
+    assert_true(editableIn("hiddenFrame").isContentEditable, "hidden again");
+}, "isContentEditable does not change as the frame is hidden and shown");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-still-loads-images-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-still-loads-images-expected.txt
@@ -1,0 +1,7 @@
+
+
+
+PASS An image in a display:none iframe loads and reports its natural size
+PASS An image set in a rendered iframe loads
+PASS An image set immediately after a display:none iframe is shown loads
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-still-loads-images.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-still-loads-images.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Images inside a display:none iframe still load</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<!--
+  A display:none iframe's content is not rendered, but the document is still the active document of its
+  navigable, so its images load and their load events fire. Chrome and Firefox both load an image inside a
+  display:none iframe while it is still hidden, and an <img> inside a display:none element loads in every
+  engine, so declining would be observable to script without the frame ever being shown.
+-->
+<div id="hidden" style="display: none"><iframe id="frame"></iframe></div>
+<div id="hiddenThenShown" style="display: none"><iframe id="shownFrame"></iframe></div>
+<div><iframe id="controlFrame"></iframe></div>
+
+<script>
+const imageURL = "/images/green.png";
+
+function loadFrame(frame, markup) {
+    return new Promise(resolve => {
+        frame.addEventListener("load", resolve, { once: true });
+        frame.srcdoc = markup;
+    });
+}
+
+// Creates an img and sets its src with nothing in between, so that the src is set in whatever state the
+// document is in right now. Resolves however the load turns out, so the assertions below report the state
+// rather than the test timing out.
+function appendImageAndWait(test, contentDocument) {
+    const image = contentDocument.createElement("img");
+    contentDocument.body.appendChild(image);
+    image.src = imageURL;
+
+    if (image.complete)
+        return Promise.resolve(image);
+
+    return new Promise(resolve => {
+        image.addEventListener("load", () => resolve(image), { once: true });
+        image.addEventListener("error", () => resolve(image), { once: true });
+        test.step_timeout(() => resolve(image), 2000);
+    });
+}
+
+promise_test(async () => {
+    const frame = document.getElementById("frame");
+    await loadFrame(frame, "<img id='image' src='" + imageURL + "'>");
+
+    const image = frame.contentDocument.getElementById("image");
+    if (!image.complete)
+        await new Promise((resolve, reject) => {
+            image.addEventListener("load", resolve, { once: true });
+            image.addEventListener("error", () => reject(new Error("image failed to load")), { once: true });
+        });
+
+    assert_true(image.complete, "image should have loaded while the frame is display:none");
+    assert_greater_than(image.naturalWidth, 0, "naturalWidth");
+}, "An image in a display:none iframe loads and reports its natural size");
+
+// Control for the test below: the same image, created and given a src the same way, in a frame that was
+// never hidden. If this one fails then the resource or the technique is at fault, not the display change.
+promise_test(async t => {
+    const frame = document.getElementById("controlFrame");
+    await loadFrame(frame, "<body></body>");
+
+    const image = await appendImageAndWait(t, frame.contentDocument);
+
+    assert_true(image.complete, "image should have loaded");
+    assert_greater_than(image.naturalWidth, 0, "naturalWidth");
+}, "An image set in a rendered iframe loads");
+
+promise_test(async t => {
+    const wrapper = document.getElementById("hiddenThenShown");
+    const frame = document.getElementById("shownFrame");
+    await loadFrame(frame, "<body></body>");
+
+    // No layout or style read between showing the frame and setting the src, so the owner document still
+    // has style pending for the iframe at the moment the image data is updated.
+    wrapper.style.display = "block";
+    const image = await appendImageAndWait(t, frame.contentDocument);
+
+    assert_true(image.complete, "image should have loaded");
+    assert_greater_than(image.naturalWidth, 0, "naturalWidth");
+}, "An image set immediately after a display:none iframe is shown loads");
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3018,6 +3018,9 @@ bool Document::updateStyleIfNeeded()
     ContentChangeObserver::StyleRecalcScope observingScope(*this);
 #endif
     resolveStyle();
+
+    updateRenderTreesForDescendantFrames();
+
     return true;
 }
 
@@ -3456,12 +3459,74 @@ bool Document::isInStyleInterleavedLayoutForSelfOrAncestor() const
     return false;
 }
 
+bool Document::ownerElementGeneratesBox() const
+{
+    CheckedPtr ownerElement = this->ownerElement();
+    if (!ownerElement) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+
+    if (ownerElement->renderer())
+        return true;
+
+    if (ownerElement->needsStyleRecalc())
+        return true;
+
+    Ref ownerElementDocument = ownerElement->document();
+
+    if (ownerElementDocument->renderTreeState() != RenderTreeState::Built)
+        return !ownerElementDocument->ownerElement() || ownerElementDocument->ownerElementGeneratesBox();
+
+    return false;
+}
+
+void Document::updateRenderTreeForOwnerElementBox()
+{
+    if (!ownerElement())
+        return;
+
+    auto needsRenderTree = ownerElementGeneratesBox() || printing() || isPluginDocument();
+    if (needsRenderTree && renderTreeState() == RenderTreeState::NotBuilt) {
+        createRenderTree();
+        return;
+    }
+
+    if (!needsRenderTree && renderTreeState() == RenderTreeState::Built)
+        destroyRenderTree(DocumentIsGoingAway::No);
+}
+
+void Document::updateRenderTreesForDescendantFrames()
+{
+    RefPtr frame = m_frame.get();
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    Vector<Ref<Document>> contentDocuments;
+    for (RefPtr descendant = frame->tree().firstChild(); descendant; descendant = descendant->tree().traverseNext(frame.get())) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(descendant.get());
+        if (RefPtr contentDocument = localFrame ? localFrame->document() : nullptr)
+            contentDocuments.append(contentDocument.releaseNonNull());
+    }
+
+    for (auto& contentDocument : contentDocuments) {
+        if (contentDocument->frame() && contentDocument->frame()->document() == contentDocument.ptr())
+            contentDocument->updateRenderTreeForOwnerElementBox();
+    }
+}
+
 void Document::createRenderTree()
 {
     ASSERT(!renderView());
     ASSERT(m_backForwardCacheState != InBackForwardCache);
 
     if (m_isNonRenderedPlaceholder)
+        return;
+
+    auto needsRenderTree = !ownerElement() || ownerElementGeneratesBox() || printing() || isPluginDocument();
+    if (!needsRenderTree)
         return;
 
     // FIXME: It would be better if we could pass the resolved document style directly here.
@@ -3571,20 +3636,29 @@ void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
 
 void Document::destroyRenderTree()
 {
-    ASSERT(renderTreeState() == RenderTreeState::Built);
     ASSERT(frame());
     ASSERT(frame()->document() == this);
     ASSERT(page());
+
+    destroyRenderTree(DocumentIsGoingAway::Yes);
+}
+
+void Document::destroyRenderTree(DocumentIsGoingAway documentIsGoingAway)
+{
+    ASSERT(renderTreeState() == RenderTreeState::Built);
 
     // Prevent Widget tree changes from committing until the RenderView is dead and gone.
     WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
 
     auto scope = SetForScope { m_renderTreeState, RenderTreeState::BeingDestroyed, RenderTreeState::NotBuilt };
 
-    if (isTopDocument())
-        clearAXObjectCache();
+    if (documentIsGoingAway == DocumentIsGoingAway::Yes) {
+        if (isTopDocument())
+            clearAXObjectCache();
 
-    documentWillBecomeInactive();
+        documentWillBecomeInactive();
+    } else
+        m_renderView->setIsInWindow(false);
 
     if (RefPtr view = this->view())
         view->willDestroyRenderTree();
@@ -3592,8 +3666,12 @@ void Document::destroyRenderTree()
     m_pendingRenderTreeUpdate = { };
     m_initialContainingBlockStyle = { };
 
-    if (RefPtr documentElement = m_documentElement)
-        RenderTreeUpdater::tearDownRenderers(*documentElement);
+    if (RefPtr documentElement = m_documentElement) {
+        if (documentIsGoingAway == DocumentIsGoingAway::Yes)
+            RenderTreeUpdater::tearDownRenderers(*documentElement);
+        else
+            RenderTreeUpdater::tearDownRenderersForDisplayNoneFrame(*documentElement);
+    }
 
     clearChildNeedsStyleRecalc();
 
@@ -4481,6 +4559,9 @@ void Document::enqueuePaintTimingEntryIfNeeded()
         return;
 
     if (!window() || !view())
+        return;
+
+    if (renderTreeState() != RenderTreeState::Built)
         return;
 
     // To make sure we don't report paint while the layer tree is still frozen.
@@ -11726,7 +11807,7 @@ bool Document::hitTest(const HitTestRequest& request, const HitTestLocation& loc
 {
     Ref protectedThis { *this };
 
-    if (!renderView())
+    if (renderTreeState() != RenderTreeState::Built)
         return false;
 
     Ref frameView = renderView()->frameView();
@@ -11737,6 +11818,9 @@ bool Document::hitTest(const HitTestRequest& request, const HitTestLocation& loc
         frameView->updateLayoutAndStyleIfNeededRecursive();
     else
         updateLayout();
+
+    if (renderTreeState() != RenderTreeState::Built)
+        return false;
 
 #if ASSERT_ENABLED
     SetForScope hitTestRestorer { m_inHitTesting, true };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -815,7 +815,10 @@ public:
     inline CachedResourceLoader& cachedResourceLoader(); // Defined in DocumentResourceLoader.h
 
     WEBCORE_EXPORT void didBecomeCurrentDocumentInFrame();
+    enum class DocumentIsGoingAway : bool { No, Yes };
+    void destroyRenderTree(DocumentIsGoingAway);
     void destroyRenderTree();
+    void updateRenderTreeForOwnerElementBox();
     WEBCORE_EXPORT void willBeRemovedFromFrame();
 
     // Override ScriptExecutionContext methods to do additional work
@@ -2189,6 +2192,8 @@ private:
     void setRenderer(RenderObject*) = delete;
 
     void createRenderTree();
+    void updateRenderTreesForDescendantFrames();
+    bool ownerElementGeneratesBox() const;
     void detachParser();
 
     DocumentEventTiming* documentEventTimingFromNavigationTiming();

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -107,8 +107,6 @@ void HTMLResourcePreloader::preload(std::unique_ptr<PreloadRequest> preload)
     if (!document || !document->frame())
         return;
 
-    ASSERT(document->renderView());
-
     auto queries = MQ::MediaQueryParser::parse(preload->media(), document->cssParserContext());
     if (!MQ::MediaQueryEvaluator { screenAtom(), *document }.evaluate(queries))
         return;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -702,6 +702,7 @@ void LocalFrame::setPrinting(bool printing, FloatSize pageSize, FloatSize origin
     Frame::setPrinting(printing, pageSize, originalPageSize, maximumShrinkRatio, shouldAdjustViewSize, notifyUIProcess);
 
     RefPtr document = m_doc;
+    document->updateRenderTreeForOwnerElementBox();
     // In setting printing, we should not validate resources already cached for the document.
     // See https://bugs.webkit.org/show_bug.cgi?id=43704
     ResourceCacheValidationSuppressor validationSuppressor(document->cachedResourceLoader());

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -741,6 +741,11 @@ void RenderTreeUpdater::tearDownRenderers(Element& root)
     tearDownRenderers(root, TeardownType::Full);
 }
 
+void RenderTreeUpdater::tearDownRenderersForDisplayNoneFrame(Element& root)
+{
+    tearDownRenderers(root, TeardownType::RendererUpdate);
+}
+
 void RenderTreeUpdater::tearDownRenderersForShadowRootInsertion(Element& host)
 {
     ASSERT(!host.shadowRoot());

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -54,6 +54,7 @@ public:
     void commit(std::unique_ptr<Style::Update>);
 
     static void tearDownRenderers(Element&);
+    static void tearDownRenderersForDisplayNoneFrame(Element&);
     static void tearDownRenderersForShadowRootInsertion(Element&);
     static void tearDownRenderersAfterSlotChange(Element& host);
     static void tearDownRenderer(Text&);

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -185,6 +185,9 @@ bool Extractor::updateStyleIfNeededForProperty(Element& element, CSSPropertyID p
 {
     Ref document = element.document();
 
+    if (RefPtr owner = document->ownerElement(); owner && !owner->renderer())
+        protect(owner->document())->updateStyleIfNeeded();
+
     document->styleScope().flushPendingUpdate();
 
     auto hasValidStyle = [&] {


### PR DESCRIPTION
#### 364b06df0efb23bab2ae49198c6b6df89c043172
<pre>
marketwatch.com: &quot;Subscribe now&quot; drop-down does not render anything
<a href="https://bugs.webkit.org/show_bug.cgi?id=321146">https://bugs.webkit.org/show_bug.cgi?id=321146</a>
&lt;<a href="https://rdar.apple.com/181639379">rdar://181639379</a>&gt;

Reviewed by Antti Koivisto.

  &lt;div style=&quot;display: none; width: 300px&quot;&gt;
    &lt;iframe srcdoc=&quot;&lt;div style=&apos;width: 250px; height: 169px&apos;&gt;&lt;/div&gt;&quot;&gt;&lt;/iframe&gt;
  &lt;/div&gt;

The box inside should measure 0x0 while the ancestor is display:none. Instead it was 250x169. We build a render tree for the content of such a
frame so script can ask for geometry, but nothing gives that content document&apos;s view a size, so it lays out against a 0x0 viewport and the
geometry answers describe nothing. Build no render tree at all under a frame whose owner element generates no box, and build it back when the
owner does.

Tests: imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html
       imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html
       imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html
       imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html
       imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-while-parent-restyles.html
       imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html
       imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-content-stays-editable.html
       imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-display-none-still-loads-images.html

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::ownerElementGeneratesBox const):
  The question, answered from the owner element having a renderer rather than from its
  display value, since it also generates no box inside a display:none subtree and when a shadow root leaves it unslotted.
  An owner element in a document with no render tree has no renderer whatever its display is,
  so that case recurses, which is what keeps nested unrendered frames hidden.
  A missing renderer settles nothing until the owner element itself has been styled, since every subframe is created
  while the parser is still building the tree around its owner element. Without that an iframe&apos;s initial empty
  document never gets a tree, so it never resolves style and never reports what it should. Asked of the owner
  element rather than of its document, so an unrelated restyle elsewhere in the parent does not make a settled
  frame look undecided and build a tree only to take it down again.

(WebCore::Document::updateRenderTreeForOwnerElementBox):
  Builds or tears down this document&apos;s render tree to match. Called from the owner
  document&apos;s style update rather than from the display change itself: an owner element
  losing its renderer may be having it replaced rather than
  removed, and nothing at the time of the change can tell those apart, so the tree is settled from state afterwards. That also makes it idempotent.

(WebCore::Document::updateRenderTreesForDescendantFrames):
  Runs the above over every descendant frame once this document has resolved style.
  Collects the documents first, because tearing a tree down can detach a frame mid-walk.

(WebCore::Document::createRenderTree):
  Withholds the tree for a frame whose owner generates no box. Needed here as well because a subframe&apos;s
  first document arrives through setDocument(), before any style update of the owner.

(WebCore::Document::destroyRenderTree):
  Takes whether the document is going away. A frame becoming unrendered is still here, so its renderers
  come down with RendererUpdate rather than a Full teardown, keeping animations and hover state.

(WebCore::Document::updateStyleIfNeeded):
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
  A frame that stops being rendered keeps a view that is still visually non-empty from
  before, so ContentfulPaintChecker was reached with no RenderView.

(WebCore::Document::hitTest):
  Checked for a render tree, flushed layout - which resolves owner documents and can take that tree away - then
  used it. Re-checks after the flush.

* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::HTMLResourcePreloader::preload): Asserted that a document with a frame has a render view, which a
  frame whose owner element generates no box no longer does. Nothing below it needs one: the media query
  evaluator checks view() and documentElement(), and takes renderView() as a pointer that may be null.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setPrinting):
  Printing a display:none frame still works, so the tree is reconciled when printing starts and stops.

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
  (WebCore::RenderTreeUpdater::tearDownRenderersForDisplayNoneFrame): TeardownType is private, so the RendererUpdate teardown gets a named entry
  point like the others.

* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/style/StyleExtractor.cpp:
  (WebCore::Style::Extractor::updateStyleIfNeededForProperty): A child&apos;s tree is decided by the parent&apos;s style update, and this only flushed the
  child, so a resolved value read after the owner was shown came back as the computed value.

* LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html: Updated for the new behavior.

Canonical link: <a href="https://commits.webkit.org/319910@main">https://commits.webkit.org/319910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5b1fece423a0c6992626865ab0e9add808e0add

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147201 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142778 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e922f0d6-c387-4fa8-8615-f564483a4f17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f0aa749-0add-43f4-9b47-cd2e37e336f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43427 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43062 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4303 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195071 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152230 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40846 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57210 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151927 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46490 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129479 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125567 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55718 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18072 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55089 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->