### PR TITLE
REGRESSION (319455@main): media/wireless-playback-media-player/route-deactivate-pauses-playback.html fails

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -185,6 +185,8 @@ void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlay
 
     ALWAYS_LOG(LOGIDENTIFIER, playbackTarget->type());
 
+    bool hadRoute = hasRoute();
+
     if (RefPtr route = this->route()) {
         route->disconnectFromSession();
         route->setClient(nullptr);
@@ -192,16 +194,17 @@ void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlay
 
     m_playbackTarget = WTF::move(playbackTarget);
 
-    if (!wirelessPlaybackTarget())
-        return;
-
     if (RefPtr route = this->route()) {
         route->setClient(this);
         updateURLIfNeeded();
         return;
     }
 
-    setNetworkState(MediaPlayer::NetworkState::FormatError);
+    if (hadRoute)
+        notifyRateAndPlaybackStateChanged();
+
+    if (wirelessPlaybackTarget())
+        setNetworkState(MediaPlayer::NetworkState::FormatError);
 }
 
 void MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget(bool shouldPlay)
@@ -214,6 +217,7 @@ void MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget(bool shou
     m_shouldPlayToTarget = shouldPlayToTarget;
 
     if (!isCurrentPlaybackTargetWireless()) {
+        notifyRateAndPlaybackStateChanged();
         setNetworkState(MediaPlayer::NetworkState::FormatError);
         return;
     }
@@ -222,6 +226,17 @@ void MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget(bool shou
 
     if (RefPtr player = m_player.get())
         player->currentPlaybackTargetIsWirelessChanged(true);
+}
+
+void MediaPlayerPrivateWirelessPlayback::notifyRateAndPlaybackStateChanged()
+{
+    RefPtr player = m_player.get();
+    if (!player)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "effectiveRate = ", effectiveRate(), ", paused = ", paused());
+    player->rateChanged();
+    player->playbackStateChanged();
 }
 
 MediaPlaybackTargetWirelessPlayback* MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTarget() const
@@ -234,6 +249,11 @@ MediaDeviceRoute* MediaPlayerPrivateWirelessPlayback::route() const
     if (RefPtr wirelessPlaybackTarget = this->wirelessPlaybackTarget())
         return wirelessPlaybackTarget->route();
     return nullptr;
+}
+
+bool MediaPlayerPrivateWirelessPlayback::hasRoute() const
+{
+    return !!route();
 }
 
 void MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded()
@@ -317,9 +337,8 @@ Ref<MediaTimePromise> MediaPlayerPrivateWirelessPlayback::seekToTarget(const See
 
 bool MediaPlayerPrivateWirelessPlayback::paused() const
 {
-    if (RefPtr route = this->route())
-        return !route->playing();
-    return false;
+    RefPtr route = this->route();
+    return !route || !route->playing();
 }
 
 MediaTime MediaPlayerPrivateWirelessPlayback::startTime() const

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -72,12 +72,14 @@ private:
 
     MediaPlaybackTargetWirelessPlayback* wirelessPlaybackTarget() const;
     MediaDeviceRoute* route() const;
+    bool hasRoute() const;
 
     void updateURLIfNeeded();
 
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
     void updateReadyState();
+    void notifyRateAndPlaybackStateChanged();
 
     // MediaPlayerPrivateInterface
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::WirelessPlayback; }


### PR DESCRIPTION
#### 16c6a9971daca74d3b6bdddba6daf8d2c4c57d8c
<pre>
REGRESSION (319455@main): media/wireless-playback-media-player/route-deactivate-pauses-playback.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=322323">https://bugs.webkit.org/show_bug.cgi?id=322323</a>
<a href="https://rdar.apple.com/185565496">rdar://185565496</a>

Reviewed by Jean-Yves Avenard.

When the active route changes to local, MediaSessionHelper pauses playback. When
MediaPlayerPrivateWirelessPlayback::pause() is called, the playing property on the route is set to
false. Later, MediaDeviceRoute receives a KVO notification of this change and notifies the MediaPlayer
and its client via rateChanged() and playbackStateChanged(). However, since a route change is
occurring, the route may have been cleared from MediaPlayerPrivateWirelessPlayback prior to the KVO
notification being received. As a result, the HTMLMediaElement thinks the media should still be
playing despite MediaSessionHelper attempting to pause it.

319455@main did not introduce this bug, but it changed the timing of how route changes are
propagated to the media player such that it exposed this underlying issue.

Resolved this by dispatching rateChanged() and playbackStateChanged() when
MediaPlayerPrivateWirelessPlayback loses its route, and changing
MediaPlayerPrivateWirelessPlayback::paused() to return true when there is no route.

No new tests. Covered by existing tests.

* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::notifyRateAndPlaybackStateChanged):
(WebCore::MediaPlayerPrivateWirelessPlayback::hasRoute const):
(WebCore::MediaPlayerPrivateWirelessPlayback::paused const):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/319677@main">https://commits.webkit.org/319677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91d3c407ed1a6bf43f4d21fbcef712352de53cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146448 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142160 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98740 "3 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cff9d3cd-6888-4202-9c43-816bf1f9342e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122594 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d81b8ba4-3c97-4646-ab88-8b15eacd53e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42831 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42452 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3509 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194273 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55737 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151581 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56428 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151284 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45882 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128711 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124548 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54939 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17448 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->