### PR TITLE
[Site Isolation][macOS] Cannot autoscroll on cross-origin <iframe> content

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe-expected.txt
@@ -1,0 +1,12 @@
+Dragging a text selection to a point below a cross-origin iframe's bottom edge should autoscroll the iframe's own content and keep extending the selection, the same way it would for an in-process iframe. This requires mouse events to keep being delivered to the iframe's process once the drag point leaves its on-screen bounds.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS initialSelection.length > 0 is true
+PASS finalScrollY > 0 is true
+PASS finalSelection.length > initialSelection.length is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Dragging a text selection to a point below a cross-origin iframe's bottom edge should autoscroll the iframe's own content and keep extending the selection, the same way it would for an in-process iframe. This requires mouse events to keep being delivered to the iframe's process once the drag point leaves its on-screen bounds.");
+jsTestIsAsync = true;
+
+let reportedSelection = "";
+let reportedScrollY = 0;
+addEventListener("message", (event) => {
+    if (event.data === "ready")
+        runTest();
+    else if (typeof event.data === "string" && event.data.startsWith("selection:"))
+        reportedSelection = event.data.substring("selection:".length);
+    else if (typeof event.data === "string" && event.data.startsWith("scrollY:"))
+        reportedScrollY = parseInt(event.data.substring("scrollY:".length));
+});
+
+function wait(milliseconds)
+{
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+let initialSelection = "";
+let finalSelection = "";
+let finalScrollY = 0;
+
+async function runTest()
+{
+    eventSender.dragMode = false;
+
+    // Press down near the top of the iframe's visible content (not near any edge, so this alone
+    // should not autoscroll) and take a small initial selection.
+    await eventSender.asyncMouseMoveTo(20, 20);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(60, 20);
+    await wait(100);
+    initialSelection = reportedSelection;
+    shouldBeTrue("initialSelection.length > 0");
+
+    // Now move to, and hold at, a point below the iframe's bottom edge (the iframe is 100px
+    // tall) and give the 50ms autoscroll timer several ticks to fire. The selection can only
+    // keep growing, and the iframe can only keep scrolling, if that held mouse position keeps
+    // being delivered to the iframe's process even though it's outside the iframe's own bounds.
+    await eventSender.asyncMouseMoveTo(20, 300);
+    await wait(500);
+    await eventSender.asyncMouseUp();
+
+    finalSelection = reportedSelection;
+    finalScrollY = reportedScrollY;
+    shouldBeTrue("finalScrollY > 0");
+    shouldBeTrue("finalSelection.length > initialSelection.length");
+    finishJSTest();
+}
+</script>
+<iframe style="position: absolute; left: 0; top: 0; width: 100px; height: 100px; border: none;" src="http://localhost:8000/site-isolation/resources/tall-selectable-text-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/tall-selectable-text-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/tall-selectable-text-frame.html
@@ -1,0 +1,17 @@
+<body style="margin: 0; font: 20px/40px monospace;">
+<div id="content"></div>
+<script>
+let markup = "";
+for (let i = 0; i < 30; i++)
+    markup += `<div>token${i} selectable line</div>`;
+document.getElementById("content").innerHTML = markup;
+
+document.addEventListener("selectionchange", () => {
+    window.top.postMessage("selection:" + getSelection().toString(), "*");
+});
+document.addEventListener("scroll", () => {
+    window.top.postMessage("scrollY:" + document.scrollingElement.scrollTop, "*");
+});
+window.top.postMessage("ready", "*");
+</script>
+</body>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2094,8 +2094,21 @@ HandleUserInputEventResult EventHandler::handleMousePressEvent(const PlatformMou
 
     if (!passedToScrollbar) {
         auto subframe = subframeForHitTestResult(mouseEvent);
-        if (auto remoteMouseEventData = userInputEventDataForRemoteFrame(dynamicDowncast<RemoteFrame>(subframe).get(), mouseEvent.hitTestResult().doublePointInInnerNodeFrame()))
-            return *remoteMouseEventData;
+        if (RefPtr remoteSubframe = dynamicDowncast<RemoteFrame>(subframe)) {
+            if (auto remoteMouseEventData = userInputEventDataForRemoteFrame(remoteSubframe, mouseEvent.hitTestResult().doublePointInInnerNodeFrame())) {
+                // Start capturing future events for this frame, mirroring the LocalFrame case below.
+                // Without this, a drag that leaves the remote subframe's on-screen bounds gets
+                // re-hit-tested into whatever's underneath instead of continuing to be delivered to
+                // the process that owns it.
+                if (m_mousePressed) {
+                    m_capturingMouseEventsElement = remoteSubframe->ownerElement();
+                    m_eventHandlerWillResetCapturingMouseEventsElement = true;
+                    if (!m_capturingMouseEventsElement)
+                        m_isCapturingRootElementForMouseEvents = true;
+                }
+                return *remoteMouseEventData;
+            }
+        }
 
         if (RefPtr localSubframe = dynamicDowncast<LocalFrame>(subframe)) {
             auto result = passMousePressEventToSubframe(mouseEvent, *localSubframe);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -2690,6 +2690,51 @@ TEST(SiteIsolation, PropagateMouseEventsToSubframe)
     EXPECT_WK_STREQ("mouseup,40,40", eventTypes[2]);
 }
 
+TEST(SiteIsolation, MouseCaptureOutsideSubframeDuringDrag)
+{
+    auto mainframeHTML = "<script>"
+    "    window.eventTypes = [];"
+    "    window.addEventListener('message', function(event) {"
+    "        window.eventTypes.push(event.data);"
+    "    });"
+    "</script>"
+    "<iframe src='https://domain2.com/subframe' style='position: absolute; left: 0; top: 0; width: 100px; height: 100px; border: none;'></iframe>"_s;
+
+    auto subframeHTML = "<script>"
+    "    addEventListener('mousedown', (event) => { window.parent.postMessage('mousedown', '*') });"
+    "    addEventListener('mousemove', (event) => { window.parent.postMessage('mousemove', '*') });"
+    "    addEventListener('mouseup', (event) => { window.parent.postMessage('mouseup', '*') });"
+    "    alert('iframe loaded');"
+    "</script>"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeHTML } },
+        { "/subframe"_s, { subframeHTML } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
+    EXPECT_WK_STREQ("iframe loaded", [webView _test_waitForAlert]);
+
+    // Press down inside the 100x100 subframe, then drag to and release at a point well
+    // outside its bounds (in the main frame's own area). Without mouse capture spanning the
+    // RemoteFrame boundary, the main frame re-hit-tests on every move and stops forwarding
+    // events to the subframe's process as soon as the point leaves its on-screen rect, so the
+    // subframe would never see the mousemove/mouseup below.
+    CGPoint insideSubframe = [webView convertPoint:CGPointMake(50, 50) toView:nil];
+    CGPoint outsideSubframe = [webView convertPoint:CGPointMake(400, 400) toView:nil];
+    [webView mouseDownAtPoint:insideSubframe simulatePressure:NO];
+    [webView mouseDragToPoint:outsideSubframe];
+    [webView mouseUpAtPoint:outsideSubframe];
+    [webView waitForPendingMouseEvents];
+
+    NSArray<NSString *> *eventTypes = [webView objectByEvaluatingJavaScript:@"window.eventTypes"];
+    while (eventTypes.count != 3u)
+        eventTypes = [webView objectByEvaluatingJavaScript:@"window.eventTypes"];
+    EXPECT_WK_STREQ("mousedown", eventTypes[0]);
+    EXPECT_WK_STREQ("mousemove", eventTypes[1]);
+    EXPECT_WK_STREQ("mouseup", eventTypes[2]);
+}
+
 TEST(SiteIsolation, RunOpenPanel)
 {
     HTTPServer server({


### PR DESCRIPTION
#### eb401eda2a846a5e0d205de597d779328b737326
<pre>
[Site Isolation][macOS] Cannot autoscroll on cross-origin &lt;iframe&gt; content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322326">https://bugs.webkit.org/show_bug.cgi?id=322326</a>
<a href="https://rdar.apple.com/183755347">rdar://183755347</a>

Reviewed by Abrar Rahman Protyasha.

EventHandler::handleMousePressEvent only set up mouse-event capture
(m_capturingMouseEventsElement) when a mousedown hit a LocalFrame
subframe, never when it hit a RemoteFrame (an out-of-process iframe
under site isolation). Without capture, every subsequent mousemove
during the drag was freshly hit-tested in the main frame&apos;s process,
so once the pointer left the iframe&apos;s on-screen bounds, events
stopped being forwarded to the iframe&apos;s process entirely. This broke
selection-drag autoscroll and made text selection stop extending as
soon as the drag moved outside a cross-origin iframe.

Fix this by capturing to the RemoteFrame&apos;s owner element the same way
already done for LocalFrame subframes, so drag events keep routing to
the correct process for the duration of the gesture.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
       http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/autoscroll-on-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/tall-selectable-text-frame.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, MouseCaptureOutsideSubframeDuringDrag)):

Canonical link: <a href="https://commits.webkit.org/319723@main">https://commits.webkit.org/319723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1262f98c4cd992dfae1f411da488f22f6961bbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146862 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b32e97b-bf8e-4bd9-a8fa-0ea5476ed2fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56205 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142485 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9328ba43-fdb5-40ac-83fe-43b4ee7a2e3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122917 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa0c5ad6-8886-425a-a9c2-d512918cf3c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44878 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42773 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3929 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194692 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40697 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151618 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46196 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129128 "Build was cancelled. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125143 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55355 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17772 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54737 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->