### PR TITLE
[JSC] Place promise first in promise capability objects

### DIFF
--- a/JSTests/stress/promise-capability-layout.js
+++ b/JSTests/stress/promise-capability-layout.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            if (Array.isArray(expected[i])) {
+                shouldBe(Array.isArray(actual[i]), true);
+                shouldBeArray(actual[i], expected[i]);
+            } else
+                shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+shouldBeArray(Reflect.ownKeys(Promise.withResolvers()), ["promise", "resolve", "reject"]);

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -96,9 +96,9 @@ JSValue JSPromise::createNewPromiseCapability(JSGlobalObject* globalObject, JSVa
 JSValue JSPromise::createPromiseCapability(VM& vm, JSGlobalObject* globalObject, JSObject* promise, JSObject* resolve, JSObject* reject)
 {
     auto* capability = constructEmptyObject(vm, globalObject->promiseCapabilityObjectStructure());
+    capability->putDirectOffset(vm, promiseCapabilityPromisePropertyOffset, promise);
     capability->putDirectOffset(vm, promiseCapabilityResolvePropertyOffset, resolve);
     capability->putDirectOffset(vm, promiseCapabilityRejectPropertyOffset, reject);
-    capability->putDirectOffset(vm, promiseCapabilityPromisePropertyOffset, promise);
     return capability;
 }
 
@@ -959,12 +959,12 @@ Structure* createPromiseCapabilityObjectStructure(VM& vm, JSGlobalObject& global
 {
     Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), JSFinalObject::defaultInlineCapacity);
     PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->promise, 0, offset);
+    RELEASE_ASSERT(offset == promiseCapabilityPromisePropertyOffset);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->resolve, 0, offset);
     RELEASE_ASSERT(offset == promiseCapabilityResolvePropertyOffset);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->reject, 0, offset);
     RELEASE_ASSERT(offset == promiseCapabilityRejectPropertyOffset);
-    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->promise, 0, offset);
-    RELEASE_ASSERT(offset == promiseCapabilityPromisePropertyOffset);
     return structure;
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -236,9 +236,9 @@ private:
     WriteBarrier<Unknown> m_slot;
 };
 
-static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 0;
-static constexpr PropertyOffset promiseCapabilityRejectPropertyOffset = 1;
-static constexpr PropertyOffset promiseCapabilityPromisePropertyOffset = 2;
+static constexpr PropertyOffset promiseCapabilityPromisePropertyOffset = 0;
+static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 1;
+static constexpr PropertyOffset promiseCapabilityRejectPropertyOffset = 2;
 
 JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionResolve);
 JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionReject);


### PR DESCRIPTION
<pre>
320831 - Promise.withResolvers returns properties in the wrong order
<a href="https://bugs.webkit.org/show_bug.cgi?id=320831">https://bugs.webkit.org/show_bug.cgi?id=320831</a>

Reviewed by NOBODY (OOPS!).

`Promise.withResolvers` creates a promise capability object by
creating properties `"promise"`, `"resolve"`, `"reject"` in order
on an initially-new object [1]. This order surfaces to the user
through `Reflect.ownKeys` [2], but as we choose to fix the structure
of these objects the order `ownKeys` sees isn't the actual
creation order. This patch reorders properties in that structure
to match `withResolvers`'s creation order.

[1]: https://tc39.es/ecma262/2026/multipage/control-abstraction-objects.html#sec-promise.withResolvers
[2]: https://tc39.es/ecma262/2026/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys

Test: JSTests/stress/promise-capability-layout.js

* JSTests/stress/promise-capability-layout.js: Added.
(shouldBe):
(shouldBeArray):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::createPromiseCapability):
(JSC::createPromiseCapabilityObjectStructure):
* Source/JavaScriptCore/runtime/JSPromise.h:

</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13da1153e24b85d85b6fb613738a10acf8cd1731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142169 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98748 "16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44571 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42839 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4569 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11406 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42463 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3522 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43415 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55750 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56441 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151292 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45890 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128724 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124567 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54952 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17459 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->