### PR TITLE
Cherry-pick(s) 51dfdb0612eb. rdar://185368308

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache-expected.txt
@@ -1,0 +1,1 @@
+PASS. Test did not crash.

--- a/LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache.html
+++ b/LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() {
+    document.body.textContent = "PASS. Test did not crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+async function main() {
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter)
+        return;
+    const device = await adapter.requestDevice();
+
+    const vertexBuffer = device.createBuffer({
+        size: 4 * 16,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true,
+    });
+    new Float32Array(vertexBuffer.getMappedRange()).set([
+        0, 0, 0, 1,
+        1, 0, 0, 1,
+        0, 1, 0, 1,
+        1, 1, 0, 1,
+    ]);
+    vertexBuffer.unmap();
+
+    // Index buffer is also bound as STORAGE so a later compute pass can overwrite it
+    // with out-of-bounds indices after the validation kernel has been dispatched.
+    const indexBuffer = device.createBuffer({
+        size: 4 * 4,
+        usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+        mappedAtCreation: true,
+    });
+    new Uint32Array(indexBuffer.getMappedRange()).set([0, 1, 2, 3]);
+    indexBuffer.unmap();
+
+    const renderShader = device.createShaderModule({ code: `
+        @vertex fn vs(@location(0) p: vec4f) -> @builtin(position) vec4f { return p; }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(1); }
+    `});
+    const renderPipeline = device.createRenderPipeline({
+        layout: "auto",
+        vertex: {
+            module: renderShader, entryPoint: "vs",
+            buffers: [{ arrayStride: 16, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x4" }] }],
+        },
+        fragment: { module: renderShader, entryPoint: "fs", targets: [{ format: "rgba8unorm" }] },
+        primitive: { topology: "triangle-list" },
+    });
+
+    const computePipeline = device.createComputePipeline({
+        layout: "auto",
+        compute: {
+            module: device.createShaderModule({ code: `
+                @group(0) @binding(0) var<storage, read_write> indices: array<u32>;
+                @compute @workgroup_size(1) fn main() {
+                    indices[0] = 100000u; indices[1] = 100001u;
+                    indices[2] = 100002u; indices[3] = 100003u;
+                }
+            `}),
+            entryPoint: "main",
+        },
+    });
+    const computeBindGroup = device.createBindGroup({
+        layout: computePipeline.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer: indexBuffer } }],
+    });
+
+    const target = device.createTexture({ size: [4, 4], format: "rgba8unorm", usage: GPUTextureUsage.RENDER_ATTACHMENT });
+    const colorAttachment = () => ({ view: target.createView(), loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 1] });
+
+    // CB1: validate indices via drawIndexed (registers a completion handler that will
+    // populate m_drawIndexedCache), then overwrite the buffer with out-of-bounds indices
+    // in the same command buffer (clears m_drawIndexedCache at encode and commit time).
+    const enc1 = device.createCommandEncoder();
+    const rp1 = enc1.beginRenderPass({ colorAttachments: [colorAttachment()] });
+    rp1.setPipeline(renderPipeline);
+    rp1.setVertexBuffer(0, vertexBuffer);
+    rp1.setIndexBuffer(indexBuffer, "uint32");
+    rp1.drawIndexed(4, 1, 0, 0, 0);
+    rp1.end();
+    const cp = enc1.beginComputePass();
+    cp.setPipeline(computePipeline);
+    cp.setBindGroup(0, computeBindGroup);
+    cp.dispatchWorkgroups(1);
+    cp.end();
+    device.queue.submit([enc1.finish()]);
+
+    // Wait for the GPU to finish so the (now stale) completion handler has fired.
+    await device.queue.onSubmittedWorkDone();
+    await new Promise(r => setTimeout(r, 200));
+
+    // CB2: identical drawIndexed parameters. Before the fix this hit the stale
+    // m_drawIndexedCache entry and skipped the index-clamp shader, passing the
+    // attacker-controlled out-of-bounds indices straight to Metal.
+    const enc2 = device.createCommandEncoder();
+    const rp2 = enc2.beginRenderPass({ colorAttachments: [colorAttachment()] });
+    rp2.setPipeline(renderPipeline);
+    rp2.setVertexBuffer(0, vertexBuffer);
+    rp2.setIndexBuffer(indexBuffer, "uint32");
+    rp2.drawIndexed(4, 1, 0, 0, 0);
+    rp2.end();
+    device.queue.submit([enc2.finish()]);
+    await device.queue.onSubmittedWorkDone();
+}
+
+onload = () => main().catch(() => { }).finally(done);
+</script>
+<body></body>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -109,7 +109,12 @@ public:
     std::span<uint8_t> getBufferContents();
 
     std::optional<DrawIndexCacheContainerIterator> canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil) const;
+<<<<<<< HEAD
     void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> = nil);
+=======
+    uint64_t drawIndexedCacheInvalidationCount() const { return m_drawIndexedCacheInvalidationCount; }
+    void drawIndexedValidated(uint64_t invalidationCountAtDispatch, uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil);
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
     void skippedDrawIndexedValidation(CommandEncoder&, DrawIndexCacheContainerIterator);
 
     bool didReadOOB(id<MTLIndirectCommandBuffer> = nil) const;
@@ -159,6 +164,7 @@ private:
     using MappedRanges = RangeSet<Range<size_t>>;
     MappedRanges m_mappedRanges;
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
+    uint64_t m_drawIndexedCacheInvalidationCount { 0 };
     uint32_t m_maxUnsignedIndex { 0 };
     uint16_t m_maxUshortIndex { 0 };
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -493,8 +493,15 @@ std::optional<DrawIndexCacheContainerIterator> Buffer::canSkipDrawIndexedValidat
     return std::nullopt;
 }
 
+<<<<<<< HEAD
 void Buffer::drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType indexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> icb)
+=======
+void Buffer::drawIndexedValidated(uint64_t invalidationCountAtDispatch, uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType indexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> icb)
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
 {
+    if (invalidationCountAtDispatch != m_drawIndexedCacheInvalidationCount)
+        return;
+
     constexpr auto maxCacheSize = 1000000;
     if (m_drawIndexedCache.size() > maxCacheSize)
         m_drawIndexedCache.clear();
@@ -611,10 +618,21 @@ void Buffer::indirectBufferInvalidated(CommandEncoder* commandEncoder)
 
     m_gpuResourceMap.clear();
     m_drawIndexedCache.clear();
+<<<<<<< HEAD
     ++m_contentsGeneration;
     ++m_indexContentsGeneration;
     m_indexValueUpperBoundUint = UINT32_MAX;
     m_indexValueUpperBoundUshort = UINT16_MAX;
+=======
+    ++m_drawIndexedCacheInvalidationCount;
+    m_indirectCache = {
+        .indirectOffset = UINT64_MAX,
+        .indexBufferOffsetInBytes = UINT64_MAX,
+        .minVertexCount = 0,
+        .minInstanceCount = 0,
+        .indexType = MTLIndexTypeUInt16
+    };
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
 }
 
 void Buffer::removeSkippedValidationCommandEncoder(uint64_t uniqueId)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -833,22 +833,37 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
 
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
+<<<<<<< HEAD
     auto encoderHandle = device.getQueue()->retainCounterSampleBuffer(encoder.parentEncoder());
     uint64_t validationGeneration = apiIndexBuffer->indexContentsGeneration();
     [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = protect(*apiIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+=======
+    auto encoderHandle = device.protectedQueue()->retainCounterSampleBuffer(encoder.parentEncoder());
+    auto invalidationCount = apiIndexBuffer->drawIndexedCacheInvalidationCount();
+    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = Ref { device }, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, invalidationCount, refIndexBuffer = Ref { *apiIndexBuffer }, indexedIndirectBuffer, indexedIndirectBufferOffset](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
         if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
             return;
         }
+<<<<<<< HEAD
         protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = WTF::move(refIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset]() mutable {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
+=======
+        protectedDevice->protectedQueue()->scheduleWork([encoderHandle, protectedDevice, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, invalidationCount, refIndexBuffer = WTF::move(refIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset]() mutable {
+            protectedDevice->protectedQueue()->releaseCounterSampleBuffer(encoderHandle);
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
             if (!indexedIndirectBuffer.contents || indexedIndirectBuffer.length < sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments) + indexedIndirectBufferOffset)
                 return;
 
             auto* offsetContents = static_cast<uint8_t*>(indexedIndirectBuffer.contents) + indexedIndirectBufferOffset;
             auto& args = *static_cast<WebKitMTLDrawIndexedPrimitivesIndirectArguments*>(static_cast<void*>(offsetContents));
             refIndexBuffer->didReadOOB(args.lostOrOOBRead);
+<<<<<<< HEAD
             refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration);
+=======
+            refIndexBuffer->drawIndexedValidated(invalidationCount, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset);
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
         });
     }];
 
@@ -1423,19 +1438,33 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
                     [commandEncoder useResource:icb.outOfBoundsReadFlag usage:MTLResourceUsageWrite stages:MTLRenderStageVertex];
                     [commandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:data.indexData.indexCount];
 
+<<<<<<< HEAD
                     auto encoderHandle = m_device->getQueue()->retainCounterSampleBuffer(m_parentEncoder);
                     uint64_t validationGeneration = indexBuffer->indexContentsGeneration();
                     [m_parentEncoder->commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(m_device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = protect(*indexBuffer), icb](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+=======
+                    auto encoderHandle = m_device->protectedQueue()->retainCounterSampleBuffer(m_parentEncoder);
+                    auto invalidationCount = indexBuffer->drawIndexedCacheInvalidationCount();
+                    [m_parentEncoder->commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = Ref { m_device }, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, invalidationCount, refIndexBuffer = Ref { *indexBuffer }, icb](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
                         if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
                             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
                             return;
                         }
 
+<<<<<<< HEAD
                         protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, icb, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = WTF::move(refIndexBuffer)]() mutable {
                             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
                             id<MTLBuffer> outOfBoundsReadFlag = icb.outOfBoundsReadFlag;
                             refIndexBuffer->didReadOOB(*static_cast<uint32_t*>(outOfBoundsReadFlag.contents), icb.indirectCommandBuffer);
                             refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, icb.indirectCommandBuffer);
+=======
+                        protectedDevice->protectedQueue()->scheduleWork([encoderHandle, protectedDevice, icb, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, invalidationCount, refIndexBuffer = WTF::move(refIndexBuffer)]() mutable {
+                            protectedDevice->protectedQueue()->releaseCounterSampleBuffer(encoderHandle);
+                            id<MTLBuffer> outOfBoundsReadFlag = icb.outOfBoundsReadFlag;
+                            refIndexBuffer->didReadOOB(*static_cast<uint32_t*>(outOfBoundsReadFlag.contents), icb.indirectCommandBuffer);
+                            refIndexBuffer->drawIndexedValidated(invalidationCount, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, icb.indirectCommandBuffer);
+>>>>>>> 51dfdb0612eb (Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB)
                         });
                     }];
                     needsBarrierBeforeExecute = true;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185368308 to main. [51dfdb0612eb] caused a merge conflict. 

```
Stale completion-handler cache repopulation in drawIndexedValidated bypasses index clamp shader causing GPU OOB
https://bugs.webkit.org/show_bug.cgi?id=319431
rdar://177404528

Reviewed by Dan Glastonbury.

When work completes out of order, require re-validation of indexed draw calls to
avoid populating the index cache incorrectly.

Test: fast/webgpu/nocrash/stale-draw-indexed-validation-cache.html
* LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/stale-draw-indexed-validation-cache.html: Added.
* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::drawIndexedCacheInvalidationCount const):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::drawIndexedValidated):
(WebGPU::Buffer::indirectBufferInvalidated):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::executeBundles):

Originally-landed-as: 305413.1116@safari-7624.5-branch (51dfdb0612eb). rdar://185368308


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ad61d2d6320f2cec8b389aaab3f0ed5c02e044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182139 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56086 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192369 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146468 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57402 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55809 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192369 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/146468 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185094 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57402 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192369 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57402 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/55809 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192369 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57402 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3529 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48717 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/55809 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194293 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55757 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194293 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56448 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194293 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56448 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128731 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124575 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54959 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/49892 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54340 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54579 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54407 "") | | | 
<!--EWS-Status-Bubble-End-->