### PR TITLE
Cherry-pick(s) e66d0b93bf1f. rdar://185366239

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -366,11 +366,95 @@ static bool UNUSED_FUNCTION NODELETE isSupportedConversionFormat(PixelFormat pix
     case PixelFormat::BGRA8:
     case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
+<<<<<<< HEAD
     case PixelFormat::RGBA16F:
 #endif
         return true;
     default:
         return false;
+=======
+static Float16 readFloat16(const std::span<const uint8_t>& span8, size_t offset)
+{
+    union {
+        Float16 float16 { };
+        std::array<uint8_t, sizeof(Float16)> bytes;
+    } float16OrBytesUnion;
+    for (size_t i = 0; i < sizeof(Float16); ++i)
+        float16OrBytesUnion.bytes[i] = span8[offset + i];
+    return float16OrBytesUnion.float16;
+}
+
+static void writeFloat16(Float16 f16, const std::span<uint8_t>& spanFloat16, size_t offset)
+{
+    union {
+        Float16 float16 { };
+        std::array<uint8_t, sizeof(Float16)> bytes;
+    } float16OrBytesUnion(f16);
+    for (size_t i = 0; i < sizeof(Float16); ++i)
+        spanFloat16[offset + i] = float16OrBytesUnion.bytes[i];
+}
+
+static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    // FIXME: Float16-to-Float16 color-space conversion is unimplemented; fall through and copy
+    // verbatim. Do not early-return on a color-space mismatch: the destination is allocated
+    // uninitialized, so skipping the write would leak heap bytes through getPixelBuffer().
+
+    struct Pixel16 {
+        Float16 r;
+        Float16 g;
+        Float16 b;
+        Float16 a;
+    };
+    static_assert(sizeof(Float16) == 2);
+    static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
+
+    // FIXME: This lambda should be moved to separate functions and the caller passes a pointer to one of them.
+    auto convertSinglePixel16 = [](const auto& sourceSpan, auto sourceAlphaFormat, auto& destinationSpan, auto destinationAlphaFormat) {
+        ASSERT(sourceSpan.size_bytes() == sizeof(Pixel16));
+        ASSERT(destinationSpan.size_bytes() == sizeof(Pixel16));
+
+        if (sourceAlphaFormat == destinationAlphaFormat) {
+            memcpySpan(destinationSpan, sourceSpan);
+            return;
+        }
+
+        const auto& sourcePixel16 = reinterpretCastSpanStartTo<Pixel16>(sourceSpan);
+        auto& destinationPixel16 = reinterpretCastSpanStartTo<Pixel16>(destinationSpan);
+
+        if (destinationAlphaFormat == AlphaPremultiplication::Premultiplied) {
+            auto fa = float(sourcePixel16.a);
+            destinationPixel16.r = Float16(float(sourcePixel16.r) * fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) * fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) * fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        if (auto fa = float(sourcePixel16.a)) {
+            destinationPixel16.r = Float16(float(sourcePixel16.r) / fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) / fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) / fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        memcpySpan(destinationSpan, sourceSpan);
+    };
+
+    size_t sourceRowStart = 0;
+    size_t destinationRowStart = 0;
+    size_t bytesPerRow = destinationSize.width() * sizeof(Pixel16);
+
+    for (int y = 0; y < destinationSize.height(); ++y) {
+        for (size_t x = 0; x < bytesPerRow; x += sizeof(Pixel16)) {
+            const auto sourceSpan = source.rows.subspan(sourceRowStart + x, sizeof(Pixel16));
+            auto destinationSpan = destination.rows.subspan(destinationRowStart + x, sizeof(Pixel16));
+            convertSinglePixel16(sourceSpan, source.format.alphaFormat, destinationSpan, destination.format.alphaFormat);
+        }
+        sourceRowStart += source.bytesPerRow;
+        destinationRowStart += destination.bytesPerRow;
+>>>>>>> e66d0b93bf1f (Converting Float16 pixels buffers to Unpremultiplied or premultiplied may miss the last row)
     }
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185366239 to main. [e66d0b93bf1f] caused a merge conflict. 

```
Converting Float16 pixels buffers to Unpremultiplied or premultiplied may miss the last row
https://bugs.webkit.org/show_bug.cgi?id=316131
rdar://177764433

Reviewed by Gerald Squelart.

convertImagePixelsFromFloat16ToFloat16() was written with the wrong assumption.
The calculations in this function assume the source and destination PixelBuffers
are rectangular. But sometimes they are not. ImageBufferBackend::getPixelBuffer()
and ImageBufferBackend::putPixelBuffer() get subspans from the source and
destination PixelBuffers starting from the starting point till the end of these
PixelBuffers. The bytesPerRow of the PixelBuffer and PixelBufferConversionView
may be larger than the bytesPerRow of the requested PixelBuffer.

Like what other conversion functions do, the solution is not to drive the width
and the height of sourceBuffer and destinationBuffer from the size_bytes and the
bytesPerRow. The fix is to convert destinationBytesPerRow pixels from the
sourceBuffer into the destinationBuffer for every row. To get the starting pixel
for the next row from the sourceBuffer, we need to move by sourceBytesPerRow.

* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsFromFloat16ToFloat16):

Originally-landed-as: 305413.1059@safari-7624.5-branch (e66d0b93bf1f). rdar://185366239


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50d29852f9b47eca509049d28083593978e9d41a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182141 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56088 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192371 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146470 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184003 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57404 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55811 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192371 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/146470 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185096 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57404 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192371 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57404 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/55811 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192371 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57404 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3531 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48719 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/55811 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194295 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55759 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194295 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56450 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194295 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56450 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128733 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124578 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54961 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/49894 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54342 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54581 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54409 "") | | | 
<!--EWS-Status-Bubble-End-->