### PR TITLE
[JSC] `Promise.withResolvers()` returns its properties in the proper order

### DIFF
--- a/JSTests/stress/promise-withResolvers.js
+++ b/JSTests/stress/promise-withResolvers.js
@@ -31,6 +31,18 @@ shouldBe(Promise.withResolvers.length, 0);
 }
 
 async function test() {
+    // withResolvers() returns functions in proper order.
+    // 27.2.4.9 Promise.withResolvers Step 4-6
+    // https://tc39.es/ecma262/2026/multipage/control-abstraction-objects.html#sec-promise.withResolvers
+    {
+        let ownKeys = Reflect.ownKeys(Promise.withResolvers());
+        let expectedKeys = ["promise", "resolve", "reject"];
+        shouldBe(ownKeys.length, expectedKeys.length);
+        for (let i = 0; i < expectedKeys.length; i++) {
+            shouldBe(ownKeys[i], expectedKeys[i]);
+        }
+    }
+
     // sync resolve
     {
         let {promise, resolve, reject} = Promise.withResolvers();

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -96,9 +96,9 @@ JSValue JSPromise::createNewPromiseCapability(JSGlobalObject* globalObject, JSVa
 JSValue JSPromise::createPromiseCapability(VM& vm, JSGlobalObject* globalObject, JSObject* promise, JSObject* resolve, JSObject* reject)
 {
     auto* capability = constructEmptyObject(vm, globalObject->promiseCapabilityObjectStructure());
+    capability->putDirectOffset(vm, promiseCapabilityPromisePropertyOffset, promise);
     capability->putDirectOffset(vm, promiseCapabilityResolvePropertyOffset, resolve);
     capability->putDirectOffset(vm, promiseCapabilityRejectPropertyOffset, reject);
-    capability->putDirectOffset(vm, promiseCapabilityPromisePropertyOffset, promise);
     return capability;
 }
 
@@ -959,12 +959,12 @@ Structure* createPromiseCapabilityObjectStructure(VM& vm, JSGlobalObject& global
 {
     Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), JSFinalObject::defaultInlineCapacity);
     PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->promise, 0, offset);
+    RELEASE_ASSERT(offset == promiseCapabilityPromisePropertyOffset);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->resolve, 0, offset);
     RELEASE_ASSERT(offset == promiseCapabilityResolvePropertyOffset);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->reject, 0, offset);
     RELEASE_ASSERT(offset == promiseCapabilityRejectPropertyOffset);
-    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->promise, 0, offset);
-    RELEASE_ASSERT(offset == promiseCapabilityPromisePropertyOffset);
     return structure;
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -236,9 +236,9 @@ private:
     WriteBarrier<Unknown> m_slot;
 };
 
-static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 0;
-static constexpr PropertyOffset promiseCapabilityRejectPropertyOffset = 1;
-static constexpr PropertyOffset promiseCapabilityPromisePropertyOffset = 2;
+static constexpr PropertyOffset promiseCapabilityPromisePropertyOffset = 0;
+static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 1;
+static constexpr PropertyOffset promiseCapabilityRejectPropertyOffset = 2;
 
 JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionResolve);
 JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionReject);


### PR DESCRIPTION
#### 3bc5c80ad97f711c61fb3a7d22bd8d1db3189a88
<pre>
[JSC] `Promise.withResolvers()` returns its properties in the proper order
<a href="https://bugs.webkit.org/show_bug.cgi?id=320831">https://bugs.webkit.org/show_bug.cgi?id=320831</a>

Reviewed by NOBODY (OOPS!).

According to [1], the result object&apos;s properties of `Promise.withResolvers()`
should be created in the order of `promise`, `resolve` and `reject`. However,
JSC creates them in the order of `resolve`, `reject` and `promise`.

To fix this, this patch adjusts their `PropertyOffset`s.

[1]: <a href="https://tc39.es/ecma262/2026/multipage/control-abstraction-objects.html#sec-promise.withResolvers">https://tc39.es/ecma262/2026/multipage/control-abstraction-objects.html#sec-promise.withResolvers</a>

No additional test files. Instead, this patch adds a test that validates
`Promise.withResolvers()` returns its properties in the proper order to
the existing test.

* JSTests/stress/promise-withResolvers.js:
(async test):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::createPromiseCapability):
(JSC::createPromiseCapabilityObjectStructure):
* Source/JavaScriptCore/runtime/JSPromise.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc5c80ad97f711c61fb3a7d22bd8d1db3189a88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44577 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42845 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4576 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11411 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42468 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3535 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43429 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55763 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56454 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151299 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45900 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128737 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124588 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54965 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->