### PR TITLE
Use-after-free of ScriptExecutionContext in trustedTypeCompliantString

### DIFF
--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The victim's JS wrapper is created in the parent realm so it never roots the iframe's window.
+let victim = document.createElement('div');
+window.__victim = victim;
+
+let f = document.createElement('iframe');
+f.srcdoc =
+    '<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for \'script\'">' +
+    '<body>' +
+    '<' + 'script>document.body.appendChild(parent.__victim); parent.__factory = trustedTypes;</' + 'script>';
+f.onload = () => setTimeout(() => setTimeout(go, 0), 0);
+document.body.appendChild(f);
+
+function callback() {
+    document.adoptNode(victim);
+    f.remove();
+    f = null;
+    if (window.GCController)
+        GCController.collect();
+    return null;
+}
+
+function go() {
+    // Register the iframe's default policy via the parent-realm createPolicy binding so the
+    // callback's stored JSDOMGlobalObject is the parent's window.
+    TrustedTypePolicyFactory.prototype.createPolicy.call(window.__factory, 'default', { createScript: callback });
+    window.__factory = null;
+    window.__victim = null;
+    if (window.GCController)
+        GCController.collect();
+    // Triggers the TrustedScript default-policy callback while the only protection for the
+    // iframe's Document is the raw ScriptExecutionContext& held by trustedTypeCompliantString.
+    try { victim.setAttribute('onclick', 'x'); } catch (e) { }
+    document.body.textContent = 'PASS if no crash';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -94,7 +94,7 @@ ExceptionOr<void> Attr::setValue(const AtomString& value)
             auto type = trustedTypeForAttribute(element->nodeName(), qualifiedName().localName(),
                 element->namespaceURI(), qualifiedName().namespaceURI());
             if (!type.attributeType.isNull()) {
-                auto compliantValue = trustedTypesCompliantAttributeValue(protect(document())->contextDocument(), type.attributeType, value,
+                auto compliantValue = trustedTypesCompliantAttributeValue(protect(protect(document())->contextDocument()), type.attributeType, value,
                     type.sink);
                 if (compliantValue.hasException())
                     return compliantValue.releaseException();


### PR DESCRIPTION
#### 5549b3663c5d3904eab780389cd14c58523d1dfa
<pre>
Use-after-free of ScriptExecutionContext in trustedTypeCompliantString
<a href="https://bugs.webkit.org/show_bug.cgi?id=317320">https://bugs.webkit.org/show_bug.cgi?id=317320</a>
<a href="https://rdar.apple.com/177766868">rdar://177766868</a>

Reviewed by Chris Dumez.

The method processValueWithDefaultPolicy can end up deleting the ScriptExecutionContext passed as parameter.
This patch fixes this by adding protection of ScriptExecutionContext.

Test: fast/html/trusted-types-set-attribute-iframe-removal-crash.html

* LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html: Added.
* LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt: Added.
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttribute):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::setAttributeNS):
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeCompliantString):
(WebCore::requireTrustedTypesForPreNavigationCheckPasses):

Originally-landed-as: 305413.1005@safari-7624.5-branch (a26cf8dc190a). <a href="https://rdar.apple.com/185368259">rdar://185368259</a>
Canonical link: <a href="https://commits.webkit.org/319801@main">https://commits.webkit.org/319801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bb5f051efe7e503d16a963b48da53292cb07965

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142466 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98929 "3 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44863 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43131 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42757 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3915 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151906 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151604 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46182 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129114 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125129 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55341 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->