### PR TITLE
Document named properties should not filter object and embed elements by exposedness

### DIFF
--- a/LayoutTests/fast/dom/HTMLDocument/document-special-properties-expected.txt
+++ b/LayoutTests/fast/dom/HTMLDocument/document-special-properties-expected.txt
@@ -42,7 +42,7 @@ Embed by name (multiple): collection(2) EMBED(name) EMBED(name)
 Embed by id (unique): undefined
 Embed by id (multiple): undefined
 Embed by id/name mixed: collection(2) EMBED(name) EMBED(name)
-Embed by name nested in object with the same name: single EMBED(name)
+Embed by name nested in object with the same name: collection(2) OBJECT(name) EMBED(name)
 
 Nonexistent iframe name: undefined
 Iframe by name (unique): single WINDOW

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/WEB_FEATURES.yml
@@ -1,0 +1,2 @@
+rules:
+- document.title-*: [title]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-case-xhtml.xhtml

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-01-expected.txt
@@ -1,3 +1,9 @@
 
 PASS img elements that have a name and id attribute, should be accessible by both values.
+PASS img elements that have a name and id attribute with same value.
+PASS Dynamically removing the name attribute from img elements, should not be accessible.
+PASS Dynamically removing the id attribute from img elements, should still be accessible by name value.
+PASS Dynamically updating the name attribute from img elements, should be accessible by values.
+PASS Dynamically updating the id attribute from img elements, should be accessible by values.
+PASS img elements that is removed, should not be accessible.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-01.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-01.html
@@ -8,12 +8,111 @@
 <div id="log"></div>
 <div id="test">
 <img id="a" name="b">
+<img id="test" name="test">
+<img id="test2a" name="test2b">
+<img id="test3a" name="test3b">
+<img id="test4a" name="test4b">
+<img id="test5a" name="test5b">
+<img id="test6a" name="test6b">
 </div>
 <script>
 test(function() {
-  assert_equals(document.a, document.getElementsByTagName("img")[0]);
-  assert_equals(document['a'], document.getElementsByTagName("img")[0]);
-  assert_equals(document.b, document.getElementsByTagName("img")[0]);
-  assert_equals(document['b'], document.getElementsByTagName("img")[0]);
+  let img = document.getElementsByTagName("img")[0];
+  assert_equals(document.a, img);
+  assert_equals(document['a'], img);
+  assert_equals(document.b, img);
+  assert_equals(document['b'], img);
 }, "img elements that have a name and id attribute, should be accessible by both values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[1];
+  assert_equals(document.test, img);
+  assert_equals(document['test'], img);
+}, "img elements that have a name and id attribute with same value.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[2];
+  assert_equals(document.test2a, img);
+  assert_equals(document['test2a'], img);
+  assert_equals(document.test2b, img);
+  assert_equals(document['test2b'], img);
+
+  img.removeAttribute("name");
+  assert_equals(document.test2a, undefined);
+  assert_equals(document['test2a'], undefined);
+  assert_equals(document.test2b, undefined);
+  assert_equals(document['test2b'], undefined);
+}, "Dynamically removing the name attribute from img elements, should not be accessible.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[3];
+  assert_equals(document.test3a, img);
+  assert_equals(document['test3a'], img);
+  assert_equals(document.test3b, img);
+  assert_equals(document['test3b'], img);
+
+  img.removeAttribute("id");
+  assert_equals(document.test3a, undefined);
+  assert_equals(document['test3a'], undefined);
+  assert_equals(document.test3b, img);
+  assert_equals(document['test3b'], img);
+}, "Dynamically removing the id attribute from img elements, should still be accessible by name value.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[4];
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, img);
+  assert_equals(document['test4b'], img);
+
+  img.name = 'test4a';
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, undefined);
+  assert_equals(document['test4b'], undefined);
+
+  img.name = 'test4c';
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, undefined);
+  assert_equals(document['test4b'], undefined);
+  assert_equals(document.test4c, img);
+  assert_equals(document['test4c'], img);
+}, "Dynamically updating the name attribute from img elements, should be accessible by values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[5];
+  assert_equals(document.test5a, img);
+  assert_equals(document['test5a'], img);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+
+  img.id = 'test5b';
+  assert_equals(document.test5a, undefined);
+  assert_equals(document['test5a'], undefined);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+
+  img.id = 'test5c';
+  assert_equals(document.test5a, undefined);
+  assert_equals(document['test5a'], undefined);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+  assert_equals(document.test5c, img);
+  assert_equals(document['test5c'], img);
+}, "Dynamically updating the id attribute from img elements, should be accessible by values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[6];
+  assert_equals(document.test6a, img);
+  assert_equals(document['test6a'], img);
+  assert_equals(document.test6b, img);
+  assert_equals(document['test6b'], img);
+
+  img.remove();
+  assert_equals(document.test6a, undefined);
+  assert_equals(document['test6a'], undefined);
+  assert_equals(document.test6b, undefined);
+  assert_equals(document['test6b'], undefined);
+}, "img elements that is removed, should not be accessible.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-02-expected.txt
@@ -7,4 +7,8 @@ PASS If an iframe has an id and no name, it should not be returned.
 PASS If an iframe has a name and a different id, it should be returned by its name.
 PASS If an iframe has an id and a different name, it should not be returned by its id.
 PASS An iframe whose name looks like an array index should work.
+PASS Dynamically removing the name attribute from iframe elements, should not be accessible.
+PASS Dynamically updating the name attribute from iframe elements, should be accessible by its name.
+PASS Dynamically updating the id attribute from iframe elements, should be accessible only by its name.
+PASS iframe elements that is removed, should not be accessible.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-02.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-02.html
@@ -25,6 +25,14 @@
 <iframe name="fail" id="test7"></iframe>
 
 <iframe name="42"></iframe>
+
+<iframe name="test9" id="test9"></iframe>
+
+<iframe></iframe>
+
+<iframe name="test11a"></iframe>
+
+<iframe name="test12"></iframe>
 </div>
 <script>
 test(function() {
@@ -96,4 +104,71 @@ test(function() {
   assert_true(42 in document, '42 in document should be true');
   assert_equals(document[42], iframe.contentWindow);
 }, "An iframe whose name looks like an array index should work.");
+
+test(function() {
+  var iframe = document.getElementsByTagName("iframe")[9];
+  assert_equals(iframe.name, "test9");
+
+  assert_true("test9" in document, 'test9 in document should be true');
+  assert_equals(document["test9"], iframe.contentWindow);
+  assert_equals(document.test9, iframe.contentWindow);
+
+  iframe.removeAttribute("name");
+  assert_false("test9" in document, 'test9 in document should be false');
+  assert_equals(document["test9"], undefined);
+  assert_equals(document.test9, undefined);
+}, "Dynamically removing the name attribute from iframe elements, should not be accessible.");
+
+test(function() {
+  var iframe = document.getElementsByTagName("iframe")[10];
+  iframe.setAttribute("name", "test10a");
+
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], iframe.contentWindow);
+  assert_equals(document.test10a, iframe.contentWindow);
+
+  iframe.setAttribute("name", "test10b");
+  assert_false("test10a" in document, 'test10a in document should be false');
+  assert_equals(document["test10a"], undefined);
+  assert_equals(document.test10a, undefined);
+  assert_true("test10b" in document, 'test10b in document should be true');
+  assert_equals(document["test10b"], iframe.contentWindow);
+  assert_equals(document.test10b, iframe.contentWindow);
+}, "Dynamically updating the name attribute from iframe elements, should be accessible by its name.");
+
+test(function() {
+  var iframe = document.getElementsByTagName("iframe")[11];
+  assert_equals(iframe.name, "test11a");
+
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], iframe.contentWindow);
+  assert_equals(document.test11a, iframe.contentWindow);
+
+  iframe.setAttribute("id", "test11a");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], iframe.contentWindow);
+  assert_equals(document.test11a, iframe.contentWindow);
+
+  iframe.setAttribute("id", "test11b");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], iframe.contentWindow);
+  assert_equals(document.test11a, iframe.contentWindow);
+  assert_false("test11b" in document, 'test11b in document should be false');
+  assert_equals(document["test11b"], undefined);
+  assert_equals(document.test11b, undefined);
+}, "Dynamically updating the id attribute from iframe elements, should be accessible only by its name.");
+
+test(function() {
+  var iframe = document.getElementsByTagName("iframe")[12];
+  assert_equals(iframe.name, "test12");
+
+  assert_true("test12" in document, 'test12 in document should be true');
+  assert_equals(document["test12"], iframe.contentWindow);
+  assert_equals(document.test12, iframe.contentWindow);
+
+  iframe.remove();
+  assert_false("test12" in document, 'test12 in document should be false');
+  assert_equals(document["test12"], undefined);
+  assert_equals(document.test12, undefined);
+}, "iframe elements that is removed, should not be accessible.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-04-expected.txt
@@ -7,4 +7,8 @@ PASS If there are two forms, a collection should be returned. (name and id)
 PASS If there are two forms, a collection should be returned. (id and name)
 PASS A name shouldn't affect getting an form by id
 PASS An id shouldn't affect getting an form by name
+PASS Dynamically removing the name attribute from form elements, should not be accessible.
+PASS Dynamically updating the name attribute from form elements, should be accessible by its name.
+PASS Dynamically updating the id attribute from form elements, should be accessible only by its name.
+PASS form elements that is removed, should not be accessible.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-04.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-04.html
@@ -26,6 +26,14 @@
 <form id=test7 name=fail></form>
 
 <form name=test8 id=fail></form>
+
+<form name=test9 id=test9></form>
+
+<form></form>
+
+<form name="test11a"></form>
+
+<form name="test12"></form>
 </div>
 <script>
 test(function() {
@@ -101,4 +109,71 @@ test(function() {
   assert_true("test8" in document, '"test8" in document should be true');
   assert_equals(document.test8, form);
 }, "An id shouldn't affect getting an form by name");
+
+test(function() {
+  var form = document.getElementsByTagName("form")[12];
+  assert_equals(form.name, "test9");
+
+  assert_true("test9" in document, 'test9 in document should be true');
+  assert_equals(document["test9"], form);
+  assert_equals(document.test9, form);
+
+  form.removeAttribute("name");
+  assert_false("test9" in document, 'test9 in document should be false');
+  assert_equals(document["test9"], undefined);
+  assert_equals(document.test9, undefined);
+}, "Dynamically removing the name attribute from form elements, should not be accessible.");
+
+test(function() {
+  var form = document.getElementsByTagName("form")[13];
+  form.setAttribute("name", "test10a");
+
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], form);
+  assert_equals(document.test10a, form);
+
+  form.setAttribute("name", "test10b");
+  assert_false("test10a" in document, 'test10a in document should be false');
+  assert_equals(document["test10a"], undefined);
+  assert_equals(document.test10a, undefined);
+  assert_true("test10b" in document, 'test10b in document should be true');
+  assert_equals(document["test10b"], form);
+  assert_equals(document.test10b, form);
+}, "Dynamically updating the name attribute from form elements, should be accessible by its name.");
+
+test(function() {
+  var form = document.getElementsByTagName("form")[14];
+  assert_equals(form.name, "test11a");
+
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], form);
+  assert_equals(document.test11a, form);
+
+  form.setAttribute("id", "test11a");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], form);
+  assert_equals(document.test11a, form);
+
+  form.setAttribute("id", "test11b");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], form);
+  assert_equals(document.test11a, form);
+  assert_false("test11b" in document, 'test11b in document should be false');
+  assert_equals(document["test11b"], undefined);
+  assert_equals(document.test11b, undefined);
+}, "Dynamically updating the id attribute from form elements, should be accessible only by its name.");
+
+test(function() {
+  var form = document.getElementsByTagName("form")[15];
+  assert_equals(form.name, "test12");
+
+  assert_true("test12" in document, 'test12 in document should be true');
+  assert_equals(document["test12"], form);
+  assert_equals(document.test12, form);
+
+  form.remove();
+  assert_false("test12" in document, 'test12 in document should be false');
+  assert_equals(document["test12"], undefined);
+  assert_equals(document.test12, undefined);
+}, "form elements that is removed, should not be accessible.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-05-expected.txt
@@ -7,4 +7,8 @@ PASS If there are two embeds, a collection should be returned. (name and id)
 PASS If there are two embeds, a collection should be returned. (id and name)
 PASS A name shouldn't affect getting an embed by id
 PASS An id shouldn't affect getting an embed by name
+PASS Dynamically removing the name attribute from embed elements, should not be accessible.
+PASS Dynamically updating the name attribute from embed elements, should be accessible by its name.
+PASS Dynamically updating the id attribute from embed elements, should be accessible only by its name.
+PASS embed elements that is removed, should not be accessible.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-05.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-05.html
@@ -26,6 +26,14 @@
 <embed id=test7 name=fail></embed>
 
 <embed name=test8 id=fail></embed>
+
+<embed name="test9" id="test9"></embed>
+
+<embed></embed>
+
+<embed name="test11a"></embed>
+
+<embed name="test12"></embed>
 </div>
 <script>
 test(function() {
@@ -101,4 +109,71 @@ test(function() {
   assert_true("test8" in document, '"test8" in document should be true');
   assert_equals(document.test8, embed);
 }, "An id shouldn't affect getting an embed by name");
+
+test(function() {
+  var embed = document.getElementsByTagName("embed")[12];
+  assert_equals(embed.name, "test9");
+
+  assert_true("test9" in document, 'test9 in document should be true');
+  assert_equals(document["test9"], embed);
+  assert_equals(document.test9, embed);
+
+  embed.removeAttribute("name");
+  assert_false("test9" in document, 'test9 in document should be false');
+  assert_equals(document["test9"], undefined);
+  assert_equals(document.test9, undefined);
+}, "Dynamically removing the name attribute from embed elements, should not be accessible.");
+
+test(function() {
+  var embed = document.getElementsByTagName("embed")[13];
+  embed.setAttribute("name", "test10a");
+
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], embed);
+  assert_equals(document.test10a, embed);
+
+  embed.setAttribute("name", "test10b");
+  assert_false("test10a" in document, 'test10a in document should be false');
+  assert_equals(document["test10a"], undefined);
+  assert_equals(document.test10a, undefined);
+  assert_true("test10b" in document, 'test10b in document should be true');
+  assert_equals(document["test10b"], embed);
+  assert_equals(document.test10b, embed);
+}, "Dynamically updating the name attribute from embed elements, should be accessible by its name.");
+
+test(function() {
+  var embed = document.getElementsByTagName("embed")[14];
+  assert_equals(embed.name, "test11a");
+
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], embed);
+  assert_equals(document.test11a, embed);
+
+  embed.setAttribute("id", "test11a");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], embed);
+  assert_equals(document.test11a, embed);
+
+  embed.setAttribute("id", "test11b");
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], embed);
+  assert_equals(document.test11a, embed);
+  assert_false("test11b" in document, 'test11b in document should be false');
+  assert_equals(document["test11b"], undefined);
+  assert_equals(document.test11b, undefined);
+}, "Dynamically updating the id attribute from embed elements, should be accessible only by its name.");
+
+test(function() {
+  var embed = document.getElementsByTagName("embed")[15];
+  assert_equals(embed.name, "test12");
+
+  assert_true("test12" in document, 'test12 in document should be true');
+  assert_equals(document["test12"], embed);
+  assert_equals(document.test12, embed);
+
+  embed.remove();
+  assert_false("test12" in document, 'test12 in document should be false');
+  assert_equals(document["test12"], undefined);
+  assert_equals(document.test12, undefined);
+}, "embed elements that is removed, should not be accessible.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-06-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-06-expected.txt
@@ -5,6 +5,7 @@ PASS If there is one img, it should not be returned (id)
 PASS If there are two imgs, nothing should be returned. (id)
 PASS If there are two imgs, the one with a name should be returned. (name and id)
 PASS If there are two imgs, the one with a name should be returned. (id and name)
-PASS A name should affect getting an img by id
-PASS An id shouldn't affect getting an img by name
+PASS Dynamically removing the name attribute from img elements, should not be accessible.
+PASS Dynamically updating the name attribute from img elements, should be accessible by its name.
+PASS img elements that is removed, should not be accessible.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-06.html
@@ -23,9 +23,11 @@
 <img id=test6>
 <img name=test6>
 
-<img id=test7 name=fail>
+<img name="test7">
 
-<img name=test8 id=fail>
+<img>
+
+<img name="test9">
 </div>
 <script>
 test(function() {
@@ -88,17 +90,46 @@ test(function() {
 
 test(function() {
   var img = document.getElementsByTagName("img")[10];
-  assert_equals(img.id, "test7");
+  assert_equals(img.name, "test7");
 
-  assert_true("test7" in document, '"test7" in document should be true');
+  assert_true("test7" in document, 'test7 in document should be true');
+  assert_equals(document["test7"], img);
   assert_equals(document.test7, img);
-}, "A name should affect getting an img by id");
+
+  img.removeAttribute("name");
+  assert_false("test7" in document, 'test7 in document should be false');
+  assert_equals(document["test7"], undefined);
+  assert_equals(document.test7, undefined);
+}, "Dynamically removing the name attribute from img elements, should not be accessible.");
 
 test(function() {
   var img = document.getElementsByTagName("img")[11];
-  assert_equals(img.name, "test8");
+  img.setAttribute("name", "test8a");
 
-  assert_true("test8" in document, '"test8" in document should be true');
-  assert_equals(document.test8, img);
-}, "An id shouldn't affect getting an img by name");
+  assert_true("test8a" in document, 'test8a in document should be true');
+  assert_equals(document["test8a"], img);
+  assert_equals(document.test8a, img);
+
+  img.setAttribute("name", "test8b");
+  assert_false("test8a" in document, 'test8a in document should be false');
+  assert_equals(document["test8a"], undefined);
+  assert_equals(document.test8a, undefined);
+  assert_true("test8b" in document, 'test8b in document should be true');
+  assert_equals(document["test8b"], img);
+  assert_equals(document.test8b, img);
+}, "Dynamically updating the name attribute from img elements, should be accessible by its name.");
+
+test(function() {
+  var img = document.getElementsByTagName("img")[12];
+  assert_equals(img.name, "test9");
+
+  assert_true("test9" in document, 'test9 in document should be true');
+  assert_equals(document["test9"], img);
+  assert_equals(document.test9, img);
+
+  img.remove();
+  assert_false("test9" in document, 'test9 in document should be false');
+  assert_equals(document["test9"], undefined);
+  assert_equals(document.test9, undefined);
+}, "img elements that is removed, should not be accessible.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-07-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-07-expected.txt
@@ -5,6 +5,15 @@ PASS If there is one object, it should be returned (id)
 PASS If there are two objects, a collection should be returned. (id)
 PASS If there are two objects, a collection should be returned. (name and id)
 PASS If there are two objects, a collection should be returned. (id and name)
-PASS A name shouldn't affect getting an object by id
-PASS An id shouldn't affect getting an object by name
+PASS Dynamically removing the name attribute from object elements, should not be accessible.
+PASS Dynamically removing the id attribute from object elements, should not be accessible.
+PASS Dynamically updating the name attribute from object elements, should be accessible by its name and id.
+PASS Dynamically updating the id attribute from object elements, should be accessible by its name and id.
+PASS object elements that is removed, should not be accessible.
+PASS If an object is nested inside an object with the same name, a collection should be returned. (name)
+PASS If an object is nested inside an object with the same id, a collection should be returned. (id)
+PASS If an embed is nested inside an object with the same name, a collection should be returned. (name)
+
+
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-07.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-07.html
@@ -22,9 +22,33 @@
 <object id=test6></object>
 <object name=test6></object>
 
-<object id=test7 name=fail></object>
+<object name=test7></object>
 
-<object name=test8 id=fail></object>
+<object id=test8></object>
+
+<object id=test9a></object>
+
+<object name=test10a></object>
+
+<object name=test11a id=test11b></object>
+
+<div id=nested1>
+  <object name=test12>
+    <object name=test12></object>
+  </object>
+</div>
+
+<div id=nested2>
+  <object id=test13>
+    <object id=test13></object>
+  </object>
+</div>
+
+<div id=nested3>
+  <object name=test14>
+    <embed name=test14>
+  </object>
+</div>
 </div>
 <script>
 test(function() {
@@ -93,17 +117,147 @@ test(function() {
 
 test(function() {
   var object = document.getElementsByTagName("object")[10];
-  assert_equals(object.id, "test7");
+  assert_equals(object.name, "test7");
 
-  assert_true("test7" in document, '"test7" in document should be true');
+  assert_true("test7" in document, 'test7 in document should be true');
+  assert_equals(document["test7"], object);
   assert_equals(document.test7, object);
-}, "A name shouldn't affect getting an object by id");
+
+  object.removeAttribute("name");
+  assert_false("test7" in document, 'test7 in document should be false');
+  assert_equals(document["test7"], undefined);
+  assert_equals(document.test7, undefined);
+}, "Dynamically removing the name attribute from object elements, should not be accessible.");
 
 test(function() {
   var object = document.getElementsByTagName("object")[11];
-  assert_equals(object.name, "test8");
+  assert_equals(object.id, "test8");
 
-  assert_true("test8" in document, '"test8" in document should be true');
+  assert_true("test8" in document, 'test8 in document should be true');
+  assert_equals(document["test8"], object);
   assert_equals(document.test8, object);
-}, "An id shouldn't affect getting an object by name");
+
+  object.removeAttribute("id");
+  assert_false("test8" in document, 'test8 in document should be false');
+  assert_equals(document["test8"], undefined);
+  assert_equals(document.test8, undefined);
+}, "Dynamically removing the id attribute from object elements, should not be accessible.");
+
+test(function() {
+  var object = document.getElementsByTagName("object")[12];
+  assert_equals(object.id, "test9a");
+  assert_true("test9a" in document, 'test9a in document should be true');
+  assert_equals(document["test9a"], object);
+  assert_equals(document.test9a, object);
+
+  object.setAttribute("name", "test9a");
+  assert_true("test9a" in document, 'test9a in document should be true');
+  assert_equals(document["test9a"], object);
+  assert_equals(document.test9a, object);
+
+  object.setAttribute("name", "test9b");
+  assert_true("test9a" in document, 'test9a in document should be true');
+  assert_equals(document["test9a"], object);
+  assert_equals(document.test9a, object);
+  assert_true("test9b" in document, 'test9b in document should be true');
+  assert_equals(document["test9b"], object);
+  assert_equals(document.test9b, object);
+
+  object.setAttribute("name", "test9c");
+  assert_true("test9a" in document, 'test9a in document should be true');
+  assert_equals(document["test9a"], object);
+  assert_equals(document.test9a, object);
+  assert_false("test9b" in document, 'test9b in document should be false');
+  assert_equals(document["test9b"], undefined);
+  assert_equals(document.test9b, undefined);
+  assert_true("test9c" in document, 'test9c in document should be true');
+  assert_equals(document["test9c"], object);
+  assert_equals(document.test9c, object);
+}, "Dynamically updating the name attribute from object elements, should be accessible by its name and id.");
+
+test(function() {
+  var object = document.getElementsByTagName("object")[13];
+  assert_equals(object.name, "test10a");
+  assert_true("test10a" in document, 'test11a in document should be true');
+  assert_equals(document["test10a"], object);
+  assert_equals(document.test10a, object);
+
+  object.setAttribute("id", "test10a");
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], object);
+  assert_equals(document.test10a, object);
+
+  object.setAttribute("id", "test10b");
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], object);
+  assert_equals(document.test10a, object);
+  assert_true("test10b" in document, 'test10b in document should be false');
+  assert_equals(document["test10b"], object);
+  assert_equals(document.test10b, object);
+
+  object.setAttribute("id", "test10c");
+  assert_true("test10a" in document, 'test10a in document should be true');
+  assert_equals(document["test10a"], object);
+  assert_equals(document.test10a, object);
+  assert_false("test10b" in document, 'test10b in document should be false');
+  assert_equals(document["test10b"], undefined);
+  assert_equals(document.test10b, undefined);
+  assert_true("test10c" in document, 'test10b in document should be false');
+  assert_equals(document["test10c"], object);
+  assert_equals(document.test10c, object);
+}, "Dynamically updating the id attribute from object elements, should be accessible by its name and id.");
+
+test(function() {
+  var object = document.getElementsByTagName("object")[14];
+  assert_equals(object.name, "test11a");
+  assert_equals(object.id, "test11b");
+
+  assert_true("test11a" in document, 'test11a in document should be true');
+  assert_equals(document["test11a"], object);
+  assert_equals(document.test11a, object);
+  assert_true("test11b" in document, 'test11b in document should be true');
+  assert_equals(document["test11b"], object);
+  assert_equals(document.test11b, object);
+
+  object.remove();
+  assert_false("test11a" in document, 'test11a in document should be false');
+  assert_equals(document["test11a"], undefined);
+  assert_equals(document.test11a, undefined);
+  assert_false("test11b" in document, 'test11b in document should be false');
+  assert_equals(document["test11b"], undefined);
+  assert_equals(document.test11b, undefined);
+}, "object elements that is removed, should not be accessible.");
+
+test(function() {
+  var objects = document.querySelectorAll("#nested1 object");
+  assert_equals(objects.length, 2);
+  assert_equals(objects[1].parentNode, objects[0]);
+
+  assert_true("test12" in document, '"test12" in document should be true');
+  var collection = document.test12;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [objects[0], objects[1]]);
+}, "If an object is nested inside an object with the same name, a collection should be returned. (name)");
+
+test(function() {
+  var objects = document.querySelectorAll("#nested2 object");
+  assert_equals(objects.length, 2);
+  assert_equals(objects[1].parentNode, objects[0]);
+
+  assert_true("test13" in document, '"test13" in document should be true');
+  var collection = document.test13;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [objects[0], objects[1]]);
+}, "If an object is nested inside an object with the same id, a collection should be returned. (id)");
+
+test(function() {
+  var object = document.querySelector("#nested3 object");
+  var embed = document.querySelector("#nested3 embed");
+  assert_equals(embed.parentNode, object);
+
+  assert_true("test14" in document, '"test14" in document should be true');
+  var collection = document.test14;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [object, embed]);
+}, "If an embed is nested inside an object with the same name, a collection should be returned. (name)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-empty-name-dynamic-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-empty-name-dynamic-crash.html
@@ -1,0 +1,7 @@
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const o = document.getElementById("a")
+  o.setAttribute(o.attributes[0].name, "")
+})
+</script>
+<img id="a" name="ä"/>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An img with an id gets exposed by its id, invalidating an already-cached named item collection, once a name attribute is added.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: img becomes exposed by id when a name is added, invalidating a cached list</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<object id="foo"></object>
+<object id="foo"></object>
+<img id="foo">
+<script>
+test(function() {
+  let img = document.querySelector("img#foo");
+  let collection = document.foo;
+  assert_equals(collection.length, 2, "before adding a name");
+  assert_false([...collection].includes(img), "before adding a name does not contain img");
+
+  img.setAttribute("name", "x");
+
+  assert_equals(document.foo.length, 3, "after adding a name");
+  assert_in_array(img, [...document.foo], "after adding a name contains img");
+}, "An img with an id gets exposed by its id, invalidating an already-cached named item collection, once a name attribute is added.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An img with an id but no name becomes exposed by its id once a name attribute is added.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: img becomes exposed by id when a name is added</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<img id="bar">
+<script>
+test(function() {
+  let img = document.querySelector("img#bar");
+  assert_equals(document.bar, undefined, "before adding a name");
+
+  img.setAttribute("name", "whatever");
+
+  assert_equals(document.bar, img, "after adding a name");
+}, "An img with an id but no name becomes exposed by its id once a name attribute is added.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Two imgs sharing an id are both exposed by that id, whether the name is set before or after insertion.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: imgs exposed by shared id whether name is set before or after insertion</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  let a = document.createElement("img");
+  a.id = "multi";
+  a.name = "x";
+  document.body.appendChild(a);
+
+  let b = document.createElement("img");
+  b.id = "multi";
+  document.body.appendChild(b);
+  b.name = "y";
+
+  assert_equals(document.multi.length, 2, "collection length");
+  assert_in_array(a, [...document.multi], "contains img with name set before insertion");
+  assert_in_array(b, [...document.multi], "contains img with name set after insertion");
+}, "Two imgs sharing an id are both exposed by that id, whether the name is set before or after insertion.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An img exposed by its id (id + name) is no longer exposed by id after its name attribute is removed.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: img exposed by id stops being exposed when its name is removed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<img id="foo" name="x">
+<object id="foo"></object>
+<object id="foo"></object>
+<script>
+test(function() {
+  let img = document.querySelector("img#foo");
+  assert_equals(document.foo.length, 3, "before removal");
+  assert_in_array(img, [...document.foo], "before removal contains img");
+
+  img.removeAttribute("name");
+
+  assert_equals(document.foo.length, 2, "after removal");
+  assert_false([...document.foo].includes(img), "after removal does not contain img");
+}, "An img exposed by its id (id + name) is no longer exposed by id after its name attribute is removed.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names-expected.txt
@@ -1,18 +1,23 @@
 
-PASS An embed name appears in a document's property names if the embed is exposed.
-FAIL An embed name does not appears in a document's property names if the embed is inside another embed. assert_false: expected false got true
+PASS An embed name appears in a document's property names.
 PASS A form name appears in a document's property names.
 PASS An iframe name appears in a document's property names.
 PASS An img name appears in a document's property names when the img has no id.
-PASS An object name appears in a document's property names if the object is exposed.
-PASS An object id appears in a document's property names if the object is exposed.
-FAIL An object name does not appear in a document's property names if the object is inside another object. assert_false: expected false got true
-FAIL An object id does not appear in a document's property names if the object is inside another object. assert_false: expected false got true
+PASS An object name appears in a document's property names.
+PASS An object id appears in a document's property names.
+PASS An embed name appears in a document's property names when the embed is inside an object that is not showing its fallback content.
+PASS An object name appears in a document's property names when the object is inside an object that is not showing its fallback content.
+PASS An object id appears in a document's property names when the object is inside an object that is not showing its fallback content.
+PASS An object with object and embed descendants is returned by the named getter (name).
+PASS An object with an object descendant is returned by the named getter (id).
+PASS An embed inside an object that is not showing its fallback content is returned by the named getter.
+PASS An object inside an object that is not showing its fallback content is returned by the named getter (name).
+PASS An object inside an object that is not showing its fallback content is returned by the named getter (id).
 PASS An img name appears in a document's property names when the img has an id.
 PASS An img id appears in a document's property names when the img has a name.
 PASS An img id does not appear in a document's property names when the img has no name.
 PASS A document's property names can include integer strings.
 PASS A template name does not appear in a document's property names.
 PASS An img name does not appear in a document's property names when the img is in a template's document fragment.
-FAIL A document's property names appear in tree order. assert_greater_than: expected a number greater than 7 but got 0
+FAIL A document's property names appear in tree order. assert_greater_than: expected a number greater than 6 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html
@@ -5,21 +5,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
-<embed name="exposed_embed">
-  <embed name="not_exposed_embed">
-  </embed>
-</embed>
+<embed name="embed">
 <form name="form">
 </form>
 <iframe name="iframe">
 </iframe>
 <img name="img">
-<object name="exposed_object_with_name">
-  <object name="not_exposed_object_with_name">
+<object data="/common/blank.html" type="text/html" name="object_with_name">
+  <embed name="embed_in_object">
+  <object name="object_in_object_with_name">
   </object>
 </object>
-<object id="exposed_object_with_id">
-  <object id="not_exposed_object_with_id">
+<object data="/common/blank.html" type="text/html" id="object_with_id">
+  <object id="object_in_object_with_id">
   </object>
 </object>
 <img name="img_with_id" id="img_id">
@@ -29,73 +27,112 @@
 </template>
 <img name="42">
 <script>
-var names = Object.getOwnPropertyNames(document);
+setup({ explicit_done: true });
 
-test(function() {
-  assert_true(names.includes("exposed_embed"))
-}, "An embed name appears in a document's property names if the embed is exposed.");
+window.addEventListener("load", function() {
+  var names = Object.getOwnPropertyNames(document);
 
-test(function() {
-  assert_false(names.includes("not_exposed_embed"))
-}, "An embed name does not appears in a document's property names if the embed is inside another embed.");
+  test(function() {
+    assert_true(names.includes("embed"))
+  }, "An embed name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("form"))
-}, "A form name appears in a document's property names.");
+  test(function() {
+    assert_true(names.includes("form"))
+  }, "A form name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("iframe"))
-}, "An iframe name appears in a document's property names.");
+  test(function() {
+    assert_true(names.includes("iframe"))
+  }, "An iframe name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("img"))
-}, "An img name appears in a document's property names when the img has no id.");
+  test(function() {
+    assert_true(names.includes("img"))
+  }, "An img name appears in a document's property names when the img has no id.");
 
-test(function() {
-  assert_true(names.includes("exposed_object_with_name"))
-}, "An object name appears in a document's property names if the object is exposed.");
+  test(function() {
+    assert_true(names.includes("object_with_name"))
+  }, "An object name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("exposed_object_with_id"))
-}, "An object id appears in a document's property names if the object is exposed.");
+  test(function() {
+    assert_true(names.includes("object_with_id"))
+  }, "An object id appears in a document's property names.");
 
-test(function() {
-  assert_false(names.includes("not_exposed_object_with_name"))
-}, "An object name does not appear in a document's property names if the object is inside another object.");
+  test(function() {
+    assert_not_equals(document.querySelector('[name="object_with_name"]').contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("embed_in_object"))
+  }, "An embed name appears in a document's property names when the embed is inside an object that is not showing its fallback content.");
 
-test(function() {
-  assert_false(names.includes("not_exposed_object_with_id"))
-}, "An object id does not appear in a document's property names if the object is inside another object.");
+  test(function() {
+    assert_not_equals(document.querySelector('[name="object_with_name"]').contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("object_in_object_with_name"))
+  }, "An object name appears in a document's property names when the object is inside an object that is not showing its fallback content.");
 
-test(function() {
-  assert_true(names.includes("img_with_id"))
-}, "An img name appears in a document's property names when the img has an id.");
+  test(function() {
+    assert_not_equals(document.querySelector("#object_with_id").contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("object_in_object_with_id"))
+  }, "An object id appears in a document's property names when the object is inside an object that is not showing its fallback content.");
 
-test(function() {
-  assert_true(names.includes("img_id"))
-}, "An img id appears in a document's property names when the img has a name.");
+  // A name is only useful if the named getter resolves it, so check that the
+  // two algorithms agree for object elements and their descendants.
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.object_with_name, object);
+  }, "An object with object and embed descendants is returned by the named getter (name).");
 
-test(function() {
-  assert_false(names.includes("img_with_just_id"))
-}, "An img id does not appear in a document's property names when the img has no name.");
+  test(function() {
+    var object = document.querySelector("#object_with_id");
+    assert_equals(document.object_with_id, object);
+  }, "An object with an object descendant is returned by the named getter (id).");
 
-test(function() {
-  assert_true(names.includes("42"))
-}, "A document's property names can include integer strings.");
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.embed_in_object, object.querySelector("embed"));
+  }, "An embed inside an object that is not showing its fallback content is returned by the named getter.");
 
-test(function() {
-  assert_false(names.includes("template"))
-}, "A template name does not appear in a document's property names.");
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.object_in_object_with_name, object.querySelector("object"));
+  }, "An object inside an object that is not showing its fallback content is returned by the named getter (name).");
 
-test(function() {
-  assert_false(names.includes("img_in_template"))
-}, "An img name does not appear in a document's property names when the img is in a template's document fragment.");
+  test(function() {
+    var object = document.querySelector("#object_with_id");
+    assert_equals(document.object_in_object_with_id, object.querySelector("object"));
+  }, "An object inside an object that is not showing its fallback content is returned by the named getter (id).");
 
-test(function() {
-  var form_index = names.indexOf("form");
-  assert_equals(names.indexOf("iframe"), form_index + 1);
-  assert_equals(names.indexOf("img"), form_index + 2);
-  assert_greater_than(names.indexOf("img_id"), names.indexOf("img"));
-  assert_greater_than(names.indexOf("42"), names.indexOf("img_id"));
-}, "A document's property names appear in tree order.");
+  test(function() {
+    assert_true(names.includes("img_with_id"))
+  }, "An img name appears in a document's property names when the img has an id.");
+
+  test(function() {
+    assert_true(names.includes("img_id"))
+  }, "An img id appears in a document's property names when the img has a name.");
+
+  test(function() {
+    assert_false(names.includes("img_with_just_id"))
+  }, "An img id does not appear in a document's property names when the img has no name.");
+
+  test(function() {
+    assert_true(names.includes("42"))
+  }, "A document's property names can include integer strings.");
+
+  test(function() {
+    assert_false(names.includes("template"))
+  }, "A template name does not appear in a document's property names.");
+
+  test(function() {
+    assert_false(names.includes("img_in_template"))
+  }, "An img name does not appear in a document's property names when the img is in a template's document fragment.");
+
+  test(function() {
+    var form_index = names.indexOf("form");
+    assert_equals(names.indexOf("iframe"), form_index + 1);
+    assert_equals(names.indexOf("img"), form_index + 2);
+    assert_greater_than(names.indexOf("img_id"), names.indexOf("img"));
+    assert_greater_than(names.indexOf("42"), names.indexOf("img_id"));
+  }, "A document's property names appear in tree order.");
+
+  done();
+});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative-expected.txt
@@ -1,0 +1,15 @@
+
+
+FAIL document.constructor is not shadowed assert_equals: expected (function) function "function HTMLDocument() {
+    [native code]
+}" but got (object) Element node <img name="constructor"></img>
+FAIL document.currentScript is not shadowed assert_equals: expected Element node <script id="this-script">
+test(function() {
+  assert_equa... but got Element node <img name="currentScript"></img>
+FAIL document.forms is not shadowed assert_true: expected true got false
+FAIL document.onreadystatechange is not shadowed assert_equals: expected null but got Element node <img name="onreadystatechange"></img>
+FAIL document.firstChild is not shadowed assert_true: expected true got false
+FAIL document.isSameNode() is not shadowed assert_true: expected true got false
+FAIL document.__proto__ is not shadowed assert_equals: expected object "[object HTMLDocument]" but got Element node <img name="__proto__"></img>
+PASS document.foobar works (sanity check)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: property names don't shadow</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- interface Document -->
+<img name="constructor">
+<img name="currentScript">
+<img name="forms">
+<img name="onreadystatechange">
+
+<!-- interface Node -->
+<img name="firstChild">
+<img name="isSameNode">
+
+<!-- Object.prototype -->
+<img name="__proto__">
+
+<img name="foobar">
+
+<script id="this-script">
+test(function() {
+  assert_equals(document.constructor, HTMLDocument);
+}, "document.constructor is not shadowed");
+
+test(function() {
+  assert_equals(document.currentScript, document.getElementById("this-script"));
+}, "document.currentScript is not shadowed");
+
+test(function() {
+  assert_true(document.forms instanceof HTMLCollection);
+  assert_equals(document.forms.length, 0);
+}, "document.forms is not shadowed");
+
+test(function() {
+  assert_equals(document.onreadystatechange, null);
+}, "document.onreadystatechange is not shadowed");
+
+test(function() {
+  assert_true(document.firstChild instanceof DocumentType);
+  assert_equals(document.firstChild, document.childNodes[0]);
+}, "document.firstChild is not shadowed");
+
+test(function() {
+  assert_true(document.isSameNode instanceof Function);
+  assert_true(document.isSameNode(document));
+}, "document.isSameNode() is not shadowed");
+
+test(function() {
+  assert_equals(document.__proto__, HTMLDocument.prototype);
+}, "document.__proto__ is not shadowed");
+
+test(function() {
+  assert_true(document.foobar instanceof HTMLImageElement);
+}, "document.foobar works (sanity check)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A named item collection is in tree order even after an element's name is mutated.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: collection is in tree order after name mutation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<img id=s1 name="a">
+<img id=s2 name="a">
+<img id=s3 name="a">
+<script>
+test(function() {
+  var collection = document.a;
+  assert_equals(collection.length, 3);
+  assert_array_equals([collection[0], collection[1], collection[2]],
+                      [s1, s2, s3], "initial order");
+  assert_equals(document.a, collection, "collection is stable");
+
+  s2.name = "b";
+  assert_equals(document.a, collection, "collection is stable after removing name");
+  assert_array_equals([collection[0], collection[1]],
+                      [s1, s3], "order after removing name");
+
+  s2.name = "a";
+  assert_equals(document.a, collection, "collection is stable after restoring name");
+  assert_array_equals([collection[0], collection[1], collection[2]],
+                      [s1, s2, s3], "order after restoring name");
+}, "A named item collection is in tree order even after an element's name is mutated.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/w3c-import.log
@@ -10,14 +10,13 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/Document.body.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/Document.currentScript.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/Document.getElementsByClassName-null-undef.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/Element.getElementsByClassName-null-undef.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/cross-domain.js
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.embeds-document.plugins-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.forms.html
@@ -45,4 +44,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-06.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-07.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-08.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-empty-name-dynamic-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed.html
 /LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order.html

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -112,27 +112,22 @@ Ref<DocumentParser> HTMLDocument::createParser()
 // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem
 std::optional<Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>>> HTMLDocument::namedItem(const AtomString& name)
 {
-    // hasDocumentNamedItem() is a fast-path that over-counts: it includes
-    // non-exposed object/embed elements. The collection applies isExposed()
-    // filtering, so it may end up empty even when the map has entries.
     if (name.isNull() || !hasDocumentNamedItem(name))
         return std::nullopt;
 
-    Ref collection = documentNamedItems(name);
-    auto length = collection->length();
-    if (!length)
-        return std::nullopt;
-
-    if (length == 1) {
-        Ref element = *collection->item(0);
-        if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element)) [[unlikely]] {
-            if (RefPtr window = iframe->contentWindow())
-                return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { window.releaseNonNull() };
-        }
-        return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(element) };
+    if (documentNamedItemContainsMultipleElements(name)) [[unlikely]] {
+        Ref collection = documentNamedItems(name);
+        ASSERT(collection->length() > 1);
+        return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(collection) };
     }
 
-    return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(collection) };
+    Ref element = *documentNamedItem(name);
+    if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element)) [[unlikely]] {
+        if (RefPtr window = iframe->contentWindow())
+            return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { window.releaseNonNull() };
+    }
+
+    return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(element) };
 }
 
 bool HTMLDocument::isSupportedPropertyName(const AtomString& name) const

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -64,16 +64,6 @@ Ref<HTMLEmbedElement> HTMLEmbedElement::create(Document& document)
     return create(embedTag, document);
 }
 
-// https://html.spec.whatwg.org/multipage/dom.html#exposed
-bool HTMLEmbedElement::isExposed() const
-{
-    for (Ref ancestor : ancestorsOfType<HTMLObjectElement>(*this)) {
-        if (ancestor->isExposed())
-            return false;
-    }
-    return true;
-}
-
 static inline RenderWidget* findWidgetRenderer(const Node* node)
 {
     if (!node->renderer())

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -33,8 +33,6 @@ public:
     static Ref<HTMLEmbedElement> create(Document&);
     static Ref<HTMLEmbedElement> create(const QualifiedName&, Document&);
 
-    bool isExposed() const;
-
 private:
     HTMLEmbedElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -57,45 +57,29 @@ bool WindowNameCollection::elementMatches(const Element& element, const AtomStri
         || element.getIdAttribute() == name;
 }
 
-static inline bool NODELETE isObjectElementForDocumentNameCollection(const Element& element)
-{
-    // This is used for supportedPropertyNames enumeration. All object elements
-    // are included unconditionally to match other browsers' behavior.
-    // The isExposed() check is applied later in elementMatches() when resolving
-    // a specific name to actual elements.
-    return is<HTMLObjectElement>(element);
-}
-
 bool DocumentNameCollection::elementMatchesIfIdAttributeMatch(const Element& element)
 {
     // FIXME: We need to fix HTMLImageElement to update the hash map for us when the name attribute is removed.
-    return isObjectElementForDocumentNameCollection(element)
+    return is<HTMLObjectElement>(element)
         || (is<HTMLImageElement>(element) && element.hasName() && !element.getNameAttribute().isEmpty());
 }
 
 bool DocumentNameCollection::elementMatchesIfNameAttributeMatch(const Element& element)
 {
-    return isObjectElementForDocumentNameCollection(element)
-        || isAnyOf<HTMLEmbedElement, HTMLFormElement, HTMLIFrameElement, HTMLImageElement>(element);
+    return isAnyOf<HTMLEmbedElement, HTMLFormElement, HTMLIFrameElement, HTMLImageElement, HTMLObjectElement>(element);
 }
 
 bool DocumentNameCollection::elementMatches(const Element& element, const AtomString& name)
 {
     // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem
-    // Only exposed object/embed elements should match when resolving a name.
-    // Note: elementMatchesIfNameAttributeMatch/elementMatchesIfIdAttributeMatch intentionally
-    // do not check isExposed() because they are used for supportedPropertyNames enumeration,
-    // where browsers include all object elements unconditionally.
-    if (auto* object = dynamicDowncast<HTMLObjectElement>(element))
-        return object->isExposed() && (element.getNameAttribute() == name || element.getIdAttribute() == name);
-    if (auto* embed = dynamicDowncast<HTMLEmbedElement>(element))
-        return embed->isExposed() && element.getNameAttribute() == name;
+    if (is<HTMLObjectElement>(element))
+        return element.getNameAttribute() == name || element.getIdAttribute() == name;
 
     if (is<HTMLImageElement>(element)) {
         const auto& nameValue = element.getNameAttribute();
         return nameValue == name || (element.getIdAttribute() == name && !nameValue.isEmpty());
     }
-    return isAnyOf<HTMLFormElement, HTMLIFrameElement>(element) && element.getNameAttribute() == name;
+    return isAnyOf<HTMLEmbedElement, HTMLFormElement, HTMLIFrameElement>(element) && element.getNameAttribute() == name;
 }
 
 }

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -28,11 +28,9 @@
 #include "CSSValueKeywords.h"
 #include "CachedImage.h"
 #include "ContainerNodeInlines.h"
-#include "ElementAncestorIteratorInlines.h"
 #include "ElementChildIteratorInlines.h"
 #include "FrameLoader.h"
 #include "HTMLDocument.h"
-#include "HTMLEmbedElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
 #include "HTMLMetaElement.h"
@@ -78,20 +76,6 @@ Ref<HTMLObjectElement> HTMLObjectElement::create(const QualifiedName& tagName, D
 HTMLObjectElement::~HTMLObjectElement()
 {
     clearForm();
-}
-
-// https://html.spec.whatwg.org/multipage/dom.html#exposed
-bool HTMLObjectElement::isExposed() const
-{
-    for (Ref ancestor : ancestorsOfType<HTMLObjectElement>(*this)) {
-        if (ancestor->isExposed())
-            return false;
-    }
-    for (auto& descendant : descendantsOfType<HTMLElement>(*this)) {
-        if (is<HTMLObjectElement>(descendant) || is<HTMLEmbedElement>(descendant))
-            return false;
-    }
-    return true;
 }
 
 int HTMLObjectElement::defaultTabIndex() const

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -37,8 +37,6 @@ public:
 
     static Ref<HTMLObjectElement> create(const QualifiedName&, Document&);
 
-    bool isExposed() const;
-
     bool hasFallbackContent() const;
     bool useFallbackContent() const final { return m_useFallbackContent; }
     void renderFallbackContent();


### PR DESCRIPTION
#### 63519535440f8da30cfffdabab46c68dda9f45a9
<pre>
Document named properties should not filter object and embed elements by exposedness
<a href="https://bugs.webkit.org/show_bug.cgi?id=322330">https://bugs.webkit.org/show_bug.cgi?id=322330</a>

Reviewed by Chris Dumez.

The HTML specification&apos;s &quot;exposed&quot; concept, which no engine implemented
consistently, is being removed: <a href="https://github.com/whatwg/html/issues/12787">https://github.com/whatwg/html/issues/12787</a>

WebKit applied isExposed() when resolving a name but not when enumerating
supported property names, so Object.getOwnPropertyNames(document) could
report a name that resolved to undefined. Stop consulting it, matching
Gecko. Two behavior changes: an object or embed element nested in an
object element with the same name or id now matches alongside its
ancestor, so lookup returns an HTMLCollection rather than the innermost
element; and an object element with object or embed descendants is now
reachable by its name and id.

Tests imported from <a href="https://github.com/web-platform-tests/wpt/pull/62149">https://github.com/web-platform-tests/wpt/pull/62149</a>

Tests: imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-empty-name-dynamic-crash.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added-cached-list.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-added.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-dynamic.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-img-name-removed.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-no-shadowing.tentative.html
       imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-tree-order.html

Canonical link: <a href="https://commits.webkit.org/319699@main">https://commits.webkit.org/319699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9590869148d2c9f5240d32f9279ab44a9cff2ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65a60efa-1cb0-4862-b677-f68d92ea142f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142191 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98774 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65181b3e-6efc-42b8-bc54-76e309f10a27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e56d7ff0-fbf1-43dc-8af3-4346db5206f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44593 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42863 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42485 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3557 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194321 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40678 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56476 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45912 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128759 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54987 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17481 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54368 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->