### PR TITLE
midjourney.com: scrubbing the video exits the video presentation

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -50,6 +50,12 @@ class MacOSInlineMediaControls extends InlineMediaControls
             this.element.classList.add("narrowviewer");
             this.fullscreenButton.isFullscreen = true;
         }
+
+        for (let clickEvent of ["click", "mousedown", "mouseup", "pointerdown", "pointerup", "touchstart", "touchend"]) {
+            this.bottomControlsBar.element.addEventListener(clickEvent, (event) => {
+                event.stopPropagation();
+            });
+        }
     }
 
     _setupVolumeSliderConfiguration()


### PR DESCRIPTION
#### 90d57b61d613e54706f17ee0a21650b2c8f4428f
<pre>
midjourney.com: scrubbing the video exits the video presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322331">https://bugs.webkit.org/show_bug.cgi?id=322331</a>
<a href="https://rdar.apple.com/181244652">rdar://181244652</a>

Reviewed by Jer Noble.

Midjourney&apos;s custom fullscreen video mode keeps the webkit presentation
mode as inline and uses the  default inline media controls. Midjourney exits this mode
when the user clicks outside the video rendering area. However, depending on the size
of the safari video, the media control bar can end up below the video area. To prevent
this from causing the video to exit, we should stop propagation of click events. We already
stop the propagation of click events for the fullscreen media controls. This patch does the
same for the inline controls.

No new tests.

* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:

Canonical link: <a href="https://commits.webkit.org/319741@main">https://commits.webkit.org/319741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4e6ee3f6f5379d18d3d7f9d8b42cee86b437ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146502 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61c33b01-850b-43da-8be0-0a7c8f545e93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142201 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98780 "2 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1c2a20f-d59b-4f1e-a74a-99b3d3f524b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4aee7b6b-259d-4ea7-9cea-3e9688dc938c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42869 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42492 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3563 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55791 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151624 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56482 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151325 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45922 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128765 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17488 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->