### PR TITLE
MESSAGE_CHECK failure in WebLockRegistryProxy::requestLock for a worker registered by a third-party frame

### DIFF
--- a/LayoutTests/http/tests/web-locks/resources/third-party-service-worker.js
+++ b/LayoutTests/http/tests/web-locks/resources/third-party-service-worker.js
@@ -1,0 +1,21 @@
+self.addEventListener("activate", (event) => {
+    event.waitUntil(clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+    if (event.request.url.indexOf("test1") >= 0) {
+        event.respondWith(new Promise((resolve) => {
+            navigator.locks.request('abc', {mode: 'shared'}, () => {
+                resolve(new Response("PASS"));
+            }).catch((error) => {
+                resolve(new Response(`FAIL - ${error}`));
+            });
+        }));
+        return;
+    }
+    if (event.request.mode !== "navigate") {
+        event.respondWith(Response.error());
+        return;
+    }
+    event.respondWith(fetch(event.request.url));
+});

--- a/LayoutTests/http/tests/web-locks/resources/third-party-serviceworker-frame.html
+++ b/LayoutTests/http/tests/web-locks/resources/third-party-serviceworker-frame.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+async function register() {
+    const serviceWorkerURL = './third-party-service-worker.js?' + Date.now();
+    const registration = await navigator.serviceWorker.register(serviceWorkerURL);
+    if (registration.active)
+        return registration;
+    return new Promise((resolve) => {
+        const worker = registration.installing;
+        worker.addEventListener("statechange", () => {
+            if (worker.state == "activated")
+                resolve(registration);
+        });
+    });
+}
+
+async function runTest() {
+    await register();
+
+    if (!navigator.serviceWorker.controller)
+        await new Promise(resolve => navigator.serviceWorker.addEventListener('controllerchange', resolve));
+
+    const response = await fetch('./test1');
+    top.postMessage(await response.text(), '*');
+}
+
+runTest().catch((error) => top.postMessage(`FAIL - ${error}`, '*'));
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/resources/third-party-sharedworker-frame.html
+++ b/LayoutTests/http/tests/web-locks/resources/third-party-sharedworker-frame.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+const worker = new SharedWorker('./shared-worker.js');
+worker.port.onmessage = (event) => top.postMessage(event.data, '*');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in a service worker registered by a third-party frame. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in a service worker registered by a third-party iframe, with site isolation enabled. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 8000);
+}
+
+window.onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a service worker registered by a third-party iframe, with site isolation enabled. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="http://localhost:8000/web-locks/resources/third-party-serviceworker-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 8000);
+}
+
+onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a service worker registered by a third-party frame. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="http://localhost:8000/web-locks/resources/third-party-serviceworker-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in a shared worker created by a third-party frame. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in a shared worker created by a third-party iframe, with site isolation enabled so that the shared worker does not run in the process of the frame that created it. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a shared worker created by a third-party iframe, with site isolation enabled so that the shared worker does not run in the process of the frame that created it. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="http://localhost:8000/web-locks/resources/third-party-sharedworker-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 8000);
+}
+
+onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a shared worker created by a third-party frame. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="http://localhost:8000/web-locks/resources/third-party-sharedworker-frame.html"></iframe>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -700,6 +700,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
     auto useProcessForRemoteWorkers = [&](WebProcessProxy& process) {
         remoteWorkerProcessProxy = process;
+        process.didBecomeRemoteWorkerHostForSite(site);
         bool alreadyEnabled = workerType == RemoteWorkerType::SharedWorker ? process.isRunningSharedWorkers() : process.isRunningServiceWorkers();
         if (!alreadyEnabled)
             process.enableRemoteWorkers(workerType, processPool->userContentControllerForRemoteWorkers());

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -410,6 +410,7 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
 {
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, &websiteDataStore, IsPrewarmed::No, crossOriginMode, lockdownMode, enhancedSecurity));
     proxy->m_committedSites.add(site);
+    proxy->m_remoteWorkerSites.add(site);
     proxy->m_site = WTF::move(site);
     proxy->enableRemoteWorkers(workerType, processPool.userContentControllerForRemoteWorkers());
     proxy->didStartRunningProcess();
@@ -1113,18 +1114,19 @@ bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clie
     if (m_committedClientOrigins.contains(clientOrigin))
         return true;
 
-    if (isRunningWorkers()) {
-        if (!m_site)
-            return m_committedSites.contains(Site { clientOrigin.topOrigin }) && m_committedSites.contains(Site { clientOrigin.clientOrigin });
-        return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
-    }
-
-    return false;
+    // A remote-worker process is authenticated only for the top-site partitions it hosts workers
+    // for, not for those workers' own (possibly cross-site) origins, so validate the top site here.
+    return m_remoteWorkerSites.contains(Site { clientOrigin.topOrigin });
 }
 
 void WebProcessProxy::didCommitLoadClientOrigin(WebCore::ClientOrigin&& clientOrigin)
 {
     m_committedClientOrigins.add(WTF::move(clientOrigin));
+}
+
+void WebProcessProxy::didBecomeRemoteWorkerHostForSite(const WebCore::Site& site)
+{
+    m_remoteWorkerSites.add(site);
 }
 
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -322,6 +322,7 @@ public:
 
     bool hasCommittedClientOrigin(const WebCore::ClientOrigin&) const;
     void didCommitLoadClientOrigin(WebCore::ClientOrigin&&);
+    void didBecomeRemoteWorkerHostForSite(const WebCore::Site&);
 
     void addVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
     void removeVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
@@ -848,6 +849,7 @@ private:
     uint64_t m_frameProcessCount { 0 };
 
     HashSet<WebCore::ClientOrigin> m_committedClientOrigins; // Only grows because WebProcess can navigate back to an old origin in a history item.
+    HashSet<WebCore::Site> m_remoteWorkerSites; // Only grows so that messages sent by a remote worker that is going away remain valid.
 
     WeakHashMap<VisitedLinkStore, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
 
@@ -871,6 +873,7 @@ private:
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
     std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };
     bool m_isInProcessCache { false };
+    bool m_isEligibleForWebProcessCache { true };
     bool m_isShuttingDown { false };
     bool m_isRunningProcess { false };
 
@@ -984,8 +987,6 @@ private:
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     RefPtr<WasmDebuggerDebuggable> m_wasmDebuggerDebuggable;
 #endif
-
-    bool m_isEligibleForWebProcessCache { true };
 
     HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 


### PR DESCRIPTION
#### b58727688abaf30310e8962431b0ce109f083555
<pre>
MESSAGE_CHECK failure in WebLockRegistryProxy::requestLock for a worker registered by a third-party frame
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=322329">https://bugs.webkit.org/show_bug.cgi?id=322329</a>&gt;
&lt;<a href="https://rdar.apple.com/179508210">rdar://179508210</a>&gt;

Reviewed by Chris Dumez.

`WebLockRegistryProxy` validates the incoming `ClientOrigin` with
`WebProcessProxy::hasCommittedClientOrigin()`. For a WebProcess that
only hosts remote workers there is no committed load, so that predicate
fell back to comparing both halves of the `ClientOrigin` against
`WebProcessProxy::m_site`.

That comparison is wrong. `m_site` of a remote worker process is the
*top* site, because `SWServer` and `WebSharedWorkerServer` ask for a
context connection with `SWServerWorker::topSite()` /
`WebSharedWorker::topSite()`, i.e. with the storage partition rather
than with the worker&apos;s own origin. A service worker or a shared worker
registered by a third-party frame has a client origin on a different
site than its partition, so `Site { clientOrigin.clientOrigin }` never
matched `m_site`, the `MESSAGE_CHECK` fired an `EXC_GUARD` fault and the
worker process was killed. Web Locks were therefore unreachable from any
third-party worker, which is legitimate content: the lock registry
itself is keyed by the full `ClientOrigin` and partitions such a worker
correctly.

Use new `WebProcessProxy::m_remoteWorkerSites` to track the storage
partitions for which a process has been made a remote worker host, and
validate the top origin of the incoming `ClientOrigin` against that set.
This is the tightest granularity the UI process actually possesses: it
is never told the origins of the workers running in a context process,
only the partitions the process was established for. A forged
`ClientOrigin` whose top origin is on another site is still rejected, so
`LayoutTests/ipc/weblock-registry-origin.html` keeps failing the check.

The set only ever grows so that a message which was already in flight
when `disableRemoteWorkers()` ran is still considered valid. A
Worker-only process has an empty `m_committedClientOrigins` and would
otherwise fail the check during that teardown window.

Tests: http/tests/web-locks/web-lock-in-third-party-serviceworker.html
       http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation.html
       http/tests/web-locks/web-lock-in-third-party-sharedworker.html
       http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation.html

* LayoutTests/http/tests/web-locks/resources/third-party-service-worker.js: Added.
* LayoutTests/http/tests/web-locks/resources/third-party-serviceworker-frame.html: Added.
* LayoutTests/http/tests/web-locks/resources/third-party-sharedworker-frame.html: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-expected.txt: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation-expected.txt: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker-site-isolation.html: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-serviceworker.html: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-expected.txt: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation-expected.txt: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation.html: Added.
* LayoutTests/http/tests/web-locks/web-lock-in-third-party-sharedworker.html: Added.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
- Record the storage partition on a reused remote-worker host process.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createForRemoteWorkers):
(WebKit::WebProcessProxy::hasCommittedClientOrigin const):
(WebKit::WebProcessProxy::didBecomeRemoteWorkerHostForSite):
* Source/WebKit/UIProcess/WebProcessProxy.h:
- Move `m_isEligibleForWebProcessCache` so the new `m_remoteWorkerSites`
  member variable does not grow `WebProcessProxy` into a larger
  allocation bucket: it stays at 1424 bytes.

Canonical link: <a href="https://commits.webkit.org/319692@main">https://commits.webkit.org/319692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bea3261467ad1396297ce4f52c35be4eedc51983

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25e39fa3-4e7a-437c-9cb4-c85ac66ce7fb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122638 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f1f1ddf-292d-4b01-b31b-ca7776f10270) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44603 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42871 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42494 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3565 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151627 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151328 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27693 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128767 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54995 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17490 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54376 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->