### PR TITLE
Unsynchronized cross-thread access to m_opaqueResponseToSizeWithPaddingMap in CacheStorageConnection::computeRecordBodySize

### DIFF
--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent
+

--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script>
+const NUM_WORKERS = 4;
+const PUTS_PER_THREAD = 30;
+const REMOTE = get_host_info().HTTP_REMOTE_ORIGIN + "/";
+
+const workerSrc = `
+const REMOTE = ${JSON.stringify(REMOTE)};
+const PUTS = ${PUTS_PER_THREAD};
+self.onmessage = async (e) => {
+    if (e.data !== "go")
+        return;
+    try {
+        const cache = await caches.open("opaque-response-race");
+        const responses = await Promise.all(
+            Array.from({length: PUTS}, (_, i) =>
+                fetch(REMOTE + "?w=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+        await Promise.all(responses.map((r, i) =>
+            cache.put("https://example.com/w-" + i + "-" + Math.random(), r).catch(() => {})));
+        postMessage("done");
+    } catch (err) {
+        postMessage("error:" + err);
+    }
+};
+`;
+
+promise_test(async t => {
+    await caches.delete("opaque-response-race");
+    const cache = await caches.open("opaque-response-race");
+
+    const url = URL.createObjectURL(new Blob([workerSrc], { type: "application/javascript" }));
+    t.add_cleanup(() => URL.revokeObjectURL(url));
+    const workers = [];
+    const workerDone = [];
+    for (let i = 0; i < NUM_WORKERS; i++) {
+        const w = new Worker(url);
+        workers.push(w);
+        workerDone.push(new Promise((resolve, reject) => {
+            w.onmessage = (e) => e.data === "done" ? resolve() : reject(new Error(e.data));
+            w.onerror = (e) => reject(new Error(e.message));
+        }));
+    }
+
+    for (const worker of workers)
+        worker.postMessage("go");
+
+    const mainResponses = await Promise.all(
+        Array.from({length: PUTS_PER_THREAD}, (_, i) =>
+            fetch(REMOTE + "?m=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+    const mainPuts = mainResponses.map((r, i) =>
+        cache.put("https://example.com/m-" + i + "-" + Math.random(), r).catch(() => {}));
+
+    await Promise.all([...mainPuts, ...workerDone]);
+
+    for (const worker of workers)
+        worker.terminate();
+    await caches.delete("opaque-response-race");
+}, "Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -64,15 +64,22 @@ uint64_t CacheStorageConnection::computeRecordBodySize(const FetchResponse& resp
         return computeRealBodySize(body);
     }
 
-    return m_opaqueResponseToSizeWithPaddingMap.ensure(response.opaqueLoadIdentifier(), [&] () {
-        uint64_t realSize = computeRealBodySize(body);
+    {
+        Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+        auto iterator = m_opaqueResponseToSizeWithPaddingMap.find(response.opaqueLoadIdentifier());
+        if (iterator != m_opaqueResponseToSizeWithPaddingMap.end())
+            return iterator->value;
+    }
 
-        // Padding the size as per https://github.com/whatwg/storage/issues/31.
-        uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
-        sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+    // We compute the size outside of the lock as form data size computation may hop to main thread.
+    uint64_t realSize = computeRealBodySize(body);
 
-        return sizeWithPadding;
-    }).iterator->value;
+    // Padding the size as per https://github.com/whatwg/storage/issues/31.
+    uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
+    sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+
+    Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+    return m_opaqueResponseToSizeWithPaddingMap.add(response.opaqueLoadIdentifier(), sizeWithPadding).iterator->value;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -30,6 +30,7 @@
 #include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -70,10 +71,11 @@ public:
     virtual void updateQuotaBasedOnSpaceUsage(const ClientOrigin&) { }
 
 private:
-    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&);
+    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&) WTF_EXCLUDES_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 
 protected:
-    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap;
+    Lock m_opaqueResponseToSizeWithPaddingMapLock;
+    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap WTF_GUARDED_BY_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 63ee8a1a7d39228e31d3f00a78fa8eef52909609
<pre>
Unsynchronized cross-thread access to m_opaqueResponseToSizeWithPaddingMap in CacheStorageConnection::computeRecordBodySize
<a href="https://rdar.apple.com/177953125">rdar://177953125</a>

Reviewed by Chris Dumez.

We add a lock and the related lock assertions to prevent unlocked access to the map.
Given the potential locking that may happen for form data size computation, we make sure to compute the response real size outside of the lock.

Test: http/wpt/cache-storage/cache-put-opaque-response-race.html

* LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt: Added.
* LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html: Added.
* Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
(WebCore::CacheStorageConnection::computeRecordBodySize):
* Source/WebCore/Modules/cache/CacheStorageConnection.h:

Originally-landed-as: 305413.1001@safari-7624.5-branch (4c69ed8ad988). <a href="https://rdar.apple.com/185368026">rdar://185368026</a>
Canonical link: <a href="https://commits.webkit.org/319865@main">https://commits.webkit.org/319865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3aeb84c275abfe2f873e00de4d4a7eb4e0ad5c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142840 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43504 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43134 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4401 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152312 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40809 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57308 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152008 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46566 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129577 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125690 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55816 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18145 "Found 1 new test failure: imported/w3c/web-platform-tests/webmessaging/postMessage_MessagePorts_xsite.sub.window.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->