### PR TITLE
[JSC] Deeply nested destructuring pattern crashes bytecode generation

### DIFF
--- a/JSTests/stress/destructuring-pattern-deep-recursion.js
+++ b/JSTests/stress/destructuring-pattern-deep-recursion.js
@@ -1,0 +1,27 @@
+function shouldThrowRangeError(script) {
+    let error;
+    try {
+        (0, eval)(script);
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof RangeError))
+        throw new Error("Expected RangeError, got " + error);
+}
+
+const depth = 12000;
+const open = "[".repeat(depth);
+const close = "]".repeat(depth);
+
+shouldThrowRangeError("let " + open + "z" + close + " = [];");
+shouldThrowRangeError("var " + open + "z" + close + " = [];");
+shouldThrowRangeError("(function (" + open + "z" + close + ") {})([]);");
+shouldThrowRangeError("try { throw []; } catch (" + open + "z" + close + ") {}");
+shouldThrowRangeError("let " + "{a:".repeat(depth) + "z" + "}".repeat(depth) + " = {};");
+
+let [[[a]]] = [[[42]]];
+if (a !== 42)
+    throw new Error("shallow array destructuring broken");
+let { b: { c } } = { b: { c: 7 } };
+if (c !== 7)
+    throw new Error("shallow object destructuring broken");

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5811,6 +5811,11 @@ static void assignDefaultValueIfUndefined(BytecodeGenerator& generator, Register
 
 void ArrayPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) const
 {
+    if (!generator.vm().isSafeToRecurse()) [[unlikely]] {
+        generator.emitThrowExpressionTooDeepException();
+        return;
+    }
+
     RefPtr<RegisterID> iterable = rhs;
     RefPtr<RegisterID> iterator = generator.newTemporary();
     RefPtr<RegisterID> nextOrIndex = generator.newTemporary();
@@ -6000,6 +6005,11 @@ void ObjectPatternNode::toString(StringBuilder& builder) const
     
 void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) const
 {
+    if (!generator.vm().isSafeToRecurse()) [[unlikely]] {
+        generator.emitThrowExpressionTooDeepException();
+        return;
+    }
+
     const Identifier* firstPropertyName = nullptr;
     if (!m_targetPatterns.isEmpty()) {
         const auto& firstTarget = m_targetPatterns[0];


### PR DESCRIPTION
#### 752ab9007271ac2a897a91b2ffb65d1e5f709c9c
<pre>
[JSC] Deeply nested destructuring pattern crashes bytecode generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322333">https://bugs.webkit.org/show_bug.cgi?id=322333</a>

Reviewed by Yusuke Suzuki.

The parser guards its own recursion and accepts destructuring patterns
nested ~20k levels deep, but ArrayPatternNode::bindValue recurses into
nested patterns with no stack check. Each level costs about 1KB of
native stack for the iterator temporaries and try/finally machinery, so
a pattern several thousand levels deep overflows the stack before the
parser&apos;s limit is reached:

    let [[[ /* 12000 levels */ z ]]] = [];  // SIGSEGV

ObjectPatternNode::bindValue has the same unbounded recursion.

Add the isSafeToRecurse() check that emitNode() already performs to the
top of both bindValue implementations. On failure, bytecode generation
reports ParserError::OutOfMemory and the caller sees a catchable
RangeError, matching other engines.

Test: JSTests/stress/destructuring-pattern-deep-recursion.js

* JSTests/stress/destructuring-pattern-deep-recursion.js: Added.
(shouldThrowRangeError):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayPatternNode::bindValue const):
(JSC::ObjectPatternNode::bindValue const):

Canonical link: <a href="https://commits.webkit.org/319778@main">https://commits.webkit.org/319778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5880cf2f17f3323d221c911e76658a1bc8c51f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146508 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142206 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98784 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42873 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4605 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11443 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42500 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43463 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55797 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40741 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45927 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128771 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124642 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54999 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17496 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->