### PR TITLE
[JSC] `using` loses the body's exception when the dispose method also throws in DFG code

### DIFF
--- a/JSTests/stress/for-using-dispose-call-live-catch-locals-ftl-validation.js
+++ b/JSTests/stress/for-using-dispose-call-live-catch-locals-ftl-validation.js
@@ -1,0 +1,11 @@
+//@ requireOptions("--useConcurrentJIT=0", "--validateGraph=1")
+
+function test() {
+    const resource = { [Symbol.dispose]() { } };
+    for (using r of [resource]) {
+        try { r(); } catch (e) { }
+    }
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();

--- a/JSTests/stress/using-dispose-throw-after-body-throw-in-jit.js
+++ b/JSTests/stress/using-dispose-throw-after-body-throw-in-jit.js
@@ -1,0 +1,40 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+const state = { throwOnDispose: false };
+
+const resources = [];
+for (let i = 0; i < 16; ++i) {
+    resources.push({
+        state,
+        [Symbol.dispose]: new Function(`if (this.state.throwOnDispose) throw new Error("dispose ${i}");`),
+    });
+}
+
+function run(resource, bodyShouldThrow) {
+    try {
+        {
+            using r = resource;
+            if (bodyShouldThrow)
+                throw new Error("body");
+        }
+    } catch (e) {
+        return e;
+    }
+    return null;
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    const error = run(resources[i % resources.length], i & 1);
+    shouldBe(error === null, !(i & 1));
+}
+
+state.throwOnDispose = true;
+const error = run(resources[0], 1);
+shouldBe(error instanceof SuppressedError, true);
+shouldBe(error.error.message, "dispose 0");
+shouldBe(error.suppressed.message, "body");

--- a/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
@@ -120,6 +120,7 @@ public:
 
         HandlerInfo* cachedHandlerResult;
         CodeOrigin cachedCodeOrigin;
+        CodeOrigin cachedCatchOrigin;
         auto catchHandler = [&] (CodeOrigin origin) -> HandlerInfo* {
             ASSERT(origin);
             if (origin == cachedCodeOrigin)
@@ -133,13 +134,7 @@ public:
                 InlineCallFrame* inlineCallFrame = origin.inlineCallFrame();
                 CodeBlock* codeBlock = m_graph.baselineCodeBlockFor(inlineCallFrame);
                 if (HandlerInfo* handler = codeBlock->handlerForBytecodeIndex(bytecodeIndexToCheck)) {
-                    liveAtCatchHead.fill(false);
-
-                    BytecodeIndex catchBytecodeIndex = BytecodeIndex(handler->target);
-                    m_graph.forAllLocalsAndTmpsLiveInBytecode(CodeOrigin(catchBytecodeIndex, inlineCallFrame), [&] (Operand operand) {
-                        liveAtCatchHead.operand(operand) = true;
-                    });
-
+                    cachedCatchOrigin = CodeOrigin(BytecodeIndex(handler->target), inlineCallFrame);
                     cachedHandlerResult = handler;
                     break;
                 }
@@ -154,6 +149,13 @@ public:
             }
 
             return cachedHandlerResult;
+        };
+
+        auto computeLiveAtCatchHead = [&] {
+            liveAtCatchHead.fill(false);
+            m_graph.forAllLocalsAndTmpsLiveInBytecode(cachedCatchOrigin, [&] (Operand operand) {
+                liveAtCatchHead.operand(operand) = true;
+            });
         };
 
         Operands<VariableAccessData*> currentBlockAccessData(OperandsLike, block->variablesAtTail, nullptr);
@@ -188,9 +190,13 @@ public:
 
             {
                 HandlerInfo* newHandler = catchHandler(node->origin.semantic);
-                if (newHandler != currentExceptionHandler && currentExceptionHandler)
-                    flushEverything(node->origin, nodeIndex);
-                currentExceptionHandler = newHandler;
+                if (newHandler != currentExceptionHandler) {
+                    if (currentExceptionHandler)
+                        flushEverything(node->origin, nodeIndex);
+                    currentExceptionHandler = newHandler;
+                    if (newHandler)
+                        computeLiveAtCatchHead();
+                }
             }
 
             if (currentExceptionHandler && (node->op() == SetLocal || node->op() == SetArgumentDefinitely || node->op() == SetArgumentMaybe)) {


### PR DESCRIPTION
#### 5baabec6fe034cc53298d8c67963802e1245dbdc
<pre>
[JSC] `using` loses the body&apos;s exception when the dispose method also throws in DFG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=322334">https://bugs.webkit.org/show_bug.cgi?id=322334</a>

Reviewed by NOBODY (OOPS!).

Once a function with a `using` declaration reaches the DFG, a dispose
method that throws after the body also threw yields its own plain Error
instead of a SuppressedError carrying both errors. Debug builds fail
FTL OSR availability validation instead.

When LiveCatchVariablePreservationPhase leaves one try range directly
into another, it flushes the locals live at the entered handler&apos;s catch
head instead of the left one&apos;s, because the handler lookup refills
liveAtCatchHead before the flush runs. The dispose call sits in such a
range, and its hasError local is read only by the synthesized catch, so
the exception exit restores it as undefined.

Record only the handler in the lookup, flush for the old handler first,
then recompute liveAtCatchHead for the new one.

Tests: JSTests/stress/for-using-dispose-call-live-catch-locals-ftl-validation.js
       JSTests/stress/using-dispose-throw-after-body-throw-in-jit.js

* JSTests/stress/for-using-dispose-call-live-catch-locals-ftl-validation.js: Added.
(test):
* JSTests/stress/using-dispose-throw-after-body-throw-in-jit.js: Added.
(shouldBe):
(run):
* Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp:
(JSC::DFG::LiveCatchVariablePreservationPhase::handleBlockForTryCatch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5baabec6fe034cc53298d8c67963802e1245dbdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142210 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98788 "1 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42877 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4609 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11446 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42503 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3573 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43467 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55801 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151634 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56492 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45928 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128775 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124647 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->