### PR TITLE
Make prewarmed and cached processes run in idle jetsam band

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -129,6 +129,8 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 @property (nonatomic, readonly) BOOL _hasServiceWorkerBackgroundActivityForTesting;
 @property (nonatomic, readonly) BOOL _hasServiceWorkerForegroundActivityForTesting;
 - (void)_setThrottleStateForTesting:(int)type;
+@property (nonatomic, readonly, copy) NSString *_processAssertionTypeForTesting;
+- (void)_setJetsamBoostEnabledForTesting:(BOOL)enabled;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
 - (void)_doAfterProcessingAllPendingKeyEvents:(dispatch_block_t)action;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -483,6 +483,28 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     protect(_page->legacyMainFrameProcess())->setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
 }
 
+- (NSString *)_processAssertionTypeForTesting
+{
+    if (!_page)
+        return nil;
+
+    auto assertionType = protect(_page->legacyMainFrameProcess())->throttler().assertionTypeForTesting();
+    if (!assertionType)
+        return nil;
+
+    return WebKit::processAssertionTypeDescription(*assertionType).createNSString().autorelease();
+}
+
+- (void)_setJetsamBoostEnabledForTesting:(BOOL)enabled
+{
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    if (_page)
+        protect(_page->legacyMainFrameProcess())->setJetsamBoostEnabled(enabled);
+#else
+    UNUSED_PARAM(enabled);
+#endif
+}
+
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting
 {
     return _page && protect(_page->configuration().processPool())->hasServiceWorkerBackgroundActivityForTesting();

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -463,7 +463,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
 #if USE(RUNNINGBOARD)
     protect(throttler())->didConnectToProcess(*this);
 #if PLATFORM(MAC)
-    m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
+    updateJetsamBoostAssertion();
 #endif
 #if USE(EXTENSIONKIT)
     ASSERT(launcher);
@@ -704,6 +704,28 @@ void AuxiliaryProcessProxy::setRunningBoardThrottlingEnabled()
 bool AuxiliaryProcessProxy::runningBoardThrottlingEnabled()
 {
     return !m_lifetimeActivity;
+}
+
+void AuxiliaryProcessProxy::setJetsamBoostEnabled(bool enabled)
+{
+    if (m_isJetsamBoostEnabled == enabled)
+        return;
+    m_isJetsamBoostEnabled = enabled;
+
+    updateJetsamBoostAssertion();
+    protect(throttler())->setShouldBackgroundActivitiesUseIdleJetsamBand(!enabled);
+}
+
+void AuxiliaryProcessProxy::updateJetsamBoostAssertion()
+{
+    bool shouldHoldAssertion = m_isJetsamBoostEnabled && processID();
+    if (shouldHoldAssertion == !!m_boostedJetsamAssertion)
+        return;
+
+    if (shouldHoldAssertion)
+        m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
+    else
+        m_boostedJetsamAssertion = nullptr;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -212,6 +212,7 @@ public:
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
     bool runningBoardThrottlingEnabled();
     void setRunningBoardThrottlingEnabled();
+    void setJetsamBoostEnabled(bool);
 #endif
 
     enum class UseLazyStop : bool { No, Yes };
@@ -344,6 +345,10 @@ private:
     Vector<String> platformOverrideLanguages() const;
     void platformStartConnectionTerminationWatchdog();
 
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    void updateJetsamBoostAssertion();
+#endif
+
     // Connection::Client
     void requestRemoteProcessTermination() final;
 
@@ -372,6 +377,7 @@ private:
 #if PLATFORM(MAC)
     RefPtr<ProcessThrottler::ForegroundActivity> m_lifetimeActivity;
     RefPtr<ProcessAssertion> m_boostedJetsamAssertion;
+    bool m_isJetsamBoostEnabled { true };
 #endif
 #endif
 #if ENABLE(EXTENSION_CAPABILITIES)

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -338,8 +338,6 @@ namespace WebKit {
 static ASCIILiteral runningBoardNameForAssertionType(ProcessAssertionType assertionType)
 {
     switch (assertionType) {
-    case ProcessAssertionType::NearSuspended:
-        return "Suspended"_s; // FIXME: This name is confusing since it doesn't cause suspension.
     case ProcessAssertionType::Background:
 #if PLATFORM(MAC)
         // The background assertions time out after 30 seconds on iOS but not macOS.
@@ -347,6 +345,12 @@ static ASCIILiteral runningBoardNameForAssertionType(ProcessAssertionType assert
 #else
         return "Background"_s;
 #endif
+    case ProcessAssertionType::NearSuspended:
+    case ProcessAssertionType::BackgroundIdleJetsam:
+        // FIXME: We should rename this assertion in the SDK, as the name doesn't make sense.
+        // Despite being called "suspended", this assertion type *does* allow the process to run.
+        // However, it runs at the idle jetsam band.
+        return "Suspended"_s;
     case ProcessAssertionType::UnboundedNetworking:
         return "UnboundedNetworking"_s;
     case ProcessAssertionType::Foreground:
@@ -371,6 +375,7 @@ static ASCIILiteral runningBoardDomainForAssertionType(ProcessAssertionType asse
     case ProcessAssertionType::Foreground:
     case ProcessAssertionType::MediaPlayback:
     case ProcessAssertionType::BoostedJetsam:
+    case ProcessAssertionType::BackgroundIdleJetsam:
         return "com.apple.webkit"_s;
     case ProcessAssertionType::FinishTaskCanSleep:
     case ProcessAssertionType::FinishTaskInterruptable:
@@ -584,7 +589,7 @@ ProcessAndUIAssertion::~ProcessAndUIAssertion()
 #if PLATFORM(IOS_FAMILY)
 void ProcessAndUIAssertion::updateRunInBackgroundCount()
 {
-    bool shouldHoldBackgroundTask = isValid() && type() != ProcessAssertionType::NearSuspended;
+    bool shouldHoldBackgroundTask = isValid() && (type() != ProcessAssertionType::NearSuspended && type() != ProcessAssertionType::BackgroundIdleJetsam);
     if (m_isHoldingBackgroundTask == shouldHoldBackgroundTask)
         return;
 

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -40,6 +40,8 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
         return "near-suspended"_s;
     case ProcessAssertionType::Background:
         return "background"_s;
+    case ProcessAssertionType::BackgroundIdleJetsam:
+        return "background-idle-jetsam"_s;
     case ProcessAssertionType::UnboundedNetworking:
         return "unbounded-networking"_s;
     case ProcessAssertionType::Foreground:

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -69,6 +69,7 @@ enum class ProcessAssertionType : uint8_t {
     FinishTaskCanSleep,
     FinishTaskInterruptable,
     BoostedJetsam,
+    BackgroundIdleJetsam,
 };
 
 ASCIILiteral processAssertionTypeDescription(ProcessAssertionType);

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -262,6 +262,8 @@ String ProcessThrottler::assertionName(ProcessAssertionType type) const
             return "Foreground"_s;
         case ProcessAssertionType::Background:
             return "Background"_s;
+        case ProcessAssertionType::BackgroundIdleJetsam:
+            return "BackgroundIdleJetsam"_s;
         case ProcessAssertionType::NearSuspended:
             return "NearSuspended"_s;
         case ProcessAssertionType::UnboundedNetworking:
@@ -284,7 +286,7 @@ ProcessAssertionType ProcessThrottler::assertionTypeForState(ProcessThrottleStat
     case ProcessThrottleState::Foreground:
         return ProcessAssertionType::Foreground;
     case ProcessThrottleState::Background:
-        return ProcessAssertionType::Background;
+        return m_shouldBackgroundActivitiesUseIdleJetsamBand ? ProcessAssertionType::BackgroundIdleJetsam : ProcessAssertionType::Background;
     case ProcessThrottleState::Suspended:
         return ProcessAssertionType::NearSuspended;
     }
@@ -296,10 +298,19 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
 {
     assertIfCalledFromBackgroundThread();
 
+    bool didChange = m_state != newState;
     m_state = newState;
 
-    ProcessAssertionType newType = assertionTypeForState(newState);
+    // It's possible for the throttle state to be unchanged but the assertion type to change due to
+    // m_shouldBackgroundActivitiesUseIdleJetsamBand, so this has to be called unconditionally.
+    acquireAssertion(assertionTypeForState(newState));
 
+    if (didChange && m_isConnectedToProcess)
+        protect(m_process)->didChangeThrottleState(newState);
+}
+
+void ProcessThrottler::acquireAssertion(ProcessAssertionType newType)
+{
     if (m_assertion && m_assertion->isValid() && m_assertion->type() == newType)
         return;
 
@@ -338,8 +349,6 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
             m_dropNearSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
     } else
         m_dropNearSuspendedAssertionTimer.stop();
-
-    process->didChangeThrottleState(newState);
 }
 
 void ProcessThrottler::ref() const
@@ -502,6 +511,17 @@ void ProcessThrottler::setAllowsActivities(bool allow)
     ASSERT(m_foregroundActivities.isEmptyIgnoringNullReferences());
     ASSERT(m_backgroundActivities.isEmptyIgnoringNullReferences());
     m_allowsActivities = allow;
+}
+
+void ProcessThrottler::setShouldBackgroundActivitiesUseIdleJetsamBand(bool shouldBackgroundActivitiesUseIdleJetsamBand)
+{
+    if (m_shouldBackgroundActivitiesUseIdleJetsamBand == shouldBackgroundActivitiesUseIdleJetsamBand)
+        return;
+    m_shouldBackgroundActivitiesUseIdleJetsamBand = shouldBackgroundActivitiesUseIdleJetsamBand;
+
+    // This looks redundant, but forces a throttle state => process assertion type recomputation.
+    if (m_state == ProcessThrottleState::Background)
+        setThrottleState(ProcessThrottleState::Background);
 }
 
 void ProcessThrottler::setShouldTakeNearSuspendedAssertion(bool shouldTakeNearSuspendedAssertion)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -141,6 +141,9 @@ public:
     bool isSuspended() const { return m_isConnectedToProcess && !m_assertion; }
     ProcessThrottleState currentState() const { return m_state; }
     bool isHoldingNearSuspendedAssertion() const { return m_assertion && m_assertion->type() == ProcessAssertionType::NearSuspended; }
+    std::optional<ProcessAssertionType> assertionTypeForTesting() const { return m_assertion ? std::optional { m_assertion->type() } : std::nullopt; }
+
+    void setShouldBackgroundActivitiesUseIdleJetsamBand(bool);
 
     void invalidateAllActivitiesAndDropAssertion();
 
@@ -151,8 +154,8 @@ private:
     ProcessThrottleState NODELETE expectedThrottleState();
     void updateThrottleStateIfNeeded(ASCIILiteral);
     void updateThrottleStateNow();
-    void setAssertionType(ProcessAssertionType);
     void setThrottleState(ProcessThrottleState);
+    void acquireAssertion(ProcessAssertionType);
     void prepareToSuspendTimeoutTimerFired();
     void dropNearSuspendedAssertionTimerFired();
     void prepareToDropLastAssertionTimeoutTimerFired();
@@ -188,6 +191,7 @@ private:
     bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
     const bool m_shouldTakeUIBackgroundAssertion { false };
     bool m_shouldTakeNearSuspendedAssertion { true };
+    bool m_shouldBackgroundActivitiesUseIdleJetsamBand { false };
     bool m_allowsActivities { true };
     bool m_isConnectedToProcess { false };
 };

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -357,6 +357,11 @@ void WebProcessProxy::addAllowedFirstPartyForCookies(const WebCore::RegistrableD
 Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, ShouldLaunchProcess shouldLaunchProcess)
 {
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, websiteDataStore, isPrewarmed, crossOriginMode, lockdownMode, enhancedSecurity));
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    // FIXME: disable jetsam boost on prewarmed processes always, not just when SI is enabled.
+    if (isPrewarmed == IsPrewarmed::Yes && WebProcessPool::hasAnyProcessPoolUsedSiteIsolation())
+        proxy->setJetsamBoostEnabled(false);
+#endif
     if (shouldLaunchProcess == ShouldLaunchProcess::Yes) {
         proxy->didStartRunningProcess();
         proxy->connect();
@@ -547,6 +552,12 @@ void WebProcessProxy::setIsInProcessCache(bool value, WillShutDown willShutDown)
     ASSERT(willShutDown == WillShutDown::No || !value);
     if (willShutDown == WillShutDown::Yes)
         return;
+
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    // FIXME: disable jetsam boost on cached processes always, not just when SI is enabled.
+    if (WebProcessPool::hasAnyProcessPoolUsedSiteIsolation())
+        setJetsamBoostEnabled(!m_isInProcessCache);
+#endif
 
     // The WebProcess might be task_suspended at this point, so use sendWithAsyncReply to resume
     // the process via a background activity long enough to process the IPC if necessary.
@@ -1038,6 +1049,10 @@ void WebProcessProxy::markIsNoLongerInPrewarmedPool()
     m_isPrewarmed = false;
     RELEASE_ASSERT(m_processPool);
     m_processPool.setIsWeak(IsWeak::No);
+
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    setJetsamBoostEnabled(true);
+#endif
 
     send(Messages::WebProcess::MarkIsNoLongerPrewarmed(), 0);
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -250,6 +250,7 @@ Tests/WebKit/WKWebView/PreferredAudioBufferSize.mm @nonARC
 Tests/WebKit/WKWebView/PrepareForMoveToWindow.mm @nonARC
 Tests/WebKit/WKWebView/PrivateClickMeasurement.mm @nonARC
 Tests/WebKit/WKWebView/ProcessInfo.mm @nonARC
+Tests/WebKit/WKWebView/ProcessJetsamPriority.mm @nonARC
 Tests/WebKit/WKWebView/ProcessPreWarming.mm @nonARC
 Tests/WebKit/WKWebView/ProcessSuspendMediaBuffering.mm @nonARC
 Tests/WebKit/WKWebView/ProcessSuspension.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+
+#import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+static bool waitForAssertionType(TestWKWebView *webView, NSString *expectedType)
+{
+    return TestWebKitAPI::Util::waitFor([&] {
+        return [expectedType isEqualToString:[webView _processAssertionTypeForTesting]];
+    });
+}
+
+TEST(ProcessJetsamPriority, DisablingJetsamBoostMovesBackgroundAssertionToIdleBand)
+{
+    // WebProcessActivityState::dropVisibleActivity() only takes a background activity when there
+    // are more than four cores. Below that it takes a foreground activity, so hiding the view does
+    // not move the process out of the foreground.
+    if (NSProcessInfo.processInfo.processorCount <= 4)
+        return;
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<body>Hello world!</body>"];
+
+    EXPECT_TRUE(waitForAssertionType(webView.get(), @"foreground"));
+
+    [webView removeFromSuperview];
+    EXPECT_TRUE(waitForAssertionType(webView.get(), @"background"));
+
+    // A process without the jetsam boost runs its background activities at the idle jetsam band.
+    [webView _setJetsamBoostEnabledForTesting:NO];
+    EXPECT_WK_STREQ("background-idle-jetsam", [webView _processAssertionTypeForTesting]);
+
+    [webView _setJetsamBoostEnabledForTesting:YES];
+    EXPECT_WK_STREQ("background", [webView _processAssertionTypeForTesting]);
+}
+
+TEST(ProcessJetsamPriority, DisablingJetsamBoostDoesNotAffectForegroundAssertion)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<body>Hello world!</body>"];
+
+    EXPECT_TRUE(waitForAssertionType(webView.get(), @"foreground"));
+
+    [webView _setJetsamBoostEnabledForTesting:NO];
+    EXPECT_WK_STREQ("foreground", [webView _processAssertionTypeForTesting]);
+}
+
+#endif // PLATFORM(MAC) && USE(RUNNINGBOARD)


### PR DESCRIPTION
#### 23997cdd825d50528bcc77d7b532e44541d6bf45
<pre>
Make prewarmed and cached processes run in idle jetsam band
<a href="https://bugs.webkit.org/show_bug.cgi?id=322336">https://bugs.webkit.org/show_bug.cgi?id=322336</a>
<a href="https://rdar.apple.com/185594943">rdar://185594943</a>

Reviewed by Per Arne Vollan.

On Mac, cached and prewarmed processes run at the background rather than the idle jetsam priority
level for a few reasons:

- All processes run with a permanent jetsam boost assertion.
- Prewarmed processes run with a background lifetime activity until the first page attaches to the
  process (mostly due to the complexity around the setRunningBoardThrottlingEnabled pref).
- Cached processes purposely hold a background activity for ~30s (see cachedProcessSuspensionDelay)
  as a PLT optimization, which boosts the process to the background jetsam level for that period.

Ideally, cached and prewarmed processes would always be at the idle jetsam level, because that
allows the kernel jetsam to kill them to reclaim memory as necessary instead of needing to wait
until the memory pressure handler fires in the UIProcess (which can take a while since the system
purposely spaces out sending memory pressure notifications to avoid thundering herd issues).

(Note that processes in the WebBackForwardCache are already at idle jetsam level, since we only
insert them in to that cache if they are holding no activities.)

The cleanest way I could figure out how to shoehorn this in to the existing ProcessThrottler
machinery was to add a new ProcessThrottler property that makes background activities use the idle
jetsam band. This maps to a new BackgroundIdleBand assertion type.

One confusing thing is that the BackgroundIdleBand assertion type maps to the existing &quot;Suspended&quot;
assertion in LifecyclePolicy. Despite the name, this is an assertion type that allows the process,
to run, but at the idle jetsam priority, which is what we want here.

Testing that cached and prewarmed processes actually get to idle jetsam level reliably is pretty
tricky because we may refuse to spawn those types of processes while under memory pressure, and the
system might kill those processes before we can read their jetsam level. Also, reading the jetsam
level of a process as an unprivileged user can basically only done via `top`. Instead, the API test
here just makes sure that `setJetsamBoost` itself works.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _processAssertionTypeForTesting]):
(-[WKWebView _setJetsamBoostEnabledForTesting:]):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::setJetsamBoostEnabled):
(WebKit::AuxiliaryProcessProxy::updateJetsamBoostAssertion):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::runningBoardNameForAssertionType):
(WebKit::runningBoardDomainForAssertionType):
(WebKit::ProcessAndUIAssertion::updateRunInBackgroundCount):
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
(WebKit::processAssertionTypeDescription):
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::assertionName const):
(WebKit::ProcessThrottler::assertionTypeForState):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::acquireAssertion):
(WebKit::ProcessThrottler::setShouldBackgroundActivitiesUseIdleJetsamBand):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::assertionTypeForTesting const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::create):
(WebKit::WebProcessProxy::setIsInProcessCache):
(WebKit::WebProcessProxy::markIsNoLongerInPrewarmedPool):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm: Added.
(waitForAssertionType):
(TEST(ProcessJetsamPriority, DisablingJetsamBoostMovesBackgroundAssertionToIdleBand)):
(TEST(ProcessJetsamPriority, DisablingJetsamBoostDoesNotAffectForegroundAssertion)):

Canonical link: <a href="https://commits.webkit.org/319809@main">https://commits.webkit.org/319809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e87b85967c78242c457f21802b954c0f375215d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147108 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142688 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4da76fde-4616-4281-991f-82fd49d45048) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46406 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123117 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98ba5eb1-8978-4c43-952d-d2b6098e9b29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45098 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43347 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42977 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4209 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56412 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152141 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40765 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57117 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151838 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46407 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125463 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55625 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17987 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54996 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->