### PR TITLE
Cherry-pick 7fdaeaab71b9. rdar://175673904

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
@@ -55,7 +55,14 @@ std::optional<AuthenticationExtensionsClientOutputs> AuthenticationExtensionsCli
     it = decodedMap.find(cbor::CBORValue("credProps"));
     if (it != decodedMap.end() && it->second.isMap()) {
         CredentialPropertiesOutput credProps;
+<<<<<<< HEAD
         credProps.rk = booleanValue(it->second.getMap(), "rk"_s);
+=======
+        const auto& credPropsMap = it->second.getMap();
+        auto credPropsIt = credPropsMap.find(cbor::CBORValue("rk"));
+        if (credPropsIt != credPropsMap.end() && credPropsIt->second.isBool())
+            credProps.rk = credPropsIt->second.getBool();
+>>>>>>> ce11a67281da (Cherry-pick 7fdaeaab71b9. rdar://175673904)
         clientOutputs.credProps = credProps;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp
@@ -31,6 +31,7 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include <WebCore/AuthenticationExtensionsClientOutputs.h>
 #include <WebCore/CBORReader.h>
 #include <limits>
 #include <utility>
@@ -762,6 +763,20 @@ TEST(CBORReaderTest, TestUnsupportedSimplevalue)
         EXPECT_FALSE(cbor.has_value());
         EXPECT_TRUE(errorCode == CBORReader::DecoderError::UnsupportedSimpleValue);
     }
+}
+
+TEST(CBORReaderTest, AuthExtensionsFromCBOR_CredPropsWithoutRk)
+{
+    // CBOR encoding of {"credProps": {}} — credProps map present but no "rk" key.
+    // a1                          -- map(1)
+    //    69                       -- text(9)
+    //       63726564 50726f7073   -- "credProps"
+    //    a0                       -- map(0)
+    Vector<uint8_t> cborData { 0xa1, 0x69, 0x63, 0x72, 0x65, 0x64, 0x50, 0x72, 0x6f, 0x70, 0x73, 0xa0 };
+    auto result = WebCore::AuthenticationExtensionsClientOutputs::fromCBOR(cborData);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->credProps.has_value());
+    EXPECT_FALSE(result->credProps->rk);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 79d7541f8363bb66866367c2bba1cb1bfd2040aa
<pre>
Cherry-pick 7fdaeaab71b9. <a href="https://rdar.apple.com/175673904">rdar://175673904</a>

    [WebCore] cross-container iterator dereference in AuthenticationExtensionsClientOutputs::fromCBOR
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313452">https://bugs.webkit.org/show_bug.cgi?id=313452</a>
    <a href="https://rdar.apple.com/175673904">rdar://175673904</a>

    Reviewed by Aditya Keerthi.

    fromCBOR() reuses a single `it` variable across the outer decoded map and the
    credProps sub-map. After reassigning `it` to the result of find(&quot;rk&quot;) on the
    sub-map, the guard compares it against decodedMap.end() — a different container&apos;s
    sentinel, so the check always passes. When &quot;rk&quot; is absent, this dereferences
    the sub-map&apos;s end iterator.

    Use a separate credPropsIt variable and compare against credPropsMap.end(), same
    pattern already used for largeBlob below.

    Test: Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp

    * Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp:
    (WebCore::AuthenticationExtensionsClientOutputs::fromCBOR):
    * Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp:
    (TestWebKitAPI::TEST(CBORReaderTest, AuthExtensionsFromCBOR_CredPropsWithoutRk)):

    Identifier: 305413.800@safari-7624-branch

Originally-landed-as: 305413.1120@safari-7624.5-branch (ce11a67281da). <a href="https://rdar.apple.com/185368000">rdar://185368000</a>
Canonical link: <a href="https://commits.webkit.org/320704@main">https://commits.webkit.org/320704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ba0e938978c0648f6cea694b86080bf502216f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145048 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100565 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47472 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45510 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45198 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6999 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59198 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154586 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59907 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154238 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48705 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58378 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20220 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57753 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->