### PR TITLE
[WebCore] Memory underflow in PlatformRawAudioData::copyTo()

### DIFF
--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+
+    const audioData = new AudioData({
+      format: "f32",
+      sampleRate: 48000,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+      timestamp: 0,
+      data: new Float32Array([0.125, -0.125])
+    });
+    const copyDestination = new Int16Array(16);
+
+    let threw = false;
+    try {
+      audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameOffset: 1 });
+    } catch (e) {
+      threw = e instanceof RangeError;
+    }
+
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameCount: 0 });
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 1, frameCount: 0 });
+
+    document.body.innerHTML = threw ? "PASS if no crash." : "FAIL: frameOffset == numberOfFrames did not throw RangeError.";
+  });
+</script>
+<body></body>

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -235,6 +235,9 @@ static Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<st
 
 void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFormat destinationFormat, size_t planeIndex, std::optional<size_t> frameOffset, std::optional<size_t>, unsigned long copyElementCount)
 {
+    if (!copyElementCount)
+        return;
+
     // WebCodecsAudioDataAlgorithms's computeCopyElementCount ensures that all parameters are correct.
     auto& audioData = downcast<PlatformRawAudioDataCocoa>(*this);
 


### PR DESCRIPTION
#### 4fa207d1c8d4a14afbda9ffa02b9070effd52d9b
<pre>
[WebCore] Memory underflow in PlatformRawAudioData::copyTo()
<a href="https://rdar.apple.com/176473804">rdar://176473804</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318500">https://bugs.webkit.org/show_bug.cgi?id=318500</a>

Reviewed by Jean-Yves Avenard

When PlatformRawAudioData::copyTo() is told to copy zero samples, just bail out early. This
avoids a calculation where the number of samples has 1 subtracted from it, causing a math
underflow.

Cherry-pick <a href="https://commits.webkit.org/314451@main">https://commits.webkit.org/314451@main</a> for test to pass.

Test: fast/webcodecs/audio-data-copy-to-zero-frames-crash.html

* LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp:
(WebCore::computeCopyElementCount):
* Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
(WebCore::PlatformRawAudioData::copyTo):

Originally-landed-as: 305413.1119@safari-7624.5-branch (6b8717a224a0). <a href="https://rdar.apple.com/185368929">rdar://185368929</a>
Canonical link: <a href="https://commits.webkit.org/319651@main">https://commits.webkit.org/319651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc5969694623d946ce696cf400d4b96970436d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142228 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42891 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42512 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3593 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194359 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151651 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56512 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45942 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128795 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124677 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55023 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->