### PR TITLE
[anon-block-removal] Adjoining margins do not collapse when the container's first child is a float or an out-of-flow box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+div {
+    width: 100px;
+    height: 30px;
+    margin-bottom: 10px;
+    background: green;
+}
+</style>
+<p>Test passes if there are two filled green rectangles and no red.</p>
+<div></div>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+div {
+    width: 100px;
+    height: 30px;
+    margin-bottom: 10px;
+    background: green;
+}
+</style>
+<p>Test passes if there are two filled green rectangles and no red.</p>
+<div></div>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: adjoining margins collapse when a float or an out-of-flow box comes first</title>
+<link rel="author" title="Alan Baradlay" href="mailto:ABaradlay@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins">
+<link rel="match" href="margin-collapse-after-float-001-ref.html">
+<meta name="assert" content="A self collapsing block's margin collapses with the following sibling's margin. A float or an out-of-flow box before them takes no part in that.">
+<style>
+.container {
+    display: flow-root;
+    position: relative;
+    width: 100px;
+    height: 30px;
+    margin-bottom: 10px;
+    background: red;
+}
+.float {
+    float: left;
+    width: 100px;
+    height: 10px;
+    background: green;
+}
+.out-of-flow {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 10px;
+    background: green;
+}
+.self-collapsing {
+    margin-top: 10px;
+}
+.bar {
+    margin-top: 10px;
+    height: 20px;
+    background: green;
+}
+</style>
+<p>Test passes if there are two filled green rectangles and no red.</p>
+<div class="container">
+    <div class="float"></div>
+    <div class="self-collapsing"></div>
+    <div class="bar"></div>
+</div>
+<div class="container">
+    <div class="out-of-flow"></div>
+    <div class="self-collapsing"></div>
+    <div class="bar"></div>
+</div>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -206,11 +206,14 @@ void RenderTreeBuilder::Block::attach(RenderBlock& parent, RenderPtr<RenderObjec
     };
 
     if (!shouldBuildAnonymousBlock()) {
-        auto isEmptyIgnoringExcludedMarker = [&] {
-            CheckedPtr firstChild = parent.firstChild();
-            return !firstChild || (isExcludedMarker(parent, *firstChild) && !firstChild->nextSibling());
+        auto hasInFlowChild = [&](auto& container) {
+            CheckedPtr firstInFlowChild = container.firstInFlowChild();
+            if (!firstInFlowChild)
+                return false;
+            // An excluded marker takes no part in in-flow layout either, so it leaves the decision to the content.
+            return !isExcludedMarker(container, *firstInFlowChild) || firstInFlowChild->nextInFlowSibling();
         };
-        if (isEmptyIgnoringExcludedMarker() && !child->isFloatingOrOutOfFlowPositioned())
+        if (!child->isFloatingOrOutOfFlowPositioned() && !hasInFlowChild(parent))
             parent.setChildrenInline(child->isInline());
         else if (child->isInline() && !isExcludedMarker(parent, *child)) {
             // An excluded marker takes no part in in-flow layout, so it does not make the children inline.


### PR DESCRIPTION
#### 2f6829bc0e9b663bb2c26bcb544560787a27b137
<pre>
[anon-block-removal] Adjoining margins do not collapse when the container&apos;s first child is a float or an out-of-flow box
<a href="https://bugs.webkit.org/show_bug.cgi?id=322332">https://bugs.webkit.org/show_bug.cgi?id=322332</a>
&lt;<a href="https://rdar.apple.com/problem/185591842">rdar://problem/185591842</a>&gt;

Reviewed by Antti Koivisto.

RenderTreeBuilder::Block::attach decides childrenInline from the first child but skips that when the child is
floating or out-of-flow, so a leading float or out-of-flow box leaves the parent non-empty and the first in-flow
child never reaches the branch that would turn the flag off. A container whose in-flow children are all block
level then runs an inline formatting context, which leaves adjoining margins between those boxes uncollapsed,
moves out-of-flow static positions and changes what align-content aligns. Ask whether an in-flow child has
arrived rather than whether the box is empty, skipping floats, out-of-flow boxes and an excluded marker.

* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::attach):
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-after-float-001-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/319696@main">https://commits.webkit.org/319696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b611f8faac512e5a8bcaeaccbbb6b4629e5342

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146534 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09860b6a-1357-45c5-921d-dcc08d6a477c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142230 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3de4a74b-db0d-479c-a284-68d4dfcf7aa0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44622 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42890 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42514 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3595 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194361 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151653 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40672 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56514 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151353 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45944 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128798 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55025 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17510 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->