### PR TITLE
OSR Availability Fails to Invalidate Local Recoveries Across LoadVarargs

### DIFF
--- a/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
+++ b/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
@@ -1,0 +1,84 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false", "--validateFTLOSRExitLiveness=true")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
+++ b/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
@@ -1,0 +1,88 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+noInline(shouldBe);
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(five);
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(eight);
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+noInline(filled);
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -33,6 +33,7 @@
 #include "DFGArgumentsUtilities.h"
 #include <wtf/IndexMap.h>
 #include "DFGClobberize.h"
+#include "DFGCombinedLiveness.h"
 #include "DFGForAllKills.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
@@ -722,7 +723,16 @@ private:
             }
 
             if (clobberStack) {
-                for (Node* node : combinedLiveness.liveAtTail[block])
+                // liveAtTail is the union of the CFG successors' liveAtHead, but a candidate can be kept
+                // alive solely by an exceptional exit to a catch entrypoint, which the DFG models as a
+                // non-CFG successor. Such a candidate is OSR-live at the terminal yet absent from
+                // liveAtTail, so a clobber of its source slots in this block would otherwise go
+                // unnoticed. Cover that gap with the nodes live at the terminal but dead on the tail.
+                // FIXME: If this is ever too conservative we can just calculate the locals used by
+                // the catch block for the terminal.
+                NodeSet possiblyLiveOut = bytecodeLivenessAtTerminal(m_graph, block);
+                possiblyLiveOut.addAll(combinedLiveness.liveAtTail[block]);
+                for (Node* node : possiblyLiveOut)
                     removeViaKill(block, block->size(), node);
 
                 for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
@@ -61,6 +61,13 @@ NodeSet liveNodesAtHead(Graph& graph, BasicBlock* block)
     return seen;
 }
 
+NodeSet bytecodeLivenessAtTerminal(Graph& graph, BasicBlock* block)
+{
+    NodeSet seen;
+    addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
+    return seen;
+}
+
 CombinedLiveness::CombinedLiveness(Graph& graph)
     : liveAtHead(graph.numBlocks())
     , liveAtTail(graph.numBlocks())
@@ -80,11 +87,8 @@ CombinedLiveness::CombinedLiveness(Graph& graph)
         // Unreachable
         //
         // And things may definitely be live in bytecode at that point in the program.
-        if (!block->numSuccessors()) {
-            NodeSet seen;
-            addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
-            liveAtTail[block] = seen;
-        }
+        if (!block->numSuccessors())
+            liveAtTail[block] = bytecodeLivenessAtTerminal(graph, block);
     }
     
     // Now compute the liveAtTail by unifying the liveAtHead of the successors.

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
@@ -35,6 +35,8 @@ namespace JSC { namespace DFG {
 // Returns the set of nodes live at head, both due to DFG and due to bytecode (i.e. OSR exit).
 NodeSet liveNodesAtHead(Graph&, BasicBlock*);
 
+NodeSet bytecodeLivenessAtTerminal(Graph&, BasicBlock*);
+
 // WARNING: This currently does not reason about the liveness of shadow values. The execution
 // semantics of DFG SSA are that an Upsilon stores to the shadow value of a Phi, and the Phi loads
 // from that shadow value. Hence, the shadow values are like variables, and have liveness. The normal

--- a/Source/JavaScriptCore/dfg/DFGForAllKills.h
+++ b/Source/JavaScriptCore/dfg/DFGForAllKills.h
@@ -34,10 +34,6 @@
 
 namespace JSC { namespace DFG {
 
-namespace ForAllKillsInternal {
-constexpr bool verbose = false;
-}
-
 // Utilities for finding the last points where a node is live in DFG SSA. This accounts for liveness due
 // to OSR exit. This is usually used for enumerating over all of the program points where a node is live,
 // by exploring all blocks where the node is live at tail and then exploring all program points where the
@@ -168,34 +164,6 @@ void forAllKilledNodesAtNodeIndex(
                     return result;
                 });
         });
-}
-
-// Tells you all of the places to start searching from in a basic block. Gives you the node index at which
-// the value is either no longer live. This pretends that nodes are dead at the end of the block, so that
-// you can use this to do per-basic-block analyses.
-template<ConstInvocable<void(unsigned, Node*)> Functor>
-void forAllKillsInBlock(
-    Graph& graph, const CombinedLiveness& combinedLiveness, BasicBlock* block,
-    const Functor& functor)
-{
-    for (Node* node : combinedLiveness.liveAtTail[block])
-        functor(block->size(), node);
-    
-    LocalOSRAvailabilityCalculator localAvailability(graph);
-    localAvailability.beginBlock(block);
-    // Start running functor at the second node, because the functor is expected to only inspect nodes from the start of
-    // the block up to nodeIndex (exclusive), so if nodeIndex is zero then the functor has nothing to do.
-    for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
-        dataLogLnIf(ForAllKillsInternal::verbose, "local availability at index: ", nodeIndex, " ", localAvailability.m_availability);
-        if (nodeIndex) {
-            forAllKilledNodesAtNodeIndex(
-                graph, localAvailability.m_availability, block, nodeIndex,
-                [&] (Node* node) {
-                    functor(nodeIndex, node);
-                });
-        }
-        localAvailability.executeNode(block->at(nodeIndex));
-    }
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -359,8 +359,10 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
     case LoadVarargs:
     case ForwardVarargs: {
         LoadVarargsData* data = node->loadVarargsData();
+        killHeaps(data->count);
         m_availability.m_locals.operand(data->count) = Availability(node->child1().node(), FlushedAt(FlushedInt32, data->machineCount));
         for (unsigned i = data->limit; i--;) {
+            killHeaps(data->start + i);
             m_availability.m_locals.operand(data->start + i) =
                 Availability(FlushedAt(FlushedJSValue, data->machineStart.isValid() ? (data->machineStart + i) : VirtualRegister()));
         }


### PR DESCRIPTION
#### 26aa84fcd527016df60838ccc19c722f39b6b68a
<pre>
OSR Availability Fails to Invalidate Local Recoveries Across LoadVarargs
<a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>
<a href="https://rdar.apple.com/178255543">rdar://178255543</a>

Reviewed by Yusuke Suzuki.

When a strict-mode `arguments` allocation produced by an inlined varargs call
is eliminated to PhantomClonedArguments, OSR availability records each argument
as a promoted heap location backed by the inlined frame&apos;s stack slots. A second
inlined varargs call that lowers to LoadVarargs may reuse those same virtual
registers. If an OSR exit later materialises the first allocation it must not
do so from those reused slots.

Two independent invariants were violated:

1. LocalOSRAvailabilityCalculator::executeNode() handles PutStack/KillStack by
   calling killHeaps() before replacing a stack operand&apos;s availability so that
   any promoted heap location flushed to that operand is invalidated. The
   LoadVarargs / ForwardVarargs case replaced the count and argument operands
   without that invalidation, leaving stale promoted recoveries pointing at the
   overwritten slots. Apply the same killHeaps() calls before each replacement.

2. DFG arguments-elimination interference analysis must disqualify a candidate
   whose source-frame stack slots are clobbered while the candidate is still
   OSR-live. It establishes the candidate&apos;s live range using
   forAllKilledNodesAtNodeIndex() plus CombinedLiveness::liveAtTail.
   liveAtTail was computed only as the union of CFG successors&apos; liveAtHead,
   each of which is pruned by bytecode liveness at the successor&apos;s first node.
   A candidate that is OSR-live at the block&apos;s terminal node but whose
   backing local is bytecode-dead at every CFG successor e.g.

   ```
       // block 1
       let a = ...;
       try {
           foo();
       } catch (e) {
           // block 2
           use(a);
       }
       // block 3
   ```

   Since DFG does not directly model exceptional control flow in the CFG
   `a` would be absent from the CFG/bytecode at block 3 and therefore absent
   from block 1&apos;s liveAtTail, so removeViaKill() would never be called on `a`.

Note: For 2, we don&apos;t include the bytecodeLiveness for the tail of
CombinedLiveness because this is both misleading with respect to how tail is
used in the rest of the DFG. Additionally, it breaks ObjectAllocationSinking.
ObjectAllocationSinking propagates its heap by pruning at each tail with
liveAtTail then merging into successors. Since we don&apos;t prune at the head we
can end up pushing phantom allocations into blocks where they don&apos;t actually
dominate.

Tests: JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
       JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js

Originally-landed-as: 305413.1062@safari-7624.5-branch (6c004fb89bd7). <a href="https://rdar.apple.com/185367795">rdar://185367795</a>
Canonical link: <a href="https://commits.webkit.org/320072@main">https://commits.webkit.org/320072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eed8e1c0787adad35beccc3c39e92f8ae2ca8005

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147912 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143313 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99506 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44010 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5705 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12541 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43598 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5021 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44897 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195781 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57215 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57919 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40224 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152528 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; 4 api tests failed or timed out; 1 api test failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Passed API tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47070 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130198 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56427 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18608 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55798 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56037 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->