### PR TITLE
Make ImageDecoderFactoryAVF thread safe

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -362,6 +362,7 @@ platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm @nonARC @no-unify-w
 platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm @nonARC
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
+platform/graphics/avfoundation/ImageDecoderFactoryAVF.cpp
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm @nonARC

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3003,6 +3003,7 @@
 		721292A3301BA12F009DA7C9 /* CanvasElementImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7224293B301ABB3600856621 /* CanvasElementImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72144333223EC8B000F12FF7 /* SVGProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EE5363223B2A2400FBA944 /* SVGProperty.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72144334223EC91600F12FF7 /* SVGPropertyOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EE5360223B2A2100FBA944 /* SVGPropertyOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		721B02F72FBE907300688E0A /* ImageDecoderFactoryAVF.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B02F52FBE7E7700688E0A /* ImageDecoderFactoryAVF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3E9629679E38004F5FF6 /* InnerSpinButtonPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3E9529679E38004F5FF6 /* InnerSpinButtonPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3ECF29680811004F5FF6 /* ColorWellPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3ECE29680811004F5FF6 /* ColorWellPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3EF52968F47D004F5FF6 /* MenuListButtonPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3EF42968F47D004F5FF6 /* MenuListButtonPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14516,6 +14517,8 @@
 		721443452240C8BA00F12FF7 /* SVGAnimatedValueProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGAnimatedValueProperty.h; sourceTree = "<group>"; };
 		721443462240CAD200F12FF7 /* SVGValueProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGValueProperty.h; sourceTree = "<group>"; };
 		7214B9B7274458FA003BE6DF /* FilterEffectVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterEffectVector.h; sourceTree = "<group>"; };
+		721B02F52FBE7E7700688E0A /* ImageDecoderFactoryAVF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageDecoderFactoryAVF.h; sourceTree = "<group>"; };
+		721B02F62FBE7E7700688E0A /* ImageDecoderFactoryAVF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageDecoderFactoryAVF.cpp; sourceTree = "<group>"; };
 		721B3E9329679E02004F5FF6 /* InnerSpinButtonMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InnerSpinButtonMac.h; sourceTree = "<group>"; };
 		721B3E9429679E02004F5FF6 /* InnerSpinButtonMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InnerSpinButtonMac.mm; sourceTree = "<group>"; };
 		721B3E9529679E38004F5FF6 /* InnerSpinButtonPart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InnerSpinButtonPart.h; sourceTree = "<group>"; };
@@ -24553,6 +24556,8 @@
 				A1C7D7C12AB7AD010055AD62 /* ContentKeyGroupDataSource.h */,
 				CDD8D311271F2C8D00DAA256 /* FormatDescriptionUtilities.cpp */,
 				CDD8D310271F2C8D00DAA256 /* FormatDescriptionUtilities.h */,
+				721B02F62FBE7E7700688E0A /* ImageDecoderFactoryAVF.cpp */,
+				721B02F52FBE7E7700688E0A /* ImageDecoderFactoryAVF.h */,
 				07E9E12F18F62B370011A3A4 /* InbandMetadataTextTrackPrivateAVF.cpp */,
 				07E9E12D18F5E2760011A3A4 /* InbandMetadataTextTrackPrivateAVF.h */,
 				07B442D4166C70B000556CAD /* InbandTextTrackPrivateAVF.cpp */,
@@ -46227,6 +46232,7 @@
 				CD19FEA81F573972000C42FB /* ImageDecoder.h in Headers */,
 				CD19FEAE1F574B6D000C42FB /* ImageDecoderAVFObjC.h in Headers */,
 				555B87ED1CAAF0AB00349425 /* ImageDecoderCG.h in Headers */,
+				721B02F72FBE907300688E0A /* ImageDecoderFactoryAVF.h in Headers */,
 				1D47658E25CCA778007AF312 /* ImageDecoderIdentifier.h in Headers */,
 				97205AB61239291000B17380 /* ImageDocument.h in Headers */,
 				5576A5651D88A70800CCC04C /* ImageFrame.h in Headers */,

--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -29,7 +29,6 @@
 #include "AsyncImageDecoder.h"
 #include "ImageFrame.h"
 #include "ScalableImageDecoder.h"
-#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if USE(CG)
@@ -37,7 +36,7 @@
 #endif
 
 #if HAVE(AVASSETREADER)
-#include "ImageDecoderAVFObjC.h"
+#include "ImageDecoderFactoryAVF.h"
 #endif
 
 #if USE(GSTREAMER) && ENABLE(VIDEO)
@@ -48,75 +47,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageDecoder);
 
-#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
-using FactoryVector = Vector<ImageDecoder::ImageDecoderFactory>;
-
-static RefPtr<ImageDecoder> createInProcessImageDecoderAVFObjC(FragmentedSharedBuffer& buffer, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaOption)
-{
-    return ImageDecoderAVFObjC::create(buffer, mimeType, alphaOption, gammaOption, ProcessIdentity { ProcessIdentity::CurrentProcess });
-}
-
-static RefPtr<AsyncImageDecoder> createInProcessAsyncImageDecoderAVFObjC(FragmentedSharedBuffer& buffer, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaOption, ImageDecoderClient& client)
-{
-    RefPtr decoder = createInProcessImageDecoderAVFObjC(buffer, mimeType, alphaOption, gammaOption);
-    if (!decoder)
-        return nullptr;
-    return AsyncImageDecoder::create(decoder.releaseNonNull(), client);
-}
-
-static void platformRegisterFactories(FactoryVector& factories)
-{
-    factories.append({
-        ImageDecoderAVFObjC::supportsMediaType,
-        ImageDecoderAVFObjC::canDecodeType,
-        createInProcessImageDecoderAVFObjC,
-        createInProcessAsyncImageDecoderAVFObjC
-    });
-}
-
-static FactoryVector& installedFactories()
-{
-    static NeverDestroyed<FactoryVector> factories;
-    static std::once_flag registerDefaults;
-    std::call_once(registerDefaults, [&] {
-        platformRegisterFactories(factories);
-    });
-
-    return factories;
-}
-
-void ImageDecoder::installFactory(ImageDecoder::ImageDecoderFactory&& factory)
-{
-    installedFactories().append(WTF::move(factory));
-}
-
-void ImageDecoder::resetFactories()
-{
-    installedFactories().clear();
-    platformRegisterFactories(installedFactories());
-}
-
-void ImageDecoder::clearFactories()
-{
-    installedFactories().clear();
-}
-#endif
-
 RefPtr<ImageDecoder> ImageDecoder::create(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
     UNUSED_PARAM(mimeType);
 
 #if HAVE(AVASSETREADER)
     if (!ImageDecoderCG::canDecodeType(mimeType)) {
-#if ENABLE(GPU_PROCESS)
-        for (auto& factory : installedFactories()) {
-            if (factory.canDecodeType(mimeType))
-                return factory.createImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption);
-        }
-#else
-        if (ImageDecoderAVFObjC::canDecodeType(mimeType))
-            return ImageDecoderAVFObjC::create(data, mimeType, alphaOption, gammaAndColorProfileOption);
-#endif
+        if (RefPtr imageDecoder = ImageDecoderFactoryAVF::singleton().createImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption))
+            return imageDecoder;
     }
 #endif
 
@@ -125,14 +63,16 @@ RefPtr<ImageDecoder> ImageDecoder::create(FragmentedSharedBuffer& data, const St
         return ImageDecoderGStreamer::create(data, mimeType, alphaOption, gammaAndColorProfileOption);
 #endif
 
-#if USE(CG)
     // ScalableImageDecoder is used on CG ports for some specific image formats which the platform doesn't support directly.
-    if (auto imageDecoder = ScalableImageDecoder::create(data, alphaOption, gammaAndColorProfileOption))
+    if (RefPtr imageDecoder = ScalableImageDecoder::create(data, alphaOption, gammaAndColorProfileOption))
         return imageDecoder;
-    return ImageDecoderCG::create(data, alphaOption, gammaAndColorProfileOption);
-#else
-    return ScalableImageDecoder::create(data, alphaOption, gammaAndColorProfileOption);
+
+#if USE(CG)
+    if (RefPtr imageDecoder = ImageDecoderCG::create(data, alphaOption, gammaAndColorProfileOption))
+        return imageDecoder;
 #endif
+
+    return nullptr;
 }
 
 ImageDecoder::ImageDecoder() = default;
@@ -141,28 +81,22 @@ ImageDecoder::~ImageDecoder() = default;
 
 bool ImageDecoder::supportsMediaType(MediaType type)
 {
-#if USE(CG)
-    if (ImageDecoderCG::supportsMediaType(type))
-        return true;
-#else
-    if (ScalableImageDecoder::supportsMediaType(type))
-        return true;
-#endif
-
 #if HAVE(AVASSETREADER)
-#if ENABLE(GPU_PROCESS)
-    for (auto& factory : installedFactories()) {
-        if (factory.supportsMediaType(type))
-            return true;
-    }
-#else
-    if (ImageDecoderAVFObjC::supportsMediaType(type))
+    if (ImageDecoderFactoryAVF::singleton().supportsMediaType(type))
         return true;
-#endif
 #endif
 
 #if USE(GSTREAMER) && ENABLE(VIDEO)
     if (ImageDecoderGStreamer::supportsMediaType(type))
+        return true;
+#endif
+
+    // ScalableImageDecoder is used on CG ports for some specific image formats which the platform doesn't support directly.
+    if (ScalableImageDecoder::supportsMediaType(type))
+        return true;
+
+#if USE(CG)
+    if (ImageDecoderCG::supportsMediaType(type))
         return true;
 #endif
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -70,24 +70,6 @@ public:
 
     static bool supportsMediaType(MediaType);
 
-#if ENABLE(GPU_PROCESS)
-    using SupportsMediaTypeFunc = Function<bool(MediaType)>;
-    using CanDecodeTypeFunc = Function<bool(const String&)>;
-    using CreateImageDecoderFunc = Function<RefPtr<ImageDecoder>(FragmentedSharedBuffer&, const String&, AlphaOption, GammaAndColorProfileOption)>;
-    using CreateAsyncImageDecoderFunc = Function<RefPtr<AsyncImageDecoder>(FragmentedSharedBuffer&, const String&, AlphaOption, GammaAndColorProfileOption, ImageDecoderClient&)>;
-
-    struct ImageDecoderFactory {
-        SupportsMediaTypeFunc supportsMediaType;
-        CanDecodeTypeFunc canDecodeType;
-        CreateImageDecoderFunc createImageDecoder;
-        CreateAsyncImageDecoderFunc createAsyncImageDecoder;
-    };
-
-    WEBCORE_EXPORT static void installFactory(ImageDecoderFactory&&);
-    WEBCORE_EXPORT static void resetFactories();
-    WEBCORE_EXPORT static void clearFactories();
-#endif
-
     virtual size_t bytesDecodedToDetermineProperties() const = 0;
 
     virtual EncodedDataStatus encodedDataStatus() const = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageDecoderFactoryAVF.h"
+
+#if HAVE(AVASSETREADER)
+
+#include "ImageDecoderAVFObjC.h"
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+ImageDecoderFactoryAVF& ImageDecoderFactoryAVF::singleton()
+{
+    static NeverDestroyed<ImageDecoderFactoryAVF> factory;
+    return factory.get();
+}
+
+ImageDecoderFactoryAVF::ImageDecoderFactoryAVF()
+    : m_decoderInterface(platformDecoderInterface())
+{
+}
+
+auto ImageDecoderFactoryAVF::platformDecoderInterface() -> DecoderInterface
+{
+    return {
+        ImageDecoderAVFObjC::supportsMediaType,
+        ImageDecoderAVFObjC::canDecodeType,
+        [](FragmentedSharedBuffer& buffer, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption) {
+            return ImageDecoderAVFObjC::create(buffer, mimeType, alphaOption, gammaAndColorProfileOption, ProcessIdentity { ProcessIdentity::CurrentProcess });
+        }
+    };
+}
+
+void ImageDecoderFactoryAVF::set(DecoderInterface&& decoderInterface)
+{
+    Locker locker { m_lock };
+    m_decoderInterface = WTF::move(decoderInterface);
+}
+
+void ImageDecoderFactoryAVF::reset()
+{
+    Locker locker { m_lock };
+    m_decoderInterface = platformDecoderInterface();
+}
+
+bool ImageDecoderFactoryAVF::supportsMediaType(ImageDecoder::MediaType type) const
+{
+    Locker locker { m_lock };
+    return m_decoderInterface.supportsMediaType(type);
+}
+
+RefPtr<ImageDecoder> ImageDecoderFactoryAVF::createImageDecoder(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption) const
+{
+    Locker locker { m_lock };
+
+    if (!m_decoderInterface.canDecodeType(mimeType))
+        return nullptr;
+
+    return m_decoderInterface.createImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption);
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVASSETREADER)
+
+#include <WebCore/ImageDecoder.h>
+#include <wtf/Forward.h>
+#include <wtf/Lock.h>
+
+namespace WebCore {
+
+class ImageDecoderFactoryAVF {
+public:
+    struct DecoderInterface {
+        using SupportsMediaTypeFunc = Function<bool(ImageDecoder::MediaType)>;
+        using CanDecodeTypeFunc = Function<bool(const String&)>;
+        using CreateImageDecoderFunc = Function<RefPtr<ImageDecoder>(FragmentedSharedBuffer&, const String&, AlphaOption, GammaAndColorProfileOption)>;
+
+        SupportsMediaTypeFunc supportsMediaType;
+        CanDecodeTypeFunc canDecodeType;
+        CreateImageDecoderFunc createImageDecoder;
+    };
+
+    WEBCORE_EXPORT static ImageDecoderFactoryAVF& singleton();
+
+    WEBCORE_EXPORT void set(DecoderInterface&&);
+    WEBCORE_EXPORT void reset();
+
+    bool supportsMediaType(ImageDecoder::MediaType) const;
+    RefPtr<ImageDecoder> createImageDecoder(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption) const;
+
+private:
+    friend NeverDestroyed<ImageDecoderFactoryAVF>;
+
+    ImageDecoderFactoryAVF();
+
+    static DecoderInterface platformDecoderInterface();
+
+    mutable Lock m_lock;
+    DecoderInterface m_decoderInterface WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -34,6 +34,7 @@
 #include "RemoteImageDecoderAVFProxyMessages.h"
 #include "SharedBufferReference.h"
 #include "WebProcess.h"
+#include <WebCore/ImageDecoderFactoryAVF.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -67,20 +68,6 @@ RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(F
 
     m_remoteImageDecoders.add(*imageDecoderIdentifier, remoteImageDecoder);
     return remoteImageDecoder;
-}
-
-RefPtr<AsyncImageDecoder> RemoteImageDecoderAVFManager::createAsyncImageDecoder(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption, ImageDecoderClient& client)
-{
-    auto imageDecoderIdentifier = createRemoteImageDecoder(data, mimeType);
-    if (!imageDecoderIdentifier)
-        return nullptr;
-
-    RefPtr remoteImageDecoder = RemoteImageDecoderAVF::create(*this, *imageDecoderIdentifier, data, mimeType);
-    if (!remoteImageDecoder)
-        return nullptr;
-
-    m_remoteImageDecoders.add(*imageDecoderIdentifier, remoteImageDecoder.get());
-    return AsyncImageDecoder::create(remoteImageDecoder.releaseNonNull(), client);
 }
 
 void RemoteImageDecoderAVFManager::deleteRemoteImageDecoder(const ImageDecoderIdentifier& identifier)
@@ -127,22 +114,17 @@ GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
 void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)
 {
     if (!useGPUProcess) {
-        ImageDecoder::resetFactories();
+        ImageDecoderFactoryAVF::singleton().reset();
         return;
     }
 
-    ImageDecoder::clearFactories();
-    ImageDecoder::installFactory({
+    ImageDecoderFactoryAVF::singleton().set({
         RemoteImageDecoderAVF::supportsMediaType,
         RemoteImageDecoderAVF::canDecodeType,
         [weakThis = ThreadSafeWeakPtr { *this }](FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption) {
             RefPtr protectedThis = weakThis.get();
             return protectedThis ? protectedThis->createImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption) : nullptr;
         },
-        [weakThis = ThreadSafeWeakPtr { *this }](FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption, ImageDecoderClient& client) {
-            RefPtr protectedThis = weakThis.get();
-            return protectedThis ? protectedThis->createAsyncImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption, client) : nullptr;
-        }
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -30,7 +30,6 @@
 #include "Connection.h"
 #include "GPUProcessConnection.h"
 #include "MessageReceiver.h"
-#include <WebCore/AsyncImageDecoder.h>
 #include <WebCore/ImageDecoder.h>
 #include <WebCore/ImageDecoderIdentifier.h>
 #include <WebCore/ImageTypes.h>
@@ -65,7 +64,6 @@ private:
 
     std::optional<WebCore::ImageDecoderIdentifier> createRemoteImageDecoder(WebCore::FragmentedSharedBuffer&, const String& mimeType);
     RefPtr<RemoteImageDecoderAVF> createImageDecoder(WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption);
-    RefPtr<WebCore::AsyncImageDecoder> createAsyncImageDecoder(WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption, WebCore::ImageDecoderClient&);
 
     // GPUProcessConnection::Client.
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;


### PR DESCRIPTION
#### b17b55f6a8fb1f801cf24aceb70a867e7db87af1
<pre>
Make ImageDecoderFactoryAVF thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=315295">https://bugs.webkit.org/show_bug.cgi?id=315295</a>
<a href="https://rdar.apple.com/177298988">rdar://177298988</a>

Reviewed by Jean-Yves Avenard.

ImageDecoderFactoryAVF is a new class which will replace the calls and uses of
installedFactories() in ImageDecoder.cpp.

installedFactories() returns  a process-wide Vector&lt;ImageDecoderFactory&gt; with
NO synchronization. A worker thread can reach to installedFactories() to call
createImageDecoder(). The main thread can also reach to installedFactories() but
to clearFactories() which deletes the heap-allocated of Vector&lt;ImageDecoderFactory&gt;
which can lead to UAF.

The fix is to move the code of installedFactories() to a new class called
ImageDecoderFactoryAVF. This class will contain a single DecoderInterface but
guarded by a Lock. All accesses to the DecoderInterface have to preceded by
acquiring the Lock through a Locker.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::create):
(WebCore::ImageDecoder::supportsMediaType):
(WebCore::createInProcessImageDecoderAVFObjC): Deleted.
(WebCore::platformRegisterFactories): Deleted.
(WebCore::installedFactories): Deleted.
(WebCore::ImageDecoder::installFactory): Deleted.
(WebCore::ImageDecoder::resetFactories): Deleted.
(WebCore::ImageDecoder::clearFactories): Deleted.
(WebCore::createInProcessAsyncImageDecoderAVFObjC): Deleted.
* Source/WebCore/platform/graphics/ImageDecoder.h:
* Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.cpp: Added.
(WebCore::ImageDecoderFactoryAVF::singleton):
(WebCore::ImageDecoderFactoryAVF::ImageDecoderFactoryAVF):
(WebCore::ImageDecoderFactoryAVF::platformDecoderInterface):
(WebCore::ImageDecoderFactoryAVF::set):
(WebCore::ImageDecoderFactoryAVF::reset):
(WebCore::ImageDecoderFactoryAVF::supportsMediaType const):
(WebCore::ImageDecoderFactoryAVF::createImageDecoder const):
* Source/WebCore/platform/graphics/avfoundation/ImageDecoderFactoryAVF.h: Added.
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::setUseGPUProcess):
(WebKit::RemoteImageDecoderAVFManager::createAsyncImageDecoder): Deleted.

Originally-landed-as: 305413.1018@safari-7624.5-branch (187f143ff26f). <a href="https://rdar.apple.com/185369465">rdar://185369465</a>
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:

Canonical link: <a href="https://commits.webkit.org/319799@main">https://commits.webkit.org/319799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85534216deb02e3e3bed5cb314ef9f913e2d67c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44970 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43224 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42850 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4066 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56273 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40761 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56977 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151713 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46286 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129245 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17850 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->