### PR TITLE
Use C++20 Concepts in `wtf/TypeTraits.h`

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -236,7 +236,7 @@ struct IsSmartPtr<CheckedPtr<T, U>> {
 };
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, PtrTraits> protect(T* ptr)
 {
     return CheckedPtr<T, PtrTraits>(ptr);
@@ -255,7 +255,7 @@ CheckedPtr<T, PtrTraits> protect(CheckedPtr<T, PtrTraits>&&)
 }
 
 template<typename T, typename Deleter, typename PtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, PtrTraits> protect(const std::unique_ptr<T, Deleter>& ptr)
 {
     return CheckedPtr<T, PtrTraits>(ptr.get());

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -287,7 +287,7 @@ inline const CheckedPtr<match_constness_t<ArgType, ExpectedType>> dynamicDowncas
 }
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, PtrTraits> protect(T& reference)
 {
     return CheckedRef<T, PtrTraits>(reference);
@@ -306,7 +306,7 @@ CheckedRef<T, PtrTraits> protect(CheckedRef<T, PtrTraits>&&)
 }
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, PtrTraits> protect(const UniqueRef<T>& reference)
 {
     return CheckedRef<T, PtrTraits>(reference.get());

--- a/Source/WTF/wtf/CrossThreadTask.h
+++ b/Source/WTF/wtf/CrossThreadTask.h
@@ -88,7 +88,7 @@ void callMemberFunctionForCrossThreadTask(C* object, MF function, ArgsTuple&& ar
 }
 
 template<typename T, typename... Parameters, typename... Arguments>
-requires (WTF::HasRefPtrMemberFunctions<T>::value)
+requires (WTF::HasRefPtrMemberFunctions<T>)
 CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
 {
     return CrossThreadTask([callee = RefPtr { &callee }, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
@@ -97,7 +97,7 @@ CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...
 }
 
 template<typename T, typename... Parameters, typename... Arguments>
-requires (!WTF::HasRefPtrMemberFunctions<T>::value)
+requires (!WTF::HasRefPtrMemberFunctions<T>)
 CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
 {
     return CrossThreadTask([callee = &callee, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -69,7 +69,7 @@ template<typename T> struct DefaultRefDerefTraits {
 };
 
 template<typename T>
-concept CanUseDefaultRefDerefTraits = HasRefPtrMemberFunctions<T>::value || !DefaultRefDerefTraits<T>::isDefaultImplementation;
+concept CanUseDefaultRefDerefTraits = HasRefPtrMemberFunctions<T> || !DefaultRefDerefTraits<T>::isDefaultImplementation;
 
 template<typename T, typename PtrTraits, typename RefDerefTraits> class Ref;
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>> Ref<T, PtrTraits, RefDerefTraits> adoptRef(T&);

--- a/Source/WTF/wtf/RefCountable.h
+++ b/Source/WTF/wtf/RefCountable.h
@@ -42,7 +42,7 @@ public:
     template<typename... Arguments>
     static Ref<RefCountable> create(Arguments&&... arguments)
     {
-        static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
+        static_assert(!HasRefPtrMemberFunctions<T>, "T should not be RefCounted");
         return adoptRef(*new RefCountable(std::forward<Arguments>(arguments)...));
     }
 
@@ -80,7 +80,7 @@ private:
     RefCountable(Arguments&&... arguments)
         : m_value(std::forward<Arguments>(arguments)...)
     {
-        static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
+        static_assert(!HasRefPtrMemberFunctions<T>, "T should not be RefCounted");
     }
 
     T m_value;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -217,7 +217,7 @@ public:
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Timer);
     public:
         template <typename TimerFiredClass>
-        requires (WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value)
+        requires (WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, [weakObject = ThreadSafeWeakPtr { *object }, function] {
                 if (RefPtr object = weakObject.get())
@@ -227,7 +227,7 @@ public:
         }
 
         template <typename TimerFiredClass>
-        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value && WTF::HasWeakPtrFunctions<TimerFiredClass>::value && WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value)
+        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass> && WTF::HasWeakPtrFunctions<TimerFiredClass> && WTF::HasRefPtrMemberFunctions<TimerFiredClass>)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, [weakObject = WeakPtr { *object }, function] {
                 if (RefPtr object = weakObject.get())
@@ -237,7 +237,7 @@ public:
         }
 
         template <typename TimerFiredClass>
-        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value && WTF::HasWeakPtrFunctions<TimerFiredClass>::value && !WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value)
+        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass> && WTF::HasWeakPtrFunctions<TimerFiredClass> && !WTF::HasRefPtrMemberFunctions<TimerFiredClass> && WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, [weakObject = WeakPtr { *object }, function] {
                 if (CheckedPtr object = weakObject)
@@ -247,7 +247,7 @@ public:
         }
 
         template <typename TimerFiredClass>
-        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value && !WTF::HasWeakPtrFunctions<TimerFiredClass>::value && WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value)
+        requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass> && !WTF::HasWeakPtrFunctions<TimerFiredClass> && WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, [object = CheckedRef { *object }, function] {
                 (object.ptr()->*function)();
@@ -264,7 +264,7 @@ public:
 #if !PLATFORM(COCOA)
         // FIXME: This constructor isn't as safe as the other ones and should be removed.
         template <typename TimerFiredClass>
-        requires (!WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && !WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value)
+        requires (!WTF::HasRefPtrMemberFunctions<TimerFiredClass> && !WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, std::bind(function, object))
         {

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -893,7 +893,7 @@ template<class T, class... Args>
 [[nodiscard]] ALWAYS_INLINE decltype(auto) makeUnique(Args&&... args)
 {
     static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use TZoneMalloc (WTF_MAKE_TZONE_ALLOCATED or one of its variants)");
-    static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
+    static_assert(!HasRefPtrMemberFunctions<T>, "T should not be RefCounted");
     return std::make_unique<T>(std::forward<Args>(args)...);
 }
 
@@ -911,7 +911,7 @@ template<class T, class U = T, class... Args>
 template<class T, class... Args>
 [[nodiscard]] ALWAYS_INLINE decltype(auto) makeUniqueWithoutFastMallocCheck(Args&&... args)
 {
-    static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
+    static_assert(!HasRefPtrMemberFunctions<T>, "T should not be RefCounted");
     return std::make_unique<T>(std::forward<Args>(args)...);
 }
 

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Fady Farag. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -35,14 +36,6 @@
 #include <utility>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
-
-// SFINAE depends on overload resolution. We indicate the overload we'd prefer
-// (if it can compile) using a higher priorty type (int), and the overload
-// to fall back to using a lower priority type (long). 0 can convert to int
-// or long, so we can trigger overload resolution using 0. C++ is awesome!
-#define SFINAE_OVERLOAD 0
-#define SFINAE_OVERLOAD_DEFAULT long
-#define SFINAE_OVERLOAD_PREFERRED int
 
 namespace WTF {
 
@@ -83,81 +76,35 @@ struct RemoveSmartPointerHelper<T, Ref<Pointee>> {
 template<typename T>
 struct RemoveSmartPointer : detail::RemoveSmartPointerHelper<T, std::remove_cv_t<T>> { };
 
-// HasRefPtrMemberFunctions implementation
-namespace detail {
+template<typename T>
+concept HasRefPtrMemberFunctions = requires(std::remove_cv_t<T>* ptr)
+{
+    ptr->ref();
+    ptr->deref();
+};
 
-template<typename>
-struct SFINAE1True : std::true_type { };
+template<typename T>
+concept HasWeakPtrFunctions = requires(std::remove_cv_t<T>* ptr)
+{
+    ptr->weakImpl();
+    ptr->weakCount();
+};
 
-template<class T>
-static inline auto HasRefPtrMemberFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->ref(), static_cast<std::remove_cv_t<T>*>(nullptr)->deref())>;
-template<class>
-static inline auto HasRefPtrMemberFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
+template<typename T>
+concept HasThreadSafeWeakPtrFunctions = requires(std::remove_cv_t<T>* ptr)
+{
+    ptr->weakRefCount();
+};
 
-} // namespace detail
-
-template<class T>
-struct HasRefPtrMemberFunctions : decltype(detail::HasRefPtrMemberFunctionsTest<T>(SFINAE_OVERLOAD)) { };
-
-// HasWeakPtrFunctions implementation
-namespace detail {
-
-template<class T>
-static inline auto HasWeakPtrFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->weakImpl(), static_cast<std::remove_cv_t<T>*>(nullptr)->weakCount())>;
-template<class>
-static inline auto HasWeakPtrFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
-
-}
-
-template<class T>
-struct HasWeakPtrFunctions : decltype(detail::HasWeakPtrFunctionsTest<T>(SFINAE_OVERLOAD)) { };
-
-// HasThreadSafeWeakPtrFunctions implementation
-namespace detail {
-
-template<class T>
-static inline auto HasThreadSafeWeakPtrFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->weakRefCount())>;
-template<class>
-static inline auto HasThreadSafeWeakPtrFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
-
-}
-
-template<class T>
-struct HasThreadSafeWeakPtrFunctions : decltype(detail::HasThreadSafeWeakPtrFunctionsTest<T>(SFINAE_OVERLOAD)) { };
-
-// HasCheckedPtrMemberFunctions implementation
-namespace detail {
-
-template<class T>
-static inline auto HasCheckedPtrMemberFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->incrementCheckedPtrCount(), static_cast<std::remove_cv_t<T>*>(nullptr)->decrementCheckedPtrCount())>;
-template<class>
-static inline auto HasCheckedPtrMemberFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
-
-} // namespace detail
-
-template<class T>
-struct HasCheckedPtrMemberFunctions : decltype(detail::HasCheckedPtrMemberFunctionsTest<T>(SFINAE_OVERLOAD)) { };
+template<typename T>
+concept HasCheckedPtrMemberFunctions = requires(std::remove_cv_t<T>* ptr)
+{
+    ptr->incrementCheckedPtrCount();
+    ptr->decrementCheckedPtrCount();
+};
 
 template<typename T>
 concept IsCompleteType = requires { sizeof(T); };
-
-// LooksLikeRCSerialDispatcher implementation
-namespace detail {
-
-template <bool b, typename>
-struct SFINAE1If : std::integral_constant<bool, b> { };
-
-template <bool b, class T>
-static inline auto LooksLikeRCSerialDispatcherTest(SFINAE_OVERLOAD_PREFERRED)
-    -> SFINAE1If<b, decltype(std::declval<T>().ref(), std::declval<T>().deref())>;
-
-template <bool, typename>
-static inline auto LooksLikeRCSerialDispatcherTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
-
-} // namespace detail
-
-template <class T>
-struct LooksLikeRCSerialDispatcher : decltype(detail::LooksLikeRCSerialDispatcherTest<std::is_base_of_v<SerialFunctionDispatcher, T>, T>(SFINAE_OVERLOAD)) { };
 
 class NativePromiseBase;
 class ConvertibleToNativePromise;

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -53,7 +53,7 @@ template<typename T, class... Args>
 [[nodiscard]] UniqueRef<T> makeUniqueRef(Args&&... args)
 {
     static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use TZoneMalloc (WTF_MAKE_TZONE_ALLOCATED or one of its variants)");
-    static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
+    static_assert(!HasRefPtrMemberFunctions<T>, "T should not be RefCounted");
     return makeUniqueRefWithoutFastMallocCheck<T>(std::forward<Args>(args)...);
 }
 

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -199,7 +199,7 @@ public:
         return m_set.size();
     }
 
-    void forEach(NOESCAPE const Function<void(T&)>& callback) requires HasRefPtrMemberFunctions<T>::value
+    void forEach(NOESCAPE const Function<void(T&)>& callback) requires HasRefPtrMemberFunctions<T>
     {
         auto items = compactMap(m_set, [](const KeyType& item) -> RefPtr<T> {
             return RefPtr { item.get() };
@@ -208,7 +208,7 @@ public:
             callback(item.get());
     }
 
-    void forEach(NOESCAPE const Function<void(T&)>& callback) requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    void forEach(NOESCAPE const Function<void(T&)>& callback) requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
     {
         auto items = compactMap(m_set, [](const KeyType& item) -> CheckedPtr<T> {
             return CheckedPtr { item.get() };

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -122,7 +122,7 @@ public:
     T* ptrAllowingHashTableEmptyValue() const
     {
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
         return !m_impl.isHashTableEmptyValue() ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
@@ -134,10 +134,10 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
         static_assert(
-            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T> && !HasCheckedPtrMemberFunctions<T>),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
@@ -166,10 +166,10 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
         static_assert(
-            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T> && !HasCheckedPtrMemberFunctions<T>),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         auto* result = get();
@@ -181,10 +181,10 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
         static_assert(
-            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T> && !HasCheckedPtrMemberFunctions<T>),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         auto* result = get();
@@ -419,14 +419,14 @@ template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inlin
 }
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits, typename RefPtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
-    requires HasRefPtrMemberFunctions<T>::value
+    requires HasRefPtrMemberFunctions<T>
 ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, RefPtrTraits, RefDerefTraits> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& weakPtr)
 {
     return RefPtr<T, RefPtrTraits, RefDerefTraits>(weakPtr.get());
 }
 
 template<typename T, typename WeakPtrImpl, typename WeakPtrPtrTraits, typename CheckedPtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, CheckedPtrTraits> protect(const WeakPtr<T, WeakPtrImpl, WeakPtrPtrTraits>& weakPtr)
 {
     return CheckedPtr<T, CheckedPtrTraits>(weakPtr.get());

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -85,7 +85,7 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
         return !m_impl.isHashTableEmptyValue() ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
@@ -95,7 +95,7 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
         ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
@@ -108,7 +108,7 @@ public:
     {
         static_assert(IsCompleteType<T>, "T must be a complete type (are you missing an #include?)");
         static_assert(
-            HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
+            HasRefPtrMemberFunctions<T> || HasCheckedPtrMemberFunctions<T> || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
         ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
@@ -240,14 +240,14 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(W
 }
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits = RawPtrTraits<T>>
-    requires HasRefPtrMemberFunctions<T>::value
+    requires HasRefPtrMemberFunctions<T>
 ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
     return Ref<T, PtrTraits>(weakRef.get());
 }
 
 template<typename T, typename WeakPtrImpl, typename CheckedPtrTraits = RawPtrTraits<T>>
-    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+    requires (HasCheckedPtrMemberFunctions<T> && !HasRefPtrMemberFunctions<T>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, CheckedPtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
     return CheckedRef<T, CheckedPtrTraits>(weakRef.get());

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -147,7 +147,7 @@ public:
     }
 
     template<typename TimerFiredClass, typename TimerFiredBaseClass>
-    requires (WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value)
+    requires (WTF::HasRefPtrMemberFunctions<TimerFiredClass> && WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>)
     Timer(TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
         : m_function([weakObject = ThreadSafeWeakPtr { object }, function] {
             if (RefPtr protectedObject = weakObject.get())
@@ -157,7 +157,7 @@ public:
     }
 
     template<typename TimerFiredClass, typename TimerFiredBaseClass>
-    requires (WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && !WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value && WTF::HasWeakPtrFunctions<TimerFiredClass>::value)
+    requires (WTF::HasRefPtrMemberFunctions<TimerFiredClass> && !WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass> && WTF::HasWeakPtrFunctions<TimerFiredClass>)
     Timer(TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
         : m_function([weakObject = WeakPtr { object }, function] {
             if (RefPtr protectedObject = weakObject.get())
@@ -167,7 +167,7 @@ public:
     }
 
     template<typename TimerFiredClass, typename TimerFiredBaseClass>
-    requires (WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value && (!WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value || (!WTF::HasWeakPtrFunctions<TimerFiredClass>::value && !WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value)))
+    requires (WTF::HasCheckedPtrMemberFunctions<TimerFiredClass> && (!WTF::HasRefPtrMemberFunctions<TimerFiredClass> || (!WTF::HasWeakPtrFunctions<TimerFiredClass> && !WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>)))
     Timer(TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
         : m_function([checkedObject = CheckedRef { object }, function] {
             (checkedObject.ptr()->*function)();


### PR DESCRIPTION
#### 140ec9c4a1ace8b9717b5f13d6e03c91c07b8b1c
<pre>
Use C++20 Concepts in `wtf/TypeTraits.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322339">https://bugs.webkit.org/show_bug.cgi?id=322339</a>
<a href="https://rdar.apple.com/185601516">rdar://185601516</a>

Reviewed by Darin Adler.

This drops the pre-C++20 overload-resolution SFINAE
detection idiom in favor of modern C++ language features.

No new tests since there should be no behavioral changes.

* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/CheckedRef.h:
* Source/WTF/wtf/CrossThreadTask.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefCountable.h:
(WTF::RefCountable::create):
(WTF::RefCountable::RefCountable):
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::makeUnique):
(WTF::makeUniqueWithoutFastMallocCheck):
* Source/WTF/wtf/TypeTraits.h:
(WTF::requires):
* Source/WTF/wtf/UniqueRef.h:
(WTF::makeUniqueRef):
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::ptrAllowingHashTableEmptyValue const):
(WTF::WeakPtr::get const):
(WTF::WeakPtr::operator-&gt; const):
(WTF::WeakPtr::operator* const):
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::ptrAllowingHashTableEmptyValue const):
(WTF::WeakRef::ptr const):
(WTF::WeakRef::get const):
* Source/WebCore/platform/Timer.h:

Canonical link: <a href="https://commits.webkit.org/319707@main">https://commits.webkit.org/319707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac111aa8657c072f34a4ce6c07c00e5a36955c43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42918 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4663 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11484 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42541 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3635 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43529 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194401 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151686 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56554 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151387 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45972 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128838 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124746 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55065 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->