### PR TITLE
Race on RemoteVideoDecoderCallbacks::m_timestampToDuration leads to use-after-free

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent VideoDecoder.decode() and output delivery should not race on the timestamp-to-duration map
+

--- a/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash.html
+++ b/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<script>
+promise_test(async (t) => {
+    let resolveChunk;
+    const haveChunk = new Promise(r => resolveChunk = r);
+    let keyChunkData;
+    let decoderConfig;
+
+    const encoder = new VideoEncoder({
+        output(chunk, metadata) {
+            if (metadata.decoderConfig)
+                decoderConfig = metadata.decoderConfig;
+            const buffer = new Uint8Array(chunk.byteLength);
+            chunk.copyTo(buffer);
+            keyChunkData = buffer;
+            resolveChunk();
+        },
+        error(e) { }
+    });
+    encoder.configure({ codec: "avc1.42001E", width: 64, height: 64, bitrate: 100000, framerate: 30, avc: { format: "annexb" } });
+    const canvas = new OffscreenCanvas(64, 64);
+    canvas.getContext("2d").fillRect(0, 0, 64, 64);
+    const frame = new VideoFrame(canvas, { timestamp: 0 });
+    encoder.encode(frame, { keyFrame: true });
+    frame.close();
+    await encoder.flush();
+    await haveChunk;
+    encoder.close();
+
+    const decoder = new VideoDecoder({
+        output(frame) { frame.close(); },
+        error(e) { }
+    });
+    decoder.configure(decoderConfig || { codec: "avc1.42001E" });
+
+    // Submit many decodes carrying a duration so that addDuration() runs on this
+    // thread while completedDecoding() drains on the LibWebRTCCodecs work queue.
+    for (let i = 0; i < 2000; ++i) {
+        decoder.decode(new EncodedVideoChunk({
+            type: "key",
+            timestamp: i,
+            duration: 1,
+            data: keyChunkData
+        }));
+        if (decoder.decodeQueueSize > 64)
+            await new Promise(r => setTimeout(r, 0));
+    }
+    await decoder.flush().catch(() => { });
+    decoder.close();
+}, "Concurrent VideoDecoder.decode() and output delivery should not race on the timestamp-to-duration map");
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -42,14 +42,19 @@ public:
     void notifyDecodingResult(RefPtr<WebCore::VideoFrame>&&, int64_t timestamp);
 
     void NODELETE close() { m_isClosed = true; }
-    void addDuration(int64_t timestamp, uint64_t duration) { m_timestampToDuration.insert_or_assign(timestamp, duration); }
+    void addDuration(int64_t timestamp, uint64_t duration)
+    {
+        Locker locker { m_timestampToDurationLock };
+        m_timestampToDuration.insert_or_assign(timestamp, duration);
+    }
 
 private:
     explicit RemoteVideoDecoderCallbacks(WebCore::VideoDecoder::OutputCallback&&);
 
     WebCore::VideoDecoder::OutputCallback m_outputCallback;
-    bool m_isClosed { false };
-    StdUnorderedMap<int64_t, uint64_t> m_timestampToDuration;
+    std::atomic<bool> m_isClosed { false };
+    Lock m_timestampToDurationLock;
+    StdUnorderedMap<int64_t, uint64_t> m_timestampToDuration WTF_GUARDED_BY_LOCK(m_timestampToDurationLock);
 };
 
 class RemoteVideoDecoder : public WebCore::VideoDecoder {
@@ -84,7 +89,7 @@ private:
 
     WebCore::VideoEncoder::DescriptionCallback m_descriptionCallback;
     WebCore::VideoEncoder::OutputCallback m_outputCallback;
-    bool m_isClosed { false };
+    std::atomic<bool> m_isClosed { false };
 };
 
 class RemoteVideoEncoder : public WebCore::VideoEncoder {
@@ -239,10 +244,13 @@ void RemoteVideoDecoderCallbacks::notifyDecodingResult(RefPtr<WebCore::VideoFram
         return;
     }
     uint64_t duration = 0;
-    auto iterator = m_timestampToDuration.find(timestamp);
-    if (iterator != m_timestampToDuration.end()) {
-        duration = iterator->second;
-        m_timestampToDuration.erase(iterator);
+    {
+        Locker locker { m_timestampToDurationLock };
+        auto iterator = m_timestampToDuration.find(timestamp);
+        if (iterator != m_timestampToDuration.end()) {
+            duration = iterator->second;
+            m_timestampToDuration.erase(iterator);
+        }
     }
     m_outputCallback(WebCore::VideoDecoder::DecodedFrame { frame.releaseNonNull(), static_cast<int64_t>(timestamp), duration });
 }


### PR DESCRIPTION
#### 9ba6cb68fcfbb1948bc4b6a1d3f88c4d9073e032
<pre>
Race on RemoteVideoDecoderCallbacks::m_timestampToDuration leads to use-after-free
<a href="https://rdar.apple.com/177096608">rdar://177096608</a>

Reviewed by Jean-Yves Avenard.

RemoteVideoDecoderCallbacks::addDuration is called from the JS thread that invoked VideoDecoder.decode.
RemoteVideoDecoderCallbacks::notifyDecodingResult is called from the LibWebRTCCodecs work queue.
Both mutate m_timestampToDuration so we need to add a lock to ensure synchronization.
We also make m_isClosed atomic on both the decoder and encoder callback objects as it is written in a thread and read in another.

Patch mostly written by Simon Lewis.

* LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-no-crash.html: Added.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoderCallbacks::addDuration):
(WebKit::RemoteVideoDecoderCallbacks::takeDuration):
(WebKit::RemoteVideoDecoderCallbacks::notifyDecodingResult):

Originally-landed-as: 305413.1093@safari-7624.5-branch (50232798d951). <a href="https://rdar.apple.com/185369402">rdar://185369402</a>
Canonical link: <a href="https://commits.webkit.org/319863@main">https://commits.webkit.org/319863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b3b87f3f2c26e4cb6c8b3324266e22d66fdb294

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147297 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142839 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43502 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43131 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4399 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40810 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57306 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152005 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46564 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129575 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18142 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->