### PR TITLE
[block-in-inline] Margin does not collapse after a self collapsing block level box on a line

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+.container {
+    border: 1px solid black;
+    width: 100px;
+}
+.bar {
+    margin-top: 100px;
+    height: 20px;
+    background: green;
+}
+</style>
+<p>Test passes if the green bar is 100px below the black box's top border.</p>
+<div class="container">
+    <div class="bar"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+.container {
+    border: 1px solid black;
+    width: 100px;
+}
+.bar {
+    margin-top: 100px;
+    height: 20px;
+    background: green;
+}
+</style>
+<p>Test passes if the green bar is 100px below the black box's top border.</p>
+<div class="container">
+    <div class="bar"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: margin of a self collapsing block level box inside an inline box is applied once</title>
+<link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins">
+<link rel="match" href="margin-collapse-through-block-in-inline-001-ref.html">
+<meta name="assert" content="The margin a self collapsing block level box inside an inline box collapses through positions the block level box after it once, also when the root cannot collapse that margin through its before edge.">
+<style>
+.container {
+    border: 1px solid black;
+    width: 100px;
+}
+.self-collapsing {
+    margin-top: 100px;
+}
+.bar {
+    height: 20px;
+    background: green;
+}
+</style>
+<p>Test passes if the green bar is 100px below the black box's top border.</p>
+<div class="container">
+    <span><div class="self-collapsing"></div></span>
+    <div class="bar"></div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1434,7 +1434,12 @@ void LineBuilder::handleBlockContent(const InlineItem& blockItem)
     // top would double-count the margin. Roll back m_lineLogicalRect.top too so the line's reported
     // bottom doesn't inherit the eager advance (which would shift the next line down).
     auto& marginState = blockLayoutState().marginState();
-    if (!marginState.atBeforeSideOfBlock) {
+    // Unless the margin collapses out through the root's before edge, the line's top already includes it: either
+    // initialize advanced the line by it, or the previous line's bottom absorbed it as a self collapsing block box's
+    // offset. Block layout applies the margin from the container's own position, so take it back off before handing over.
+    auto marginCollapsesThroughBeforeSide = marginState.atBeforeSideOfBlock && marginState.canCollapseMarginBeforeWithChildren;
+    auto lineTopIncludesPendingMargin = !marginCollapsesThroughBeforeSide;
+    if (lineTopIncludesPendingMargin) {
         if (auto blockMargin = marginState.margin())
             m_lineLogicalRect = { m_lineLogicalRect.top() - blockMargin, m_lineInitialLogicalRect.left(), m_lineInitialLogicalRect.width(), m_lineInitialLogicalRect.height() };
     }


### PR DESCRIPTION
#### dd58efd5acc56ff28293307f49cee0caba5be914
<pre>
[block-in-inline] Margin does not collapse after a self collapsing block level box on a line
<a href="https://bugs.webkit.org/show_bug.cgi?id=322338">https://bugs.webkit.org/show_bug.cgi?id=322338</a>
&lt;<a href="https://rdar.apple.com/problem/185598333">rdar://problem/185598333</a>&gt;

Reviewed by Antti Koivisto.

A block level box on a line is handed to block layout at the line&apos;s top, and block layout applies the pending
margin from the container&apos;s own position, so LineBuilder::handleBlockContent takes that margin back off the line
top first - but only when the margin was no longer at the before side of the block, while the line was advanced by
it whenever the margin could not collapse out through the root&apos;s before edge. With a border or padding on the
root the two disagree: the line top already holds the margin and block layout adds it again, so
&lt;span&gt;&lt;div style=&quot;margin-top:100px&quot;&gt;&lt;/div&gt;&lt;/span&gt;&lt;div&gt; puts the second block 200px down instead of 100px. Make
the rollback test the condition the advance already uses.

* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleBlockContent):
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-block-in-inline-001-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/319697@main">https://commits.webkit.org/319697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dae93594f2ab74bedeb1a3ba08fcec59c524f3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146548 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7feefc75-f60d-4144-b17e-081fc60a5d0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e7ec4c4-22a8-40da-bf5b-92c00131a109) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122669 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffb8c087-45f6-4020-8792-05ecb4373f63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44635 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42901 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42526 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3609 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151661 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56528 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151361 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45956 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128812 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124699 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55039 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17522 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54420 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->