### PR TITLE
[LBSE] non-scaling-stroke uses the wrong reference coordinate system

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -68,9 +68,6 @@ imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox.ht
 
 # Failing WPT reftests
 imported/w3c/web-platform-tests/svg/painting/marker-009.svg                                                    [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-001.html                              [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-002.html                              [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-004.html                              [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/scripted/marker-element-added.html                                [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg         [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/render/reftests/blending-svg-foreign-object.html                           [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -44,6 +44,7 @@
 #include "RenderView.h"
 #include "SVGPaintServerHandlingInlines.h"
 #include "SVGPathFromElement.h"
+#include "SVGTransformComputation.h"
 #include "SVGURIReference.h"
 #include "SVGVisitedRendererTracking.h"
 #include "StyleComputedStyle+GettersInlines.h"
@@ -179,7 +180,7 @@ bool RenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeTransfo
 
 AffineTransform RenderSVGShape::nonScalingStrokeTransform() const
 {
-    return protect(graphicsElement())->getScreenCTM(StyleUpdateStrategy::Disallow);
+    return SVGTransformComputation(*this).computeTransformToSVGRoot();
 }
 
 void RenderSVGShape::fillShape(const Style::ComputedStyle& style, GraphicsContext& context)

--- a/Source/WebCore/rendering/svg/SVGTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGTransformComputation.h
@@ -70,10 +70,8 @@ public:
                     ancestorContainer = enclosingLayerRenderer;
             } else
                 ancestorContainer = stopAtRenderer;
-        } else if (trackingMode == TransformState::TrackSVGScreenCTMMatrix && stopAtRenderer) {
-            ASSERT(stopAtRenderer->isComposited());
+        } else if (trackingMode == TransformState::TrackSVGScreenCTMMatrix && stopAtRenderer)
             ancestorContainer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first();
-        }
 
         TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
         transformState.setTransformMatrixTracking(trackingMode);
@@ -105,6 +103,26 @@ public:
 
         ctm.translate(-toFloatSize(m_renderer->nominalSVGLayoutLocation()));
         return ctm;
+    }
+
+    AffineTransform computeTransformToSVGRoot() const
+    {
+        auto* svgRoot = ancestorsOfType<RenderSVGRoot>(m_renderer.get()).first();
+        if (!svgRoot)
+            return { };
+
+        // Accumulate up to and including the anonymous RenderSVGViewportContainer, which carries the 'viewBox'
+        // transformation (and page zoom) -- but stop before the transform of 'svgRoot' itself.
+        auto* viewportContainer = svgRoot->viewportContainer();
+        if (!viewportContainer)
+            return { };
+
+        auto ctm = computeAccumulatedTransform(viewportContainer, TransformState::TrackSVGScreenCTMMatrix);
+        auto zoom = svgRoot->style().usedZoom();
+        if (zoom == 1)
+            return ctm;
+
+        return AffineTransform::makeScale({ 1 / zoom, 1 / zoom }).multiply(ctm);
     }
 
     FloatSize calculateAccumulatedSVGAncestorTransformScale()


### PR DESCRIPTION
#### 9e4acd3a3813fa7bbeb453f8d7349a65fb310ba7
<pre>
[LBSE] non-scaling-stroke uses the wrong reference coordinate system
<a href="https://bugs.webkit.org/show_bug.cgi?id=322340">https://bugs.webkit.org/show_bug.cgi?id=322340</a>

Reviewed by Rob Buis.

The reference coordinate system for a non-scaling stroke is the one of the
outermost &lt;svg&gt;. It holds all SVG internal transforms and nothing above them.
Page zoom is not part of it either, because zoom scales the whole rendering,
the stroke included. We are currently using getScreenCTM() which includes
all transformations up to RenderView, which is incorrect.

Fix: Introduce computeTransformToSVGRoot() to accumulates up to and including
the anonymous RenderSVGViewportContainer, which caries the outermost &apos;viewBox&apos;
transform and stop there. This is the correct coordinate system for
non-scaling-stroke.

Fixes three non-scaling-stroke tests in LBSE.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nonScalingStrokeTransform const):
* Source/WebCore/rendering/svg/SVGTransformComputation.h:
(WebCore::SVGTransformComputation::computeAccumulatedTransform const):
(WebCore::SVGTransformComputation::computeTransformToSVGRoot const):

Canonical link: <a href="https://commits.webkit.org/319688@main">https://commits.webkit.org/319688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba4dcbed16fc23527f0ed97b0ef4618009dc717

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142238 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44639 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42900 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42520 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3666 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55839 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56530 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151363 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128814 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124701 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55041 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17516 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->