### PR TITLE
[Win] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -108,6 +108,7 @@ imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 
 # WEB_CODECS is disabled
 fast/webcodecs/audio-data-copy-to-crash.html [ Skip ]
+fast/webcodecs/audio-data-copy-to-zero-frames-crash.html [ Skip ]
 
 # WebGPU is disabled
 http/tests/webgpu [ Skip ]
@@ -4805,3 +4806,32 @@ http/wpt/web-locks/back-forward-cache-suspend-test.https.html [ Skip ] # Flaky C
 imported/w3c/web-platform-tests/largest-contentful-paint/contracted-image.html [ Pass Failure ]
 imported/w3c/web-platform-tests/largest-contentful-paint/observe-image.html [ Pass Failure ]
 imported/w3c/web-platform-tests/largest-contentful-paint/repeated-image.html [ Pass Failure ]
+
+# Gardening: unexpected results on the last 20 Win-Tests-EWS runs (98613-98655, 319581@main-319601@main).
+
+# Consistent image failures, in every run. These are all reftests, so they cannot be
+# rebaselined; corner-shape is not applied through the composited path on Windows.
+compositing/corner-shape-ancestor-clip.html [ ImageOnlyFailure ]
+compositing/corner-shape-mask-layer-offset.html [ ImageOnlyFailure ]
+http/tests/canvas/canvas-tainted-image-capture-video-frame.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow-composite.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-notch-mixed.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-negative-100.html [ ImageOnlyFailure ]
+
+# Consistent text failures, in every run
+compositing/geometry/composited-bounds-single-axis-clip-taller-than-document.html [ Failure ]
+compositing/geometry/composited-bounds-with-single-axis-clip.html [ Failure ]
+editing/input/compositionend-after-clicking-outside-editable.html [ Failure ]
+editing/input/compositionend-data-after-aborting-composition.html [ Failure ]
+fast/dom/navigator-detached-no-crash.html [ Failure ]
+fast/quirks/active-quirks-by-domain.html [ Failure ]
+imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.sub.html [ Failure ]
+
+# Consistent timeouts, in every run
+fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash.html [ Skip ] # Timeout, like offscreen-worker-unsafe-isPointInStroke-call.html above
+fast/text/font-face/css-font-face-setstatus-reentrancy-crash.html [ Skip ] # Timeout
+
+# Crashes
+http/wpt/user-activation/bless-edge-cases.sub.html [ Skip ] # Crash, in 17 of the 20 runs
+http/wpt/user-activation/bless-nested.sub.html [ Skip ] # Crash, unmasked once bless-edge-cases.sub.html above is skipped
+http/wpt/web-locks/lock-name-length-restriction.https.html [ Skip ] # Flaky Crash


### PR DESCRIPTION
#### b3a499630be0446522dac3ddb225fd7567ee779b
<pre>
[Win] Unreviewed test gardening

Unreviewed test gardening.

Update Windows expectations from the last 20 completed Win-Tests-EWS runs
(builds 98613-98655, testing changes between 319581@main and 319601@main).
Each EWS build tests a different pull request, so tests failing across many
builds are tree issues rather than patch issues.

Fifteen tests produced an unexpected result in all 20 runs: six image
failures, seven text failures and two timeouts. Mark them accordingly, and
skip the two timeouts as the file already does for the neighbouring
offscreen-worker-unsafe-isPointInStroke-call.html. All six image failures
are reftests, so they cannot be rebaselined - five of them show corner-shape
not being applied through the composited path on Windows.

http/wpt/user-activation/bless-edge-cases.sub.html crashed in 17 of the 20
runs and http/wpt/web-locks/lock-name-length-restriction.https.html crashed
in two; skip both. Skipping bless-edge-cases.sub.html lets the run reach
bless-nested.sub.html, which then crashes the GPU process, so skip it too.

Also skip fast/webcodecs/audio-data-copy-to-zero-frames-crash.html, added
recently alongside audio-data-copy-to-crash.html. It fails with &quot;Can&apos;t find
variable: AudioData&quot; because WEB_CODECS is disabled on Windows, so it goes
in that section next to its sibling rather than with the gardening above.

* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319742@main">https://commits.webkit.org/319742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c0ad0f541f071824462e38ebb8f0f1b7e6f8bdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192891 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56332 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122993 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42845 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4062 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56269 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56973 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151710 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46282 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55481 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17845 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->