### PR TITLE
[WebCore] Use-after-free in ImageLoader::dispatchPendingLoadEvent / dispatchPendingErrorEvent

### DIFF
--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Window 'showModalDialog' function is deprecated and will be removed soon.
+CONSOLE MESSAGE: showModalDialog() is deprecated and will be removed. Please use the <dialog> element instead.
+PASS if no crash.

--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] --><!DOCTYPE html>
+<html>
+<body>
+<div id="host" style="display:none"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.setCanShowModalDialogOverride(true);
+
+var host = document.getElementById('host');
+var sr = host.attachShadow({mode: 'open'});
+sr.innerHTML = '<picture id="pic"><source srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"><img></picture>';
+var pic = sr.getElementById('pic');
+
+pic.addEventListener('load', function listener() {
+    pic.removeEventListener('load', listener, true);
+    // Removing the <img> from its <picture> re-enters ImageLoader::updatedHasPendingEvent()
+    // and arms m_derefElementTimer.
+    pic.textContent = '';
+    // showModalDialog spins a nested run loop which fires m_derefElementTimer, dropping
+    // m_protectedElement while ImageLoader::dispatchPendingLoadEvent() is still on the stack.
+    showModalDialog('resources/self-closing-modal-dialog.html');
+
+    // The trailing updatedHasPendingEvent() (the crash point) runs after this handler
+    // returns, so finish on the next task rather than waiting a fixed delay.
+    setTimeout(function() {
+        document.write('PASS if no crash.');
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}, /*capture*/ true);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
+++ b/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script>
+setTimeout(function() {
+    if (window.testRunner)
+        testRunner.abortModal();
+    window.close();
+}, 10);
+</script>

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -701,7 +701,8 @@ void ImageLoader::dispatchPendingLoadEvent()
     if (!m_image)
         return;
     m_hasPendingLoadEvent = false;
-    Ref document = element().document();
+    Ref protectedElement = element();
+    Ref document = protectedElement->document();
     if (document->canEverRender())
         dispatchLoadEvent();
 
@@ -716,9 +717,10 @@ void ImageLoader::dispatchPendingErrorEvent()
         return;
     m_hasPendingErrorEvent = false;
     loadEventSender().cancelEvent(*this, eventNames().errorEvent);
-    Ref document = element().document();
+    Ref protectedElement = element();
+    Ref document = protectedElement->document();
     if (document->canEverRender())
-        protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        protectedElement->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // Only consider updating the protection ref-count of the Element immediately before returning
     // from this function as doing so might result in the destruction of this ImageLoader.


### PR DESCRIPTION
#### d40f4efab0e0cee61e29c8540abff5285bf5275d
<pre>
[WebCore] Use-after-free in ImageLoader::dispatchPendingLoadEvent / dispatchPendingErrorEvent
<a href="https://rdar.apple.com/177909775">rdar://177909775</a>

Reviewed by Alan Baradlay.

dispatchPendingLoadEvent() and dispatchPendingErrorEvent() dispatch author script and then
touch `this` again via updatedHasPendingEvent(). The only thing keeping the element alive
across the dispatch is a full-expression-scoped Ref plus the m_protectedElement member, and
the 0s m_derefElementTimer can clear that member. A load handler can re-arm the timer by
removing the &lt;img&gt; from its &lt;picture&gt; (selectImageSource(RelevantMutation::Yes) calls
updatedHasPendingEvent()), then spin a nested run loop via showModalDialog(). The timer
fires and drops m_protectedElement while the dispatch is still on the stack. When the
dispatch returns the temporary Ref destructs as the last reference, ~HTMLImageElement frees
the loader via its unique_ptr&lt;HTMLImageLoader&gt;, and the trailing updatedHasPendingEvent()
runs on freed `this`.

Hold a stack Ref to the element across the dispatch and the trailing updatedHasPendingEvent()
in both functions. The loader is owned by the element, so keeping the element alive keeps
this ImageLoader alive.

Test: fast/images/image-load-event-in-modal-dialog-crash.html

* LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt: Added.
* LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html: Added.
* LayoutTests/fast/images/resources/self-closing-modal-dialog.html: Added.
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::dispatchPendingLoadEvent):
(WebCore::ImageLoader::dispatchPendingErrorEvent):

Originally-landed-as: 305413.1064@safari-7624.5-branch (fe774071a22a). <a href="https://rdar.apple.com/185367866">rdar://185367866</a>
Canonical link: <a href="https://commits.webkit.org/319690@main">https://commits.webkit.org/319690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bd0cbe05e12d284dc71390902d80cdabffae313

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56107 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46106 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44790 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42685 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3831 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49015 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194594 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56055 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56746 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151531 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46108 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125017 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->