### PR TITLE
[IFC] Do not leave stale display content when partial merge fails in InlineContentBuilder

### DIFF
--- a/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt
+++ b/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html
+++ b/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#outer { width: 200px; font-family: Ahem; font-size: 10px; }
+</style>
+<div id=outer><span>aa bb cc<div id=inner>xx<br id=br>yy zz ww vv</div>dd ee ff</span></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// Initial layout: outer IFC contains a block-in-inline (#inner) that establishes its own IFC.
+document.body.offsetHeight;
+
+// Remove a leaf from the inner IFC via a partial-invalidation-eligible mutation. The removed
+// renderer's Layout::Box is retained by InlineDamage while the previous inline display content
+// (which still holds a CheckedPtr to it) is kept for partial layout.
+br.remove();
+document.body.offsetHeight;
+
+// Force another full layout of the outer IFC so that inner's LineLayout::layout() runs
+// clearInlineContent() again on the previous display boxes.
+outer.style.width = '190px';
+document.body.offsetHeight;
+
+document.body.textContent = 'PASS if no crash.';
+</script>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -347,15 +347,22 @@ FloatRect InlineContentBuilder::handlePartialDisplayContentUpdate(Layout::Inline
         return { boxCount };
     }();
 
+    auto damagedRect = FloatRect { };
+
     if (!firstDamagedLineIndex || !numberOfDamagedLines || !firstDamagedBoxIndex || !numberOfDamagedBoxes) {
         ASSERT_NOT_REACHED();
-        return { };
+        // We failed to compute the damaged range. The existing display content may still hold references to
+        // layout boxes that were detached (see InlineDamage::m_detachedLayoutBoxes) and will be destroyed as
+        // soon as line damage is released. Do not leave those stale display boxes in place.
+        for (auto& line : inlineContent.displayContent().lines)
+            damagedRect.unite(line.inkOverflow());
+        inlineContent.displayContent().clear();
+        return damagedRect;
     }
 
     auto numberOfNewLines = layoutResult.displayContent.lines.size();
     auto numberOfNewBoxes = layoutResult.displayContent.boxes.size();
 
-    auto damagedRect = FloatRect { };
     auto adjustDamagedRectWithLineRange = [&](size_t firstLineIndex, size_t lineCount) {
         auto& lines = inlineContent.displayContent().lines;
         ASSERT(firstLineIndex + lineCount <= lines.size());


### PR DESCRIPTION
#### 884e3169771bfde0f93c3bc3ed12c55144d5cd04
<pre>
[IFC] Do not leave stale display content when partial merge fails in InlineContentBuilder
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319704">https://bugs.webkit.org/show_bug.cgi?id=319704</a>&gt;
&lt;<a href="https://rdar.apple.com/177161065">rdar://177161065</a>&gt;

Reviewed by Alan Baradlay.

Field MTE reports show a use-after-free destroying InlineDisplay::Content during
LineLayout::layout()&apos;s clearInlineContent(): a display box&apos;s CheckedPtr&lt;Layout::Box&gt;
still references a Layout::Box that was already freed.

Partial inline layout keeps the previous display content alive so the newly-built
lines can be spliced into it, relying on InlineDamage::m_detachedLayoutBoxes to keep
removed layout boxes alive across the merge. When handlePartialDisplayContentUpdate
cannot compute a valid damaged range, it returned early through ASSERT_NOT_REACHED()
and left the previous display content untouched. The caller then destroys the
InlineDamage (m_lineDamage = { }), freeing the detached layout boxes while the display
boxes still reference them; the next clearInlineContent() touches freed memory.

Drop the previous display content on that fallback path (after collecting its ink
overflow for repaint) so we never carry stale CheckedPtr&lt;Layout::Box&gt; references past
the point their target is released. This hardens an ASSERT_NOT_REACHED() branch and
does not change behavior on the fast path.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::handlePartialDisplayContentUpdate const):
* LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html: Added.
* LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt: Added.

Originally-landed-as: 305413.1123@safari-7624.5-branch (039ba968916b). <a href="https://rdar.apple.com/185369077">rdar://185369077</a>
Canonical link: <a href="https://commits.webkit.org/319657@main">https://commits.webkit.org/319657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7891f1b1f9a6063fcd078b1ee1f78cbe52b0a908

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42921 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42543 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3641 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151688 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56560 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45974 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128844 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124749 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55071 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17539 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->