### PR TITLE
use-after-free of AudioParam via cross-thread non-atomic ref/deref in AudioNodeOutput::disconnectAllParams()

### DIFF
--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function gc()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+async function go()
+{
+    // The offline render thread runs renderQuantum() in a tight loop on a dedicated
+    // thread, calling handlePostRenderTasks() (and thus handleDeferredDerefs()) on
+    // every quantum.
+    let context = new OfflineAudioContext(1, 48000 * 120, 48000);
+
+    // |target| holds the AudioParam (target.gain) whose ref-count is raced.
+    let target = new GainNode(context);
+    target.connect(context.destination);
+
+    let lockHog = new GainNode(context);
+
+    let done = false;
+    context.startRendering().then(() => { done = true; }, () => { done = true; });
+
+    for (let iteration = 0; iteration < 200 && !done; ++iteration) {
+        // |sources| each connect their output to target.gain so that
+        // (a) their outputs hold a Ref<AudioParam> in m_params and
+        // (b) target.gain pulls each source on the render thread, taking a
+        //     transient RefPtr<AudioNode> via protect(node()) inside pull().
+        let sources = [];
+        for (let i = 0; i < 16; ++i) {
+            let source = new GainNode(context);
+            source.connect(target.gain);
+            sources.push(source);
+        }
+
+        // Let handlePreRenderTasks() promote the new outputs into m_renderingOutputs.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Hold the graph lock from the main thread so the render thread's
+        // AudioNode::deref() (from the protect() above) tryLock-fails and is
+        // queued onto m_deferredDerefList.
+        for (let i = 0; i < 4000; ++i)
+            lockHog.channelCount = (i & 1) ? 1 : 2;
+
+        // Drop the wrappers; ~JSGainNode runs AudioNode::deref() on the main thread.
+        // Any deferred-deref entries from above keep m_normalRefCount > 0 here.
+        sources = null;
+        gc();
+
+        // Once we stop touching the graph lock, the next handlePostRenderTasks() ->
+        // handleDeferredDerefs() drives a source's m_normalRefCount to 0 on the
+        // render thread, reaching markNodeForDeletionIfNecessary() ->
+        // AudioNodeOutput::disconnectAllParams() and ref'ing / deref'ing target.gain
+        // there. Touch the wrapper concurrently from the main thread.
+        let until = performance.now() + 8;
+        while (performance.now() < until) {
+            target.gain;
+            gc();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    document.body.textContent = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.onload = go;
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
#### 3e5b31e006359db053de870eaacfede629f49c64
<pre>
use-after-free of AudioParam via cross-thread non-atomic ref/deref in AudioNodeOutput::disconnectAllParams()
<a href="https://rdar.apple.com/177930032">rdar://177930032</a>

Reviewed by Youenn Fablet.

Make AudioParam use thread-safe refcounted.

Test: webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html

* LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt: Added.
* LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html: Added.
* Source/WebCore/Modules/webaudio/AudioParam.h:

Originally-landed-as: 305413.1077@safari-7624.5-branch (62fcbfe61a49). <a href="https://rdar.apple.com/185368484">rdar://185368484</a>
Canonical link: <a href="https://commits.webkit.org/319658@main">https://commits.webkit.org/319658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be6e6b9b74a09a6082748f00ff61e1687b8b4120

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42927 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42549 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3649 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40610 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56568 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151395 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45982 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55079 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->