### PR TITLE
Inline box boundary changes the preceding text run's advance width

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text: an inline box boundary must not change the text run's advance</title>
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org">
+<style>
+@font-face {
+  font-family: "lato";
+  src: url("/fonts/Lato-Medium.ttf");
+}
+div {
+  font-family: "lato", system-ui;
+  font-size: 40px;
+}
+</style>
+<div>One-Two-Three-Four</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text: an inline box boundary must not change the text run's advance</title>
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org">
+<style>
+@font-face {
+  font-family: "lato";
+  src: url("/fonts/Lato-Medium.ttf");
+}
+div {
+  font-family: "lato", system-ui;
+  font-size: 40px;
+}
+</style>
+<div>One-Two-Three-Four</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text: an inline box boundary must not change the text run's advance</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#boundary-shaping">
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org">
+<link rel="match" href="text-advance-across-inline-box-boundary-ref.html">
+<link rel="assert" title="Tests that An empty inline box that splits a text run at a soft-wrap opportunity must not change the run's advance width.">
+<style>
+@font-face {
+  font-family: "lato";
+  src: url("/fonts/Lato-Medium.ttf");
+}
+div {
+  font-family: "lato", system-ui;
+  font-size: 40px;
+}
+</style>
+<!--
+  The hyphens are soft-wrap opportunities that split "One-Two-Three" into separate
+  inline text items. The sum of the per-item advances (which includes kerning within
+  each item) must equal the advance of the whole run shaped at once; otherwise the
+  inline box, and the "-Four" inside it, is pushed to the right and a gap appears
+  before it. "-Four" starts with a glyph that does not kern with the preceding "e",
+  so the reference below is an exact pixel match.
+-->
+<div>One-Two-Three<span>-Four</span></div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -294,6 +294,28 @@ void Line::appendInlineBoxStart(const InlineItem& inlineItem, const Style::Compu
     // This is really just a placeholder to mark the start of the inline box <span>.
     ++m_nonSpanningInlineLevelBoxCount;
     auto logicalLeft = lastRunLogicalRight();
+
+    // The preceding text run's logical width is the sum of its per-item widths, which may exceed
+    // the width of the run when shaped as a whole. Measuring items independently loses
+    // cross-boundary kerning/shaping. Re-measure the run as a whole and use that width to
+    // position this inline box, preventing it from being pushed to the right.
+    if (!m_runs.isEmpty()) {
+        auto& lastRun = m_runs.last();
+        if (lastRun.isText() && lastRun.textContent().length && !lastRun.hasTrailingWhitespace()) {
+            if (CheckedPtr textBox = dynamicDowncast<InlineTextBox>(lastRun.layoutBox())) {
+                auto from = static_cast<unsigned>(lastRun.textContent().start);
+                auto to = static_cast<unsigned>(lastRun.textContent().start + lastRun.textContent().length);
+                auto wholeRunWidth = TextUtil::width(*textBox, lastRun.style().fontCascade(), from, to, lastRun.logicalLeft(), TextUtil::UseTrailingWhitespaceMeasuringOptimization::No);
+                auto overMeasuredWidth = lastRun.logicalWidth() - wholeRunWidth;
+                if (overMeasuredWidth > 0) {
+                    lastRun.shrinkHorizontally(overMeasuredWidth);
+                    m_contentLogicalWidth -= overMeasuredWidth;
+                    logicalLeft = lastRunLogicalRight();
+                }
+            }
+        }
+    }
+
     // Do not let negative margin make the content shorter than it already is.
     m_contentLogicalWidth = std::max(m_contentLogicalWidth, logicalLeft + logicalWidth);
 


### PR DESCRIPTION
#### 576ba36c147a8505c502d99f17a9d578fc2ed02f
<pre>
Inline box boundary changes the preceding text run&apos;s advance width
<a href="https://bugs.webkit.org/show_bug.cgi?id=322345">https://bugs.webkit.org/show_bug.cgi?id=322345</a>

Reviewed by NOBODY (OOPS!).

An inline box (e.g. &lt;a&gt; or &lt;span&gt;) that follows text containing soft-wrap opportunities
(hyphens or spaces) can render with an unexpected gap when a kerning font is used.
Chrome and Firefox do not exhibit this behavior.

The inline formatting context measures each InlineTextItem independently and sums their
advances to determine the text run&apos;s logical width. Soft-wrap opportunities split the run
into separate items, causing kerning and shaping across those boundaries to be lost. As a
result, the summed width can exceed the advance of the same text shaped as a whole. The
following inline box is positioned using this overestimated width, while the text is
painted using whole-run shaping, pushing the box and subsequent content to the right.

This patch re-measures the preceding text run as a whole when positioning a following
inline box and use that width for the run. The general solution would be to shape each
contiguous run once and slice sub-ranges from the resulting shape, ensuring that the sum
of the parts matches the whole by construction.

The bug only reproduces with real fonts. Since WebKitTestRunner uses a restricted font
set, the regression test uses the bundled web-platform-tests Lato-Medium.ttf.

New Test:
- imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary.html

* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::appendInlineBoxStart): Re-measure the preceding text run as a
whole and shrink it by the over-count before positioning the inline box.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-advance-across-inline-box-boundary-expected.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/576ba36c147a8505c502d99f17a9d578fc2ed02f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142272 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98828 "5 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185216 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45977 "Found 5 new test failures: editing/deleting/5369009.html editing/selection/end-of-document.html fast/css/textCapitalizeEdgeCases.html fast/text/capitalize-boundaries.html tables/mozilla_expected_failures/bugs/bug89315.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44661 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42929 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155061 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42551 "Found 8 new test failures: editing/deleting/5369009.html editing/selection/end-of-document.html fast/css/textCapitalizeEdgeCases.html fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/text/backslash-to-yen-sign-euc.html fast/text/decorations-with-text-combine.html tables/mozilla_expected_failures/bugs/bug89315.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3651 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47184 "Found 8 new test failures: editing/deleting/5369009.html editing/selection/end-of-document.html fast/css/textCapitalizeEdgeCases.html fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/text/backslash-to-yen-sign-euc.html fast/text/decorations-with-text-combine.html tables/mozilla_expected_failures/bugs/bug89315.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194417 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151696 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56570 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39176 "Found 8 new test failures: editing/deleting/5369009.html editing/selection/end-of-document.html fast/css/textCapitalizeEdgeCases.html fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/text/backslash-to-yen-sign-euc.html fast/text/decorations-with-text-combine.html tables/mozilla_expected_failures/bugs/bug89315.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151397 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45981 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128854 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124761 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55081 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17548 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->