### PR TITLE
[Wasm] Delegate should widen types like End

### DIFF
--- a/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
+++ b/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
@@ -1,0 +1,74 @@
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        3,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 1: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 2: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x01, 0x02]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   try (result i64)                 ;; outer: delegate target
+    //     try (result anyref)            ;; inner
+    //       local.get $ext
+    //       any.convert_extern           ;; -> anyref (NaN-boxed JS number)
+    //       local.get $cond
+    //       br_if 0                      ;; carry the anyref to the inner continuation
+    //       drop
+    //       local.get $s                 ;; fallthrough: (ref 0), a subtype of anyref
+    //     delegate 0                     ;; terminates inner try; result MUST widen to anyref
+    //     ref.cast (ref 0)               ;; must NOT elide IsCell / IsWasmGCObject checks
+    //     struct.get 0 0
+    //   catch_all
+    //     i64.const 0
+    //   end)
+    const body0 = [
+        0x00,
+        0x06, 0x7E,             // try (result i64)
+          0x06, 0x6E,           //   try (result anyref)
+            0x20, 0x01,         //     local.get 1
+            0xFB, 0x1A,         //     any.convert_extern
+            0x20, 0x00,         //     local.get 0
+            0x0D, 0x00,         //     br_if 0
+            0x1A,               //     drop
+            0x20, 0x02,         //     local.get 2
+          0x18, 0x00,           //   delegate 0
+          0xFB, 0x16, 0x00,     //   ref.cast (ref 0)
+          0xFB, 0x02, 0x00, 0x00, // struct.get 0 0
+        0x19,                   // catch_all
+          0x42, 0x00,           //   i64.const 0
+        0x0B,                   // end (outer try)
+        0x0B,                   // end (func)
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: br_if not taken; the try body's (ref 0) fallthrough survives the
+    // delegate. Widened to anyref, ref.cast succeeds and struct.get reads the field.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: br_if delivers an anyref-wrapped JS number to the inner continuation.
+    // The post-delegate value is statically anyref, so ref.cast must perform the full
+    // runtime check and trap rather than dereference the non-cell value.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -254,6 +254,7 @@ private:
     };
 
     [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
+    [[nodiscard]] PartialResult endBlockAndCheckResultTypes(ControlEntry&);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1923,6 +1924,22 @@ auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlDa
             m_expressionStack[m_currentStackBegin + i].setType(expectedType);
     }
 
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::endBlockAndCheckResultTypes(ControlEntry& entry) -> PartialResult
+{
+    // Widen each result to the block signature type before ending the block.
+    // FIXME: mutating the expression stack for the block result is effectful, but there's no
+    // better API yet. See https://bugs.webkit.org/show_bug.cgi?id=164353
+    WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(entry.controlData, MergePoint));
+    const uint32_t parentBegin = parentEntryBegin();
+    auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+    // We should avoid adding other callsites of endBlock. Since a new block is a sign of a
+    // merge point and it would be a security bug to fail to widen the types.
+    WASM_TRY_ADD_TO_CONTEXT(endBlock(entry, enclosedStack));
+    m_currentStackBegin = parentBegin;
     return { };
 }
 
@@ -3724,13 +3741,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
-
-        const uint32_t parentBegin = parentEntryBegin();
-        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, enclosedStack));
-
-        m_currentStackBegin = parentBegin;
+        // Unlike the sibling catch/catch_all arms, delegate ends the try block, so it widens results.
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(controlEntry));
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         return { };
     }
@@ -3865,16 +3877,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             m_expressionStack.shrink(m_currentStackBegin);
             m_expressionStack.append(data.elseBlockStack.span());
         }
-        // FIXME: endBlock may modify the expressionStack slice for the result of the block.
-        // That's a little too effectful but we don't have a better API right now.
-        // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-
-        const uint32_t parentBegin = parentEntryBegin();
-        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
-
-        m_currentStackBegin = parentBegin;
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
         if (!ControlType::isTopLevel(data.controlData))
             resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
@@ -4070,12 +4073,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack.shrink(m_currentStackBegin);
                 m_expressionStack.append(data.elseBlockStack.span());
-                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-
-                // Reachable End handling: the combined enclosedStack now lives in
-                // m_expressionStack[parentBegin..end].
-                auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-                WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
+                WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
             } else {
                 m_expressionStack.shrink(m_currentStackBegin);
                 const auto& sig = data.controlData.signature();


### PR DESCRIPTION
#### 261bcb42d83f2838cb8245675ffd6e53eebf55bc
<pre>
[Wasm] Delegate should widen types like End
<a href="https://bugs.webkit.org/show_bug.cgi?id=318755">https://bugs.webkit.org/show_bug.cgi?id=318755</a>
<a href="https://rdar.apple.com/181457816">rdar://181457816</a>

Reviewed by Yusuke Suzuki.

The legacy Delegate wasm bytecode is essentially shorthand for: `Rethrow;
End`. So like other merge points it needs to widen the types on the
expression stack. To help avoid this problem in the future add a new
helper `endBlockAndCheckResultTypes`, which ensures the types are
appropriately widened.

Test: JSTests/wasm/stress/delegate-widens-result-type-to-signature.js

Originally-landed-as: 305413.1096@safari-7624.5-branch (db3010593c27). <a href="https://rdar.apple.com/185366253">rdar://185366253</a>
Canonical link: <a href="https://commits.webkit.org/320048@main">https://commits.webkit.org/320048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30447033b767afb6992b3695c1d7152a26deebd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147905 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143306 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99500 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45775 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5698 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12536 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43593 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5014 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44890 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57208 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152839 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57912 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152521 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47065 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126502 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18603 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->