### PR TITLE
<picture> <source> candidates are speculatively preloaded for an <img> that is not a direct child of the <picture>

### DIFF
--- a/LayoutTests/http/tests/preload/picture-img-not-direct-child-expected.txt
+++ b/LayoutTests/http/tests/preload/picture-img-not-direct-child-expected.txt
@@ -1,0 +1,28 @@
+The speculative preload scanner must only treat an <img> that is a direct child of a <picture> as that <picture>'s image.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isPreloaded('/resources/square20.jpg?case1-source'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case1-img'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?case2-source'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?case2-img'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case3-source'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case3-img'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?case4-source'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case4-img'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?case5-source'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case5-img'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?case6-source'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case6-nested'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?case6-img'); is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+
+
+
+
+

--- a/LayoutTests/http/tests/preload/picture-img-not-direct-child.html
+++ b/LayoutTests/http/tests/preload/picture-img-not-direct-child.html
@@ -1,0 +1,77 @@
+<html>
+<head>
+    <script>
+        if (window.testRunner && window.internals) {
+            testRunner.dumpAsText();
+            internals.clearMemoryCache();
+        }
+    </script>
+
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=101&test=picture-img-not-direct-child"></script>
+</head>
+<body>
+<script>
+    description("The speculative preload scanner must only treat an &lt;img&gt; that is a direct child of a &lt;picture&gt; as that &lt;picture&gt;'s image.");
+
+    if (window.testRunner && window.internals) {
+        // Direct child.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case1-source');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case1-img');");
+
+        // Wrapped in a <div>.
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case2-source');");
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case2-img');");
+
+        // Void element does not nest.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case3-source');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case3-img');");
+
+        // Foster-parented out of the table.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case4-source');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case4-img');");
+
+        // Closed wrapper.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case5-source');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case5-img');");
+
+        // Nested <img> then a direct-child <img>.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case6-source');");
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?case6-nested');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?case6-img');");
+    }
+</script>
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case1-source">
+    <img src="/resources/square20.jpg?case1-img">
+</picture>
+
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case2-source">
+    <div><img src="/resources/square20.jpg?case2-img"></div>
+</picture>
+
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case3-source">
+    <br>
+    <img src="/resources/square20.jpg?case3-img">
+</picture>
+
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case4-source">
+    <table><img src="/resources/square20.jpg?case4-img"></table>
+</picture>
+
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case5-source">
+    <div></div>
+    <img src="/resources/square20.jpg?case5-img">
+</picture>
+
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?case6-source">
+    <div><img src="/resources/square20.jpg?case6-nested"></div>
+    <img src="/resources/square20.jpg?case6-img">
+</picture>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <picture><source srcset="/images/blue.png"><div><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=89634cd5-b993-4dfb-a227-8893fe9a8537&amp;encodingcheck=&Gbreve;"></div></picture>
+
+
+
+PASS Speculative parsing, document.write(): picture-source-div-img-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): picture-source-div-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'picture-source-div-img-src', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <picture><source srcset="/images/blue.png"><div><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"></div></picture>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <picture><source srcset="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=8e2a6a2e-c30b-4a5b-9019-16deea5f1c87&amp;encodingcheck=&Gbreve;"><div><img></div></picture>
+
+
+
+PASS Speculative parsing, document.write(): picture-source-div-img
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): picture-source-div-img</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'picture-source-div-img', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <picture><source srcset="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"><div><img></div></picture>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: picture-source-div-img-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: picture-source-div-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/picture-source-div-img-src-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'picture-source-div-img-src', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: picture-source-div-img
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: picture-source-div-img</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/picture-source-div-img-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'picture-source-div-img', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): picture-source-div-img</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<picture><source srcset="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"><div><img></div></picture>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-src-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-src-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): picture-source-div-img-src</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<picture><source srcset="/images/blue.png"><div><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></div></picture>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): picture-source-div-img</title>
+<!-- non-speculative case -->
+<picture><source srcset="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"><div><img></div></picture>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-src-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-src-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): picture-source-div-img-src</title>
+<!-- non-speculative case -->
+<picture><source srcset="/images/blue.png"><div><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></div></picture>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/tools/generate.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/tools/generate.py
@@ -426,6 +426,24 @@ tentative_tests = [
       u'true'
     ),
     (
+      # Unlike <br> above, a <div> nests the <img>, so it is not the <picture>'s image
+      u'picture-source-div-img',
+      u'utf-8',
+      u'<picture><source srcset="{}"><div><img></div></picture>',
+      None,
+      u'false',
+      u'true'
+    ),
+    (
+      # The nested <img> loads its own src, even though a <source> above it matched
+      u'picture-source-div-img-src',
+      u'utf-8',
+      u'<picture><source srcset="/images/blue.png"><div><img src="{}"></div></picture>',
+      None,
+      u'true',
+      u'true'
+    ),
+    (
       u'video-poster',
       u'utf-8',
       u'<video poster="{}"></video>',

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -107,6 +107,45 @@ ASCIILiteral TokenPreloadScanner::initiatorFor(TagId tagId)
     return "unknown"_s;
 }
 
+// Void elements are popped as soon as they are inserted, and an <img> in a table context is
+// foster-parented out to the <picture>, so neither nests a following <img>.
+static bool tagCreatesNestingLevel(const HTMLToken::DataVector& tagName)
+{
+    static constexpr SortedArraySet set { WTF::toArray<PackedASCIILiteral<uint64_t>>({
+        "area"_s,
+        "base"_s,
+        "basefont"_s,
+        "bgsound"_s,
+        "br"_s,
+        "col"_s,
+        "colgroup"_s,
+        "embed"_s,
+        "frame"_s,
+        "hr"_s,
+        "image"_s,
+        "img"_s,
+        "input"_s,
+        "keygen"_s,
+        "link"_s,
+        "meta"_s,
+        "param"_s,
+        "source"_s,
+        "table"_s,
+        "tbody"_s,
+        "tfoot"_s,
+        "thead"_s,
+        "tr"_s,
+        "track"_s,
+        "wbr"_s,
+    }) };
+    return !set.contains(tagName.span());
+}
+
+static bool isPictureChild(const Vector<PreloadScannerPictureState>& pictureState)
+{
+    return !pictureState.isEmpty() && !pictureState.last().elementDepth;
+}
+
 class TokenPreloadScanner::StartTagScanner {
 public:
     explicit StartTagScanner(Document& document, TagId tagId, float deviceScaleFactor = 1.0)
@@ -132,7 +171,7 @@ public:
             processAttribute(knownAttributeName, attribute.value.span(), pictureState);
         }
 
-        if (m_tagId == TagId::Source && !pictureState.isEmpty() && !pictureState.last().sourceMatched && m_mediaMatched && m_typeMatched && !m_srcSetAttribute.isEmpty()) {
+        if (m_tagId == TagId::Source && isPictureChild(pictureState) && !pictureState.last().sourceMatched && m_mediaMatched && m_typeMatched && !m_srcSetAttribute.isEmpty()) {
             auto sourceSize = SizesAttributeParser(m_sizesAttribute, m_document).effectiveSize();
             ImageCandidate imageCandidate = bestFitSourceForImageAttributes(m_deviceScaleFactor, m_urlToLoad, m_srcSetAttribute, sourceSize);
             if (!imageCandidate.isEmpty()) {
@@ -234,7 +273,7 @@ private:
 
     void processAttribute(const AtomString& attributeName, StringView attributeValue, const Vector<PreloadScannerPictureState>& pictureState)
     {
-        bool inPicture = !pictureState.isEmpty();
+        bool inPicture = isPictureChild(pictureState);
         bool alreadyMatchedSource = inPicture && pictureState.last().sourceMatched;
         switch (m_tagId) {
         case TagId::Img:
@@ -506,6 +545,11 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
         }
         if (m_templateCount)
             return;
+        if (tagId != TagId::Picture && !m_pictureSourceState.isEmpty() && tagCreatesNestingLevel(token.name())) {
+            auto& elementDepth = m_pictureSourceState.last().elementDepth;
+            if (elementDepth)
+                --elementDepth;
+        }
         if (tagId == TagId::Style) {
             if (m_inStyle)
                 m_cssScanner.reset();
@@ -540,6 +584,9 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
         }
         if (m_templateCount)
             return;
+        // Track nesting so that only a direct child of the innermost <picture> is its content.
+        if (tagId != TagId::Picture && !m_pictureSourceState.isEmpty() && tagCreatesNestingLevel(token.name()))
+            ++m_pictureSourceState.last().elementDepth;
         if (tagId == TagId::Style) {
             m_inStyle = true;
             return;
@@ -589,7 +636,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             return;
         }
 
-        if (tagId == TagId::Img && !m_pictureSourceState.isEmpty()) {
+        if (tagId == TagId::Img && isPictureChild(m_pictureSourceState)) {
             auto& pictureState = m_pictureSourceState.last();
             if (scanner.isLazyloadingImage())
                 pictureState.bufferedSourceRequest.reset();

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.h
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.h
@@ -40,8 +40,10 @@ namespace WebCore {
 // stream. This avoids speculatively fetching alternative-format <source>
 // candidates (e.g. JXL/WebP/AVIF) for images that are still far below the
 // viewport.
+// elementDepth counts open elements between the <picture> and the current token.
 struct PreloadScannerPictureState {
     bool sourceMatched { false };
+    unsigned elementDepth { 0 };
     std::unique_ptr<PreloadRequest> bufferedSourceRequest;
 };
 


### PR DESCRIPTION
#### 2c67eca82c24e590b30115dd36abf46ef1a27cb8
<pre>
&lt;picture&gt; &lt;source&gt; candidates are speculatively preloaded for an &lt;img&gt; that is not a direct child of the &lt;picture&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=322347">https://bugs.webkit.org/show_bug.cgi?id=322347</a>
<a href="https://rdar.apple.com/185619139">rdar://185619139</a>

Reviewed by NOBODY (OOPS!).

The preload scanner pushes per-&lt;picture&gt; state on the &lt;picture&gt; start tag and pops
it on &lt;/picture&gt;, with no notion of nesting in between, so every &lt;img&gt; seen inside
that range is treated as the &lt;picture&gt;&apos;s image. Source-set selection actually
requires the &lt;img&gt;&apos;s parent to be the &lt;picture&gt;: HTMLImageElement::insertionSteps
checks `&amp;parentOfInsertedTree == parentElement()`, and the eager
HTMLConstructionSite hook keys off currentNode().

For &lt;picture&gt;&lt;source srcset=A&gt;&lt;div&gt;&lt;img src=B&gt;&lt;/div&gt;&lt;/picture&gt; that is wrong twice
over. A is fetched although the &lt;img&gt; never selects it, and B -- the URL the
element does load -- is not preloaded at all, because processAttribute() breaks out
on alreadyMatchedSource before reaching processImageAndScriptAttribute() and so
never reads the src attribute. Neither half is a regression from <a href="https://commits.webkit.org/313833@main">313833@main</a>; that
change only moved where the first one manifests, from the &lt;source&gt; token to the
&lt;img&gt; token.

Track the number of open elements between the &lt;picture&gt; and the current token and
treat only a direct child as &lt;picture&gt; content. A nested &lt;img&gt; then behaves as if
there were no &lt;picture&gt;: it reads its own src, and the buffered candidate is left
pending for a later direct-child &lt;img&gt; rather than being consumed or dropped.

Two classes of start tag must not count as a nesting level, or the fix would
regress markup it should leave alone. Void elements are popped by the tree builder
as soon as they are inserted, which is what WPT picture-source-br-img already
pins. An &lt;img&gt; in a table context is foster-parented back out to become a direct
child of the &lt;picture&gt;, and a preceding sibling of the &lt;source&gt;, so selection still
applies. Over-reporting nesting is the harmful direction -- it would preload an src
the non-speculative parse never fetches -- so tag names the set cannot represent
resolve to &quot;nested&quot; only for elements that genuinely nest, and anything unparseable
falls through to the existing behaviour.

The scanner has no tree, so this stays an approximation: misnesting the tree builder
would repair is not modelled, nor is a self-closing foreign-content tag, which
m_foreignContentCount ignores in the same way. Both resolve to &quot;nested&quot;, costing at
most one speculative fetch.

The new WPT tests are tentative because speculative parsing behaviour is
unspecified; they assert the speculative case matches the non-speculative one.

Tests: http/tests/preload/picture-img-not-direct-child.html
       imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub.html
       imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub.html
       imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative.html
       imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative.html

* LayoutTests/http/tests/preload/picture-img-not-direct-child-expected.txt: Added.
* LayoutTests/http/tests/preload/picture-img-not-direct-child.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img-src.tentative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-div-img.tentative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img-src.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-div-img.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-framed.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-div-img-src-framed.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-nonspeculative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-div-img-src-nonspeculative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/tools/generate.py:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::tagCreatesNestingLevel):
(WebCore::isPictureChild):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::scan):
* Source/WebCore/html/parser/HTMLPreloadScanner.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c67eca82c24e590b30115dd36abf46ef1a27cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f1630c7-1126-480c-a502-3953347d72b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55937 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142274 "Found 1 new test failure: http/tests/loading/preload-picture-invalid.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98830 "17 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00c0e370-2e97-4d2b-af80-f3ba9146022e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06717617-68f4-45c0-ab88-f650e45c4b81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42933 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155065 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42555 "Found 1 new test failure: http/tests/loading/preload-picture-invalid.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3657 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48845 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47188 "Found 1 new test failure: http/tests/loading/preload-picture-invalid.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162526 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151698 "Found 1 new test failure: http/tests/loading/preload-picture-invalid.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56576 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39180 "Found 1 new test failure: http/tests/loading/preload-picture-invalid.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151399 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45986 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128860 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124769 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17555 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->