### PR TITLE
missing bounds check in RtpPacket::SetCsrcs for RTCEncodedVideoFrameMetadata.contributingSources

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
@@ -159,25 +159,18 @@ void LibWebRTCRtpTransformableFrame::setOptions(const RTCEncodedVideoFrameMetada
 
     if (newMetadata.frameId)
         rtcMetadata.SetFrameId(*newMetadata.frameId);
-    if (newMetadata.dependencies)
-        rtcMetadata.SetDependencies(newMetadata.dependencies->span());
+    // FIXME: newMetadata.dependencies
     if (newMetadata.width)
         rtcMetadata.SetWidth(*newMetadata.width);
     if (newMetadata.height)
         rtcMetadata.SetHeight(*newMetadata.height);
-    if (newMetadata.spatialIndex)
-        rtcMetadata.SetSpatialIndex(*newMetadata.spatialIndex);
+    // FIXME: newMetadata.spatialIndex
     if (newMetadata.temporalIndex)
         rtcMetadata.SetTemporalIndex(*newMetadata.temporalIndex);
     if (newMetadata.synchronizationSource)
         rtcMetadata.SetSsrc(*newMetadata.synchronizationSource);
     // FIXME: newMetadata.payloadType
-    if (newMetadata.contributingSources) {
-        std::vector<uint32_t> csrcs(newMetadata.contributingSources->size());
-        for (auto& csrc : *newMetadata.contributingSources)
-            csrcs.push_back(csrc);
-        rtcMetadata.SetCsrcs(WTF::move(csrcs));
-    }
+    // FIXME: newMetadata.contributingSources
     if (newMetadata.rtpTimestamp)
         m_rtcFrame->SetRTPTimestamp(*newMetadata.rtpTimestamp);
     // FIXME: newMetadata.mimeType


### PR DESCRIPTION
#### 76f03b22155beaba28f6be01aa50775ad61c3564
<pre>
missing bounds check in RtpPacket::SetCsrcs for RTCEncodedVideoFrameMetadata.contributingSources
<a href="https://rdar.apple.com/177147013">rdar://177147013</a>

Reviewed by Eric Carlson.

There is no use of updating csrcs, especially since this functionality is off by default.
We remove updating csrcs from RTCEncodedVideoFrame constructor for now.
We also remove dependencies and spatial index as they are not used either.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp:
(WebCore::LibWebRTCRtpTransformableFrame::setOptions):

Originally-landed-as: 305413.999@safari-7624.5-branch (747321afe7db). <a href="https://rdar.apple.com/185368602">rdar://185368602</a>
Canonical link: <a href="https://commits.webkit.org/319876@main">https://commits.webkit.org/319876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1073bb688a6623ba2f3fbf6816e61766bc2d5b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45302 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43179 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4453 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195220 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56654 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152354 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40820 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57359 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152050 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46610 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129628 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->