### PR TITLE
[Skia] Do not transfer accelerated ImageBuffer to a different thread

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
@@ -39,13 +39,23 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaSerializedImageBuffer);
 
 SkiaSerializedImageBuffer::SkiaSerializedImageBuffer(ImageBuffer& imageBuffer)
-    : m_imageBuffer(imageBuffer)
+    : m_memoryCost(imageBuffer.memoryCost())
 {
-    if (m_imageBuffer->renderingMode() != RenderingMode::Accelerated)
+    // Non accelerated ImageBuffer can be transferred to other threads.
+    if (imageBuffer.renderingMode() != RenderingMode::Accelerated) {
+        m_imageBuffer = imageBuffer;
         return;
+    }
 
-    m_imageBuffer->flushDrawingContext();
-    m_image = m_imageBuffer->createNativeImageReference();
+    // Accelerated ImageBuffer can't be transferred to other threads, so
+    // we take an image snapshot and the parameters needed to create a
+    // new ImageBuffer to draw the image snapshot into.
+    imageBuffer.flushDrawingContext();
+    m_image = imageBuffer.createNativeImageReference();
+    m_logicalSize = imageBuffer.logicalSize();
+    m_resolutionScale = imageBuffer.resolutionScale();
+    m_colorSpace = imageBuffer.colorSpace();
+    m_bufferFormat = { imageBuffer.pixelFormat() };
     m_fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
 }
 
@@ -53,18 +63,15 @@ SkiaSerializedImageBuffer::~SkiaSerializedImageBuffer() = default;
 
 RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
 {
-    if (!m_image)
-        return m_imageBuffer.get();
+    if (m_imageBuffer)
+        return m_imageBuffer;
+
+    ASSERT(m_image);
 
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return nullptr;
 
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    if (grContext == m_image->grContext())
-        return m_imageBuffer.get();
-
-    auto copiedImageBuffer = m_imageBuffer->context().createImageBuffer(m_imageBuffer->logicalSize(), m_imageBuffer->resolutionScale(),
-        m_imageBuffer->colorSpace(), RenderingMode::Accelerated, std::nullopt, { m_imageBuffer->pixelFormat() });
+    auto copiedImageBuffer = ImageBuffer::create(m_logicalSize, RenderingMode::Accelerated, RenderingPurpose::Unspecified, m_resolutionScale, m_colorSpace, m_bufferFormat);
     if (!copiedImageBuffer)
         return nullptr;
 
@@ -73,9 +80,9 @@ RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
         m_fence = nullptr;
     }
 
-    FloatRect destination({ }, m_imageBuffer->logicalSize());
+    FloatRect destination({ }, m_logicalSize);
     FloatRect source = destination;
-    source.scale(m_imageBuffer->resolutionScale());
+    source.scale(m_resolutionScale);
     copiedImageBuffer->context().drawNativeImage(*m_image, destination, source, { CompositeOperator::Copy });
     // Flush the context to ensure all operations are done before the source image buffer is destroyed.
     copiedImageBuffer->flushDrawingContext();
@@ -84,7 +91,7 @@ RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
 
 size_t SkiaSerializedImageBuffer::memoryCost() const
 {
-    return m_imageBuffer->memoryCost();
+    return m_memoryCost;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
@@ -44,9 +44,14 @@ private:
     RefPtr<ImageBuffer> sinkIntoImageBuffer() override;
     size_t memoryCost() const override;
 
-    Ref<ImageBuffer> m_imageBuffer;
+    RefPtr<ImageBuffer> m_imageBuffer;
+    FloatSize m_logicalSize;
+    float m_resolutionScale { 1 };
+    DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
+    ImageBufferFormat m_bufferFormat;
     RefPtr<NativeImage> m_image;
     std::unique_ptr<GLFence> m_fence;
+    size_t m_memoryCost { 0 };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1feb6ac19b06a18bee095b204f70551cb22eff3b
<pre>
[Skia] Do not transfer accelerated ImageBuffer to a different thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=322349">https://bugs.webkit.org/show_bug.cgi?id=322349</a>

Reviewed by Nikolas Zimmermann.

The SkSurface created by an accelerated ImageBuffer is expected to be
released in the same thread it was created so that GL resources are
freed by the right GrContext. For accelerated ImageBuffer we take an
image snapshot and save all ImageBuffer parameters required to create
a new one in the destination thread to copy the image snapshot into.

* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp:
(WebCore::SkiaSerializedImageBuffer::SkiaSerializedImageBuffer):
(WebCore::SkiaSerializedImageBuffer::sinkIntoImageBuffer):
(WebCore::SkiaSerializedImageBuffer::memoryCost const):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h:

Canonical link: <a href="https://commits.webkit.org/319660@main">https://commits.webkit.org/319660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e5a9b2178f8dd1dc753225aa26aadd39e0a9ac4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142282 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42943 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42565 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3668 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194433 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55895 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151409 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27681 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45996 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128870 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124786 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55097 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17566 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->