### PR TITLE
[JSC] Make Air Greedy RegAlloc faster

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1392,9 +1392,9 @@ private:
         // First pass: collect coalescable pairs and the cannot-spill-in-place set.
         for (BasicBlock* block : m_code) {
             for (Inst& inst : block->insts()) {
-                inst.forEachArg([&](Arg& arg, Arg::Role, Bank, Width) {
+                for (Arg& arg : inst.args()) {
                     if (arg.isTmp() && inst.admitsStack(arg))
-                        return;
+                        continue;
 
                     // Arg cannot be spilled in-place.
                     arg.forEachTmpFast([&](Tmp& tmp) {
@@ -1403,7 +1403,7 @@ private:
                         else
                             cannotSpillInPlaceFP.add(tmp);
                     });
-                });
+                }
                 if (mayBeCoalescable(inst)) {
                     ASSERT(inst.args().size() == 2);
                     if (inst.args()[0].isReg() || inst.args()[1].isReg()) {
@@ -2753,12 +2753,28 @@ private:
         if (tmpData.liveRange.size() < splitMinRangeSize)
             return false; // Not enough instructions to be worthwhile
 
-        auto instUsesOrDefsTmp = [](Inst& inst, Tmp tmp) {
-            bool result = false;
+        struct ClobberSite {
+            Point point;
+            BasicBlock* block;
+            bool usesOrDefsTmp;
+        };
+        Vector<ClobberSite, 16> clobberSites;
+        // A call clobbers every caller-saved register at a single point, so the same instruction is
+        // reached once per candidate register below. What is computed here depends only on the
+        // point, thus caching here.
+        auto clobberSiteAt = [&](Point point) -> ClobberSite {
+            auto iterator = std::ranges::lower_bound(clobberSites, point, { }, &ClobberSite::point);
+            if (iterator != clobberSites.end() && iterator->point == point)
+                return *iterator;
+            BasicBlock* block = findBlockContainingPoint(point);
+            Inst& inst = block->at(this->instIndex(positionOfHead(block), point));
+            bool usesOrDefsTmp = false;
             inst.forEachTmpFast([&](Tmp useOrDef) {
-                result |= useOrDef == tmp;
+                usesOrDefsTmp |= useOrDef == tmp;
             });
-            return result;
+            ClobberSite site { point, block, usesOrDefsTmp };
+            clobberSites.insert(iterator - clobberSites.begin(), site);
+            return site;
         };
         ASSERT(tmpData.spillCost() != unspillableCost); // Should have evicted.
 
@@ -2773,10 +2789,8 @@ private:
             m_regRanges[r].forEachConflict(tmpData.liveRange, width,
                 [&](auto& conflict) -> IterationStatus {
                     if (conflict.tmp.isReg() && conflict.interval.distance() == 1) {
-                        BasicBlock* block = findBlockContainingPoint(conflict.interval.begin());
-                        unsigned instIndex = this->instIndex(positionOfHead(block), conflict.interval.begin());
-                        Inst& inst = block->at(instIndex);
-                        if (instUsesOrDefsTmp(inst, tmp)) {
+                        ClobberSite site = clobberSiteAt(conflict.interval.begin());
+                        if (site.usesOrDefsTmp) {
                             // If the inst that clobbers regs also use/def the tmp trying to be split, then
                             // can't split the tmp around this clobber.
                             // FIXME: could allow uses, but then we'd have to make split tmp conflict with any
@@ -2785,7 +2799,7 @@ private:
                             return IterationStatus::Done;
                         }
                         // Times 2 for 'MOV tmp, gapTmp' and 'MOV gapTmp, tmp'
-                        splitCost += UseDefCost(adjustedBlockFrequency(block) * 2);
+                        splitCost += UseDefCost(adjustedBlockFrequency(site.block) * 2);
                         if (splitCost >= minSplitCost)
                             return IterationStatus::Done; // Not the best or already over limit, exit early.
                         return IterationStatus::Continue;
@@ -2849,6 +2863,28 @@ private:
     // Note that the use/def lists are computed only once and not kept up to date.
     // So after a Tmp is split or spilled that Tmp's use/def list may include instructions that now
     // reference the new split tmp or spill slot rather than the Tmp itself.
+    // Only the Tmps matter when indexing use/def sites, not their roles, so the role-free walk is
+    // used. This asserts the two walks really do enumerate the same Tmps for every opcode form.
+    static void validateFastTmpEnumeration(Inst& inst)
+    {
+        auto collect = [](auto&& walk) {
+            Vector<int, 8> values;
+            walk([&](Tmp& tmp) { values.append(tmp.internalValue()); });
+            std::ranges::sort(values);
+            Vector<int, 8> unique;
+            for (int value : values) {
+                if (unique.isEmpty() || unique.last() != value)
+                    unique.append(value);
+            }
+            return unique;
+        };
+        auto fast = collect([&](auto&& functor) { inst.forEachTmpFast(functor); });
+        auto viaArgs = collect([&](auto&& functor) {
+            inst.forEachArg([&](Arg& arg, Arg::Role, Bank, Width) { arg.forEachTmpFast(functor); });
+        });
+        RELEASE_ASSERT(fast == viaArgs, fast.size(), viaArgs.size());
+    }
+
     void ensureUseDefLists()
     {
         if (m_hasUseDefLists)
@@ -2859,11 +2895,11 @@ private:
         for (BasicBlock* block : m_code) {
             Point instPoint = this->positionOfHead(block);
             for (Inst& inst : block->insts()) {
-                inst.forEachArg([&](Arg& arg, Arg::Role, Bank, Width) {
-                    arg.forEachTmpFast([&](Tmp& tmp) {
-                        m_useDefLists[tmp].add(instPoint);
-                    });
+                inst.forEachTmpFast([&](Tmp& tmp) {
+                    m_useDefLists[tmp].add(instPoint);
                 });
+                if (Options::airValidateGreedRegAlloc()) [[unlikely]]
+                    validateFastTmpEnumeration(inst);
                 instPoint += PointOffsets::PointsPerInst;
             }
         }
@@ -3094,6 +3130,24 @@ private:
             Point positionOfHead = this->positionOfHead(block);
             for (unsigned instIndex = 0; instIndex < block->size(); ++instIndex) {
                 Inst& inst = block->at(instIndex);
+
+                // Everything below is reached only through an Arg that is a spilled Tmp of this
+                // bank, and deciding whether the instruction mentions one does not need the Arg roles.
+                bool mayMentionSpilledTmp = false;
+                inst.forEachTmpFast([&](Tmp& tmp) {
+                    if (!mayMentionSpilledTmp && tmp.bank() == bank && spillSlot<bank>(tmp))
+                        mayMentionSpilledTmp = true;
+                });
+                if (!mayMentionSpilledTmp) {
+                    if (Options::airValidateGreedRegAlloc()) [[unlikely]] {
+                        inst.forEachArg([&](Arg& arg, Arg::Role, Bank argBank, Width) {
+                            if (arg.isTmp() && argBank == bank)
+                                RELEASE_ASSERT(!spillSlot<bank>(arg.tmp()));
+                        });
+                    }
+                    continue;
+                }
+
                 unsigned indexOfEarly = positionOfEarly(positionOfHead, instIndex);
 
                 bool useMove32IfDidSpill = false;

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(B3_JIT)
 
+#include "AirCode.h"
 #include "CCallHelpers.h"
 #include "MacroAssemblerPrinter.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -43,8 +44,15 @@ PrintSpecial::PrintSpecial(Printer::PrintRecordList* list)
 
 PrintSpecial::~PrintSpecial() = default;
 
-void PrintSpecial::forEachArg(Inst&, const ScopedLambda<Inst::EachArgCallback>&)
+void PrintSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallback>& callback)
 {
+    // The printed Tmps must be reported, or liveness ends their ranges before the print and the
+    // register allocator has nothing to hand generate().
+    for (unsigned i = numSpecialArgs; i < inst.args().size(); ++i) {
+        Bank bank = inst.args()[i].bank();
+        Width width = code().usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
+        callback(inst.args()[i], Arg::Use, bank, width);
+    }
 }
 
 bool PrintSpecial::isValid(Inst&)
@@ -68,13 +76,16 @@ void PrintSpecial::reportUsedRegisters(Inst&, const RegisterSet&)
 
 MacroAssembler::Jump PrintSpecial::generate(Inst& inst, CCallHelpers& jit, GenerationContext&)
 {
-    size_t currentArg = 1; // Skip the PrintSpecial arg.
+    size_t currentArg = numSpecialArgs;
     for (auto& term : *m_printRecordList) {
         if (term.printer == Printer::printAirArg) {
             const Arg& arg = inst.args()[currentArg++];
             switch (arg.kind()) {
             case Arg::Tmp:
-                term = Printer::Printer<MacroAssembler::RegisterID>(arg.gpr());
+                if (arg.isGP())
+                    term = Printer::Printer<MacroAssembler::RegisterID>(arg.gpr());
+                else
+                    term = Printer::Printer<MacroAssembler::FPRegisterID>(arg.fpr());
                 break;
             case Arg::Addr:
             case Arg::ExtendedOffsetAddr:

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
@@ -91,12 +91,7 @@ class PrintSpecial final : public Special {
 public:
     PrintSpecial(Printer::PrintRecordList*);
     ~PrintSpecial() final;
-    
-    // You cannot use this register to pass arguments. It just so happens that this register is not
-    // used for arguments in the C calling convention. By the way, this is the only thing that causes
-    // this special to be specific to C calls.
-    static constexpr GPRReg scratchRegister = GPRInfo::nonArgGPR0;
-    
+
 private:
     void forEachArg(Inst&, const ScopedLambda<Inst::EachArgCallback>&) final;
     bool isValid(Inst&) final;
@@ -106,21 +101,12 @@ private:
     MacroAssembler::Jump generate(Inst&, CCallHelpers&, GenerationContext&) final;
     RegisterSet extraEarlyClobberedRegs(Inst&) final;
     RegisterSet extraClobberedRegs(Inst&) final;
-    
+
     void dumpImpl(PrintStream&) const final;
     void deepDumpImpl(PrintStream&) const final;
-    
-    static constexpr unsigned specialArgOffset = 0;
+
     static constexpr unsigned numSpecialArgs = 1;
-    static constexpr unsigned calleeArgOffset = numSpecialArgs;
-    static constexpr unsigned numCalleeArgs = 1;
-    static constexpr unsigned returnGPArgOffset = numSpecialArgs + numCalleeArgs;
-    static constexpr unsigned numReturnGPArgs = 2;
-    static constexpr unsigned returnFPArgOffset = numSpecialArgs + numCalleeArgs + numReturnGPArgs;
-    static constexpr unsigned numReturnFPArgs = 1;
-    static constexpr unsigned argArgOffset =
-    numSpecialArgs + numCalleeArgs + numReturnGPArgs + numReturnFPArgs;
-    
+
     Printer::PrintRecordList* m_printRecordList;
 };
 


### PR DESCRIPTION
#### 96b1030b8df45a6799b4e4bc1f354287c20e56c8
<pre>
[JSC] Make Air Greedy RegAlloc faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=322350">https://bugs.webkit.org/show_bug.cgi?id=322350</a>
<a href="https://rdar.apple.com/185620492">rdar://185620492</a>

Reviewed by Sosuke Suzuki.

Perform several optimizations to reduce compile time in Air Greedy RegAlloc.

1. Caching ClobberSite for each point. Some of Air Inst, like Call is
   clobbering all caller-save registers. Thus this query can be executed
   frequently with the same point. Let&apos;s just cache it in the Vector so
   that we can quickly answer to the question here.
2. Use forEachTmpFast if possible as it is dramatically faster than forEachArg.
   We also fixes AirPrintSpecial was not reporting the args correctly.
3. In emitSpillCodeAndEnqueueNewTmps, before doing complicated spill
   analysis and emission code, we do quick rejection via forEachTmpFast
   check.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::validateFastTmpEnumeration):
(JSC::B3::Air::Greedy::GreedyAllocator::ensureUseDefLists):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
* Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp:
(JSC::B3::Air::PrintSpecial::forEachArg):
(JSC::B3::Air::PrintSpecial::generate):
* Source/JavaScriptCore/b3/air/AirPrintSpecial.h:

Canonical link: <a href="https://commits.webkit.org/319706@main">https://commits.webkit.org/319706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10bcf7df1b3796722e4ff6b3f2b0bd897bff45be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b22e5a4-f850-481c-8553-7f78679993aa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f25ca16b-bb1e-4278-b750-468a2dcd9f77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122711 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/861f8b4c-f6e0-4fc1-b834-a6c759bd20d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42939 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4677 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11502 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42559 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3665 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43559 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55893 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151706 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151407 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27711 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45992 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128868 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55095 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17557 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54476 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->