### PR TITLE
[JSC] Make FixObviousSpills faster

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -91,7 +91,8 @@ private:
             dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Executing block ", *m_block, ": ", m_state);
             for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
                 dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Executing ", m_block->at(m_instIndex), ": ", m_state);
-                clobberAllDefs();
+                if (!m_state.isEmpty())
+                    clobberAllDefs();
                 addInstAliases();
             }
 
@@ -129,6 +130,10 @@ private:
             m_state = m_atHead[block];
 
             for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
+                if (m_state.isEmpty()) {
+                    addInstAliases();
+                    continue;
+                }
                 clobberEarlyDefs();
                 fixInst();
                 clobberLateDefs();
@@ -196,6 +201,31 @@ private:
         }
     }
 
+    template<typename IsWhichDef>
+    void clobberDefTmps(Arg& arg, Arg::Role role, Bank bank, Width width, const IsWhichDef& isWhichDef)
+    {
+        auto mayReportDefTmp = [](const Arg& arg, bool argRoleIsDef) {
+            return argRoleIsDef || arg.isPreIndex() || arg.isPostIndex();
+        };
+
+        if (!mayReportDefTmp(arg, isWhichDef(role))) {
+            if (Options::airValidateGreedRegAlloc()) [[unlikely]] {
+                arg.forEachTmp(role, bank, width,
+                    [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
+                        RELEASE_ASSERT(!(isWhichDef(refinedRole) && tmp.isReg()));
+                    });
+            }
+            return;
+        }
+        arg.forEachTmp(role, bank, width,
+            [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
+                if (isWhichDef(refinedRole) && tmp.isReg()) {
+                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", tmp.reg());
+                    m_state.clobber(tmp.reg());
+                }
+            });
+    }
+
     void clobberDefs(Inst* prevInst, Inst* nextInst)
     {
         auto walk = [&] (Inst* inst, auto isWhichDef) {
@@ -207,13 +237,7 @@ private:
                     dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", *arg.stackSlot());
                     m_state.clobber(arg.stackSlot());
                 }
-                arg.forEachTmp(role, bank, width,
-                    [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
-                        if (isWhichDef(refinedRole) && tmp.isReg()) {
-                            dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", tmp.reg());
-                            m_state.clobber(tmp.reg());
-                        }
-                    });
+                clobberDefTmps(arg, role, bank, width, isWhichDef);
             });
         };
         walk(prevInst, [] (Arg::Role role) { return Arg::isLateDef(role); });
@@ -248,11 +272,7 @@ private:
         inst.forEachArg([&](Arg& arg, Arg::Role role, Bank bank, Width width) {
             if (Arg::isAnyDef(role) && arg.isStack() && arg.stackSlot()->isSpill())
                 m_state.clobber(arg.stackSlot());
-            arg.forEachTmp(role, bank, width,
-                [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
-                    if (Arg::isAnyDef(refinedRole) && tmp.isReg())
-                        m_state.clobber(tmp.reg());
-                });
+            clobberDefTmps(arg, role, bank, width, [](Arg::Role role) { return Arg::isAnyDef(role); });
         });
 
         // Patch ops have extra-clobbered registers that aren't represented as
@@ -329,6 +349,25 @@ private:
         // FIXME: This code should be taught how to simplify the spill-to-spill move
         // instruction. Basically it needs to know to remove the scratch arg.
         // https://bugs.webkit.org/show_bug.cgi?id=171133
+
+        // Substitution below only ever replaces a spill slot argument, and it can only do that from
+        // a RegSlot or a SlotConst, so without either there is nothing to look for.
+        if (m_state.hasNoSlotAlias())
+            return;
+
+        // It also needs the instruction to mention a spill slot at all. Deciding that does not need
+        // the Arg roles, and iterating args() can only over-approximate what forEachArg reports, so
+        // this cannot skip an instruction the scan below would have changed. Worth doing before the
+        // Inst copy, which is otherwise paid by every instruction that gets this far.
+        bool mentionsSpillSlot = false;
+        for (Arg& arg : inst.args()) {
+            if (isSpillSlot(arg)) {
+                mentionsSpillSlot = true;
+                break;
+            }
+        }
+        if (!mentionsSpillSlot)
+            return;
 
         // Create a copy in case we invalidate the instruction. That doesn't happen often.
         Inst instCopy = inst;
@@ -499,7 +538,7 @@ private:
         {
             return slot;
         }
-        
+
         friend bool NODELETE operator==(const SlotConst&, const SlotConst&) = default;
 
         bool NODELETE operator<(const SlotConst& other) const
@@ -517,6 +556,10 @@ private:
     };
 
     struct State {
+        bool NODELETE isEmpty() const { return regConst.isEmpty() && slotConst.isEmpty() && regSlot.isEmpty(); }
+
+        bool NODELETE hasNoSlotAlias() const { return slotConst.isEmpty() && regSlot.isEmpty(); }
+
         void addAlias(const RegConst& newAlias)
         {
             regConst.append(newAlias);


### PR DESCRIPTION
#### ecc99e50298faee67ef9230e09e691441e1bd81d
<pre>
[JSC] Make FixObviousSpills faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=322351">https://bugs.webkit.org/show_bug.cgi?id=322351</a>
<a href="https://rdar.apple.com/185622139">rdar://185622139</a>

Reviewed by Sosuke Suzuki.

Apply several optimizations.

1. State tends to be empty frequently. So let&apos;s skip various analysis
   when state is empty.
2. Do quick check before copying Inst.
3. Do not scan an operand&apos;s Tmps for defs when it cannot report one.

* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:

Canonical link: <a href="https://commits.webkit.org/319711@main">https://commits.webkit.org/319711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f24fdd59fa90a1ebdb04621f73c35f3cc87ed31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbe53913-291c-43fe-a2bd-af9720f2358e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56199 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16c48096-026b-4b34-addd-c381a6f98a4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46189 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122906 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8ed50da-6497-4f47-910e-e6ab20ba0ebb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/4871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/11711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3923 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43813 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49107 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194686 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56147 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56838 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27717 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46190 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55349 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17767 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54731 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->