### PR TITLE
Incomplete fix of WebKit bug 315528 (Message check file urls in back/forward list messages)

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -40,7 +40,11 @@
 #include "WebPageProxy.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+<<<<<<< HEAD
 #include <wtf/Borrow.h>
+=======
+#include <WebCore/Page.h>
+>>>>>>> ce08c270d322 (Incomplete fix of WebKit bug 315528 (Message check file urls in back/forward list messages))
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
 #include <wtf/SetForScope.h>
@@ -759,8 +763,12 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
+static constexpr unsigned maxFrameStateDepthForMessageCheck = WebCore::Page::maxFrameDepth;
+
+static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process, unsigned depth = 0)
 {
+    MESSAGE_CHECK_WITH_RETURN_VALUE(process, depth < maxFrameStateDepthForMessageCheck, false);
+
     URL itemURL { frameState->urlString };
     URL itemOriginalURL { frameState->originalURLString };
 #if PLATFORM(COCOA)
@@ -775,6 +783,11 @@ static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProx
 #if PLATFORM(COCOA)
     }
 #endif
+
+    for (auto& child : frameState->children) {
+        if (!messageCheckItemURLs(child, process, depth + 1))
+            return false;
+    }
     return true;
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -40,6 +40,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <WebCore/Page.h>
 #include <wtf/Borrow.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
@@ -759,8 +760,12 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
+static constexpr unsigned maxFrameStateDepthForMessageCheck = WebCore::Page::maxFrameDepth;
+
+static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process, unsigned depth = 0)
 {
+    MESSAGE_CHECK_WITH_RETURN_VALUE(process, depth < maxFrameStateDepthForMessageCheck, false);
+
     URL itemURL { frameState->urlString };
     URL itemOriginalURL { frameState->originalURLString };
 #if PLATFORM(COCOA)
@@ -775,6 +780,11 @@ static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProx
 #if PLATFORM(COCOA)
     }
 #endif
+
+    for (auto& child : frameState->children) {
+        if (!messageCheckItemURLs(child, process, depth + 1))
+            return false;
+    }
     return true;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -1,0 +1,1371 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import <WebCore/Page.h>
+#import <WebKit/WKBackForwardListItemPrivate.h>
+#import <WebKit/WKBackForwardListPrivate.h>
+#import <WebKit/WKNavigationDelegatePrivate.h>
+#import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKFeature.h>
+#import <WebKit/_WKFrameTreeNode.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <WebKit/_WKSessionState.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/WTFString.h>
+
+static NSString *loadableURL1 = @"data:text/html,no%20error%20A";
+static NSString *loadableURL2 = @"data:text/html,no%20error%20B";
+static NSString *loadableURL3 = @"data:text/html,no%20error%20C";
+
+TEST(WKBackForwardList, RemoveCurrentItem)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, loadableURL3.UTF8String);
+
+    _WKSessionState *sessionState = [webView _sessionStateWithFilter:^BOOL(WKBackForwardListItem *item)
+    {
+        return [item.URL isEqual:[NSURL URLWithString:loadableURL2]];
+    }];
+
+    [webView _restoreSessionState:sessionState andNavigate:NO];
+
+    WKBackForwardList *newList = [webView backForwardList];
+
+    EXPECT_EQ((NSUInteger)0, newList.backList.count);
+    EXPECT_EQ((NSUInteger)0, newList.forwardList.count);
+    EXPECT_STREQ([[newList.currentItem URL] absoluteString].UTF8String, loadableURL2.UTF8String);
+}
+
+TEST(WKBackForwardList, CanNotGoBackAfterRestoringEmptySessionState)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ(YES, [webView canGoBack]);
+    EXPECT_EQ(NO, [webView canGoForward]);
+    EXPECT_EQ((NSUInteger)1, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+
+    auto singlePageWebView = adoptNS([[WKWebView alloc] init]);
+
+    [singlePageWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [singlePageWebView _test_waitForDidFinishNavigation];
+
+    [webView _restoreSessionState:[singlePageWebView _sessionState] andNavigate:NO];
+
+    WKBackForwardList *newList = [webView backForwardList];
+
+    EXPECT_EQ(NO, [webView canGoBack]);
+    EXPECT_EQ(NO, [webView canGoForward]);
+    EXPECT_EQ((NSUInteger)0, newList.backList.count);
+    EXPECT_EQ((NSUInteger)0, newList.forwardList.count);
+}
+
+TEST(WKBackForwardList, RestoringNilSessionState)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ(YES, [webView canGoBack]);
+    EXPECT_EQ(NO, [webView canGoForward]);
+    EXPECT_EQ((NSUInteger)1, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+
+    auto singlePageWebView = adoptNS([[WKWebView alloc] init]);
+
+    [singlePageWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [singlePageWebView _test_waitForDidFinishNavigation];
+
+    [webView _restoreSessionState:nil andNavigate:NO];
+
+    WKBackForwardList *newList = [webView backForwardList];
+
+    EXPECT_EQ(YES, [webView canGoBack]);
+    EXPECT_EQ(NO, [webView canGoForward]);
+    EXPECT_EQ((NSUInteger)1, newList.backList.count);
+    EXPECT_EQ((NSUInteger)0, newList.forwardList.count);
+}
+
+static bool done;
+static size_t navigations;
+
+@interface AsyncPolicyDecisionDelegate : NSObject <WKNavigationDelegate, WKUIDelegate>
+@end
+
+@implementation AsyncPolicyDecisionDelegate
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(null_unspecified WKNavigation *)navigation
+{
+    if (navigations++)
+        done = true;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
+        decisionHandler(WKNavigationActionPolicyAllow);
+    });
+}
+
+@end
+
+TEST(WKBackForwardList, WindowLocationAsyncPolicyDecision)
+{
+    NSURL *simple = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *simple2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    auto webView = adoptNS([[WKWebView alloc] init]);
+    auto delegate = adoptNS([[AsyncPolicyDecisionDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    [webView loadHTMLString:@"<script>window.location='simple.html'</script>" baseURL:simple2];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_STREQ(webView.get().backForwardList.currentItem.URL.absoluteString.UTF8String, simple.absoluteString.UTF8String);
+}
+
+TEST(WKBackForwardList, InteractionStateRestoration)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+
+    id interactionState = [webView interactionState];
+    RetainPtr<NSURL> temporaryFile = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString] isDirectory:NO];
+    NSError *error = nil;
+    RetainPtr<NSData> archivedInteractionState = [NSKeyedArchiver archivedDataWithRootObject:interactionState requiringSecureCoding:YES error:&error];
+    EXPECT_TRUE(!error);
+    interactionState = nil;
+    [archivedInteractionState writeToURL:temporaryFile.get() options:NSDataWritingAtomic error:&error];
+    archivedInteractionState = nil;
+    EXPECT_TRUE(!error);
+
+    webView = adoptNS([[WKWebView alloc] init]);
+
+    archivedInteractionState = [NSData dataWithContentsOfURL:temporaryFile.get()];
+    interactionState = [NSKeyedUnarchiver unarchivedObjectOfClass:[(id)[webView interactionState] class] fromData:archivedInteractionState.get() error:&error];
+    EXPECT_TRUE(!error);
+
+    [webView setInteractionState:interactionState];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *newList = [webView backForwardList];
+
+    EXPECT_EQ((NSUInteger)2, newList.backList.count);
+    EXPECT_EQ((NSUInteger)0, newList.forwardList.count);
+    EXPECT_STREQ([[newList.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+
+    done = false;
+    [webView evaluateJavaScript:@"document.body.innerText" completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE(!error);
+        NSString* bodyText = result;
+        EXPECT_WK_STREQ(@"Third simple HTML file.", bodyText);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [webView goBack];
+    [webView _test_waitForDidFinishNavigation];
+
+    done = false;
+    [webView evaluateJavaScript:@"document.body.innerText" completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE(!error);
+        NSString* bodyText = result;
+        EXPECT_WK_STREQ(@"Second simple HTML file.", bodyText);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [webView goBack];
+    [webView _test_waitForDidFinishNavigation];
+
+    done = false;
+    [webView evaluateJavaScript:@"document.body.innerText" completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE(!error);
+        NSString* bodyText = result;
+        EXPECT_WK_STREQ(@"Simple HTML file.", bodyText);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WKBackForwardList, InteractionStateRestorationNil)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+
+    [webView setInteractionState:nil];
+
+    list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+}
+
+TEST(WKBackForwardList, InteractionStateRestorationInvalid)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    WKBackForwardList *list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+
+    NSString *invalidState = @"foo";
+    [webView setInteractionState:invalidState];
+
+    list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)2, list.backList.count);
+    EXPECT_EQ((NSUInteger)0, list.forwardList.count);
+    EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, [url3 absoluteString].UTF8String);
+}
+
+@interface WKBackForwardNavigationDelegate : NSObject <WKNavigationDelegatePrivate>
+- (void)waitForDidFinishNavigationOrDidSameDocumentNavigation;
+@end
+
+static RetainPtr<WKNavigation> lastNavigation;
+
+@implementation WKBackForwardNavigationDelegate {
+    bool _navigated;
+    bool _didFinishNavigation;
+}
+
+- (instancetype) init
+{
+    self = [super init];
+    return self;
+}
+
+- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
+{
+    EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
+    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    _navigated = true;
+    _didFinishNavigation = true;
+    lastNavigation = navigation;
+}
+
+- (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
+{
+    if (navigationType == _WKSameDocumentNavigationTypeSessionStatePush || navigationType == _WKSameDocumentNavigationTypeSessionStatePop) {
+        _navigated = true;
+        lastNavigation = navigation;
+    }
+}
+
+- (void)waitForDidFinishNavigationOrDidSameDocumentNavigation
+{
+    _navigated = false;
+    TestWebKitAPI::Util::run(&_navigated);
+}
+
+- (void)waitForDidFinishNavigation
+{
+    _didFinishNavigation = false;
+    TestWebKitAPI::Util::run(&_didFinishNavigation);
+}
+
+@end
+
+// _beginBackSwipeForTesting / _completeBackSwipeForTesting are not implemented on macOS.
+#if !PLATFORM(MAC)
+
+TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
+{
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView setAllowsBackForwardNavigationGestures:YES];
+    [webView becomeFirstResponder];
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Add back/forward list items without user gestures.
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#a');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#b');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#c');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    // Navigating back via a swipe gesture should skip those back/forward list items without a user gesture.
+    [webView _beginBackSwipeForTesting];
+    [webView _completeBackSwipeForTesting];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 4U);
+}
+
+TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
+{
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView setAllowsBackForwardNavigationGestures:YES];
+    [webView becomeFirstResponder];
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Add back/forward list item with a user gesture.
+    [webView evaluateJavaScript:@"history.pushState(null, document.title, location.pathname + '#a');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    // Navigating back via a swipe gesture should skip those back/forward list items without a user gesture.
+    [webView _beginBackSwipeForTesting];
+    [webView _completeBackSwipeForTesting];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+}
+
+#endif
+
+static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<void(WKWebView *, ASCIILiteral destination)>&& navigate)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Test case:
+    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3.
+
+    // Add back/forward list items without user gestures.
+    navigate(webView.get(), "location.pathname + '#a'"_s);
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_FALSE([lastNavigation _isUserInitiated]);
+    EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+    RetainPtr expectedURLString = makeString(String([url2 absoluteString]), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    navigate(webView.get(), "location.pathname + '#b'"_s);
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_FALSE([lastNavigation _isUserInitiated]);
+    EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+    expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    navigate(webView.get(), "location.pathname + '#c'"_s);
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_FALSE([lastNavigation _isUserInitiated]);
+    EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_FALSE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 5U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    // We are now on url3. Let's go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // We should go back to url2#c.
+    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+
+    // Let's go back again.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // We should have skipped over url2#b, url2#a and url2, to end up on url1.
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 5U);
+
+    // Now let's go forward.
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // We should get to the latest url2 URL, that is url2#c.
+    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+
+    // Let's go forward again.
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // We should now be on url3.
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url3 absoluteString].UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 5U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    // Navigating via the JS API shouldn't skip those back/forward list items.
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 3U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushState)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushStateAfterEvaluateJS)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
+        // Do a call to evaluateJavaScript (with user gesture) *BEFORE* the pushState and make sure it doesn't count
+        // as a user gesture for the pushState().
+        __block bool didRunScript = false;
+        [webView evaluateJavaScript:@"window.foo = 1;" completionHandler:^(id, NSError *) {
+            didRunScript = true;
+        }];
+        TestWebKitAPI::Util::run(&didRunScript);
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubframe)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/source.html"_s, { "foo"_s } },
+        { "/destination.html"_s, { "<iframe src='iframe.html'></iframe>"_s } },
+        { "/iframe.html"_s, { "<script>onload = () => { setTimeout(() => { history.pushState(null, document.title, '#'); }, 0); };</script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:server.request("/source.html"_s)];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:server.request("/destination.html"_s)];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Wait for the subframe to call pushState().
+    while ([webView backForwardList].backList.count != 2)
+        TestWebKitAPI::Util::spinRunLoop();
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // We should be back to source.html since we would have ignored the history item
+    // added by the subframe without user interaction.
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/source.html"_s).URL.absoluteString.UTF8String);
+
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/destination.html"_s).URL.absoluteString.UTF8String);
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsClientSideRedirectWithCOOP)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/source.html"_s, { "<a id='testLink' href='form.html'>click me</a>"_s } },
+        { "/form.html"_s, { "<body><form id='testForm' method='POST' action='redirect.html'><input type='submit' value='submit'></form><script>document.getElementById('testForm').submit()</script></body>"_s } },
+        { "/redirect.html"_s, { { { "Content-Type"_s, "text/html"_s }, { "cross-origin-opener-policy"_s, "same-origin"_s } }, "<head><meta http-equiv='refresh' content='0; url=destination.html'></head>"_s } },
+        { "/destination.html"_s, { "foo"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Https);
+
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:server.request("/source.html"_s)];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView evaluateJavaScript:@"document.getElementById('testLink').click()" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/form.html"_s).URL.absoluteString.UTF8String);
+
+    // Wait for form submission to happen.
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/redirect.html"_s).URL.absoluteString.UTF8String);
+
+    // Wait for redirect to finish.
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/destination.html"_s).URL.absoluteString.UTF8String);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/source.html"_s).URL.absoluteString.UTF8String);
+}
+
+static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function<void(WKWebView *, ASCIILiteral fragment)>&& navigate)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    // Test case: url1 -> url2 -> url2#a (with user gesture)
+    // No item should be skipped when navigating backwards or forwards.
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Add back/forward list items without user gestures.
+    navigate(webView.get(), "#a"_s);
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    RetainPtr expectedURLString = makeString(String([url2 absoluteString]), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    RetainPtr lastURL = [webView URL];
+    EXPECT_FALSE([lastURL isEqual:url2.get()]);
+
+    EXPECT_FALSE(webView.get().backForwardList.backItem._wasCreatedByJSWithoutUserInteraction);
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    EXPECT_FALSE(webView.get().backForwardList.backItem._wasCreatedByJSWithoutUserInteraction);
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    expectedURLString = makeString(String([url2 absoluteString]), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [lastURL absoluteString].UTF8String);
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesturePushState)
+{
+    runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
+        [webView evaluateJavaScript:makeString("history.pushState(null, document.title, location.pathname + '"_s, fragment, "');"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGestureFragment)
+{
+    runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
+        [webView evaluateJavaScript:makeString("location.href = location.pathname + '"_s, fragment, "';"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsFromLoadRequest)
+{
+    runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
+        auto newURLString = makeString(String([webView URL].absoluteString), fragment);
+        [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:newURLString.createNSString().get()]).get()]).get()];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGesturePushState)
+{
+    runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
+        // Call pushState() in a setTimeout() so that it has a recent user gesture but not a current one.
+        [webView evaluateJavaScript:makeString("setTimeout(() => { history.pushState(null, document.title, location.pathname + '"_s, fragment, "'); }, 0);"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestureFragment)
+{
+    runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
+        // Do fragment navigation in a setTimeout() so that it has a recent user gesture but not a current one.
+        [webView evaluateJavaScript:makeString("setTimeout(() => { location.href = location.pathname + '"_s, fragment, "'; }, 0);"_s).createNSString().get() completionHandler:nil];
+    });
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUserGesture)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"fragment-navigation-before-load-event" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Page navigated to #fragment before the load event.
+    RetainPtr expectedURLString = makeString(String([url2 absoluteString]), "#fragment"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+
+    // Navigate with a user gesture.
+    [webView evaluateJavaScript:@"location.href = location.pathname + '#otherFragment';" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Should go back to #fragment.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+}
+
+TEST(WKBackForwardList, BackNavigationHijacking)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, null, '');" completionHandler:nil];
+    __block bool ranJS = false;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"onpopstate = (e) => { history.forward(); };false" completionHandler:^(id, NSError *) {
+        ranJS = true;
+    }];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    TestWebKitAPI::Util::run(&ranJS);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    EXPECT_TRUE(webView.get().backForwardList.backItem._wasCreatedByJSWithoutUserInteraction);
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+
+    TestWebKitAPI::Util::spinRunLoop(10);
+    usleep(100000);
+    TestWebKitAPI::Util::spinRunLoop(10);
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+}
+
+TEST(WKBackForwardList, BackForwardListRemoveAndAddSubframes)
+{
+    auto indexHTML = "<iframe id='1' src='/frame1'></iframe>"
+        "<iframe id='2' src='/frame2'></iframe>"_s;
+    TestWebKitAPI::HTTPServer server({
+        { "/index"_s, { indexHTML } },
+        { "/frame1"_s, { ""_s } },
+        { "/frame2"_s, { "<script> alert('frame2'); </script>"_s } },
+        { "/frame3"_s, { "<script> alert('frame3'); </script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Https);
+    auto webView = adoptNS([[WKWebView alloc] init]);
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:server.request("/index"_s)];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "frame2");
+
+    [webView _frames:^(_WKFrameTreeNode *mainFrame) {
+        [webView evaluateJavaScript:@"location.href = '/frame3'" inFrame:mainFrame.childFrames[1].info inContentWorld:WKContentWorld.pageWorld completionHandler:nil];
+    }];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "frame3");
+
+    auto removeAndAddFrame = @"let frame = document.getElementById('1');"
+        "frame.parentNode.removeChild(frame);"
+        "let newFrame = document.createElement('iframe');"
+        "newFrame.src = '/frame1';"
+        "document.body.appendChild(newFrame);";
+    __block bool done = false;
+    [webView evaluateJavaScript:removeAndAddFrame completionHandler:^(id, NSError *) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    [webView goBack];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "frame2");
+
+    __block auto expectedFrameURL = server.request("/frame2"_s).URL.absoluteString.UTF8String;
+    [webView evaluateJavaScript:@"document.getElementById('2').contentWindow.location.href" completionHandler:^(id result, NSError *) {
+        EXPECT_WK_STREQ(expectedFrameURL, [result UTF8String]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WKBackForwardList, SessionStateTitleTruncation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "<script>document.title='a'.repeat(10000);window.history.pushState({}, '', window.location+'?a=b');</script>"_s } }
+    });
+
+    auto webView = adoptNS([WKWebView new]);
+    [webView loadRequest:server.request()];
+    while (!webView.get().canGoBack)
+        TestWebKitAPI::Util::spinRunLoop();
+    while (webView.get()._sessionState.data.length < 1000u)
+        TestWebKitAPI::Util::spinRunLoop();
+    _WKSessionState *sessionState = webView.get()._sessionState;
+    NSData *stateData = sessionState.data;
+    EXPECT_LT(stateData.length, 2000u);
+}
+
+TEST(WKBackForwardList, RestoreSessionStateResetProvisionalItem)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    [webView synchronouslyGoBack];
+    [webView synchronouslyGoForward];
+
+    RetainPtr sessionState = [webView _sessionStateWithFilter:^BOOL(WKBackForwardListItem *item) {
+        return [item.URL isEqual:[NSURL URLWithString:loadableURL1]];
+    }];
+    [webView _restoreSessionState:sessionState.get() andNavigate:NO];
+    [[webView backForwardList] currentItem];
+}
+
+TEST(WKBackForwardList, GoBackToPageAfterNavigatingIframeAndRestoringSession)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/example"_s, { "<iframe src='/a'></iframe>"_s } },
+        { "/a"_s, { "<script>alert('a');</script>"_s } },
+        { "/b"_s, { "<script>alert('b');</script>"_s } },
+    });
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    [webView loadRequest:server.request("/example"_s)];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "a");
+
+    [webView evaluateJavaScript:@"document.querySelector('iframe').src = '/b';" completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "b");
+
+    [webView loadRequest:server.requestWithLocalhost("/example"_s)];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "a");
+
+    [webView _restoreSessionState:[webView _sessionState] andNavigate:NO];
+    [webView goBack];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "b");
+    EXPECT_WK_STREQ([webView URL].absoluteString, server.request("/example"_s).URL.absoluteString.UTF8String);
+}
+
+#if ENABLE(IPC_TESTING_API)
+
+static void enableIPCTestingAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+}
+
+TEST(WKBackForwardList, BackForwardUpdateItemRejectsFileURL)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/page"_s, { "<!DOCTYPE html><html><body>page</body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto poolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [poolConfig setProcessSwapsOnNavigation:YES];
+    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfig.get()]);
+
+    auto configA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configA setProcessPool:pool.get()];
+    enableIPCTestingAPI(configA.get());
+
+    auto webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configA.get()]);
+    [webViewA synchronouslyLoadRequest:server.request("/page"_s)];
+
+    // B shares A's process via _relatedWebView.
+    auto configB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configB setProcessPool:pool.get()];
+    configB.get()._relatedWebView = webViewA.get();
+    enableIPCTestingAPI(configB.get());
+
+    auto webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configB.get()]);
+    [webViewB synchronouslyLoadRequest:server.request("/page"_s)];
+
+    EXPECT_EQ([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    long long bPageID = [[webViewB stringByEvaluatingJavaScript:@"String(IPC.pageID)"] longLongValue];
+    EXPECT_GT(bPageID, 0LL);
+
+    // Using pushState on A, capture an `AddItem` IPC message for later use.
+    [webViewA stringByEvaluatingJavaScript:
+        @"(function() {"
+        "    var addName = null, updateName = null;"
+        "    var keys = Object.keys(IPC.messages);"
+        "    for (var i = 0; i < keys.length; i++) {"
+        "        if (keys[i].indexOf('BackForwardAddItem') !== -1 && keys[i].indexOf('InProcess') === -1)"
+        "            addName = IPC.messages[keys[i]].name;"
+        "        if (keys[i].indexOf('BackForwardUpdateItem') !== -1)"
+        "            updateName = IPC.messages[keys[i]].name;"
+        "    }"
+        "    window._updateItemMsgName = updateName;"
+        "    window._addBuf = null;"
+        "    IPC.addOutgoingMessageListener('UI', function(msg) {"
+        "        if (msg.name === addName && msg.buffer)"
+        "            window._addBuf = new Uint8Array(msg.buffer.slice(0));"
+        "    });"
+        "    history.pushState({}, '', '?pad=' + 'X'.repeat(40));"
+        "})()"
+    ];
+    int attempts = 0;
+    while (![[webViewA stringByEvaluatingJavaScript:@"window._addBuf ? 'ok' : ''"] isEqualToString:@"ok"] && ++attempts < 50)
+        TestWebKitAPI::Util::spinRunLoop(5);
+    EXPECT_LT(attempts, 50);
+
+    // Modify the captured buffer to carry a file:// URL, then send it as
+    // BackForwardUpdateItem to page B's destination ID. B's handler
+    // resolves A's item via the global itemForID map — the ownership
+    // check (item->pageID() vs B's identifier) must reject it.
+    NSString *attackJS = [NSString stringWithFormat:
+        @"(function() {"
+        "var HDR = 0x10;"
+        "var args = new Uint8Array(window._addBuf.buffer.slice(HDR));"
+        "var origURL = location.href;"
+        "var targetBase = 'file:///etc/passwd';"
+        "var padTarget = targetBase + '/'.repeat(Math.max(0, origURL.length - targetBase.length));"
+        "if (padTarget.length !== origURL.length) return 'FAIL:len_mismatch';"
+        "var oldBytes = new TextEncoder().encode(origURL);"
+        "var newBytes = new TextEncoder().encode(padTarget);"
+        "var count = 0;"
+        "for (var i = 0; i <= args.length - oldBytes.length; i++) {"
+        "    var match = true;"
+        "    for (var j = 0; j < oldBytes.length; j++) {"
+        "        if (args[i+j] !== oldBytes[j]) { match = false; break; }"
+        "    }"
+        "    if (match) {"
+        "        args.set(newBytes, i);"
+        "        count++;"
+        "        i += oldBytes.length - 1;"
+        "    }"
+        "}"
+        "if (!count) return 'FAIL:no_url_found';"
+        "IPC.sendMessage('UI', %lld, window._updateItemMsgName, args);"
+        "return 'sent:' + count;"
+        "})()", bPageID
+    ];
+    NSString *attackResult = [webViewA stringByEvaluatingJavaScript:attackJS];
+    EXPECT_TRUE([attackResult hasPrefix:@"sent:"]);
+
+    for (int i = 0; i < 100; i++)
+        TestWebKitAPI::Util::spinRunLoop();
+
+    WKBackForwardList *list = [webViewA backForwardList];
+    EXPECT_FALSE([list.currentItem.URL.absoluteString hasPrefix:@"file://"]);
+    for (WKBackForwardListItem *item in list.backList)
+        EXPECT_FALSE([item.URL.absoluteString hasPrefix:@"file://"]);
+}
+
+static constexpr auto forgedFileURLTestMainBytes = R"TESTRESOURCE(
+<!DOCTYPE html>
+<script src="coreipc.js"></script>
+<script>
+(async () => {
+    if (typeof IPC !== 'object') {
+        alert('FAIL: IPC testing API not available');
+        return;
+    }
+
+    // Patch the shared coreipc.js: parseMarkable returns a flat value when present,
+    // but serializeMarkable expects it wrapped in { optionalValue }. Make them agree
+    // for the duration of this test.
+    const origParseMarkable = ArgumentParser.parseMarkable;
+    ArgumentParser.parseMarkable = function (buffer, position, innerType) {
+        const [newPos, result] = origParseMarkable.call(this, buffer, position, innerType);
+        if (result && typeof result === 'object' && Object.keys(result).length > 0 && !Object.hasOwn(result, 'optionalValue'))
+            return [newPos, { optionalValue: result }];
+        return [newPos, result];
+    };
+
+    const CoreIPC = new CoreIPCClass();
+
+    // Fixups for FrameState round-tripping.
+    function fixTypeInfo(ti) {
+        for (const k in ti) {
+            const v = ti[k];
+            if (!Array.isArray(v)) continue;
+            for (const f of v) {
+                if (typeof f.type === 'string') {
+                    if (f.type.startsWith('HashSet<') && f.type.includes(', IntHash')) {
+                        const inner = f.type.slice('HashSet<'.length, -1).split(',')[0].trim();
+                        f.type = 'HashSet<' + inner + '>';
+                    }
+                    f.type = f.type.replace(/std::monostate/g, 'std::nullptr_t');
+                }
+                if (f.variantTypes)
+                    f.variantTypes = f.variantTypes.map(t => t === 'std::monostate' ? 'std::nullptr_t' : t);
+            }
+        }
+    }
+    fixTypeInfo(CoreIPC.typeInfo);
+    try { fixTypeInfo(IPC.serializedTypeInfo); } catch (e) {}
+
+    const origSerializeOptional = ArgumentSerializer.prototype.serializeOptional;
+    ArgumentSerializer.prototype.serializeOptional = function (t, a) { return origSerializeOptional.call(this, t, a ?? {}); };
+    const origSerializeMarkable = ArgumentSerializer.prototype.serializeMarkable;
+    ArgumentSerializer.prototype.serializeMarkable = function (t, a) { return origSerializeMarkable.call(this, t, a ?? {}); };
+
+    function fixNullVariants(o, depth = 0) {
+        if (depth > 100) return o;
+        if (o && typeof o === 'object') {
+            if (o.variantType === 'std::nullptr_t' && o.variant === 'null') o.variant = null;
+            for (const k in o) fixNullVariants(o[k], depth + 1);
+        }
+        return o;
+    }
+
+    // Capture a legitimate BackForwardAddItem IPC template via same-origin pushState.
+    let bfTemplate = null;
+    const BF_NAME = IPC.messages.WebBackForwardList_BackForwardAddItem.name;
+    const tap = new IPCWireTap('UI', 'Outgoing');
+    tap.tapAll((proc, dest, name, typed, parsed) => {
+        if (name === BF_NAME && !bfTemplate)
+            bfTemplate = parsed;
+    });
+    history.pushState({}, '', location.pathname + '?capture=1');
+    for (let i = 0; i < 40 && !bfTemplate; i++)
+        await new Promise(r => setTimeout(r, 25));
+    if (!bfTemplate) {
+        alert('FAIL: could not capture BackForwardAddItem template');
+        return;
+    }
+    fixNullVariants(bfTemplate);
+
+    // Our process identifier, extracted from the captured item's BackForwardItemIdentifier.
+    const myProcId = bfTemplate.navigatedFrameState.itemID.optionalValue.processIdentifier;
+
+    // Forge a BackForwardAddItem for a file:// URL this process has never visited.
+    const forgedItemID = { object: 0x5a5a5a5an, processIdentifier: myProcId };
+    const forgedFrameItemID = { object: 0x5b5b5b5bn, processIdentifier: myProcId };
+    const fs = bfTemplate.navigatedFrameState;
+    fs.urlString = 'file:///etc/forged-never-visited-by-this-process';
+    fs.originalURLString = fs.urlString;
+    fs.referrer = '';
+    fs.target = { string: '' };
+    fs.title = '';
+    fs.frameID = { optionalValue: BigInt(IPC.frameID) };
+    fs.itemID = { optionalValue: forgedItemID };
+    fs.frameItemID = { optionalValue: forgedFrameItemID };
+    fs.children = [];
+    fs.stateObjectData = {};
+    fs.httpBody = {};
+    fs.sessionStateObject = {};
+    fs.documentState = [];
+
+    CoreIPC.UI.WebBackForwardList.BackForwardAddItem(IPC.webPageProxyID, bfTemplate);
+
+    // Yield so the UI process can dispatch the (rejected) message.
+    await new Promise(r => setTimeout(r, 100));
+
+    // Synchronous probe: is the forged item in the back-forward list?
+    let wasAdded = null;
+    CoreIPC.UI.WebBackForwardList.BackForwardListContainsItem(IPC.webPageProxyID,
+        { itemID: forgedItemID },
+        (reply) => { wasAdded = reply.contains; });
+
+    if (wasAdded === false)
+        alert('PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK');
+    else
+        alert('FAIL: forged file:// back-forward item leaked into the list (wasAdded=' + wasAdded + ')');
+})().catch(e => alert('FAIL: ' + e + '\n' + (e && e.stack ? e.stack : '')));
+</script>
+)TESTRESOURCE"_s;
+
+TEST(WKBackForwardList, ForgedFileURLItemIsRejected)
+{
+    RetainPtr coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    RetainPtr coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL.get()];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { forgedFileURLTestMainBytes } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData.get() } },
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get()]);
+    [webView loadRequest:server.request("/"_s)];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK");
+}
+
+static constexpr auto messageCheckSpoofHTML = R"TESTRESOURCE(
+<!DOCTYPE html>
+<script src="coreipc.js"></script>
+<script>
+
+const origParseMarkable = ArgumentParser.parseMarkable;
+ArgumentParser.parseMarkable = function (buffer, position, innerType) {
+    const [newPos, result] = origParseMarkable.call(this, buffer, position, innerType);
+    if (result && typeof result === 'object' && Object.keys(result).length > 0 && !Object.hasOwn(result, 'optionalValue'))
+        return [newPos, { optionalValue: result }];
+    return [newPos, result];
+};
+
+const wiretap = new IPCWireTap('UI', 'Outgoing');
+
+let frameItemIDCounter = 100000n;
+
+window.spoofBackForwardSetChildItem = function(topURL, nestedChildURLs) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Timed out waiting for outgoing BackForwardAddItem')), 5000);
+
+        wiretap.tapNext(IPC.messages['WebBackForwardList_BackForwardAddItem'].name,
+            (process, connectionID, messageName, typedResult, result) => {
+                clearTimeout(timer);
+                try {
+                    if (!result) {
+                        reject(new Error('BackForwardAddItem result was undefined (parse likely failed; see WireTap console output)'));
+                        return;
+                    }
+
+                    const parentFrameItemID = result.navigatedFrameState && result.navigatedFrameState.frameItemID && result.navigatedFrameState.frameItemID.optionalValue;
+                    if (!parentFrameItemID || parentFrameItemID.object === undefined) {
+                        reject(new Error('navigatedFrameState.frameItemID was empty or missing fields; expected a present Markable from a real pushState'));
+                        return;
+                    }
+
+                    const fresh = () => ({
+                        object: ++frameItemIDCounter,
+                        processIdentifier: parentFrameItemID.processIdentifier
+                    });
+
+                    const makeFrameState = (urlString, children) => ({
+                        urlString: urlString,
+                        originalURLString: urlString,
+                        referrer: "",
+                        target: { string: "" },
+                        frameID: { },
+                        stateObjectData: { },
+                        documentSequenceNumber: 0n,
+                        itemSequenceNumber: 0n,
+                        navigationAPIKey: { },
+                        scrollPosition: { x: 0, y: 0 },
+                        shouldRestoreScrollPosition: false,
+                        pageScaleFactor: 0,
+                        httpBody: { },
+                        itemID: { },
+                        frameItemID: { optionalValue: fresh() },
+                        title: "",
+                        shouldOpenExternalURLsPolicy: 0,
+                        sessionStateObject: { },
+                        wasCreatedByJSWithoutUserInteraction: false,
+                        wasRestoredFromSession: false,
+                        policyContainer: { },
+                        children: children,
+                        documentState: []
+                    });
+
+                    // Build children[0] -> children[0] -> ... -> nestedChildURLs[N-1] chain.
+                    let chain = [];
+                    for (let i = nestedChildURLs.length - 1; i >= 0; --i)
+                        chain = [makeFrameState(nestedChildURLs[i], chain)];
+
+                    CoreIPC.UI.WebBackForwardList.BackForwardSetChildItem(IPC.pageID, {
+                        frameItemID: parentFrameItemID,
+                        frameState: makeFrameState(topURL, chain)
+                    });
+                    resolve();
+                } catch (e) {
+                    reject(new Error(`Tap callback failed: ${e && e.stack ? e.stack : e}`));
+                }
+            });
+
+        // Triggering a same-document pushState gets the WebContent process to send
+        // BackForwardAddItem out, which the wiretap above will intercept.
+        history.pushState(null, '', '#trigger-' + Math.random());
+    });
+};
+</script>
+)TESTRESOURCE"_s;
+
+static RetainPtr<NSString> runMessageCheckSpoof(NSString *topURL, NSArray<NSString *> *nestedChildURLs)
+{
+    RetainPtr coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    RetainPtr coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL.get()];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { messageCheckSpoofHTML } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData.get() } },
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(configuration.get());
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    __block bool spoofDone = false;
+    __block RetainPtr<NSError> spoofError;
+    NSDictionary *args = @{
+        @"topURL": topURL,
+        @"nested": nestedChildURLs,
+    };
+    [webView callAsyncJavaScript:@"return spoofBackForwardSetChildItem(topURL, nested);"
+        arguments:args
+        inFrame:nil
+        inContentWorld:WKContentWorld.pageWorld
+        completionHandler:^(id result, NSError *error) {
+            spoofError = error;
+            spoofDone = true;
+        }];
+    TestWebKitAPI::Util::run(&spoofDone);
+    if (spoofError)
+        NSLog(@"spoofBackForwardSetChildItem rejected: %@", spoofError.get());
+    EXPECT_NULL(spoofError.get());
+
+    // Let the spoofed BackForwardSetChildItem reach the UIProcess and get dispatched.
+    TestWebKitAPI::Util::spinRunLoop(30);
+    TestWebKitAPI::Util::runFor(0.05_s);
+
+    return [[webView backForwardList] _loggingStringForTesting];
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsNestedFileURLChild)
+{
+    NSString *fileURL = @"file:///Users/victim/Library/Cookies/Cookies.binarycookies";
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", @[ fileURL ]);
+    EXPECT_FALSE([logging containsString:fileURL]);
+    EXPECT_FALSE([logging containsString:@"file://"]);
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsDeeplyNestedFileURLChild)
+{
+    NSString *fileURL = @"file:///etc/passwd";
+    NSArray *nestedChain = @[
+        @"https://attacker.example/level1",
+        @"https://attacker.example/level2",
+        @"https://attacker.example/level3",
+        @"https://attacker.example/level4",
+        fileURL,
+    ];
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", nestedChain);
+    EXPECT_FALSE([logging containsString:fileURL]);
+    EXPECT_FALSE([logging containsString:@"file://"]);
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsExcessiveChildDepth)
+{
+    // Send a chain guaranteed to be deeper than the max frame depth to catch the message check.
+    static constexpr unsigned chainDepth = static_cast<unsigned>(WebCore::Page::maxFrameDepth) + 1;
+
+    RetainPtr nestedChain = adoptNS([[NSMutableArray alloc] initWithCapacity:chainDepth]);
+    for (unsigned i = 0; i < chainDepth; ++i)
+        [nestedChain addObject:[NSString stringWithFormat:@"https://attacker.example/depth-%u", i]];
+
+    NSString *probeURL = [nestedChain lastObject];
+
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", nestedChain.get());
+    EXPECT_FALSE([logging containsString:probeURL]);
+}
+
+TEST(WKBackForwardList, MessageCheckAcceptsBenignNestedChildren)
+{
+    NSString *innerURL = @"https://example.com/inner";
+    NSArray *nestedChain = @[
+        @"https://example.com/middle",
+        innerURL,
+    ];
+    RetainPtr logging = runMessageCheckSpoof(@"https://example.com/outer", nestedChain);
+    EXPECT_TRUE([logging containsString:innerURL]);
+    EXPECT_TRUE([logging containsString:@"https://example.com/outer"]);
+    EXPECT_TRUE([logging containsString:@"https://example.com/middle"]);
+}
+
+#endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### 7f183f2619480cc54dd1c430229ea6a6edfd9170
<pre>
Incomplete fix of WebKit bug 315528 (Message check file urls in back/forward list messages)
<a href="https://rdar.apple.com/177953315">rdar://177953315</a>

Reviewed by Chris Dumez.

Apply the message check to sub-items in the history item tree, and other validations of the tree.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::messageCheckItemURLs):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
((WKBackForwardList, MessageCheckRejectsNestedFileURLChild)):
((WKBackForwardList, MessageCheckRejectsDeeplyNestedFileURLChild)):
((WKBackForwardList, MessageCheckRejectsExcessiveChildDepth)):
((WKBackForwardList, MessageCheckAcceptsBenignNestedChildren)):

Originally-landed-as: 305413.993@safari-7624.5-branch (ce08c270d322). <a href="https://rdar.apple.com/185366596">rdar://185366596</a>
Canonical link: <a href="https://commits.webkit.org/320667@main">https://commits.webkit.org/320667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9acb239b1353ec9d1e4eb90b09563aadfebb693b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185562 "78 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195881 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48687 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47414 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45160 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6934 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59134 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59843 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154192 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48658 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129093 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->