### PR TITLE
Spin buttons for input type="number" do not repaint when window active state changes

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode-expected-mismatch.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark" />
+    </head>
+    <body>
+        <input type="number">
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark" />
+    </head>
+    <body>
+        <input type="number">
+    </body>
+    <script>
+        if (window.testRunner) {
+            window.testRunner.dontForceRepaint();
+            window.testRunner.setWindowIsKey(false);
+        }
+    </script>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode-expected-mismatch.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="light" />
+    </head>
+    <body>
+        <input type="number">
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="light" />
+    </head>
+    <body>
+        <input type="number">
+    </body>
+    <script>
+        if (window.testRunner) {
+            window.testRunner.dontForceRepaint();
+            window.testRunner.setWindowIsKey(false);
+        }
+    </script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8151,6 +8151,8 @@ fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
 fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html [ Skip ]
 fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html [ Skip ]
+fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html [ Skip ]
+fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html [ Skip ]
 
 # rdar://155348715 (REGRESSION (Liquid Glass): [ iOS 26 ] 72 WPT/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-*.html tests are constantly failing (IMAGE).)
 # Explicit pass expectations for many of these tests are set above. Uncomment that block once this is resolved.

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -185,6 +185,8 @@ fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
 fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html [ Skip ]
 fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html [ Skip ]
+fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html [ Skip ]
+fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html [ Skip ]
 
 # webkit.org/b/300929 REGRESSION(297559@main): interaction-region/form-control-refresh/date-native-interaction-region.html does not pass on visionOS
 interaction-region/form-control-refresh/date-native-interaction-region.html [ Failure ]

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1469,6 +1469,7 @@ bool RenderThemeCocoa::controlSupportsTints(const RenderElement& box) const
     case StyleAppearance::Checkbox:
     case StyleAppearance::Radio:
         return isChecked(box) || isIndeterminate(box);
+    case StyleAppearance::InnerSpinButton:
     case StyleAppearance::ListButton:
     case StyleAppearance::ProgressBar:
     case StyleAppearance::SliderHorizontal:


### PR DESCRIPTION
#### 729c8c6ccb67f59c290dab45953c2b53eb603b34
<pre>
Spin buttons for input type=&quot;number&quot; do not repaint when window active state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322353">https://bugs.webkit.org/show_bug.cgi?id=322353</a>
<a href="https://rdar.apple.com/185625389">rdar://185625389</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Update `RenderThemeCocoa::controlSupportsTints` to return true for
spin buttons, thus causing them to be repainted when the window active
state changes.

Tests: fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html
       fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html

* LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/spinbutton-window-inactive-state-light-mode.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::controlSupportsTints const):

Canonical link: <a href="https://commits.webkit.org/319683@main">https://commits.webkit.org/319683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee807960f851886e17d284b66af8557c7d9886bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146618 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0e06fba-2639-4fef-9f2d-5b6a8ef982c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142290 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e7f7965-f088-48bf-9896-c850db0bea24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45997 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163046 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122723 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46f0a91c-d14f-4bb3-81e0-fd4bc7a1dbb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42949 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42571 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3680 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194445 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151716 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40656 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56598 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151417 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46002 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128882 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124805 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55109 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17570 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->