### PR TITLE
int truncation of OBU size in RtpPacketizerAv1::ParseObus

### DIFF
--- a/LayoutTests/webrtc/script-transform-av1-large-obu-crash-expected.txt
+++ b/LayoutTests/webrtc/script-transform-av1-large-obu-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RtpPacketizerAv1 should reject an encoded frame whose OBU payload size overflows int
+

--- a/LayoutTests/webrtc/script-transform-av1-large-obu-crash-worker.js
+++ b/LayoutTests/webrtc/script-transform-av1-large-obu-crash-worker.js
@@ -1,0 +1,42 @@
+onrtctransform = event => {
+    const reader = event.transformer.readable.getReader();
+    const writer = event.transformer.writable.getWriter();
+    let fired = false;
+    function pump() {
+        reader.read().then(({ value, done }) => {
+            if (done)
+                return;
+            if (!fired) {
+                fired = true;
+                try {
+                    // Three OBUs: sizes 10 / (1 + 0xFFFFFFDB -> int -36) / 20.
+                    const obu1Payload = 0xFFFFFFDB;
+                    const total = 0x100000000;
+                    const bytes = new Uint8Array(total);
+                    let off = 0;
+                    bytes[off++] = 0x32;
+                    bytes[off++] = 0x09;
+                    for (let i = 0; i < 9; ++i)
+                        bytes[off++] = 0xAA;
+                    bytes[off++] = 0x32;
+                    bytes[off++] = 0xDB;
+                    bytes[off++] = 0xFF;
+                    bytes[off++] = 0xFF;
+                    bytes[off++] = 0xFF;
+                    bytes[off++] = 0x0F;
+                    off += obu1Payload;
+                    bytes[off++] = 0x30;
+                    for (let i = 0; i < 19; ++i)
+                        bytes[off++] = 0xBB;
+                    value.data = bytes.buffer;
+                } catch (e) {
+                }
+                writer.write(value);
+                self.postMessage("wrote");
+            } else
+                writer.write(value);
+            pump();
+        });
+    }
+    pump();
+};

--- a/LayoutTests/webrtc/script-transform-av1-large-obu-crash.html
+++ b/LayoutTests/webrtc/script-transform-av1-large-obu-crash.html
@@ -1,0 +1,47 @@
+<!doctype html><!-- webkit-test-runner [ WebRTCAV1CodecEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="64" height="64"></canvas>
+<script>
+promise_test(async (test) => {
+    const av1Codecs = RTCRtpSender.getCapabilities("video").codecs.filter(c => /AV1/i.test(c.mimeType));
+    if (!av1Codecs.length)
+        return;
+
+    const context = canvas.getContext("2d");
+    let hue = 0;
+    (function draw() {
+        context.fillStyle = "hsl(" + (hue++ % 360) + ",100%,50%)";
+        context.fillRect(0, 0, 64, 64);
+        requestAnimationFrame(draw);
+    })();
+    const stream = canvas.captureStream(30);
+
+    const worker = new Worker("script-transform-av1-large-obu-crash-worker.js");
+    const wrote = new Promise(resolve => worker.onmessage = e => { if (e.data === "wrote") resolve(); });
+
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+    test.add_cleanup(() => { pc1.close(); pc2.close(); });
+    pc1.onicecandidate = e => e.candidate && pc2.addIceCandidate(e.candidate);
+    pc2.onicecandidate = e => e.candidate && pc1.addIceCandidate(e.candidate);
+
+    const sender = pc1.addTrack(stream.getVideoTracks()[0], stream);
+    pc1.getTransceivers()[0].setCodecPreferences(av1Codecs);
+    sender.transform = new RTCRtpScriptTransform(worker, { side: "sender" });
+
+    await pc1.setLocalDescription();
+    await pc2.setRemoteDescription(pc1.localDescription);
+    await pc2.setLocalDescription();
+    await pc1.setRemoteDescription(pc2.localDescription);
+
+    await wrote;
+    await new Promise(resolve => test.step_timeout(resolve, 500));
+}, "RtpPacketizerAv1 should reject an encoded frame whose OBU payload size overflows int");
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
@@ -16,6 +16,10 @@
 #include <span>
 #include <vector>
 
+#if WEBRTC_WEBKIT_BUILD
+#include <limits>
+#endif
+
 #include "api/video/video_frame_type.h"
 #include "modules/rtp_rtcp/source/leb128.h"
 #include "modules/rtp_rtcp/source/rtp_format.h"
@@ -115,6 +119,14 @@ std::vector<RtpPacketizerAv1::Obu> RtpPacketizerAv1::ParseObus(
           reinterpret_cast<const uint8_t*>(payload_reader.Data()), size);
       payload_reader.Consume(size);
     }
+#if WEBRTC_WEBKIT_BUILD
+    if (obu.payload.size() > static_cast<size_t>(std::numeric_limits<int>::max() - obu.size)) {
+      RTC_DLOG(LS_ERROR) << "Malformed AV1 input: OBU payload size "
+                         << obu.payload.size()
+                         << " exceeds maximum supported size";
+      return {};
+    }
+#endif
     obu.size += obu.payload.size();
     // Skip obus that shouldn't be transfered over rtp.
     int obu_type = ObuType(obu.header);


### PR DESCRIPTION
#### d7c8ef5a571492a339b90378a27432e4010f10c8
<pre>
int truncation of OBU size in RtpPacketizerAv1::ParseObus
<a href="https://rdar.apple.com/177214855">rdar://177214855</a>

Reviewed by Eric Carlson.

Obu::size and Packet::packet_size are signed 32-bit while OBU payload lengths are size_t.
ParseObus adds obu.payload.size() into obu.size, which wraps negative for an OBU &gt;= 2 GiB.
PacketizeInternal then accepts the negative size as fitting into a single packet and computes a small packet_size,
but NextPacket allocates the RTP buffer from that truncated value and memcpy() the untruncated size_t payload, writing past the CopyOnWriteBuffer.

This is reachable via a RTCRtpScriptTransform creating a big AV1 data buffer.

The fix is to reject the frame in ParseObus when an OBU payload would overflow Obu::size, matching the existing handling for other malformed inputs.

Patch written with Simon Lewis.

Test: webrtc/script-transform-av1-large-obu-crash.html

* LayoutTests/webrtc/script-transform-av1-large-obu-crash-expected.txt: Added.
* LayoutTests/webrtc/script-transform-av1-large-obu-crash-worker.js: Added.
(onrtctransform.event.pump):
* LayoutTests/webrtc/script-transform-av1-large-obu-crash.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_packetizer_av1.cc:

Originally-landed-as: 305413.1000@safari-7624.5-branch (ffec8ee666a1). <a href="https://rdar.apple.com/185368538">rdar://185368538</a>
Canonical link: <a href="https://commits.webkit.org/319877@main">https://commits.webkit.org/319877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb8eccc612a06e6192805d669c44100d41f37adb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147349 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45300 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43177 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4452 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40819 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57358 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152049 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46612 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125764 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55866 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18188 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55474 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->