### PR TITLE
Cherry-pick(s) bd4c91c57d10. rdar://185369399

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -108,6 +108,8 @@ media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Skip ]
 media/media-source/media-source-append-play-corrupt-aac.html [ Skip ]
 media/media-source/media-source-mp4ttsimple.html [ Skip ]
 media/media-source/media-source-inband-cea608-track.html [ Skip ]
+# WebM generator not present in safari-7624.5-branch branch.
+media/media-source/media-source-webm-reversed-timestamps-crash.html [ Failure ]
 media/modern-media-controls/ios-inline-media-controls/touch [ Skip ]
 media/modern-media-controls/overflow-support [ Skip ]
 media/modern-media-controls/visionos-inline-media-controls [ Skip ]

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
@@ -1,0 +1,11 @@
+Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(sourceBuffer.abort())
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-webm-reversed-timestamps-crash</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // A WebM SimpleBlock cluster whose block timestamps go backward causes the
+    // WebM parser to compute a negative sample duration. When appended after
+    // abort() (which resets the track buffer's highest presentation timestamp
+    // while preserving its samples), Coded Frame Processing step 1.14 calls
+    // findSamplesBetweenPresentationTimes() with endTime < beginTime; the
+    // resulting reversed iterator range walks past the end of the sample map.
+    // This test passes if it does not crash.
+
+    var source;
+    var sourceBuffer;
+    var initData;
+
+    function simpleBlockCluster(trackNumber, clusterTimecode, blocks)
+    {
+        // Hand-roll a Cluster of SimpleBlocks (no BlockDuration), so the
+        // parser must derive each sample's duration from the gap to the
+        // next block's timestamp.
+        function vintSize(n)
+        {
+            if (n < 0x7F)
+                return new Uint8Array([0x80 | n]);
+            return new Uint8Array([0x40 | (n >> 8), n & 0xFF]);
+        }
+        var body = [new Uint8Array([0xE7, 0x81, clusterTimecode & 0xFF])];
+        for (var block of blocks) {
+            var ts = new Uint8Array(2);
+            new DataView(ts.buffer).setInt16(0, block.timestamp, false);
+            var payload = WebM.concat(new Uint8Array([0x80 | trackNumber]), ts,
+                new Uint8Array([block.isSync ? 0x80 : 0x00]), block.data);
+            body.push(new Uint8Array([0xA3]), vintSize(payload.byteLength), payload);
+        }
+        var clusterBody = WebM.concat(...body);
+        return WebM.concat(new Uint8Array([0x1F, 0x43, 0xB6, 0x75]),
+            vintSize(clusterBody.byteLength), clusterBody);
+    }
+
+    async function runTest()
+    {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        initData = WebM.initSegment({ tracks: [{ id: 1, type: 'video', defaultDuration: 0 }] });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        var samples = [{ duration: 50, isSync: true }];
+        for (var i = 0; i < 7; ++i)
+            samples.push({ duration: 50, isSync: false });
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: samples }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.abort()');
+
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        sourceBuffer.appendBuffer(simpleBlockCluster(1, 0, [
+            { timestamp: 200, isSync: true, data: new Uint8Array([0x30, 0x12, 0x00, 0x9D, 0x01, 0x2A, 0x40, 0x01, 0xF0, 0x00, 0x00]) },
+            { timestamp: 10, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+            { timestamp: 250, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+        ]));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+    }
+
+    window.addEventListener('load', () => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.</div>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -326,7 +326,10 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 {
     if (endTime <= beginTime)
         return { end(), end() };
+<<<<<<< HEAD
 
+=======
+>>>>>>> bd4c91c57d10 (Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.)
     // startTime is inclusive, so use lower_bound to include samples wich start exactly at startTime.
     // endTime is not inclusive, so use lower_bound to exclude samples which start exactly at endTime.
     auto lower_bound = m_samples.lower_bound(beginTime);
@@ -340,7 +343,10 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 {
     if (endTime <= beginTime)
         return { end(), end() };
+<<<<<<< HEAD
 
+=======
+>>>>>>> bd4c91c57d10 (Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.)
     reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
     });

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1202,11 +1202,25 @@ void WebMParser::VideoTrackData::processPendingMediaSamples(const MediaTime& pre
     if (!m_pendingMediaSamples.size())
         return;
     auto& lastSample = m_pendingMediaSamples.last();
+<<<<<<< HEAD
     // The queued sample may come from an earlier cluster, which need not precede this one in time;
     // a frame starting before it can't close it, so leave it queued, as is done for frames sharing
     // a presentation time.
     if (presentationTime < lastSample.presentationTime)
         return;
+=======
+    // The WebM container does not encode per-frame durations; we derive them
+    // from the gap to the next frame's presentation time. A malformed cluster
+    // whose block timestamps decrease would yield a negative duration here,
+    // which propagates to SourceBufferPrivate::processMediaSample() as
+    // frameEndTimestamp < presentationTimestamp. Treat any non-increasing
+    // timestamp the same as the existing equal-timestamp case below: leave the
+    // pending sample queued (with zero duration) until a later frame arrives.
+    if (presentationTime < lastSample.presentationTime) {
+        lastSample.duration = MediaTime::zeroTime();
+        return;
+    }
+>>>>>>> bd4c91c57d10 (Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.)
     lastSample.duration = presentationTime - lastSample.presentationTime;
     if (presentationTime == lastSample.presentationTime)
         return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -232,12 +232,16 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
+<<<<<<< HEAD
     // An inverted range must not produce a pair whose first iterator follows its second.
     iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(20, 1), MediaTime(5, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
     iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(10, 1), MediaTime(10, 1));
+=======
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(5, 1), MediaTime(2, 1));
+>>>>>>> bd4c91c57d10 (Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
@@ -278,11 +282,15 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
+<<<<<<< HEAD
     iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(20, 1), MediaTime(5, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
     iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(10, 1), MediaTime(10, 1));
+=======
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(5, 1), MediaTime(2, 1));
+>>>>>>> bd4c91c57d10 (Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185369399 to main. [bd4c91c57d10] caused a merge conflict. 

```
Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.
rdar://177494050

Reviewed by Eric Carlson.

We guard against non-monotonically increasing presentation timestamps in SourceBufferParserWebM
and SampleMap

Tests: media/media-source/media-source-webm-reversed-timestamps-crash.html
       Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp

* LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt: Added.
* LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html: Added.
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimes):
(WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::VideoTrackData::processPendingMediaSamples):
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)):

Originally-landed-as: 305413.1082@safari-7624.5-branch (bd4c91c57d10). rdar://185369399


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/908315a65e34cb97445cb6686a288ae48b02ff6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182295 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56242 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192528 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146624 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184157 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57558 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55965 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192528 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/146624 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185250 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57558 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192528 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57558 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/55965 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192528 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57558 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3686 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48873 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/55965 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194451 "Build is in progress. Recent messages:Printed configuration; Running checkout-pull-request") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55913 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194451 "Build is in progress. Recent messages:Printed configuration; Running checkout-pull-request") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56604 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194451 "Build is in progress. Recent messages:Printed configuration; Running checkout-pull-request") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56604 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128888 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124814 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55115 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50048 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54496 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54735 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54563 "") | | | 
<!--EWS-Status-Bubble-End-->