### PR TITLE
[Wasm] Exclude wasmBoundsCheckingSizeRegister from the callee saves restored

### DIFF
--- a/JSTests/wasm/stress/tail-call-unused-pins.js
+++ b/JSTests/wasm/stress/tail-call-unused-pins.js
@@ -1,0 +1,50 @@
+//@ requireOptions("--useWasmFastMemory=true")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const watA = `
+(module
+    (type $sig (func (param i32 i64)))
+    (import "e" "mem" (memory 1 1))
+    (import "e" "nop" (func $nop))
+    (table (export "tbl") 1 1 funcref)
+    (func (export "f") (param $do_call i32) (param $off i32) (param $val i64)
+        (call $nop)
+        (if (local.get $do_call)
+            (then (return_call_indirect (type $sig)
+                    (local.get $off) (local.get $val) (i32.const 0))))))
+`;
+
+const watB = `
+(module
+    (import "e" "mem" (memory 1 1))
+    (func (export "g") (param $off i32) (param $val i64)
+        (i64.store (local.get $off) (local.get $val))))
+`;
+
+async function test() {
+    const memA = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "Signaling");
+    const memB = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "BoundsChecking");
+    assert.eq(WebAssemblyMemoryMode(memA), "Signaling");
+    assert.eq(WebAssemblyMemoryMode(memB), "BoundsChecking");
+
+    const instA = await instantiate(watA, { e: { mem: memA, nop: () => {} } }, { tail_call: true });
+    const { f, tbl } = instA.exports;
+
+    const instB = await instantiate(watB, { e: { mem: memB } });
+    const { g } = instB.exports;
+
+    assert.throws(() => g(0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    // Tier g into BBQ. IPInt's prologue reloads regCS4 on entry but BBQ does not.
+    for (let i = 0; i < wasmTestLoopCount; ++i) g(0, 0n);
+
+    // Tier f to OMG without ever taking the tail-call branch.
+    for (let i = 0; i < wasmTestLoopCount; ++i) f(0, 0, 0n);
+
+    tbl.set(0, g);
+
+    assert.throws(() => f(1, 0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1328,6 +1328,9 @@ OMGIRGenerator::OMGIRGenerator(AbstractHeapRepository& heaps, CompilationContext
 
     m_proc.pinRegister(GPRInfo::wasmContextInstancePointer);
     m_proc.pinRegister(GPRInfo::wasmBaseMemoryPointer);
+    // FIXME: The wasm ABI effectively has to assume this is a caller save when getting
+    // called by wasm, so there's no point in saving and restoring it if B3 chooses to
+    // use it. We actively don't restore this register in many cases anyway e.g. tail calls.
     if (mode == MemoryMode::BoundsChecking)
         m_proc.pinRegister(GPRInfo::wasmBoundsCheckingSizeRegister);
 
@@ -5841,6 +5844,11 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     entries.reserveInitialCapacity(calleeSaves.registerCount() + functionSignature.argumentCount() + 1);
 
     for (const auto& regAtOffset : calleeSaves) {
+        // Don't restore wasmBoundsCheckingSizeRegister since we may have set it when checking for
+        // a cross-instance call. It's not a normal callee save independent of whether we used
+        // it or not.
+        if (regAtOffset.reg() == GPRInfo::wasmBoundsCheckingSizeRegister)
+            continue;
         ShuffleEntry entry;
         entry.src = ShuffleLocation::fromStack(fpOffsetToSPOffset(regAtOffset.offset()));
         if (regAtOffset.reg().isGPR()) {


### PR DESCRIPTION
#### 929f6e81e0e0881cde4edc161df05074f32541b5
<pre>
[Wasm] Exclude wasmBoundsCheckingSizeRegister from the callee saves restored
<a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>
<a href="https://rdar.apple.com/177693309">rdar://177693309</a>

Reviewed by Yijia Huang.

GPRInfo::wasmBoundsCheckingSizeRegister (callee save) is only pinned in B3 when
the OMG callee is compiled for MemoryMode::BoundsChecking. In Signaling mode
it stays in B3/Air&apos;s mutable register set, and createTailCallPatchpoint
declares the full callee-save set as clobberEarly so that B3 does not place
an input there before the tail-call&apos;s parallel move runs. That clobberEarly
causes AirHandleCalleeSaves to include regCS4 in the function&apos;s
calleeSaveRegisterAtOffsetList(). The OMG prologue saves
wasmBoundsCheckingSizeRegister to the callee save list and when making a
tail call that callee save is restored after the callee&apos;s memory bounds
are set.

The wasm ABI already treats the pinned registers as effectively caller-save
across wasm-to-wasm calls. Tail calls do not restore them either. Restoring
wasmBoundsCheckingSizeRegister to the prologue-saved caller value in
prepareForTailCallImpl is therefore unnecessary.

This patch teaches emitRestoreCalleeSavesFor to take a dontRestoreRegisters
set and uses it from prepareForTailCallImpl to skip
wasmBoundsCheckingSizeRegister. I also added a FIXME at the pinRegister
site noting that wasmBoundsCheckingSizeRegister is effectively caller-save
in the wasm ABI.

Originally-landed-as: 305413.1027@safari-7624.5-branch (654718255548). <a href="https://rdar.apple.com/185368944">rdar://185368944</a>
Canonical link: <a href="https://commits.webkit.org/320061@main">https://commits.webkit.org/320061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77259449fd8b3b65192d5be128c3995354a67f6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147910 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143308 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99505 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45778 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44008 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5700 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12535 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43592 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5019 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44895 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57213 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57917 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152526 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47075 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130196 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126508 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56425 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18602 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->