### PR TITLE
[Wasm] Argument and Result block types should always widen

### DIFF
--- a/JSTests/wasm/stress/block-param-type-widening.js
+++ b/JSTests/wasm/stress/block-param-type-widening.js
@@ -1,0 +1,72 @@
+import * as assert from "../assert.js";
+
+// When a block/if/try/try_table declares a parameter type that is a *supertype*
+// of the value actually on the stack, the block body must be validated against
+// the DECLARED type, not the narrower concrete type that flowed in
+// Each case below is built twice with an identical body:
+//   - declared type = anyref (wide): `struct.get 0 0` is invalid on anyref, so
+//     the module must be REJECTED. Before widening, the body saw the concrete
+//     `(ref null 0)` and this was (incorrectly) accepted.
+//   - declared type = (ref null 0) (concrete): `struct.get 0 0` is valid, so the
+//     module must VALIDATE. This control confirms the scaffolding is otherwise
+//     well-formed, so the rejection above is due to widening alone.
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+// Module layout:
+//   type 0: struct { i64 mut }
+//   type 1: <blockSig>       (the signature of the block under test)
+//   type 2: func () -> i64   (the exported function "test")
+function buildModule(blockSig, body0) {
+    const typeSection = section(1, [
+        0x03,
+        0x5F, 0x01, 0x7E, 0x01,          // type 0: struct { i64 mut }
+        ...blockSig,                     // type 1
+        0x60, 0x00, 0x01, 0x7E,          // type 2: () -> i64
+    ]);
+    const funcSection = section(3, [0x01, 0x02]);                               // func 0 : type 2
+    const exportSection = section(7, [0x01, ...encodeString("test"), 0x00, 0x00]); // export "test" func 0
+    const codeSection = section(10, [0x01, ...uleb128(body0.length), ...body0]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const sigParam = (t) => [0x60, 0x01, ...t, 0x01, 0x7E]; // (t) -> (i64)
+const ANYREF = [0x6E];
+const REF_NULL_0 = [0x63, 0x00]; // (ref null 0)
+
+const GET = [0xFB, 0x02, 0x00, 0x00]; // struct.get 0 0
+const REF_NULL_TYPE0 = [0xD0, 0x00];  // ref.null 0  -> (ref null 0)
+
+// name -> { sig: (refTypeBytes) -> typeEntry, body }
+const cases = {
+    // (block (param T) (result i64) (struct.get 0 0))
+    "block param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x02, 0x01, ...GET, 0x0B, 0x0B],
+    },
+    // (if (param T) (result i64) (then struct.get 0 0) (else drop i64.const 0))
+    "if param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x41, 0x01, 0x04, 0x01, ...GET, 0x05, 0x1A, 0x42, 0x00, 0x0B, 0x0B],
+    },
+    // (try (param T) (result i64) (do struct.get 0 0) (catch_all i64.const 0))
+    "try param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x06, 0x01, ...GET, 0x19, 0x42, 0x00, 0x0B, 0x0B],
+    },
+    // (try_table (param T) (result i64) (struct.get 0 0))   -- 0 catch clauses
+    "try_table param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x1F, 0x01, 0x00, ...GET, 0x0B, 0x0B],
+    },
+};
+
+for (const [name, { sig, body }] of Object.entries(cases)) {
+    assert.falsy(WebAssembly.validate(buildModule(sig(ANYREF), body)),
+        `${name}: struct.get on a widened anyref must be rejected (declared type not the concrete incoming type)`);
+    assert.truthy(WebAssembly.validate(buildModule(sig(REF_NULL_0), body)),
+        `${name}: struct.get on the concrete (ref null 0) must validate`);
+}

--- a/JSTests/wasm/stress/loop-param-type-widening.js
+++ b/JSTests/wasm/stress/loop-param-type-widening.js
@@ -1,0 +1,138 @@
+function uleb128(n) {
+    const r = [];
+    do {
+        let b = n & 0x7f;
+        n >>>= 7;
+        if (n) b |= 0x80;
+        r.push(b);
+    } while (n);
+    return r;
+}
+function encodeString(s) {
+    const b = [];
+    for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i));
+    return [...uleb128(b.length), ...b];
+}
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+// --- Part 1 ---------------------------------------------------------------
+// A loop declaring `(param anyref)` entered with a `(ref $0)` on the stack must
+// typecheck its body against `anyref`, so `struct.get 0 0` at the top of the body
+// is a validation error. Previously the body was typechecked against the narrower
+// `(ref $0)` and the module was (unsoundly) accepted.
+{
+    // Type 0: struct { i64 mut }
+    // Type 1: func (anyref) -> (i64)           — loop block signature
+    // Type 2: func (i32, externref, ref 0) -> (i64)
+    // Type 3: func () -> (ref 0)
+    const typeSection = section(1, [
+        0x04,
+        0x5F, 0x01, 0x7E, 0x01,
+        0x60, 0x01, 0x6E, 0x01, 0x7E,
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E,
+        0x60, 0x00, 0x01, 0x64, 0x00,
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [
+        0x02,
+        ...encodeString("f"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01,
+    ]);
+    const body0 = [
+        0x01, 0x01, 0x7E,       // 1 local: i64
+        0x20, 0x02,             // local.get 2 (ref $0)
+        0x03, 0x01,             // loop (type 1)  — param anyref
+        0xFB, 0x02, 0x00, 0x00, //   struct.get 0 0    <-- must fail: anyref !<: (ref null $0)
+        0x21, 0x03,             //   local.set 3
+        0x20, 0x01,             //   local.get 1 (externref)
+        0xFB, 0x1A,             //   any.convert_extern
+        0x20, 0x00,             //   local.get 0
+        0x0D, 0x00,             //   br_if 0
+        0x1A,                   //   drop
+        0x20, 0x03,             //   local.get 3
+        0x0B,                   // end loop
+        0x0B,                   // end func
+    ];
+    const body1 = [0x00, 0x42, 0x00, 0xFB, 0x00, 0x00, 0x0B]; // i64.const 0; struct.new 0
+    const codeSection = section(10, [
+        0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1,
+    ]);
+    const bin = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection,
+    ]);
+
+    if (WebAssembly.validate(bin))
+        throw new Error("Part 1: module with struct.get on anyref loop param must not validate");
+}
+
+// --- Part 2 ---------------------------------------------------------------
+// A loop declaring `(param (ref null $0))` entered with a non-null `(ref $0)` is
+// valid, but the body must be compiled against the nullable type: struct.get must
+// emit its null check so a null delivered on the back-edge traps cleanly.
+{
+    // Type 0: struct { i64 mut }
+    // Type 1: func (ref null 0) -> (i64)       — loop block signature
+    // Type 2: func (i32, ref 0) -> (i64)
+    // Type 3: func () -> (ref 0)
+    const typeSection = section(1, [
+        0x04,
+        0x5F, 0x01, 0x7E, 0x01,
+        0x60, 0x01, 0x63, 0x00, 0x01, 0x7E,
+        0x60, 0x02, 0x7F, 0x64, 0x00, 0x01, 0x7E,
+        0x60, 0x00, 0x01, 0x64, 0x00,
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [
+        0x02,
+        ...encodeString("f"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01,
+    ]);
+    const body0 = [
+        0x01, 0x01, 0x7E,       // 1 local: i64
+        0x20, 0x01,             // local.get 1 (ref $0, non-null)
+        0x03, 0x01,             // loop (type 1)  — param (ref null $0)
+        0xFB, 0x02, 0x00, 0x00, //   struct.get 0 0    <-- must keep null check
+        0x21, 0x02,             //   local.set 2
+        0xD0, 0x71,             //   ref.null none
+        0x20, 0x00,             //   local.get 0
+        0x0D, 0x00,             //   br_if 0        <-- back-edge with null
+        0x1A,                   //   drop
+        0x20, 0x02,             //   local.get 2
+        0x0B,                   // end loop
+        0x0B,                   // end func
+    ];
+    const body1 = [0x00, 0x42, 0x2A, 0xFB, 0x00, 0x00, 0x0B]; // i64.const 42; struct.new 0
+    const codeSection = section(10, [
+        0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1,
+    ]);
+    const bin = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection,
+    ]);
+
+    if (!WebAssembly.validate(bin))
+        throw new Error("Part 2: module must validate");
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(bin));
+    const s = inst.exports.make();
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        if (inst.exports.f(0, s) !== 42n)
+            throw new Error("Part 2: expected 42");
+    }
+
+    let trapped = false;
+    try {
+        inst.exports.f(1, s);
+    } catch (e) {
+        if (!(e instanceof WebAssembly.RuntimeError))
+            throw new Error("Part 2: expected WebAssembly.RuntimeError, got " + e);
+        trapped = true;
+    }
+    if (!trapped)
+        throw new Error("Part 2: expected null-dereference trap on back-edge");
+}

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -247,13 +247,8 @@ private:
     [[nodiscard]] PartialResult parseUnreachableExpression();
     [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
     [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
-
-    enum FallThroughStateTag {
-        NewSiblingBlock,
-        MergePoint,
-    };
-
-    [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
+    [[nodiscard]] PartialResult checkArgumentsAndWiden(const BlockSignature&);
+    [[nodiscard]] PartialResult checkResultsAndWiden(const BlockSignature&);
     [[nodiscard]] PartialResult endBlockAndCheckResultTypes(ControlEntry&);
 
     enum BranchConditionalityTag {
@@ -659,12 +654,9 @@ auto FunctionParser<Context>::binaryCompareCase(OpType op, BinaryOperationHandle
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
             const uint32_t argumentCount = inlineSignature.argumentCount();
-            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
             const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-            for (unsigned i = 0; i < argumentCount; ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
             auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
@@ -729,12 +721,9 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
             const uint32_t argumentCount = inlineSignature.argumentCount();
-            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
             const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-            for (unsigned i = 0; i < argumentCount; ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
             auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
@@ -1907,21 +1896,40 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
 }
 
 template<typename Context>
-auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlData, FallThroughStateTag fallthrough) -> PartialResult
+auto FunctionParser<Context>::checkArgumentsAndWiden(const BlockSignature& blockSignature) -> PartialResult
 {
-    const auto& blockSignature = controlData.signature();
+    const uint32_t argumentCount = blockSignature.argumentCount();
+    const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+    WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects "_s, argumentCount, ", but only "_s, sliceSize, " were present. Block has signature: "_s, blockSignature);
+    const uint32_t offset = m_expressionStack.size() - argumentCount;
+    for (unsigned i = 0; i < argumentCount; ++i) {
+        auto& slot = m_expressionStack[offset + i];
+        const auto expectedType = blockSignature.argumentType(i);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(slot.type(), expectedType), "Block expects the argument at index "_s, i, " to be "_s, expectedType, " but argument has type "_s, slot.type());
+        // Widen the operand to the block's declared parameter type, per the spec's
+        // push_ctrl(op, in, out) doing push_vals(in): the block body must be validated
+        // against its declared parameter types, not the narrower subtype that flowed in.
+        // https://webassembly.github.io/spec/core/bikeshed/#validation-of-opcode-sequences
+        slot.setType(expectedType);
+    }
+
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::checkResultsAndWiden(const BlockSignature& blockSignature) -> PartialResult
+{
     const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
     WASM_VALIDATOR_FAIL_IF(blockSignature.returnCount() != sliceSize, " block with type: "_s, blockSignature, " returns: "_s, blockSignature.returnCount(), " but stack has: "_s, sliceSize, " values"_s);
     for (unsigned i = 0; i < blockSignature.returnCount(); ++i) {
-        const auto actualType = m_expressionStack[m_currentStackBegin + i].type();
+        auto& slot = m_expressionStack[m_currentStackBegin + i];
         const auto expectedType = blockSignature.returnType(i);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
-        // The spec requires the output type of a structured control instruction to be
-        // the result type from its signature, even when the fallthrough value is a subtype.
-        // FIXME: We should support some sort of abstract interpretation so this can be the
-        // least upper bound of the merging CFG.
-        if (fallthrough == MergePoint)
-            m_expressionStack[m_currentStackBegin + i].setType(expectedType);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(slot.type(), expectedType), "control flow returns with unexpected type. "_s, slot.type(), " is not a "_s, expectedType);
+        // Widen the operand to the block's declared result type, per the spec's
+        // end doing push_vals(frame.end_types): results leave the block as the
+        // declared type, not the narrower subtype that reached the end.
+        // https://webassembly.github.io/spec/core/bikeshed/#validation-of-opcode-sequences
+        slot.setType(expectedType);
     }
 
     return { };
@@ -1933,7 +1941,7 @@ auto FunctionParser<Context>::endBlockAndCheckResultTypes(ControlEntry& entry) -
     // Widen each result to the block signature type before ending the block.
     // FIXME: mutating the expression stack for the block result is effectful, but there's no
     // better API yet. See https://bugs.webkit.org/show_bug.cgi?id=164353
-    WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(entry.controlData, MergePoint));
+    WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(entry.controlData.signature()));
     const uint32_t parentBegin = parentEntryBegin();
     auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
     // We should avoid adding other callsites of endBlock. Since a new block is a sign of a
@@ -3491,15 +3499,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get block's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
-        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType block;
@@ -3512,15 +3513,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get loop's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for loop block. Loop expects ", argumentCount, ", but only ", sliceSize, " were present. Loop has inlineSignature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType loop;
@@ -3539,13 +3534,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition"_s);
 
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type());
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
@@ -3566,7 +3557,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
         auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, ifBranchResults));
         m_expressionStack.shrink(m_currentStackBegin);
@@ -3580,13 +3571,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for try block. Try expects ", argumentCount, ", but only ", sliceSize, " were present. Try block has signature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Try expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
@@ -3607,7 +3594,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
 
         ResultList results;
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
@@ -3633,7 +3620,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
 
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatchAll(preCatchStack, controlEntry.controlData));
@@ -3649,14 +3636,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try_table's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
-        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
 
         uint32_t numberOfCatches;
         Vector<CatchHandler> targets;
@@ -3871,7 +3852,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case End: {
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
-            WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, NewSiblingBlock));
+            WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(data.controlData.signature()));
             auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, ifBranchResults));
             m_expressionStack.shrink(m_currentStackBegin);


### PR DESCRIPTION
#### 9dcbd254af217b64f37947d680ce0c6eae0ab7e3
<pre>
[Wasm] Argument and Result block types should always widen
<a href="https://bugs.webkit.org/show_bug.cgi?id=318807">https://bugs.webkit.org/show_bug.cgi?id=318807</a>
<a href="https://rdar.apple.com/181458746">rdar://181458746</a>

Reviewed by Yusuke Suzuki.

The wasm spec says that any types passing through a block signature
have to widen to the signature. This is critical both for correctness
and for security. We didn&apos;t widen in most cases, this change widens
any time we enter or exit a block via fallthroughs.

In the branch case we don&apos;t always widen. For br_table in particular, we
have to check against each branch target, which may have different
target types but the concrete value type could be a subtype of all of
them. If we widened the first checked target would pass but on a second
(or later) it might fail with the first&apos;s widened type.

Tests: JSTests/wasm/stress/block-param-type-widening.js
       JSTests/wasm/stress/loop-param-type-widening.js

Originally-landed-as: 305413.1112@safari-7624.5-branch (0aff244e6923). <a href="https://rdar.apple.com/185368381">rdar://185368381</a>
Canonical link: <a href="https://commits.webkit.org/320071@main">https://commits.webkit.org/320071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919439a1d2f138e507aded7ed33c701b678edc9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99518 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45792 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5715 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12551 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43608 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5041 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44916 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57234 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152858 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57938 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152541 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130217 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126529 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56446 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55817 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->