### PR TITLE
Heap-use-after-free of RemoteLayerTreeEventDispatcher's RunLoop::Timer on the scrolling thread

### DIFF
--- a/LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash in the UI process during page close.

--- a/LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash.html
+++ b/LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+let cycle = 0;
+const maxCycles = 30;
+
+function finish() {
+    document.body.textContent = "PASS if no crash in the UI process during page close.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function runCycle() {
+    if (cycle++ >= maxCycles)
+        return finish();
+
+    let popup = window.open("about:blank", "", "width=200,height=200");
+    if (!popup)
+        return finish();
+
+    popup.document.body.innerHTML =
+        '<div style="width:50px;height:50px;background:green;animation:s 10s linear infinite;will-change:transform"></div>' +
+        '<style>@keyframes s{from{transform:rotate(0)}to{transform:rotate(360deg)}}</style>';
+
+    // Wait two main-thread rAFs so the popup gets a layer-tree commit and the
+    // scrolling-thread display link observer registers, scheduling the 1ms timer.
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            popup.close();
+            // Closing the popup destroys its RemoteLayerTreeEventDispatcher on the
+            // main thread. Race against the scrolling-thread timer callback.
+            setTimeout(runCycle, 0);
+        });
+    });
+}
+
+runCycle();
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 2df698f59386b2ffccd45c7ef28422b69eba8c44
<pre>
Heap-use-after-free of RemoteLayerTreeEventDispatcher&apos;s RunLoop::Timer on the scrolling thread
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=315533">https://bugs.webkit.org/show_bug.cgi?id=315533</a>&gt;
&lt;<a href="https://rdar.apple.com/177889453">rdar://177889453</a>&gt;

Reviewed by Simon Fraser.

`RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTimer()`
lazily creates `m_delayedRenderingUpdateDetectionTimer` on the
scrolling thread, against the scrolling thread&apos;s run loop.  When
the owning page is closed,
`RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()`
runs on the main thread, calls
`RemoteLayerTreeEventDispatcher::invalidate()`, and then drops the
last reference, destroying the dispatcher (and the timer) on the
main thread.

`CFRunLoopTimerInvalidate()` called from `~TimerBase()` on the main
thread does not synchronize with a CFRunLoopTimer callback that the
scrolling thread&apos;s run loop has already begun dispatching, so the
callback can read the freed `TimerBase` via its raw context
pointer.  ASan reports this as a heap-use-after-free in
`RunLoop::TimerBase::start()::$_0::__invoke` on the scrolling
thread.

Fix by destroying `m_delayedRenderingUpdateDetectionTimer` on the
scrolling thread from `invalidate()`, holding a strong reference to
the dispatcher across the dispatch so it outlives the timer.
Because the dispatch and the timer callback both run serially on
the scrolling thread&apos;s run loop, the timer is either destroyed
before the callback fires, or after the callback has returned.
This mirrors the equivalent fix in
`ThreadedScrollingTree::invalidate()` (225114@main).

The dispatch is performed after `m_scrollingTree` has been cleared
so any in-flight or subsequently queued `didRefreshDisplay()`
returns early and cannot recreate the timer.

Also reorder the ASSERTs in `~RemoteLayerTreeEventDispatcher` to
match the declaration order of the asserted members.

Test: fast/scrolling/mac/event-dispatcher-timer-close-crash.html

* LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash-expected.txt: Add.
* LayoutTests/fast/scrolling/mac/event-dispatcher-timer-close-crash.html: Add.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):

Originally-landed-as: 305413.1021@safari-7624.5-branch (fb7f8555bdf0). <a href="https://rdar.apple.com/185368389">rdar://185368389</a>
Canonical link: <a href="https://commits.webkit.org/319667@main">https://commits.webkit.org/319667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677a5e7bc66c8c8cda301f1b0523385b05a9dc38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42959 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42581 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3700 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151726 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56618 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151427 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27685 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46012 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124842 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55129 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17580 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->