### PR TITLE
[JSC] Do not clone patchpoints for Wasm calls within a try block

### DIFF
--- a/JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js
+++ b/JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js
@@ -1,0 +1,151 @@
+// The module is hand-assembled as raw bytes rather than written in WAT because
+// the current in-tree WAT assemblers do not support both GC and exceptions.
+
+// --- WebAssembly encoding helpers ------------------------------------------------
+
+// Unsigned LEB128.
+function u32(value)
+{
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        result.push(byte);
+    } while (value);
+    return result;
+}
+
+// A name/vec(byte): length-prefixed UTF-8 bytes.
+function str(value)
+{
+    const result = [];
+    for (let i = 0; i < value.length; ++i)
+        result.push(value.charCodeAt(i));
+    return [...u32(result.length), ...result];
+}
+
+// section(id, payload) = id, size(payload), payload.
+function section(id, payload)
+{
+    return [id, ...u32(payload.length), ...payload];
+}
+
+// A function body: vec(locals), code, 0x0b(end-of-function). `localGroups` is a
+// list of [count, valtype] pairs; `code` is the instruction stream.
+function body(localGroups, code)
+{
+    const payload = [...u32(localGroups.length)];
+    for (const [count, type] of localGroups)
+        payload.push(...u32(count), type);
+    payload.push(...code, 0x0b);                       // 0x0b = end (of function)
+    return [...u32(payload.length), ...payload];
+}
+
+const localGet = (index) => [0x20, ...u32(index)];     // 0x20 = local.get
+const localSet = (index) => [0x21, ...u32(index)];     // 0x21 = local.set
+const bitsCount = 24;
+
+// valtype bytes: 0x7f = i32, 0x7e = i64, 0x6f = externref. Section ids: 1 type,
+// 2 import, 3 function, 7 export, 10 code, 13 tag.
+
+function makeModule()
+{
+    // --- Type section (id 1): four function types ------------------------------
+    const helperParams = [...new Array(bitsCount).fill(0x7e), 0x6f]; // 24 x i64, then externref
+    const typeSection = [
+        ...u32(4),                                     // 4 types
+        0x60, 0x00, 0x01, 0x7f,                        // type 0: () -> i32                      ($thrower)
+        0x60, ...u32(helperParams.length), ...helperParams, 0x01, 0x7f, // type 1: (i64 x24, externref) -> i32  ($helper)
+        0x60, 0x01, 0x7f, 0x01, 0x6f,                  // type 2: (i32) -> externref            ($target)
+        0x60, 0x00, 0x00,                              // type 3: () -> ()                       (tag type)
+    ];
+
+    // --- Import section (id 2): one function + 25 mutable globals ---------------
+    const imports = [
+        [...str("m"), ...str("thrower"), 0x00, ...u32(0)],          // func   "m"."thrower" : type 0
+        [...str("m"), ...str("object"), 0x03, 0x6f, 0x01],          // global "m"."object"  : externref, mutable
+    ];
+    for (let index = 0; index < bitsCount; ++index)
+        imports.push([...str("m"), ...str(`bits${index}`), 0x03, 0x7e, 0x01]); // global "m"."bitsN" : i64, mutable
+    const importSection = [...u32(imports.length), ...imports.flat()];
+
+    // --- Function section (id 3): the two defined functions ---------------------
+    // Imported funcs occupy index 0 ($thrower); defined funcs follow:
+    //   func 1 = $helper (type 1), func 2 = $target (type 2).
+    const functionSection = [...u32(2), ...u32(1), ...u32(2)];
+
+    // --- Tag section (id 13): one exception tag of type 3 -----------------------
+    const tagSection = [...u32(1), 0x00, ...u32(3)];   // 1 tag, attribute 0 (exception), type 3
+
+    // --- Export section (id 7): export $target ----------------------------------
+    const exportSection = [...u32(1), ...str("target"), 0x00, ...u32(2)]; // "target" = func 2
+
+    // --- Code section (id 10): bodies for $helper and $target -------------------
+
+    // $helper: padding nops keep it above the inlining threshold, then it calls the
+    // imported JS thrower (which always throws).
+    const helperBody = body([], [
+        ...new Array(600).fill(0x01),                  // nop x600 (0x01 = nop)
+        0x10, 0x00,                                    // call 0  ($thrower)
+    ]);
+
+    // $target: the trigger. One externref local ($live = local 1; local 0 = param).
+    const targetBody = body([[1, 0x6f]], [
+        0x06, 0x6f,                                                            // try (result externref)
+          ...new Array(bitsCount).fill(0).flatMap((_, index) => [0x23, ...u32(1 + index)]), // global.get $bits0 .. $bits23  (globals 1..24)
+          0xd0, 0x6f,                                                         //   ref.null extern         (0xd0 ref.null, 0x6f extern; constant select arm)
+          0x23, 0x00,                                                         //   global.get 0            ($object, the other select arm)
+          ...localGet(0),                                                     //   local.get 0             ($predicate, the select condition)
+          0x1c, 0x01, 0x6f,                                                   //   select (result externref) (0x1c typed-select, 1 result type, externref)
+          ...localSet(1),                                                     //   local.set 1             ($live = select result)
+          ...localGet(1),                                                     //   local.get 1             ($live, passed as the call's externref arg)
+          0x10, 0x01,                                                         //   call 1                  ($helper; exception-capable call cloned by specializeSelect)
+          0x1a,                                                               //   drop                    (discard $helper's i32 result)
+          ...localGet(1),                                                     //   local.get 1             ($live)
+          0xd4,                                                               //   ref.as_non_null         (0xd4; the Check whose Select specializeSelect rewrites)
+          0x1a,                                                               //   drop
+          0xd0, 0x6f,                                                         //   ref.null extern         (normal-path try result; unreachable, $helper always throws)
+        0x19,                                                                 // catch_all (0x19)
+          ...localGet(1),                                                     //   local.get 1             ($live -> restored externref, the function result)
+        0x0b,                                                                 // end (of try)
+    ]);
+
+    const codeSection = [...u32(2), ...helperBody, ...targetBody]; // 2 function bodies
+
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // "\0asm", version 1
+        ...section(1, typeSection),
+        ...section(2, importSection),
+        ...section(3, functionSection),
+        ...section(13, tagSection),
+        ...section(7, exportSection),
+        ...section(10, codeSection),
+    ]);
+}
+
+// --- Imports: a throwing function, a marker externref, and 24 i64 sentinels ------
+
+const marker = { marker: 0x1227 };
+const raw42 = 0xfffe00000000002an;
+const imports = {
+    thrower() {
+        throw marker;
+    },
+    object: new WebAssembly.Global({ value: "externref", mutable: true }, marker),
+};
+for (let index = 0; index < bitsCount; ++index) {
+    imports[`bits${index}`] = new WebAssembly.Global(
+        { value: "i64", mutable: true },
+        BigInt.asIntN(64, raw42 + BigInt(index) * 0x100n));
+}
+
+const target = new WebAssembly.Instance(
+    new WebAssembly.Module(makeModule()), { m: imports }).exports.target;
+
+for (let iteration = 0; iteration < wasmTestLoopCount; ++iteration) {
+    const result = target(1);
+    if (result !== null)
+        throw new Error(`expected null catch restoration, got ${String(result)} at iteration ${iteration}`);
+}

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3292,7 +3292,23 @@ private:
                         && (value->child(1)->isConstant() || value->child(2)->isConstant());
                 });
             
-            if (select) {
+            if (!select)
+                break;
+
+            // All values between Select and Check must be cloneable.
+            bool canClone = true;
+            for (unsigned i = m_index; ; --i) {
+                Value* value = m_block->at(i);
+                if (value->kind().isCloningForbidden()) {
+                    canClone = false;
+                    break;
+                }
+                if (value == select)
+                    break;
+                RELEASE_ASSERT(i); // Select should be found
+            }
+
+            if (canClone) {
                 specializeSelect(select);
                 m_didSpecializeSelect = true;
                 break;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4990,6 +4990,8 @@ RefPtr<PatchpointExceptionHandle> OMGIRGenerator::preparePatchpointForExceptions
     if (!mustSaveState)
         return nullptr;
 
+    ASSERT(patch->kind().isCloningForbidden());
+
     unsigned firstStackmapChildOffset = patch->numChildren();
     unsigned firstStackmapParamOffset = firstStackmapChildOffset + m_proc.resultCount(patch->type());
 
@@ -5597,7 +5599,10 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const RTT& signatur
     auto constrainedPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfo, tmpArgs);
 
     advanceCallSiteIndex();
-    PatchpointValue* patchpoint = m_proc.add<PatchpointValue>(returnType, origin());
+    // Calls inside a try carry a catch-restoration stackmap keyed by CallSiteIndex, see preparePatchpointForExceptions.
+    // Forbid cloning so a B3 transform won't alias two call sites to one stackmap.
+    auto patchpointKind = m_tryCatchDepth ? cloningForbidden(Patchpoint) : Patchpoint;
+    PatchpointValue* patchpoint = m_proc.add<PatchpointValue>(returnType, origin(), patchpointKind);
     patchpoint->effects.writesPinned = true;
     patchpoint->effects.readsPinned = true;
     patchpoint->clobberEarly(RegisterSet::macroClobberedGPRs());


### PR DESCRIPTION
#### 9f07374e9eb2398ebf629352f5fc0a509ae631b8
<pre>
[JSC] Do not clone patchpoints for Wasm calls within a try block
<a href="https://rdar.apple.com/178657225">rdar://178657225</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316791">https://bugs.webkit.org/show_bug.cgi?id=316791</a>

Reviewed by Yijia Huang.

Similar to throw/rethrow patchpoints, a Wasm OMG call patchpoint inside
a Try block carries an exception-restoration stackmap keyed by its CallSiteIndex,
so it should not be cloned. If B3 Select specialization (or B3DuplicateTails)
duplicates them, that leaves two call sites sharing one stackmap even with
potentially differing live-value layouts.

Extend 266643@main to also mark call patchpoints cloningForbidden when
m_tryCatchDepth != 0, and make specializeSelect() bail when a
cloning-forbidden value is in the range it would clone.

Test: JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js

Originally-landed-as: 305413.972@safari-7624.5-branch (db24355101bd). <a href="https://rdar.apple.com/185368817">rdar://185368817</a>
Canonical link: <a href="https://commits.webkit.org/319664@main">https://commits.webkit.org/319664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cac5f9f41cb24ea59e0990f401f26a874b22adfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142300 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42961 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4699 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11526 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42583 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3702 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43595 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194467 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55929 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40618 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151429 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46014 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128904 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55131 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->