### PR TITLE
[LBSE] Assertion failure for SVG resource containers with a namespace prefix

### DIFF
--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1138,16 +1138,19 @@ void SVGElement::postConnectionSteps()
 
 bool SVGElement::isResourceContainerTagName(const QualifiedName& tagName)
 {
-    static NeverDestroyed resourceContainerTags = MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName> {
-        SVGNames::clipPathTag,
-        SVGNames::filterTag,
-        SVGNames::linearGradientTag,
-        SVGNames::markerTag,
-        SVGNames::maskTag,
-        SVGNames::patternTag,
-        SVGNames::radialGradientTag,
+    if (tagName.namespaceURI() != SVGNames::svgNamespaceURI)
+        return false;
+
+    static NeverDestroyed resourceContainerLocalNames = MemoryCompactLookupOnlyRobinHoodHashSet<AtomString> {
+        SVGNames::clipPathTag->localName(),
+        SVGNames::filterTag->localName(),
+        SVGNames::linearGradientTag->localName(),
+        SVGNames::markerTag->localName(),
+        SVGNames::maskTag->localName(),
+        SVGNames::patternTag->localName(),
+        SVGNames::radialGradientTag->localName(),
     };
-    return resourceContainerTags.get().contains(tagName);
+    return resourceContainerLocalNames.get().contains(tagName.localName());
 }
 
 bool SVGElement::isInSVGResourceContainer() const


### PR DESCRIPTION
#### df06a95a287e3dd4e525ea60934a433e2ccba9fa
<pre>
[LBSE] Assertion failure for SVG resource containers with a namespace prefix
<a href="https://bugs.webkit.org/show_bug.cgi?id=322357">https://bugs.webkit.org/show_bug.cgi?id=322357</a>

Reviewed by Patrick Griffis.

Creating the renderer for &lt;svg:filter&gt; fires an assertion:

ASSERTION FAILED: SVGElement::isResourceContainerTagName(element.tagQName())
Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp(47)
...

A tag can be written with a namespace prefix, as in &lt;svg:filter&gt;. Two
QualifiedNames are only equal when their prefixes match as well, so
&lt;svg:filter&gt; is not equal to SVGNames::filterTag. isResourceContainerTagName()
looked up the whole tag in a HashSet&lt;QualifiedName&gt; and thus missed every
prefixed resource container. Element::hasTagName() gets this right by calling
QualifiedName::matches(), which compares the local name and the namespace and
ignores the prefix.

Fix debug assertions in svg/dynamic-updates - covered by existing tests.

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::isResourceContainerTagName):

Canonical link: <a href="https://commits.webkit.org/319663@main">https://commits.webkit.org/319663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc8f2e3d3a1f43705966b3c019338cf99e905804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142304 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42967 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42589 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3708 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55935 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151734 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56626 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151435 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46020 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128910 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55137 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->