### PR TITLE
Use-after-free in MediaElementAudioSourceNode::provideInput when iframe is detached

### DIFF
--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
@@ -1,0 +1,10 @@
+Test that removing an iframe whose <audio> is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script>
+        function runTest()
+        {
+            description("Test that removing an iframe whose &lt;audio&gt; is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.");
+            jsTestIsAsync = true;
+
+            const context = new AudioContext({ sampleRate: 44100 });
+
+            const frame = document.createElement("iframe");
+            frame.src = "resources/mediaelementsource-clear-detached-frame-iframe.html";
+            frame.onload = async function() {
+                const audio = frame.contentDocument.querySelector("audio");
+                const source = context.createMediaElementSource(audio);
+                source.connect(context.destination);
+                audio.play().catch(() => { });
+
+                await new Promise(resolve => setTimeout(resolve, 200));
+
+                frame.remove();
+
+                setTimeout(function() {
+                    testPassed("Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.");
+                    finishJSTest();
+                }, 100);
+            };
+            document.body.appendChild(frame);
+        }
+    </script>
+</head>
+<body onload="runTest()">
+</body>

--- a/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
+++ b/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <audio src="media/24bit-22khz.wav" loop></audio>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7114,7 +7114,7 @@ void HTMLMediaElement::userCancelledLoad(ShouldDestroyMediaPlayer shouldDestroyM
     updateActiveTextTrackCues(MediaTime::zeroTime());
 }
 
-void HTMLMediaElement::clearMediaPlayer()
+void HTMLMediaElement::clearMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -7154,6 +7154,12 @@ void HTMLMediaElement::clearMediaPlayer()
     }
 
     if (RefPtr player = m_player) {
+#if ENABLE(WEB_AUDIO)
+        RefPtr audioSourceNode = m_audioSourceNode.get();
+        std::optional<Locker<Lock>> audioSourceNodeLocker;
+        if (audioSourceNode)
+            audioSourceNodeLocker.emplace(audioSourceNode->processLock());
+#endif
         player->invalidate();
         m_player = nullptr;
     }


### PR DESCRIPTION
#### 55d9d9007f54ee61fa38accb59cd88a8d4075847
<pre>
Use-after-free in MediaElementAudioSourceNode::provideInput when iframe is detached
<a href="https://bugs.webkit.org/show_bug.cgi?id=315989">https://bugs.webkit.org/show_bug.cgi?id=315989</a>
<a href="https://rdar.apple.com/175673159">rdar://175673159</a>

Reviewed by Chris Dumez.

HTMLMediaElement::clearMediaPlayer() resets m_player on the main thread without holding
m_audioSourceNode-&gt;processLock(), but the audio render thread reads m_player via
audioSourceProvider() inside MediaElementAudioSourceNode::process() while holding that lock.
Because audioSourceProvider() returns a raw AudioSourceProvider* and drops its local
RefPtr&lt;MediaPlayer&gt; on return, and MediaPlayer is DestructionThread::Main, the main thread can
synchronously run ~MediaPlayer (destroying the RemoteAudioSourceProvider) while the render thread
is still inside provideInput() with the now-dangling pointer.

This is reachable from HTMLMediaElement::stop() (ActiveDOMObject stop on iframe detach) and
userCancelledLoad().

Match the contract already enforced by createMediaPlayer() and
mediaPlayerWill/DidInitializeMediaEngine() by holding the audio node&apos;s processLock around
player-&gt;invalidate() / m_player = nullptr in clearMediaPlayer(). process() acquires the same lock
with tryLock(), so this cannot deadlock — the render thread will simply zero its output for one
quantum while the main thread tears down.

Test: webaudio/mediaelementsource-clear-detached-frame.html

* LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt: Added.
* LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html: Added.
* LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::clearMediaPlayer): Deleted.

Originally-landed-as: 305413.1065@safari-7624.5-branch (e186258f7967). <a href="https://rdar.apple.com/185367736">rdar://185367736</a>
Canonical link: <a href="https://commits.webkit.org/319666@main">https://commits.webkit.org/319666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36969986e006c55059d3076517c362effa2a3f03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142308 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42971 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42593 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3712 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194477 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151737 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56630 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151438 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46024 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128914 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124857 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55141 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->