### PR TITLE
[JSC] DFG Uint32Array load should consider about Int32 speculation path

### DIFF
--- a/JSTests/stress/uint32-array-result-int32-dfg.js
+++ b/JSTests/stress/uint32-array-result-int32-dfg.js
@@ -1,0 +1,41 @@
+//@ runDefault("--useConcurrentJIT=false", "--useFTLJIT=false", "--jitPolicyScale=0.1")
+// See rdar://176792844 for additional details on this test.
+
+let a = new Uint32Array(4);
+a[0] = 42;
+
+let dummy = [1, 2, 3]; dummy[0] = 1; dummy[0] = {};
+
+const sBodyArgs = ['a', 'idx', 'flag', 'intArr',
+"\n" +
+"    let i = idx;\n" +
+"    if (flag) i = 0.5;\n" +
+"    let v = a[i];\n" +
+"    let d = v - 0.5;\n" +
+"    intArr[0] = v;\n" +
+"    return d;\n"];
+
+let f1 = new Function(...sBodyArgs);
+noInline(f1);
+
+let intArr1 = [1, 2, 3]; intArr1[0] = 1;
+for (let k = 0; k < 100; k++)
+    f1(a, 0, false, intArr1);
+
+for (let k = 0; k < 110; k++)
+    f1(a, 100, false, intArr1);
+
+let evict = new Function('z', 'return z'); evict(0);
+
+let f2 = new Function(...sBodyArgs);
+noInline(f2);
+
+let intArr2 = [1, 2, 3]; intArr2[0] = 1;
+
+for (let k = 0; k < 100; k++)
+    f2(a, 0, false, intArr2);
+
+f2(a, 0, false, intArr2);
+
+if (intArr2[0] !== 42)
+    throw new Error("incorrect value " + intArr2[0]);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3210,8 +3210,13 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
 
     if (shouldBox) {
         if (isUInt32) {
-            convertUInt32ToDouble(resultReg, resultFPR);
-            boxDouble(resultFPR, resultRegs);
+            if (node->shouldSpeculateInt32() && canSpeculate) {
+                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch32(LessThan, resultReg, TrustedImm32(0)));
+                boxInt32(resultReg, resultRegs);
+            } else {
+                convertUInt32ToDouble(resultReg, resultFPR);
+                boxDouble(resultFPR, resultRegs);
+            }
         } else
             boxInt32(resultRegs.payloadGPR(), resultRegs);
         if (outOfBounds.isSet())


### PR DESCRIPTION
#### 8283d4f1273add66f659b203baaae8e56c4fc3f2
<pre>
[JSC] DFG Uint32Array load should consider about Int32 speculation path
<a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>
<a href="https://rdar.apple.com/176792844">rdar://176792844</a>

Reviewed by Mark Lam.

DFG Uint32Array GetByVal may have Int32 result with speculation. But the
current code is always using boxed-double for boxed result. We should
use boxed-int32 when this speculation is set. The same thing is already
done in FTL.

Test: JSTests/stress/uint32-array-result-int32-dfg.js

* JSTests/stress/uint32-array-result-int32-dfg.js: Added.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):

Originally-landed-as: 305413.1114@safari-7624.5-branch (2bc65ac3560e). <a href="https://rdar.apple.com/185368553">rdar://185368553</a>
Canonical link: <a href="https://commits.webkit.org/319669@main">https://commits.webkit.org/319669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a55789db35e5deebb677c46a28ba7593e00c970

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42973 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4709 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11538 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42595 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43607 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55941 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40626 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56632 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46026 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128916 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17594 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->