### PR TITLE
Cherry-pick(s) 669fce73f5f9. rdar://185365963

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -254,7 +254,19 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
 
     auto configureTCP = options.requireUnreliable ? NW_PARAMETERS_DISABLE_PROTOCOL : NW_PARAMETERS_DEFAULT_CONFIGURATION;
 
+<<<<<<< HEAD
     return adoptNS(nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, configureTCP));
+=======
+    RetainPtr parameters = adoptNS(softLink_Network_nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, configureTCP));
+    String bundleIdentifier = connectionToWebProcess.networkProcess().uiProcessBundleIdentifier();
+    if (CheckedPtr sessionCocoa = downcast<NetworkSessionCocoa>(connectionToWebProcess.networkProcess().networkSession(connectionToWebProcess.sessionID())))
+        bundleIdentifier = sessionCocoa->sourceApplicationBundleIdentifier();
+    setNWParametersApplicationIdentifiers(parameters.get(), bundleIdentifier.utf8().data(), connectionToWebProcess.networkProcess().sourceApplicationAuditToken(), emptyString());
+    bool isTracker = isKnownTracker(WebCore::RegistrableDomain { url });
+    bool isFirstParty = WebCore::RegistrableDomain { clientOrigin.clientOrigin } == WebCore::RegistrableDomain { clientOrigin.topOrigin };
+    setNWParametersTrackerOptions(parameters.get(), false, isFirstParty, isTracker, IsRTC::No);
+    return parameters;
+>>>>>>> 669fce73f5f9 ([cocoa] uiProcessBundleIdentifier may mark the WebTransport connection incorrectly)
 }
 
 RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess& connectionToWebProcess, WebTransportSessionIdentifier identifier, URL&& url, WebCore::WebTransportOptions&& options, Vector<KeyValuePair<String, String>>&& additionalHeaders, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185365963 to main. [669fce73f5f9] caused a merge conflict. 

```
[cocoa] uiProcessBundleIdentifier may mark the WebTransport connection incorrectly
https://bugs.webkit.org/show_bug.cgi?id=321381
rdar://184420964

Reviewed by Mike Wyrzykowski.

The original fix for rdar://184076013 used the NetworkProcess's
uiProcessBundleIdentifier(). That is too strict for what we want. There are
some cases where we don't want the literal UI Process' bundle ID, and instead
we have a substitute. The NetworkSession owns that substitute, and we use that
alternative bundle ID in all other cases where we mark connections. This aligns
the WebTransport connections with the other connections.

* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::createParameters):

Originally-landed-as: 316606.352@safari-7625-branch (669fce73f5f9). rdar://185365963


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e18eddde487cade815ca40fabe00239af2f98e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182337 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56284 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192571 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146666 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57600 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56007 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192571 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/146666 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185292 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57600 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192571 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57600 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/56007 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192571 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57600 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3728 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48915 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/56007 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194493 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55955 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/194493 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56646 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/194493 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56646 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128930 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124884 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55157 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50090 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54538 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54777 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54605 "") | | | 
<!--EWS-Status-Bubble-End-->