### PR TITLE
Cherry-pick 53ed150fb399. https://bugs.webkit.org/show_bug.cgi?id=313163

### DIFF
--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
@@ -1,0 +1,20 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        margin: 10px;
+        display: inline-block;
+    }
+    .image, .tainted-canvas {
+        background-color: lime;
+    }
+    .image-capture-canvas {
+        background-color: red;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <div class="image box"></div>
+    <div class="tainted-canvas box"></div>
+    <div class="image-capture-canvas box"></div>
+</body>

--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
@@ -1,0 +1,17 @@
+<style>
+    img {
+        margin: 10px;
+        width: 100px;
+        height: 100px;
+    }
+    iframe {
+        margin: 10px;
+        width: 250px;
+        height: 100px;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <img src="http://localhost:8000/canvas/resources/100x100-lime-rect.svg">
+    <iframe src="http://127.0.0.1:8000/canvas/resources/cross-origin-image-capture-video-frame.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
@@ -1,0 +1,54 @@
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+        overflow: clip;
+    }
+    canvas {
+        width: 100px;
+        height: 100px;
+        margin-left: 0;
+        margin-right: 20px;
+        background: red;
+    }
+</style>
+<body>
+    <canvas id="src"></canvas>
+    <canvas id="dest"></canvas>
+    <script>
+        (async () => {
+            var srcCanvas = document.getElementById('src');
+            srcCanvas.width = 100;
+            srcCanvas.height = 100;
+
+            var destCanvas = document.getElementById('dest');
+            destCanvas.width = 100;
+            destCanvas.height = 100;
+
+            // 1. Capture the stream of the source canvas while it is still origin-clean.
+            var stream = srcCanvas.captureStream(0);
+            var track = stream.getVideoTracks()[0];
+            track.requestFrame();
+
+            // 2. Load the cross-origin image.
+            var img = new Image();
+            img.src = 'http://localhost:8000/canvas/resources/100x100-lime-rect.svg';
+            await new Promise(function(ok, fail) {
+                img.onload = ok;
+            });
+
+            // 3. Draw the the cross-origin image onto the canvas — this taints it; direct reads are now blocked.
+            var srcCtx = srcCanvas.getContext('2d');
+            srcCtx.drawImage(img, 0, 0);
+
+            // 4. grabFrame() snapshots the tainted canvas.
+            var bmp = await new ImageCapture(track).grabFrame();
+
+            // 5. Draw the frame to a fresh canvas - nothing should be drawn from the tainted canvas.
+            var destCtx = destCanvas.getContext('2d');
+            destCtx.drawImage(bmp, 0, 0);
+
+            window.parent.postMessage("onload", "*");
+        })();
+    </script>
+</body>

--- a/LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test big frame sizes.
+

--- a/LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size.html
+++ b/LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<script>
+
+function configureEncoder(width, height)
+{
+    let resolve;
+    const promise = new Promise(r => resolve = r);
+    const encoder = new VideoEncoder({
+        output: () => { },
+        error: (e) => { resolve(false);}
+    });
+    encoder.configure({ codec: "vp09.00.10.08", width, height, bitrate: 1, framerate: 1 });
+    setTimeout(() => resolve(true), 0);
+    return promise;
+}
+
+promise_test(async t => {
+    assert_true(await configureEncoder(32767, 32767));
+    assert_false(await configureEncoder(32768, 32767));
+    assert_false(await configureEncoder(32767, 32768));
+    assert_false(await configureEncoder(32768, 32768));
+}, 'Test big frame sizes.');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1917,6 +1917,8 @@ webkit.org/b/284429 imported/w3c/web-platform-tests/webcodecs/audio-encoder.http
 # is not supported) is expected to fail.
 http/wpt/webcodecs/H264-422.html [ Failure ]
 
+http/wpt/webcodecs/configure-encoder-big-frame-size.html [ Pass Failure ]
+
 http/wpt/webcodecs/encoder-decoder-vp9-I420.html [ Failure ]
 
 fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html [ Pass Failure ]

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -201,6 +201,9 @@ RefPtr<VideoFrame> CanvasCaptureMediaStreamTrack::Source::grabFrame()
     if (!canvas)
         return nullptr;
 
+    if (!canvas->originClean())
+        return nullptr;
+
 #if ENABLE(WEBGL)
     if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
         return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
@@ -221,16 +224,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
         m_shouldEmitFrame = false;
     }
 
-    if (!canvas->originClean())
-        return;
-
-    RefPtr videoFrame = [&]() -> RefPtr<VideoFrame> {
-#if ENABLE(WEBGL)
-        if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
-            return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
-#endif
-        return canvas->toVideoFrame();
-    }();
+    RefPtr videoFrame = grabFrame();
     if (!videoFrame)
         return;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -74,15 +74,19 @@ WebCodecsVideoEncoder::WebCodecsVideoEncoder(ScriptExecutionContext& context, In
 
 WebCodecsVideoEncoder::~WebCodecsVideoEncoder() = default;
 
-static bool isSupportedEncoderCodec(const String& codec, const SettingsValues& settings)
+static bool isSupportedEncoderCodec(const WebCodecsVideoEncoderConfig& config, const SettingsValues& settings)
 {
-    return codec.startsWith("vp8"_s) || codec.startsWith("vp09.00"_s) || codec.startsWith("avc1."_s)
+    constexpr size_t maxFrameDimension = 32767;
+    if (config.width > maxFrameDimension || config.height > maxFrameDimension)
+        return false;
+
+    return config.codec.startsWith("vp8"_s) || config.codec.startsWith("vp09.00"_s) || config.codec.startsWith("avc1."_s)
 #if ENABLE(WEB_RTC)
-        || (codec.startsWith("vp09.02"_s) && settings.webRTCVP9Profile2CodecEnabled)
+        || (config.codec.startsWith("vp09.02"_s) && settings.webRTCVP9Profile2CodecEnabled)
 #endif
-        || (codec.startsWith("hev1."_s) && settings.webCodecsHEVCEnabled)
-        || (codec.startsWith("hvc1."_s) && settings.webCodecsHEVCEnabled)
-        || (codec.startsWith("av01.0"_s) && settings.webCodecsAV1Enabled);
+        || (config.codec.startsWith("hev1."_s) && settings.webCodecsHEVCEnabled)
+        || (config.codec.startsWith("hvc1."_s) && settings.webCodecsHEVCEnabled)
+        || (config.codec.startsWith("av01.0"_s) && settings.webCodecsAV1Enabled);
 }
 
 static bool isValidEncoderConfig(const WebCodecsVideoEncoderConfig& config)
@@ -175,7 +179,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
         } });
     }
 
-    bool isSupportedCodec = isSupportedEncoderCodec(config.codec, context.settingsValues());
+    bool isSupportedCodec = isSupportedEncoderCodec(config, context.settingsValues());
     queueControlMessageAndProcess({ *this, [this, config = WTF::move(config), isSupportedCodec]() mutable {
         if (isSupportedCodec && m_internalEncoder && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
             updateRates(config);
@@ -348,7 +352,7 @@ void WebCodecsVideoEncoder::isConfigSupported(ScriptExecutionContext& context, W
         return;
     }
 
-    if (!isSupportedEncoderCodec(config.codec, context.settingsValues())) {
+    if (!isSupportedEncoderCodec(config, context.settingsValues())) {
         promise->template resolve<IDLDictionary<WebCodecsVideoEncoderSupport>>(WebCodecsVideoEncoderSupport { false, WTF::move(config) });
         return;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10118,14 +10118,6 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
 
     Ref navigationResponse = API::NavigationResponse::create(API::FrameInfo::create(FrameInfoData { frameInfo }).get(), request, response, canShowMIMEType, WTF::move(downloadAttribute), navigation.get());
 
-    auto expectSafeBrowsing = ShouldExpectSafeBrowsingResult::No;
-    MonotonicTime requestStart;
-
-    if (navigation && navigation->safeBrowsingCheckOngoing()) {
-        expectSafeBrowsing = ShouldExpectSafeBrowsingResult::Yes;
-        requestStart = navigation->requestStart();
-    }
-
     Ref listener = frame->setUpPolicyListenerProxy([
         this,
         protectedThis = Ref { *this },
@@ -10264,16 +10256,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
-    if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
-        navigation->whenSafeBrowsingCheckCompletes([listener] mutable {
-            listener->didReceiveSafeBrowsingResults();
-        });
-        Seconds timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s;
-        RunLoop::mainSingleton().dispatchAfter(timeout, [listener] mutable {
-            listener->didReceiveSafeBrowsingResults();
-        });
-    }
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForResponse(*this, *frame, response, request, canShowMIMEType, WTF::move(listener));


### PR DESCRIPTION
#### ad62a525b5bc3456a5fa38726bbe743e9da49283
<pre>
Cherry-pick 53ed150fb399. <a href="https://bugs.webkit.org/show_bug.cgi?id=313163">https://bugs.webkit.org/show_bug.cgi?id=313163</a>

    Don&apos;t block page loading due pending SafeBrowsing result
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313163">https://bugs.webkit.org/show_bug.cgi?id=313163</a>
    <a href="https://rdar.apple.com/165058397">rdar://165058397</a>

    Reviewed by Pascoe.

    WebPageProxy::decidePolicyForResponseShared() no longer waits for
    the SafeBrowsing request to be completed before responding. This
    unblocks the WebContent process to proceed with the load. This is not
    a bypass of the SafeBrowsing logic since a warning that arrives later
    is still handled and shown.

    * Source/WebKit/UIProcess/API/APINavigation.h:
    (API::Navigation::setSafeBrowsingCheckTimedOut): Deleted.
    (API::Navigation::safeBrowsingCheckTimedOut): Deleted.
    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::decidePolicyForResponseShared):

    Identifier: 305413.801@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.974@safari-7624.4-branch">https://commits.webkit.org/305413.974@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/317695.147@webkitglib/2.54">https://commits.webkit.org/317695.147@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1964e82fe09dc6f0548564e8c20c1061c109c243
<pre>
Cherry-pick 305413.925@safari-7624.4-branch (723dbeacf061). <a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>

    When captured as a video frame, canvas has to be tainted if cross-origin image are drawn into it
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>
    <a href="https://rdar.apple.com/171846032">rdar://171846032</a>

    Reviewed by Simon Fraser.

    HTMLCanvasElement::captureStream() allows streaming a canvas&apos;s output to a &lt;video&gt;
    element. The track frames of this video is obtained from CanvasCaptureMediaStreamTrack
    ::grabFrame(). This function unconditionally gets a VideoFrame by calling
    HTMLCanvasElement::toVideoFrame().

    If cross-origin images are drawn into the canvas, this canvas has to be tainted.
    So no getImageData() can see the pixels of the cross-origin images.

    * LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html: Added.
    * LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html: Added.
    * LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html: Added.
    * Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
    (WebCore::CanvasCaptureMediaStreamTrack::Source::grabFrame):
    (WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):

    Identifier: 305413.925@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/317695.146@webkitglib/2.54">https://commits.webkit.org/317695.146@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 18024edc94df3d4b0a2c55b99f60236ba757bc3f
<pre>
Cherry-pick 305413.884@safari-7624.4-branch (b8eb06fa26e8). <a href="https://bugs.webkit.org/show_bug.cgi?id=320765">https://bugs.webkit.org/show_bug.cgi?id=320765</a>

    Heap Buffer Overflow in WebRTC VP9 Encoder
    <a href="https://rdar.apple.com/177719944">rdar://177719944</a>

    Reviewed by Jean-Yves Avenard.

    We restrict video encoder support to frames of size below 32767.
    This aligns with Chrome so should not be a compat issue.

    Test: http/wpt/webcodecs/configure-encoder-big-frame-size.html

    * LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size-expected.txt: Added.
    * LayoutTests/http/wpt/webcodecs/configure-encoder-big-frame-size.html: Added.
    * Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
    (WebCore::isSupportedEncoderCodec):
    (WebCore::WebCodecsVideoEncoder::configure):
    (WebCore::WebCodecsVideoEncoder::isConfigSupported):

    Identifier: 305413.884@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/317695.145@webkitglib/2.54">https://commits.webkit.org/317695.145@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f541afd7836b0575fee6d28db6605fe389770208

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182441 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56388 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146770 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184303 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57704 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56111 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146770 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57704 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122837 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57704 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56111 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57704 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3835 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49019 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56111 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194598 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56059 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151835 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56750 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151533 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27697 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56750 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129034 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125024 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55261 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50194 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54642 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54881 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54709 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->