### PR TITLE
Tall `::selection` eats into its background on subsequent lines

### DIFF
--- a/LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,26 +1,26 @@
 This is a test of writingsideways in vertical text
 with multiline text and alongwordthat'slong andanotherword.
-Bug 286961 : 62,44,20,1
-Click at 5, 5 for left above first line : 17,21,25,1
-Click at 5, 275 for right above first line : 17,21,25,1
-Click at 25, 5 for left of first line : 17,21,25,1
-Click at 25, 275 for right of first line : 17,237,25,1
-Click at 45, 5 for left of second line : 42,21,20,1
-Click at 45, 275 for right of second line : 42,248,20,1
-Click at 65, 5 for left of third line : 62,21,20,1
-Click at 65, 275 for right of third line : 62,176,20,1
-Click at 85, 5 for left of fourth line : 82,21,20,1
-Click at 85, 275 for right of fourth line : 82,262,20,1
-Click at 105, 5 for left of fifth line : 102,21,19,1
-Click at 105, 275 for right of fifth line : 102,68,19,1
-Click at 125, 5 for left of sixth line : 121,21,20,1
-Click at 125, 275 for right of sixth line : 121,260,20,1
-Click at 145, 5 for left of seventh line : 141,21,20,1
-Click at 145, 275 for right of seventh line : 141,200,20,1
-Click at 170, 5 for left below last line : 141,200,20,1
-Click at 170, 275 for right below last line : 141,200,20,1
-Click at 25, 30 for inside first root inline fragment : 17,32,25,1
-Click at 125, 30 for inside middle fragment of root inline fragment : 121,32,20,1
-Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,32,20,1
-Click at 65, 30 for inside last fragment of non-root inline fragment : 62,32,20,1
-Click at 85, 220 for inside unfragmented non-root inline : 82,225,20,1
+Bug 286961 : 59,60,22,1
+Click at 5, 5 for left above first line : 19,21,22,1
+Click at 5, 435 for right above first line : 19,21,22,1
+Click at 25, 5 for left of first line : 19,21,22,1
+Click at 25, 435 for right of first line : 19,381,22,1
+Click at 45, 5 for left of second line : 39,21,22,1
+Click at 45, 435 for right of second line : 39,400,22,1
+Click at 65, 5 for left of third line : 59,21,22,1
+Click at 65, 435 for right of third line : 59,280,22,1
+Click at 85, 5 for left of fourth line : 79,21,22,1
+Click at 85, 435 for right of fourth line : 79,422,22,1
+Click at 105, 5 for left of fifth line : 100,21,20,1
+Click at 105, 435 for right of fifth line : 100,100,20,1
+Click at 125, 5 for left of sixth line : 120,21,20,1
+Click at 125, 435 for right of sixth line : 120,405,20,1
+Click at 145, 5 for left of seventh line : 140,21,20,1
+Click at 145, 435 for right of seventh line : 140,320,20,1
+Click at 170, 5 for left below last line : 140,320,20,1
+Click at 170, 435 for right below last line : 140,320,20,1
+Click at 25, 30 for inside first root inline fragment : 19,21,22,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 120,21,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 39,21,22,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 59,21,22,1
+Click at 85, 380 for inside unfragmented non-root inline : 79,381,22,1

--- a/LayoutTests/editing/caret/caret-position-sideways-lr.html
+++ b/LayoutTests/editing/caret/caret-position-sideways-lr.html
@@ -2,12 +2,12 @@
 <style>
 #test {
     writing-mode: sideways-lr;
-    /* If this test ends up being flaky, consider using Ahem. But it's more rigorous not to. */
+    /* Ahem so that the ascent and descent, and with them the caret's extent, are the same on every platform. */
     outline: solid gray 1px;
     padding: 1em;
     width: 10em;
     height: 20ch;
-    font: 20px/1 monospace;
+    font: 20px/1 Ahem;
     background: /* Create a 10px grid to help with debugging. */
         repeating-linear-gradient(transparent 0em 9px, #FC88 9px 10px),
         repeating-linear-gradient(to left, transparent 0px 9px, #FC88 9px 10px);

--- a/LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,26 +1,26 @@
 This is a test of writingsideways in vertical text
 with multiline text and alongwordthat'slong andanotherword.
-Bug 286961 : 82,60,20,1
-Click at 5, 5 for left above first line : 42,20,25,1
-Click at 5, 275 for right above first line : 42,20,25,1
-Click at 25, 5 for left of first line : 42,32,25,1
-Click at 25, 275 for right of first line : 62,248,20,1
-Click at 45, 5 for left of second line : 82,60,20,1
-Click at 45, 275 for right of second line : 82,176,20,1
-Click at 65, 5 for left of third line : 82,176,20,1
-Click at 65, 275 for right of third line : 82,176,20,1
-Click at 85, 5 for left of fourth line : 102,80,20,1
-Click at 85, 275 for right of fourth line : 121,100,19,1
-Click at 105, 5 for left of fifth line : 141,120,20,1
-Click at 105, 275 for right of fifth line : 141,260,20,1
-Click at 125, 5 for left of sixth line : 161,140,20,1
-Click at 125, 275 for right of sixth line : 161,200,20,1
-Click at 145, 5 for left of seventh line : 161,140,20,1
-Click at 145, 275 for right of seventh line : 161,200,20,1
-Click at 170, 5 for left below last line : 161,200,20,1
-Click at 170, 275 for right below last line : 161,200,20,1
-Click at 25, 30 for inside first root inline fragment : 42,32,25,1
-Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,1
-Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,1
-Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,1
-Click at 85, 220 for inside unfragmented non-root inline : 102,225,20,1
+Bug 286961 : 81,60,22,1
+Click at 5, 5 for left above first line : 41,20,22,1
+Click at 5, 435 for right above first line : 41,20,22,1
+Click at 25, 5 for left of first line : 41,40,22,1
+Click at 25, 435 for right of first line : 61,400,22,1
+Click at 45, 5 for left of second line : 81,60,22,1
+Click at 45, 435 for right of second line : 81,280,22,1
+Click at 65, 5 for left of third line : 81,280,22,1
+Click at 65, 435 for right of third line : 81,280,22,1
+Click at 85, 5 for left of fourth line : 101,80,22,1
+Click at 85, 435 for right of fourth line : 120,100,20,1
+Click at 105, 5 for left of fifth line : 120,100,20,1
+Click at 105, 435 for right of fifth line : 120,100,20,1
+Click at 125, 5 for left of sixth line : 140,120,20,1
+Click at 125, 435 for right of sixth line : 140,405,20,1
+Click at 145, 5 for left of seventh line : 160,140,20,1
+Click at 145, 435 for right of seventh line : 160,320,20,1
+Click at 170, 5 for left below last line : 160,320,20,1
+Click at 170, 435 for right below last line : 160,320,20,1
+Click at 25, 30 for inside first root inline fragment : 41,20,22,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 140,120,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 61,40,22,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 81,60,22,1
+Click at 85, 380 for inside unfragmented non-root inline : 101,381,22,1

--- a/LayoutTests/editing/caret/caret-position-vertical-rl.html
+++ b/LayoutTests/editing/caret/caret-position-vertical-rl.html
@@ -2,12 +2,12 @@
 <style>
 #test {
     writing-mode: vertical-rl;
-    /* If this test ends up being flaky, consider using Ahem. But it's more rigorous not to. */
+    /* Ahem so that the ascent and descent, and with them the caret's extent, are the same on every platform. */
     outline: solid gray 1px;
     padding: 1em;
     width: 10em;
     height: 20ch;
-    font: 20px/1 monospace;
+    font: 20px/1 Ahem;
     background: /* Create a 10px grid to help with debugging. */
         repeating-linear-gradient(transparent 0em 9px, #FC88 9px 10px),
         repeating-linear-gradient(to left, transparent 0px 9px, #FC88 9px 10px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-expected.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        width: 100px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: 0;
+        top: 55px;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        position: absolute;
+        left: 0;
+        top: 70px;
+        font: 100px/70px Ahem;
+        color: transparent;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 0);
+        range.setEnd(target.firstChild, 1);
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-ref.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        width: 100px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: 0;
+        top: 55px;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        position: absolute;
+        left: 0;
+        top: 70px;
+        font: 100px/70px Ahem;
+        color: transparent;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 0);
+        range.setEnd(target.firstChild, 1);
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight painting with overlapping line boxes</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-bounds">
+<link rel="match" href="highlight-painting-overlapping-line-boxes-001-ref.html">
+<meta name="assert" value="The ::selection overlay of a line box covers the whole em box of the selected text, even when the line height is smaller than the em box, so that the overlay overlaps the preceding line box.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        width: 100px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: 0;
+        top: 55px;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        font: 100px/70px Ahem;
+        color: transparent;
+        width: 100px;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 2);
+        range.setEnd(target.firstChild, 3);
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-expected.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        margin-left: 20px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: -15px;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        position: absolute;
+        left: 0;
+        top: 0;
+        writing-mode: vertical-lr;
+        font: 100px/70px Ahem;
+        color: transparent;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 0);
+        range.setEnd(target.firstChild, 1);
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-ref.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        margin-left: 20px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: -15px;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        position: absolute;
+        left: 0;
+        top: 0;
+        writing-mode: vertical-lr;
+        font: 100px/70px Ahem;
+        color: transparent;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 0);
+        range.setEnd(target.firstChild, 1);
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight painting with overlapping line boxes in vertical-lr</title>
+<link rel="author" name="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-bounds">
+<link rel="match" href="highlight-painting-overlapping-line-boxes-002-ref.html">
+<meta name="assert" value="The ::selection overlay of a line box covers the whole em box of the selected text, even when the line height is smaller than the em box, so that the overlay overlaps the following line box in a line inverted writing mode.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="support/selections.js"></script>
+<style>
+    #layers {
+        position: relative;
+        z-index: 0;
+        margin-left: 20px;
+    }
+    #backdrop {
+        position: absolute;
+        z-index: -1;
+        left: -15px;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #target {
+        writing-mode: vertical-lr;
+        font: 100px/70px Ahem;
+        color: transparent;
+        height: 100px;
+    }
+    #target::selection {
+        background: green;
+        color: transparent;
+    }
+</style>
+<p>Test passes if there is a filled square and <strong>no red</strong>.</p>
+<div id="layers">
+    <div id="backdrop"></div>
+    <div id="target">x x</div>
+</div>
+<script>
+    const target = document.getElementById("target");
+    selectRangeWith(range => {
+        range.setStart(target.firstChild, 0);
+        range.setEnd(target.firstChild, 1);
+    });
+</script>

--- a/LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,26 +1,26 @@
 This is a test of writingsideways in vertical text
 with multiline text and alongwordthat'slong andanotherword.
-Bug 286961 : 62,45,20,2
-Click at 5, 5 for left above first line : 17,22,25,2
-Click at 5, 275 for right above first line : 17,22,25,2
-Click at 25, 5 for left of first line : 17,22,25,2
-Click at 25, 275 for right of first line : 17,238,25,2
-Click at 45, 5 for left of second line : 42,22,20,2
-Click at 45, 275 for right of second line : 42,249,20,2
-Click at 65, 5 for left of third line : 62,22,20,2
-Click at 65, 275 for right of third line : 62,177,20,2
-Click at 85, 5 for left of fourth line : 82,22,20,2
-Click at 85, 275 for right of fourth line : 82,263,20,2
-Click at 105, 5 for left of fifth line : 102,22,19,2
-Click at 105, 275 for right of fifth line : 102,69,19,2
-Click at 125, 5 for left of sixth line : 121,22,20,2
-Click at 125, 275 for right of sixth line : 121,261,20,2
-Click at 145, 5 for left of seventh line : 141,22,20,2
-Click at 145, 275 for right of seventh line : 141,201,20,2
-Click at 170, 5 for left below last line : 141,201,20,2
-Click at 170, 275 for right below last line : 141,201,20,2
-Click at 25, 30 for inside first root inline fragment : 17,33,25,2
-Click at 125, 30 for inside middle fragment of root inline fragment : 121,33,20,2
-Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,33,20,2
-Click at 65, 30 for inside last fragment of non-root inline fragment : 62,33,20,2
-Click at 85, 220 for inside unfragmented non-root inline : 82,226,20,2
+Bug 286961 : 59,61,22,2
+Click at 5, 5 for left above first line : 19,22,22,2
+Click at 5, 435 for right above first line : 19,22,22,2
+Click at 25, 5 for left of first line : 19,22,22,2
+Click at 25, 435 for right of first line : 19,382,22,2
+Click at 45, 5 for left of second line : 39,22,22,2
+Click at 45, 435 for right of second line : 39,401,22,2
+Click at 65, 5 for left of third line : 59,22,22,2
+Click at 65, 435 for right of third line : 59,281,22,2
+Click at 85, 5 for left of fourth line : 79,22,22,2
+Click at 85, 435 for right of fourth line : 79,423,22,2
+Click at 105, 5 for left of fifth line : 100,22,20,2
+Click at 105, 435 for right of fifth line : 100,101,20,2
+Click at 125, 5 for left of sixth line : 120,22,20,2
+Click at 125, 435 for right of sixth line : 120,413,20,2
+Click at 145, 5 for left of seventh line : 140,22,20,2
+Click at 145, 435 for right of seventh line : 140,321,20,2
+Click at 170, 5 for left below last line : 140,321,20,2
+Click at 170, 435 for right below last line : 140,321,20,2
+Click at 25, 30 for inside first root inline fragment : 19,22,22,2
+Click at 125, 30 for inside middle fragment of root inline fragment : 120,22,20,2
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 39,22,22,2
+Click at 65, 30 for inside last fragment of non-root inline fragment : 59,22,22,2
+Click at 85, 380 for inside unfragmented non-root inline : 79,382,22,2

--- a/LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,26 +1,26 @@
 This is a test of writingsideways in vertical text
 with multiline text and alongwordthat'slong andanotherword.
-Bug 286961 : 82,60,20,2
-Click at 5, 5 for left above first line : 42,20,25,2
-Click at 5, 275 for right above first line : 42,20,25,2
-Click at 25, 5 for left of first line : 42,31,25,2
-Click at 25, 275 for right of first line : 62,247,20,2
-Click at 45, 5 for left of second line : 82,60,20,2
-Click at 45, 275 for right of second line : 82,175,20,2
-Click at 65, 5 for left of third line : 82,175,20,2
-Click at 65, 275 for right of third line : 82,175,20,2
-Click at 85, 5 for left of fourth line : 102,80,20,2
-Click at 85, 275 for right of fourth line : 121,100,19,2
-Click at 105, 5 for left of fifth line : 141,120,20,2
-Click at 105, 275 for right of fifth line : 141,259,20,2
-Click at 125, 5 for left of sixth line : 161,140,20,2
-Click at 125, 275 for right of sixth line : 161,199,20,2
-Click at 145, 5 for left of seventh line : 161,140,20,2
-Click at 145, 275 for right of seventh line : 161,199,20,2
-Click at 170, 5 for left below last line : 161,199,20,2
-Click at 170, 275 for right below last line : 161,199,20,2
-Click at 25, 30 for inside first root inline fragment : 42,31,25,2
-Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,2
-Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,2
-Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,2
-Click at 85, 220 for inside unfragmented non-root inline : 102,224,20,2
+Bug 286961 : 81,60,22,2
+Click at 5, 5 for left above first line : 41,20,22,2
+Click at 5, 435 for right above first line : 41,20,22,2
+Click at 25, 5 for left of first line : 41,39,22,2
+Click at 25, 435 for right of first line : 61,399,22,2
+Click at 45, 5 for left of second line : 81,60,22,2
+Click at 45, 435 for right of second line : 81,279,22,2
+Click at 65, 5 for left of third line : 81,279,22,2
+Click at 65, 435 for right of third line : 81,279,22,2
+Click at 85, 5 for left of fourth line : 101,80,22,2
+Click at 85, 435 for right of fourth line : 120,100,20,2
+Click at 105, 5 for left of fifth line : 120,100,20,2
+Click at 105, 435 for right of fifth line : 120,100,20,2
+Click at 125, 5 for left of sixth line : 140,120,20,2
+Click at 125, 435 for right of sixth line : 140,411,20,2
+Click at 145, 5 for left of seventh line : 160,140,20,2
+Click at 145, 435 for right of seventh line : 160,319,20,2
+Click at 170, 5 for left below last line : 160,319,20,2
+Click at 170, 435 for right below last line : 160,319,20,2
+Click at 25, 30 for inside first root inline fragment : 41,20,22,2
+Click at 125, 30 for inside middle fragment of root inline fragment : 140,120,20,2
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 61,40,22,2
+Click at 65, 30 for inside last fragment of non-root inline fragment : 81,60,22,2
+Click at 85, 380 for inside unfragmented non-root inline : 101,380,22,2

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -69,7 +69,7 @@ public:
                 break;
             if (precedingLineBox.logicalBottom() < logicalTop())
                 break;
-            return precedingLineBox.contentLogicalBottom();
+            return std::min(contentLogicalTop(), precedingLineBox.contentLogicalBottom());
         }
         return contentLogicalTop();
     }
@@ -80,7 +80,7 @@ public:
         auto followingLineBox = LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex + 1 };
         if (followingLineBox.hasBlockLevelBox())
             return contentLogicalBottom();
-        return followingLineBox.contentLogicalTop();
+        return std::max(contentLogicalBottom(), followingLineBox.contentLogicalTop());
     }
 
     float contentLogicalLeft() const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
@@ -449,7 +449,7 @@ TEST(DragAndDropTests, ContentEditableMoveParagraphs)
     EXPECT_FALSE(firstParagraphOffset == NSNotFound);
     EXPECT_FALSE(secondParagraphOffset == NSNotFound);
     EXPECT_GT(firstParagraphOffset, secondParagraphOffset);
-    checkCGRectIsEqualToCGRectWithLogging(CGRectMake(251, 209, 2, 19), [simulator finalSelectionStartRect]);
+    checkCGRectIsEqualToCGRectWithLogging(CGRectMake(251, 208, 2, 19), [simulator finalSelectionStartRect]);
     EXPECT_TRUE([simulator lastKnownDropProposal].precise);
 }
 


### PR DESCRIPTION
#### 1f4f3d9ab219014ee11cb54ad5f591730087baa1
<pre>
Tall `::selection` eats into its background on subsequent lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=309047">https://bugs.webkit.org/show_bug.cgi?id=309047</a>
<a href="https://rdar.apple.com/172160711">rdar://172160711</a>

Reviewed by NOBODY (OOPS!).

A line&apos;s highlight starts at the preceding line&apos;s content bottom so that consecutive highlights are contiguous
and cover the leading between the lines. With a line height smaller than the content height the leading is
negative and the lines overlap, so there is no space to cover and that bottom is below this line&apos;s own content:
the highlight ends up shifted down by the overlap, painting over the following line instead of the text it
belongs to. Clamp the adjustment so it can only move the highlight&apos;s top up, never past our own content, and do
the same for the following line box in a line inverted writing mode. Non-overlapping lines are unaffected.

CSS Pseudo-Elements 4 says a highlight overlay for text &quot;must cover at least the entire em box and may extend
further above/below the em box to the line box edges&quot;. When the line height is smaller than the em box there is
nothing to extend to, so the em box is both the floor and the ceiling for the overlay.
See <a href="https://drafts.csswg.org/css-pseudo-4/#highlight-bounds.">https://drafts.csswg.org/css-pseudo-4/#highlight-bounds.</a>

Our highlight is the content area, which is the em box grown by whatever ascent and descent the font asks for,
so it normally sits within what that clause permits. The shifted highlight covered less than the em box, which
it does not permit either way. The tests use Ahem, whose ascent and descent add up to exactly one em, so the
content area and the em box coincide and the expected rect is the same whichever one an implementation paints.

The caret rect comes from the same line geometry (LineSelection::logicalRect), so it was truncated and shifted
the same way, which is what the caret-position-vertical-rl and caret-position-sideways-lr rebaselines are. Those
two tests used a 20px/1 monospace font, whose ascent and descent vary by OS, so whether their lines overlapped
at all varied with the OS as well. Use Ahem to pin them. The 1px borders on the test&apos;s inline boxes still make
every line holding a span overlap its neighbours, so the tests keep covering this and now do it identically
everywhere: the caret is 22 on all of those lines rather than 22 on the first one and 20 on the rest.

The iOS, Windows and generic baselines for those two tests still need to be rebaselined from the bots. The caret
is 2px wide on macOS and iOS but 1px elsewhere, and iOS reports an empty rect for some of the fragment clicks,
so neither can be derived from the macOS results.

The same shift moves the caret rect that the ContentEditableMoveParagraphs API test asserts. Its page is a
contenteditable in -apple-system at 1em with the default line height, and that is a negative leading case on iOS:
Font::platformInit derives the line spacing from the rounded ascent and descent, 15 + 4 = 19, while the content
height keeps the unrounded ones, 15.234 + 3.859 = 19.094, so every line overlaps the one before it by 0.094px.
The caret&apos;s top was the preceding line&apos;s content bottom, lineTop + 0.047, which truncated to lineTop; it is now
this line&apos;s own content top, lineTop - 0.047, which truncates to lineTop - 1. Its height stays 19 either way.
Expect 208 rather than 209. This one is computed from the metrics rather than observed, so it needs the bots to
confirm it along with the two baselines above.

Tests: imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-ref.html
       imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001.html
       imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-ref.html
       imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002.html

* LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt:
* LayoutTests/editing/caret/caret-position-sideways-lr.html:
* LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt:
* LayoutTests/editing/caret/caret-position-vertical-rl.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-overlapping-line-boxes-002.html: Added.
* LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt:
* LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalTopAdjustedForPrecedingLineBox const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalBottomAdjustedForFollowingLineBox const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f4f3d9ab219014ee11cb54ad5f591730087baa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147041 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142627 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99032 "layout-tests (failure) (timed out)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123062 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c6cd458-21c0-40bf-9879-562c10a5e684) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43296 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42920 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4143 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152080 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57050 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151779 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46353 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129318 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125351 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17923 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54996 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->