### PR TITLE
cssCanvasClients() returns a set of raw Element pointers

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -197,9 +197,9 @@ void CanvasBase::notifyObserversCanvasDisplayBufferPrepared()
         observer->canvasDisplayBufferPrepared(*this);
 }
 
-HashSet<Element*> CanvasBase::cssCanvasClients() const
+HashSet<Ref<Element>> CanvasBase::cssCanvasClients() const
 {
-    HashSet<Element*> cssCanvasClients;
+    HashSet<Ref<Element>> cssCanvasClients;
     for (CheckedRef observer : m_observers) {
         RefPtr image = dynamicDowncast<Style::CanvasImage>(observer.get());
         if (!image)
@@ -208,7 +208,7 @@ HashSet<Element*> CanvasBase::cssCanvasClients() const
         for (auto entry : image->clients()) {
             CheckedRef client = entry.key;
             if (RefPtr element = client->element())
-                cssCanvasClients.add(element.get());
+                cssCanvasClients.add(element.releaseNonNull());
         }
     }
     return cssCanvasClients;

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -98,7 +98,7 @@ public:
     void notifyObserversCanvasDisplayBufferPrepared();
     bool hasDisplayBufferObservers() const { return !m_displayBufferObservers.isEmptyIgnoringNullReferences(); }
 
-    HashSet<Element*> cssCanvasClients() const;
+    HashSet<Ref<Element>> cssCanvasClients() const;
 
     // !rect means caller knows the full canvas is invalidated previously.
     void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -290,7 +290,7 @@ JSC::JSValue InspectorCanvas::resolveContext(JSC::JSGlobalObject* exec)
     );
 }
 
-HashSet<Element*> InspectorCanvas::cssCanvasClientNodes() const
+HashSet<Ref<Element>> InspectorCanvas::cssCanvasClientNodes() const
 {
     return WTF::switchOn(m_context,
         [](const WeakRef<CanvasRenderingContext>& weakContext) {
@@ -299,14 +299,14 @@ HashSet<Element*> InspectorCanvas::cssCanvasClientNodes() const
         },
         [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
             Ref device = weakDevice;
-            HashSet<Element*> cssCanvasClientNodes;
+            HashSet<Ref<Element>> cssCanvasClientNodes;
             Locker locker { CanvasRenderingContext::instancesLock() };
             for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
                 if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
                     continue;
 
-                for (auto& cssCanvasClientNode : context->canvasBase().cssCanvasClients())
-                    cssCanvasClientNodes.add(cssCanvasClientNode);
+                for (Ref cssCanvasClientNode : context->canvasBase().cssCanvasClients())
+                    cssCanvasClientNodes.add(WTF::move(cssCanvasClientNode));
             }
             return cssCanvasClientNodes;
         }

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -82,7 +82,7 @@ public:
 
     JSC::JSValue resolveContext(JSC::JSGlobalObject*);
 
-    HashSet<Element*> cssCanvasClientNodes() const;
+    HashSet<Ref<Element>> cssCanvasClientNodes() const;
     size_t memoryCost() const;
 
     void canvasChanged();

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -129,10 +129,10 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::N
         return makeUnexpected(errorString);
 
     auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
-    for (RefPtr cssCanvasClientNode : inspectorCanvas->cssCanvasClientNodes()) {
+    for (Ref cssCanvasClientNode : inspectorCanvas->cssCanvasClientNodes()) {
         // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
         if (auto documentNodeId = domAgent->boundNodeId(protect(cssCanvasClientNode->document()).ptr()))
-            nodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, cssCanvasClientNode));
+            nodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, cssCanvasClientNode.ptr()));
     }
 
     m_pendingCSSCanvasClientNodesChange.remove(*inspectorCanvas);


### PR DESCRIPTION
#### 6743d4ebb647587a2b5b6ae8df4041490b87eb54
<pre>
cssCanvasClients() returns a set of raw Element pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322363">https://bugs.webkit.org/show_bug.cgi?id=322363</a>
<a href="https://rdar.apple.com/185651379">rdar://185651379</a>

Reviewed by Chris Dumez.

CanvasBase::cssCanvasClients() and InspectorCanvas::cssCanvasClientNodes() were
the last HashSet&lt;Element*&gt; in WebCore; every other Element set in the tree is a
HashSet&lt;Ref&lt;Element&gt;&gt; or a WeakHashSet&lt;Element&gt;. Nothing misbehaves today —
the set is built and drained inside a single synchronous inspector call, with no
script or layout in between — but the uncounted container has no reason to exist
here: the producer already holds a RefPtr to each element, and both consumers
immediately re-ref every entry.

Return HashSet&lt;Ref&lt;Element&gt;&gt; instead and let the callers iterate Refs directly.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::cssCanvasClients const):
(WebCore:: const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::cssCanvasClientNodes const):
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::requestCSSCanvasClientNodes):

Canonical link: <a href="https://commits.webkit.org/319679@main">https://commits.webkit.org/319679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81715b09fc5f3beaddd891aed2b3d00b1cfe8f9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146684 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae70bf34-7ea3-4e88-bbdb-426db5369cb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142341 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b13016f8-34ac-4080-84d9-eabdd89ad842) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122774 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53a6ef74-0773-4d9f-9a47-0ba6ecbb5985) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43003 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42624 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3747 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194511 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55973 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151770 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40648 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56664 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39249 "Too many flaky failures: http/tests/cookies/same-site/post-from-cross-site-popup.html, http/tests/media/reload-after-dialog.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/postredirect-basic.html, http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction.html, http/tests/security/canvas-remote-read-remote-image-blocked-then-allowed.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-redirect-allowed.html, http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https.html, http/tests/site-isolation/focus-tab-navigation-activeElement.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151471 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46050 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128948 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124907 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55175 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17623 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->