### PR TITLE
[Site Isolation] Console reports wrong error counts and loses messages after console.clear() on pages with iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope-expected.txt
@@ -1,0 +1,16 @@
+CONSOLE MESSAGE: subframe-ready
+CONSOLE MESSAGE: clear-scope-replay
+CONSOLE MESSAGE: clear-scope-refresh
+CONSOLE MESSAGE: clear-scope-refresh
+Under Site Isolation, console.clear() in one frame must clear every frame's console agent.
+
+
+== Running test suite: SiteIsolation.Console.ClearScope
+-- Running test case: SiteIsolation.Console.ClearScope.ClearEmptiesEveryAgent
+PASS: Site Isolation should be enabled.
+PASS: The subframe should have its own target, distinct from the main frame's.
+PASS: The main frame's agent should have no messages left to replay after a console.clear() in another frame.
+
+-- Running test case: SiteIsolation.Console.ClearScope.ClearResetsDedupState
+PASS: A message logged after a console.clear() should arrive as a new message, not a repeat count update.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope.html
@@ -1,0 +1,142 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/inspector/resources/inspector-test.js"></script>
+<script>
+// Utilities for page code.
+function addSubframe() {
+    const iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/console/resources/console-subframe.html";
+    document.body.appendChild(iframe);
+}
+
+function tellSubframe(what) {
+    frames[0].postMessage(what, "*");
+}
+
+function mainFrameError(text) {
+    console.error(text);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Console.ClearScope");
+
+    // console.clear() reaches only the calling frame's console agent, but the frontend clears
+    // its whole log, so other agents keep messages the user was told were cleared.
+
+    let mainFrameTarget = null;
+    let subframeTarget = null;
+    let framesReady = false;
+
+    // Distinct message text per case: a repeat of a stored message takes a different path.
+    async function setUpFrames() {
+        if (framesReady)
+            return;
+
+        mainFrameTarget = WI.targets.find((target) => target.type === WI.TargetType.Frame);
+
+        let [readyEvent] = await Promise.all([
+            WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+            InspectorTest.evaluateInPage(`addSubframe()`),
+        ]);
+        subframeTarget = readyEvent.data.message.target;
+
+        // console.clear() from page script only reaches the agent when the API is allowed.
+        await subframeTarget.ConsoleAgent.setConsoleClearAPIEnabled(true);
+
+        framesReady = true;
+    }
+
+    // Resolves on whichever arrives, so a test can assert which one the backend chose.
+    function awaitMessageAddedOrRepeat() {
+        return new Promise((resolve) => {
+            function cleanup() {
+                WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, addedListener);
+                WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, repeatListener);
+            }
+
+            let addedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                cleanup();
+                resolve({kind: "message-added", messageText: event.data.message.messageText});
+            });
+
+            let repeatListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, (event) => {
+                cleanup();
+                resolve({kind: "repeat-count-updated", count: event.data.count});
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.ClearScope.ClearEmptiesEveryAgent",
+        description: "console.clear() in one frame should clear every frame's console agent, not just its own.",
+        async test() {
+            InspectorTest.expectTrue(WI.isSiteIsolationEnabled(), "Site Isolation should be enabled.");
+            await setUpFrames();
+            InspectorTest.expectNotEqual(subframeTarget, mainFrameTarget, "The subframe should have its own target, distinct from the main frame's.");
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-replay")`),
+            ]);
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared),
+                InspectorTest.evaluateInPage(`tellSubframe("clear")`),
+            ]);
+
+            // Re-enabling Console replays whatever the agent still buffers.
+            let replayed = [];
+            let listener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                if (event.data.message.target === mainFrameTarget)
+                    replayed.push(event.data.message.messageText);
+            });
+
+            await mainFrameTarget.ConsoleAgent.disable();
+            await mainFrameTarget.ConsoleAgent.enable();
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+
+            InspectorTest.expectEqual(replayed.length, 0, "The main frame's agent should have no messages left to replay after a console.clear() in another frame.");
+            for (let messageText of replayed)
+                InspectorTest.log(`    Unexpectedly replayed: ${JSON.stringify(messageText)}`);
+        },
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.ClearScope.ClearResetsDedupState",
+        description: "After a console.clear() in another frame, a re-logged message should arrive as a new message rather than a repeat of a cleared one.",
+        async test() {
+            await setUpFrames();
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-refresh")`),
+            ]);
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared),
+                InspectorTest.evaluateInPage(`tellSubframe("clear")`),
+            ]);
+
+            // A stale pre-clear copy would make this a repeat-count update instead, which the
+            // frontend drops: clearing the log discarded the view the count would apply to.
+            let [result] = await Promise.all([
+                awaitMessageAddedOrRepeat(),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-refresh")`),
+            ]);
+
+            InspectorTest.expectEqual(result.kind, "message-added", "A message logged after a console.clear() should arrive as a new message, not a repeat count update.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Under Site Isolation, console.clear() in one frame must clear every frame's console agent.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level-expected.txt
@@ -1,0 +1,18 @@
+CONSOLE MESSAGE: subframe-ready
+CONSOLE MESSAGE: main-frame-error
+CONSOLE MESSAGE: subframe-log
+CONSOLE MESSAGE: main-frame-error
+Under Site Isolation, a repeated message's level must be counted from its own target rather than the globally-last message's level.
+
+
+== Running test suite: SiteIsolation.Console.RepeatCountMessageLevel
+-- Running test case: SiteIsolation.Console.RepeatCountMessageLevel.InterleavedTargets
+PASS: Site Isolation should be enabled.
+PASS: The main frame should have a frame target.
+PASS: The subframe should have loaded and logged.
+PASS: The subframe should have its own target, distinct from the main frame's.
+PASS: The first console.error() should be counted.
+PASS: The repeat should be reported with count 2.
+PASS: The repeat should be attributed to the main frame's target.
+PASS: errorCount should count both console.error() calls.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level.html
@@ -1,0 +1,80 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/inspector/resources/inspector-test.js"></script>
+<script>
+// Utilities for page code.
+function addSubframe() {
+    const iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/console/resources/console-subframe.html";
+    document.body.appendChild(iframe);
+}
+
+function tellSubframe(what) {
+    frames[0].postMessage(what, "*");
+}
+
+function mainFrameError() {
+    console.error("main-frame-error");
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Console.RepeatCountMessageLevel");
+
+    // Each frame's console agent dedups against its own store, so a repeat must be counted at
+    // the level of that target's last message, not the globally-last one.
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.RepeatCountMessageLevel.InterleavedTargets",
+        description: "A repeated message's level must be taken from its own target, not from the globally-last message.",
+        async test() {
+            InspectorTest.expectTrue(WI.isSiteIsolationEnabled(), "Site Isolation should be enabled.");
+
+            let mainFrameTarget = WI.targets.find((target) => target.type === WI.TargetType.Frame);
+            InspectorTest.expectThat(mainFrameTarget, "The main frame should have a frame target.");
+
+            let [readyEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`addSubframe()`),
+            ]);
+            let subframeTarget = readyEvent.data.message.target;
+            InspectorTest.expectEqual(readyEvent.data.message.messageText, "subframe-ready", "The subframe should have loaded and logged.");
+            InspectorTest.expectNotEqual(subframeTarget, mainFrameTarget, "The subframe should have its own target, distinct from the main frame's.");
+
+            let errorCountBefore = WI.consoleManager.errorCount;
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError()`),
+            ]);
+            InspectorTest.expectEqual(WI.consoleManager.errorCount - errorCountBefore, 1, "The first console.error() should be counted.");
+
+            // A different level from another target, which moved the old global "last level".
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`tellSubframe("log")`),
+            ]);
+
+            // The main frame's agent still matches, so the backend sends a repeat count update.
+            let [repeatEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated),
+                InspectorTest.evaluateInPage(`mainFrameError()`),
+            ]);
+
+            InspectorTest.expectEqual(repeatEvent.data.count, 2, "The repeat should be reported with count 2.");
+            InspectorTest.expectEqual(repeatEvent.data.target, mainFrameTarget, "The repeat should be attributed to the main frame's target.");
+
+            InspectorTest.expectEqual(WI.consoleManager.errorCount - errorCountBefore, 2, "errorCount should count both console.error() calls.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Under Site Isolation, a repeated message's level must be counted from its own target rather than the globally-last message's level.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/console/resources/console-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/resources/console-subframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<p>subframe</p>
+<script>
+// Logging from inside this frame is what attributes the message to its own console agent.
+window.addEventListener("message", (event) => {
+    switch (event.data) {
+    case "log":
+        console.log("subframe-log");
+        break;
+    case "error":
+        console.error("subframe-error");
+        break;
+    case "clear":
+        console.clear();
+        break;
+    }
+});
+
+window.addEventListener("load", () => {
+    console.log("subframe-ready");
+});
+</script>

--- a/LayoutTests/inspector/console/resources/site-isolation-console-subframe.html
+++ b/LayoutTests/inspector/console/resources/site-isolation-console-subframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<p>subframe</p>
+<script>
+// Logging from inside this frame is what attributes the message to its own console agent.
+window.addEventListener("message", (event) => {
+    switch (event.data) {
+    case "log":
+        console.log("subframe-log");
+        break;
+    case "error":
+        console.error("subframe-error");
+        break;
+    case "clear":
+        console.clear();
+        break;
+    }
+});
+
+window.addEventListener("load", () => {
+    console.log("subframe-ready");
+});
+</script>

--- a/LayoutTests/inspector/console/site-isolation-console-clear-scope-expected.txt
+++ b/LayoutTests/inspector/console/site-isolation-console-clear-scope-expected.txt
@@ -1,0 +1,16 @@
+CONSOLE MESSAGE: subframe-ready
+CONSOLE MESSAGE: clear-scope-replay
+CONSOLE MESSAGE: clear-scope-refresh
+CONSOLE MESSAGE: clear-scope-refresh
+Same-process variant: console.clear() in a same-origin subframe must still clear every frame's console agent.
+
+
+== Running test suite: SiteIsolation.Console.ClearScope
+-- Running test case: SiteIsolation.Console.ClearScope.ClearEmptiesEveryAgent
+PASS: Site Isolation should be enabled.
+PASS: The subframe should have its own target, distinct from the main frame's.
+PASS: The main frame's agent should have no messages left to replay after a console.clear() in another frame.
+
+-- Running test case: SiteIsolation.Console.ClearScope.ClearResetsDedupState
+PASS: A message logged after a console.clear() should arrive as a new message, not a repeat count update.
+

--- a/LayoutTests/inspector/console/site-isolation-console-clear-scope.html
+++ b/LayoutTests/inspector/console/site-isolation-console-clear-scope.html
@@ -1,0 +1,142 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+// Utilities for page code.
+function addSubframe() {
+    const iframe = document.createElement("iframe");
+    iframe.src = "resources/site-isolation-console-subframe.html";
+    document.body.appendChild(iframe);
+}
+
+function tellSubframe(what) {
+    frames[0].postMessage(what, "*");
+}
+
+function mainFrameError(text) {
+    console.error(text);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Console.ClearScope");
+
+    // console.clear() reaches only the calling frame's console agent, but the frontend clears
+    // its whole log, so other agents keep messages the user was told were cleared.
+
+    let mainFrameTarget = null;
+    let subframeTarget = null;
+    let framesReady = false;
+
+    // Distinct message text per case: a repeat of a stored message takes a different path.
+    async function setUpFrames() {
+        if (framesReady)
+            return;
+
+        mainFrameTarget = WI.targets.find((target) => target.type === WI.TargetType.Frame);
+
+        let [readyEvent] = await Promise.all([
+            WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+            InspectorTest.evaluateInPage(`addSubframe()`),
+        ]);
+        subframeTarget = readyEvent.data.message.target;
+
+        // console.clear() from page script only reaches the agent when the API is allowed.
+        await subframeTarget.ConsoleAgent.setConsoleClearAPIEnabled(true);
+
+        framesReady = true;
+    }
+
+    // Resolves on whichever arrives, so a test can assert which one the backend chose.
+    function awaitMessageAddedOrRepeat() {
+        return new Promise((resolve) => {
+            function cleanup() {
+                WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, addedListener);
+                WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, repeatListener);
+            }
+
+            let addedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                cleanup();
+                resolve({kind: "message-added", messageText: event.data.message.messageText});
+            });
+
+            let repeatListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, (event) => {
+                cleanup();
+                resolve({kind: "repeat-count-updated", count: event.data.count});
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.ClearScope.ClearEmptiesEveryAgent",
+        description: "console.clear() in one frame should clear every frame's console agent, not just its own.",
+        async test() {
+            InspectorTest.expectTrue(WI.isSiteIsolationEnabled(), "Site Isolation should be enabled.");
+            await setUpFrames();
+            InspectorTest.expectNotEqual(subframeTarget, mainFrameTarget, "The subframe should have its own target, distinct from the main frame's.");
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-replay")`),
+            ]);
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared),
+                InspectorTest.evaluateInPage(`tellSubframe("clear")`),
+            ]);
+
+            // Re-enabling Console replays whatever the agent still buffers.
+            let replayed = [];
+            let listener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                if (event.data.message.target === mainFrameTarget)
+                    replayed.push(event.data.message.messageText);
+            });
+
+            await mainFrameTarget.ConsoleAgent.disable();
+            await mainFrameTarget.ConsoleAgent.enable();
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+
+            InspectorTest.expectEqual(replayed.length, 0, "The main frame's agent should have no messages left to replay after a console.clear() in another frame.");
+            for (let messageText of replayed)
+                InspectorTest.log(`    Unexpectedly replayed: ${JSON.stringify(messageText)}`);
+        },
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.ClearScope.ClearResetsDedupState",
+        description: "After a console.clear() in another frame, a re-logged message should arrive as a new message rather than a repeat of a cleared one.",
+        async test() {
+            await setUpFrames();
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-refresh")`),
+            ]);
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared),
+                InspectorTest.evaluateInPage(`tellSubframe("clear")`),
+            ]);
+
+            // A stale pre-clear copy would make this a repeat-count update instead, which the
+            // frontend drops: clearing the log discarded the view the count would apply to.
+            let [result] = await Promise.all([
+                awaitMessageAddedOrRepeat(),
+                InspectorTest.evaluateInPage(`mainFrameError("clear-scope-refresh")`),
+            ]);
+
+            InspectorTest.expectEqual(result.kind, "message-added", "A message logged after a console.clear() should arrive as a new message, not a repeat count update.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Same-process variant: console.clear() in a same-origin subframe must still clear every frame's console agent.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/console/site-isolation-repeat-count-message-level-expected.txt
+++ b/LayoutTests/inspector/console/site-isolation-repeat-count-message-level-expected.txt
@@ -1,0 +1,18 @@
+CONSOLE MESSAGE: subframe-ready
+CONSOLE MESSAGE: main-frame-error
+CONSOLE MESSAGE: subframe-log
+CONSOLE MESSAGE: main-frame-error
+Same-process variant: under Site Isolation a same-origin subframe still gets its own console agent, so a repeated message's level must be counted from its own target.
+
+
+== Running test suite: SiteIsolation.Console.RepeatCountMessageLevel
+-- Running test case: SiteIsolation.Console.RepeatCountMessageLevel.InterleavedTargets
+PASS: Site Isolation should be enabled.
+PASS: The main frame should have a frame target.
+PASS: The subframe should have loaded and logged.
+PASS: The subframe should have its own target, distinct from the main frame's.
+PASS: The first console.error() should be counted.
+PASS: The repeat should be reported with count 2.
+PASS: The repeat should be attributed to the main frame's target.
+PASS: errorCount should count both console.error() calls.
+

--- a/LayoutTests/inspector/console/site-isolation-repeat-count-message-level.html
+++ b/LayoutTests/inspector/console/site-isolation-repeat-count-message-level.html
@@ -1,0 +1,80 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+// Utilities for page code.
+function addSubframe() {
+    const iframe = document.createElement("iframe");
+    iframe.src = "resources/site-isolation-console-subframe.html";
+    document.body.appendChild(iframe);
+}
+
+function tellSubframe(what) {
+    frames[0].postMessage(what, "*");
+}
+
+function mainFrameError() {
+    console.error("main-frame-error");
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Console.RepeatCountMessageLevel");
+
+    // Each frame's console agent dedups against its own store, so a repeat must be counted at
+    // the level of that target's last message, not the globally-last one.
+
+    suite.addTestCase({
+        name: "SiteIsolation.Console.RepeatCountMessageLevel.InterleavedTargets",
+        description: "A repeated message's level must be taken from its own target, not from the globally-last message.",
+        async test() {
+            InspectorTest.expectTrue(WI.isSiteIsolationEnabled(), "Site Isolation should be enabled.");
+
+            let mainFrameTarget = WI.targets.find((target) => target.type === WI.TargetType.Frame);
+            InspectorTest.expectThat(mainFrameTarget, "The main frame should have a frame target.");
+
+            let [readyEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`addSubframe()`),
+            ]);
+            let subframeTarget = readyEvent.data.message.target;
+            InspectorTest.expectEqual(readyEvent.data.message.messageText, "subframe-ready", "The subframe should have loaded and logged.");
+            InspectorTest.expectNotEqual(subframeTarget, mainFrameTarget, "The subframe should have its own target, distinct from the main frame's.");
+
+            let errorCountBefore = WI.consoleManager.errorCount;
+
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`mainFrameError()`),
+            ]);
+            InspectorTest.expectEqual(WI.consoleManager.errorCount - errorCountBefore, 1, "The first console.error() should be counted.");
+
+            // A different level from another target, which moved the old global "last level".
+            await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`tellSubframe("log")`),
+            ]);
+
+            // The main frame's agent still matches, so the backend sends a repeat count update.
+            let [repeatEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated),
+                InspectorTest.evaluateInPage(`mainFrameError()`),
+            ]);
+
+            InspectorTest.expectEqual(repeatEvent.data.count, 2, "The repeat should be reported with count 2.");
+            InspectorTest.expectEqual(repeatEvent.data.target, mainFrameTarget, "The repeat should be attributed to the main frame's target.");
+
+            InspectorTest.expectEqual(WI.consoleManager.errorCount - errorCountBefore, 2, "errorCount should count both console.error() calls.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Same-process variant: under Site Isolation a same-origin subframe still gets its own console agent, so a repeated message's level must be counted from its own target.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -34,7 +34,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._errorCount = 0;
         this._issues = [];
 
-        this._lastMessageLevel = null;
+        this._lastMessageLevelForTarget = new WeakMap;
         this._clearMessagesRequested = false;
         this._legacyPendingMainFrameNavigationClear = false;
         this._remoteObjectsToRelease = null;
@@ -186,7 +186,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         const request = null;
         let message = new WI.ConsoleMessage(target, source, level, text, type, url, line, column, repeatCount, parameters, stackTrace, request, timestamp);
 
-        this._incrementMessageLevelCount(message.level, message.repeatCount);
+        this._incrementMessageLevelCount(target, message.level, message.repeatCount);
 
         this.dispatchEventToListeners(WI.ConsoleManager.Event.MessageAdded, {message});
 
@@ -200,7 +200,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         }
     }
 
-    messagesCleared(reason)
+    messagesCleared(target, reason)
     {
         if (this._remoteObjectsToRelease) {
             for (let remoteObject of this._remoteObjectsToRelease)
@@ -240,6 +240,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         case WI.ConsoleManager.ClearReason.ConsoleAPI:
             console.assert(WI.settings.consoleClearAPIEnabled.value);
             this._clearMessages();
+            this._clearMessagesForOtherTargets(target);
             return;
 
         case WI.ConsoleManager.ClearReason.MainFrameNavigation:
@@ -254,7 +255,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     messageRepeatCountUpdated(target, count, timestamp)
     {
-        this._incrementMessageLevelCount(this._lastMessageLevel, 1);
+        this._incrementMessageLevelCount(target, this._lastMessageLevelForTarget.get(target), 1);
 
         this.dispatchEventToListeners(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, {target, count, timestamp});
     }
@@ -289,7 +290,19 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     // Private
 
-    _incrementMessageLevelCount(level, count)
+    _clearMessagesForOtherTargets(target)
+    {
+        // The replies carry ClearReason.Frontend, so this does not recurse.
+        for (let otherTarget of WI.targets) {
+            if (otherTarget === target)
+                continue;
+
+            if (otherTarget.hasDomain("Console"))
+                otherTarget.ConsoleAgent.clearMessages();
+        }
+    }
+
+    _incrementMessageLevelCount(target, level, count)
     {
         switch (level) {
         case WI.ConsoleMessage.MessageLevel.Warning:
@@ -300,7 +313,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
             break;
         }
 
-        this._lastMessageLevel = level;
+        this._lastMessageLevelForTarget.set(target, level);
     }
 
     _clearMessages()
@@ -309,7 +322,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._errorCount = 0;
         this._issues = [];
 
-        this._lastMessageLevel = null;
+        this._lastMessageLevelForTarget = new WeakMap;
 
         this.dispatchEventToListeners(WI.ConsoleManager.Event.Cleared);
     }

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -45,7 +45,7 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
 
     messagesCleared(reason)
     {
-        WI.consoleManager.messagesCleared(reason);
+        WI.consoleManager.messagesCleared(this._target, reason);
     }
 
     heapSnapshot(timestamp, snapshotStringData, title)


### PR DESCRIPTION
#### 1ff4451fea055b2fc6890851cce6c9e9e22d6a4d
<pre>
[Site Isolation] Console reports wrong error counts and loses messages after console.clear() on pages with iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322364">https://bugs.webkit.org/show_bug.cgi?id=322364</a>
<a href="https://rdar.apple.com/problem/185652132">rdar://problem/185652132</a>

Reviewed by NOBODY (OOPS!).

Under Site Isolation each frame keeps its own console messages. The frontend
counted a repeated message at the level of whichever frame logged most recently,
and a console.clear() from one frame emptied the visible log while leaving the
other frames&apos; messages in place, so they reappeared when the inspector reopened.
Count repeats per frame, and clear every frame.

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager): Track the last message level per target rather than globally.
(WI.ConsoleManager.prototype.messageWasAdded):
(WI.ConsoleManager.prototype.messagesCleared): Take the target the clear came from.
(WI.ConsoleManager.prototype.messageRepeatCountUpdated): Count the repeat at the
level of its own target&apos;s last message.
(WI.ConsoleManager.prototype._clearMessagesForOtherTargets): Added.
(WI.ConsoleManager.prototype._incrementMessageLevelCount):
(WI.ConsoleManager.prototype._clearMessages):
* Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js:
(WI.ConsoleObserver.prototype.messagesCleared): Forward the target, as the other
Console events already do.

* LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/console-clear-scope.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/repeat-count-message-level.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/resources/console-subframe.html: Added.
* LayoutTests/inspector/console/resources/site-isolation-console-subframe.html: Added.
* LayoutTests/inspector/console/site-isolation-console-clear-scope-expected.txt: Added.
* LayoutTests/inspector/console/site-isolation-console-clear-scope.html: Added.
* LayoutTests/inspector/console/site-isolation-repeat-count-message-level-expected.txt: Added.
* LayoutTests/inspector/console/site-isolation-repeat-count-message-level.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff4451fea055b2fc6890851cce6c9e9e22d6a4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146688 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b5dba06-df0b-4453-ad00-b8ea0f5a092d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98863 "3 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b81dbf2e-2379-49e1-a7ca-c42e376cb199) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122776 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52fd8df9-cb0a-4d80-9bca-4fc1fce515d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44731 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43005 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42627 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3751 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194515 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151772 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56668 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151473 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128952 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17626 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->