### PR TITLE
Drop the hardening added to DOMWrapperWorld in 315505@main

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -31,123 +31,14 @@
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/MainThread.h>
 
-#if PLATFORM(COCOA)
-#include <mutex>
-#include <sys/mman.h>
-#include <wtf/FastMalloc.h>
-#include <wtf/HashMap.h>
-#include <wtf/Lock.h>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/PageBlock.h>
-#include <wtf/WeakRandomNumber.h>
-#endif
-
 namespace WebCore {
 using namespace JSC;
-
-#if PLATFORM(COCOA)
-
-bool gGuardWrapperMaps = false;
-
-// Guard ~1 in N WebContent processes (tuning knob: lower the average Speedometer cost to rate x full).
-static constexpr unsigned kWrapperMapGuardSampleRate = 64;
-
-static void initializeWrapperMapGuardingOnce()
-{
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        gGuardWrapperMaps = !(weakRandomNumber<unsigned>() % kWrapperMapGuardSampleRate);
-    });
-}
-
-thread_local WrapperMutationScope* WrapperMutationScope::s_active { nullptr };
-
-// Registry of live page-aligned m_wrappers backings, so free() knows the mmap length to unmap.
-static Lock backingRegistryLock;
-static HashMap<void*, size_t>& backingRegistry() WTF_REQUIRES_LOCK(backingRegistryLock)
-{
-    static NeverDestroyed<HashMap<void*, size_t>> registry;
-    return registry;
-}
-
-void* WrapperMapTableMalloc::allocate(size_t size)
-{
-    size_t pageSize = WTF::pageSize();
-    size_t requested = size ? size : 1;
-    size_t rounded = (requested + pageSize - 1) & ~(pageSize - 1);
-    void* base = mmap(nullptr, rounded, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
-    RELEASE_ASSERT(base != MAP_FAILED);
-    {
-        Locker locker { backingRegistryLock };
-        backingRegistry().set(base, rounded);
-    }
-    // Newly allocated table starts writable; the surrounding WrapperMutationScope re-protects it.
-    if (auto* world = WrapperMutationScope::currentlyMutatedWorld())
-        world->noteTableBacking(base, rounded);
-    return base;
-}
-
-void* WrapperMapTableMalloc::malloc(size_t size) { return gGuardWrapperMaps ? allocate(size) : WTF::fastMalloc(size); }
-void* WrapperMapTableMalloc::zeroedMalloc(size_t size) { return gGuardWrapperMaps ? allocate(size) : WTF::fastZeroedMalloc(size); } // mmap(MAP_ANON) is zero-filled.
-
-void WrapperMapTableMalloc::free(void* p)
-{
-    if (!p)
-        return;
-    // gGuardWrapperMaps is fixed for the process before the first allocation, so the allocation path
-    // and this free path always agree.
-    if (!gGuardWrapperMaps) {
-        WTF::fastFree(p);
-        return;
-    }
-    size_t size = 0;
-    {
-        Locker locker { backingRegistryLock };
-        size = backingRegistry().take(p);
-    }
-    RELEASE_ASSERT(size);
-    if (auto* world = WrapperMutationScope::currentlyMutatedWorld())
-        world->forgetTableBacking(p);
-    munmap(p, size);
-}
-
-void DOMWrapperWorld::setWrappersTableWritable(bool writable)
-{
-    if (writable) {
-        if (m_wrappersTableWritableDepth++)
-            return;
-    } else {
-        ASSERT(m_wrappersTableWritableDepth);
-        if (--m_wrappersTableWritableDepth)
-            return;
-    }
-    if (m_wrappersTableBase)
-        SUPPRESS_NODELETE RELEASE_ASSERT(!mprotect(m_wrappersTableBase, m_wrappersTableSize, PROT_READ | (writable ? PROT_WRITE : 0)));
-}
-
-void WrapperMutationScope::enter()
-{
-    m_previous = s_active;
-    s_active = this;
-    m_world->setWrappersTableWritable(true);
-}
-
-void WrapperMutationScope::leave()
-{
-    m_world->setWrappersTableWritable(false);
-    s_active = m_previous;
-}
-
-#endif // PLATFORM(COCOA)
 
 DOMWrapperWorld::DOMWrapperWorld(JSC::VM& vm, Type type, const String& name)
     : m_vm(vm)
     , m_name(name)
     , m_type(type)
 {
-#if PLATFORM(COCOA)
-    initializeWrapperMapGuardingOnce();
-#endif
     VM::ClientData* clientData = m_vm.clientData;
     ASSERT(clientData);
     downcast<JSVMClientData>(clientData)->rememberWorld(*this);
@@ -158,15 +49,6 @@ DOMWrapperWorld::~DOMWrapperWorld()
     VM::ClientData* clientData = m_vm.clientData;
     ASSERT(clientData);
     downcast<JSVMClientData>(clientData)->forgetWorld(*this);
-
-    // The m_wrappers member destructor (runs after this body) destroys buckets and frees the
-    // table, which writes to it; make the read-only backing writable so those writes don't fault.
-#if PLATFORM(COCOA)
-    if (m_wrappersTableBase) {
-        mprotect(m_wrappersTableBase, m_wrappersTableSize, PROT_READ | PROT_WRITE);
-        m_wrappersTableWritableDepth = 0;
-    }
-#endif
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())
@@ -182,10 +64,7 @@ void DOMWrapperWorld::clearWrappers()
             eventListener->invalidate();
     }
 
-    {
-        WrapperMutationScope scope { *this };
-        m_wrappers.clear();
-    }
+    m_wrappers.clear();
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -29,34 +29,9 @@ namespace WebCore {
 class JSEventListener;
 class WindowProxy;
 
-#if PLATFORM(COCOA)
-// Diagnostic (rdar://157587352): allocate the m_wrappers hash-table backing in its own page(s)
-// so it can be kept read-only except during the world's own mutating operations. Any stray write
-// that corrupts the map (the bug we are hunting) then faults immediately with the writer's stack.
-// To keep the cost off Speedometer, guarding is sampled per-process: gGuardWrapperMaps is decided
-// once at startup, and when false the allocator falls back to FastMalloc and the scopes are no-ops.
-// The whole facility relies on mmap/mprotect and is only built on Cocoa; elsewhere m_wrappers is a
-// plain HashMap and none of this code exists.
-WEBCORE_EXPORT extern bool gGuardWrapperMaps;
-
-struct WrapperMapTableMalloc {
-    WEBCORE_EXPORT static void* malloc(size_t);
-    WEBCORE_EXPORT static void* zeroedMalloc(size_t);
-    WEBCORE_EXPORT static void free(void*);
-private:
-    static void* allocate(size_t);
-};
-
-using DOMObjectWrapperMap = HashMap<void*, JSC::Weak<JSC::JSObject>, WTF::DefaultHash<void*>, WTF::HashTraits<void*>, WTF::HashTraits<JSC::Weak<JSC::JSObject>>, WTF::HashTableTraits, WTF::ShouldValidateKey::Yes, WrapperMapTableMalloc>;
-#else
-using DOMObjectWrapperMap = HashMap<void*, JSC::Weak<JSC::JSObject>>;
-#endif
+typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
 
 class DOMWrapperWorld : public RefCounted<DOMWrapperWorld>, public CanMakeSingleThreadWeakPtr<DOMWrapperWorld> {
-#if PLATFORM(COCOA)
-    friend struct WrapperMapTableMalloc;
-    friend class WrapperMutationScope;
-#endif
 public:
     enum class Type {
         Normal,   // Main (e.g. Page)
@@ -127,19 +102,6 @@ private:
     HashSet<WindowProxy*> m_jsWindowProxies;
     DOMObjectWrapperMap m_wrappers;
 
-#if PLATFORM(COCOA)
-    // Diagnostic page-protection state for m_wrappers (rdar://157587352). The backing is kept
-    // read-only except inside a WrapperMutationScope; WrapperMapTableMalloc reports each (re)allocated
-    // backing here so the scope can re-protect the current (possibly grown/shrunk) table. The whole
-    // facility relies on mmap/mprotect and is only built on Cocoa.
-    void noteTableBacking(void* base, size_t size) { m_wrappersTableBase = base; m_wrappersTableSize = size; }
-    void forgetTableBacking(void* base) { if (m_wrappersTableBase == base) { m_wrappersTableBase = nullptr; m_wrappersTableSize = 0; } }
-    SUPPRESS_NODELETE void NODELETE setWrappersTableWritable(bool);
-    void* m_wrappersTableBase { nullptr };
-    size_t m_wrappersTableSize { 0 };
-    unsigned m_wrappersTableWritableDepth { 0 };
-#endif
-
     WeakHashSet<JSEventListener> m_eventListeners;
 
     String m_name;
@@ -154,46 +116,6 @@ private:
     bool m_allowNodeSnapshotCreation : 1 { false };
     bool m_allowPostLegacySynchronousMessage : 1 { false };
     bool m_isMediaControls : 1 { false };
-};
-
-// RAII guard bracketing a mutating operation on a world's m_wrappers. On Cocoa it makes the
-// page-protected backing writable for the duration and read-only again afterwards (re-reading the
-// current backing, which may have been reallocated by a rehash during the operation); it is a cheap
-// branch on gGuardWrapperMaps when this process does not guard its wrapper maps. Off Cocoa the
-// diagnostic does not exist and the scope is an empty no-op, so call sites can construct it
-// unconditionally on every platform. rdar://157587352.
-class WrapperMutationScope {
-public:
-#if PLATFORM(COCOA)
-    explicit WrapperMutationScope(DOMWrapperWorld& world)
-        : m_world(world)
-    {
-        if (gGuardWrapperMaps) [[unlikely]]
-            enter();
-    }
-    ~WrapperMutationScope()
-    {
-        if (gGuardWrapperMaps) [[unlikely]]
-            leave();
-    }
-
-    // The world whose m_wrappers backing is currently being mutated on this thread (so the backing
-    // allocator can record each (re)allocated table on it), or nullptr when no scope is active.
-    static DOMWrapperWorld* currentlyMutatedWorld() { return s_active ? s_active->m_world.ptr() : nullptr; }
-#else
-    explicit WrapperMutationScope(DOMWrapperWorld&) { }
-#endif
-    WrapperMutationScope(const WrapperMutationScope&) = delete;
-    WrapperMutationScope& operator=(const WrapperMutationScope&) = delete;
-
-#if PLATFORM(COCOA)
-private:
-    WEBCORE_EXPORT void enter();
-    WEBCORE_EXPORT void leave();
-    static thread_local WrapperMutationScope* s_active;
-    SingleThreadWeakRef<DOMWrapperWorld> m_world;
-    WrapperMutationScope* m_previous { nullptr };
-#endif
 };
 
 DOMWrapperWorld& NODELETE normalWorld(JSC::VM&);

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -173,7 +173,6 @@ template<typename DOMClass, typename WrapperClass> inline void cacheWrapper(DOMW
     JSC::WeakHandleOwner* owner = wrapperOwner(world, domObject);
     if (setInlineCachedWrapper(world, domObject, wrapper, owner))
         return;
-    WrapperMutationScope scope { world }; // rdar://157587352: keep the page-protected backing writable for this mutation when guarding is enabled (no-op otherwise).
     weakAdd(world.wrappers(), wrapperKey(domObject), JSC::Weak<JSC::JSObject>(wrapper, owner, &world));
 }
 
@@ -181,7 +180,6 @@ template<typename DOMClass, typename WrapperClass> inline void uncacheWrapper(DO
 {
     if (clearInlineCachedWrapper(world, domObject, wrapper))
         return;
-    WrapperMutationScope scope { world }; // rdar://157587352: keep the page-protected backing writable for this mutation when guarding is enabled (no-op otherwise).
     weakRemove(world.wrappers(), wrapperKey(domObject), wrapper);
 }
 


### PR DESCRIPTION
#### 2f352b53432a3a71f20aa6934b286d82b45574d3
<pre>
Drop the hardening added to DOMWrapperWorld in 315505@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=322365">https://bugs.webkit.org/show_bug.cgi?id=322365</a>
<a href="https://rdar.apple.com/184886311">rdar://184886311</a>

Reviewed by David Kilzer.

Drop the hardening added to DOMWrapperWorld in 315505@main now the cause
of the crash has been identified.

* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::DOMWrapperWorld::DOMWrapperWorld):
(WebCore::DOMWrapperWorld::~DOMWrapperWorld):
(WebCore::DOMWrapperWorld::clearWrappers):
(WebCore::initializeWrapperMapGuardingOnce): Deleted.
(): Deleted.
(WebCore::WTF_REQUIRES_LOCK): Deleted.
(WebCore::WrapperMapTableMalloc::allocate): Deleted.
(WebCore::WrapperMapTableMalloc::malloc): Deleted.
(WebCore::WrapperMapTableMalloc::zeroedMalloc): Deleted.
(WebCore::WrapperMapTableMalloc::free): Deleted.
(WebCore::DOMWrapperWorld::setWrappersTableWritable): Deleted.
(WebCore::WrapperMutationScope::enter): Deleted.
(WebCore::WrapperMutationScope::leave): Deleted.
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::noteTableBacking): Deleted.
(WebCore::DOMWrapperWorld::forgetTableBacking): Deleted.
(WebCore::WrapperMutationScope::WrapperMutationScope): Deleted.
(WebCore::WrapperMutationScope::~WrapperMutationScope): Deleted.
(WebCore::WrapperMutationScope::currentlyMutatedWorld): Deleted.
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::cacheWrapper):
(WebCore::uncacheWrapper):

Canonical link: <a href="https://commits.webkit.org/319767@main">https://commits.webkit.org/319767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05157a6fa6954f7c7db82aae2887d8c57c561ad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146690 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6e84f31-8696-4176-a571-58c74c6b628d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142349 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98864 "2 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b010e65-c7cc-4a74-a7e3-c569bd9831b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122782 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32214789-aa37-409d-97b1-d80992e9cee0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43007 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42635 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3753 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194517 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55979 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40735 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56670 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151477 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46054 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128954 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55181 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17634 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54562 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54801 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54629 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->