### PR TITLE
CanvasNoiseInjection dirty rect is never cleared when the dirty region is fully transparent

### DIFF
--- a/LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect-expected.txt
@@ -1,0 +1,16 @@
+Test that a dirty rect whose pixels are all transparent is cleared once the canvas has been read back.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Initial canvas should not have pending dirty rects
+PASS fillRect with a transparent fill should require noise injection
+PASS getImageData should clear the dirty rect when every pixel in it is transparent
+PASS fillRect with a transparent fill should require noise injection
+PASS toDataURL should clear the dirty rect when every pixel in it is transparent
+PASS fillRect with an opaque fill should require noise injection
+PASS getImageData should apply all required noise
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect.html
+++ b/LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+    description("Test that a dirty rect whose pixels are all transparent is cleared once the canvas has been read back.");
+
+    function hasPendingCanvasNoiseInjection(canvas) {
+        return internals.doesCanvasHavePendingCanvasNoiseInjection(canvas);
+    }
+
+    function expectFalse(result, msg) {
+        expectTrue(!result, msg);
+    }
+
+    if (window.internals) {
+        let canvas = document.createElement("canvas");
+        internals.setCanvasNoiseInjectionSalt(canvas, 5);
+        document.body.appendChild(canvas);
+
+        let ctx = canvas.getContext("2d");
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "Initial canvas should not have pending dirty rects");
+
+        ctx.fillStyle = "rgba(0, 0, 0, 0)";
+        ctx.fillRect(0, 0, 50, 50);
+        expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect with a transparent fill should require noise injection");
+
+        ctx.getImageData(0, 0, canvas.width, canvas.height);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should clear the dirty rect when every pixel in it is transparent");
+
+        ctx.fillRect(60, 60, 50, 50);
+        expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect with a transparent fill should require noise injection");
+
+        canvas.toDataURL();
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "toDataURL should clear the dirty rect when every pixel in it is transparent");
+
+        ctx.fillStyle = "blue";
+        ctx.fillRect(0, 0, 50, 50);
+        expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect with an opaque fill should require noise injection");
+
+        ctx.getImageData(0, 0, canvas.width, canvas.height);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should apply all required noise");
+
+        document.body.removeChild(canvas);
+    } else
+        document.body.innerHTML = "window.internals is required for this test";
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -202,10 +202,10 @@ void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;
 
-    if (postProcessPixelBufferResults(*pixelBuffer, salt)) {
+    if (postProcessPixelBufferResults(*pixelBuffer, salt))
         imageBuffer->putPixelBuffer(*pixelBuffer, { IntPoint::zero(), dirtyRect.size() }, dirtyRect.location());
-        m_postProcessDirtyRect = { };
-    }
+
+    m_postProcessDirtyRect = { };
 }
 
 static std::pair<int, int> NODELETE lowerAndUpperBound(int component1, int component2, int component3)


### PR DESCRIPTION
#### f2faeb01517c97a8ee551309aa97c3c9a4d7d271
<pre>
CanvasNoiseInjection dirty rect is never cleared when the dirty region is fully transparent
<a href="https://bugs.webkit.org/show_bug.cgi?id=322367">https://bugs.webkit.org/show_bug.cgi?id=322367</a>
<a href="https://rdar.apple.com/185653414">rdar://185653414</a>

Reviewed by Gerald Squelart.

postProcessPixelBufferResults() only sets wasPixelBufferModified after the
`if (!alphaChannel) continue;` guard, so it returns false when every pixel in the
dirty rect is transparent. postProcessDirtyCanvasBuffer() gated both the
putPixelBuffer() write-back and the `m_postProcessDirtyRect = { }` reset on that
return value, so the dirty rect survived the readback. Nothing else clears it:
CanvasBase::didDraw() only calls clearDirtyRect() for a whole-canvas draw with
ShouldApplyPostProcessingToDirtyRect::No.

The stale rect makes every subsequent getImageData()/toDataURL()/toBlob() redo an
unpremultiplied RGBA8 getPixelBuffer() over it and throw the result away, and
leaves havePendingCanvasNoiseInjection() permanently true, forcing
drawImage(thatCanvas, ...) down the post-processing didDraw() path.

Skipping the write-back when nothing changed is still correct, so decouple the
two: reset the dirty rect once the pixel buffer has been processed, and only write
back when a pixel actually changed. The early returns for a missing image buffer
or a failed readback still preserve the rect.

Only reachable with a non-zero noise salt; salt 0 is the testing path and returns
true before the loop, which is why canvas-noise-injection.html misses this.

Test: fast/canvas/canvas-noise-injection-transparent-dirty-rect.html

* LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-noise-injection-transparent-dirty-rect.html: Added.
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):

Canonical link: <a href="https://commits.webkit.org/319682@main">https://commits.webkit.org/319682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88b60f72234e4b565d0bce26bcbc78046c1fba56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56354 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d429d583-aaaf-4c19-873b-0451f9c85eeb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56077 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71e63683-b420-4fbf-9722-c81b2e52a1f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46083 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/122814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5063619c-d46d-4b51-af0a-a86ca24facd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44767 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3801 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48985 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194563 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56025 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40654 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56716 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46088 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55227 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->