### PR TITLE
[JSC] Store `OSRExitDescriptor` exit values as a compact byte stream

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -228,9 +228,8 @@ void compile(State& state, Safepoint::Result& safepointResult)
     if (graph.needsScopeRegister() && codeBlock->scopeRegister().isValid())
         codeBlock->setScopeRegister(codeBlock->scopeRegister() + localsOffset);
 
+    state.jitCode->setOSRExitLocalsOffset(localsOffset);
     for (OSRExitDescriptor& descriptor : state.jitCode->osrExitDescriptors) {
-        for (unsigned i = descriptor.m_values.size(); i--;)
-            descriptor.m_values[i] = descriptor.m_values[i].withLocalsOffset(localsOffset);
         for (ExitTimeObjectMaterialization* materialization : descriptor.m_materializations)
             materialization->accountForLocalsOffset(localsOffset);
     }

--- a/Source/JavaScriptCore/ftl/FTLExitValue.h
+++ b/Source/JavaScriptCore/ftl/FTLExitValue.h
@@ -77,45 +77,21 @@ public:
         return result;
     }
     
-    static ExitValue inJSStack(VirtualRegister reg)
+    static ExitValue inJSStack(ExitValueKind kind, VirtualRegister reg)
     {
         ExitValue result;
-        result.m_kind = ExitValueInJSStack;
+        result.m_kind = kind;
         UnionType u;
         u.virtualRegister = reg.offset();
         result.m_value = WTF::move(u);
+        ASSERT(result.isInJSStackSomehow());
         return result;
     }
-    
-    static ExitValue inJSStackAsInt32(VirtualRegister reg)
-    {
-        ExitValue result;
-        result.m_kind = ExitValueInJSStackAsInt32;
-        UnionType u;
-        u.virtualRegister = reg.offset();
-        result.m_value = WTF::move(u);
-        return result;
-    }
-    
-    static ExitValue inJSStackAsInt52(VirtualRegister reg)
-    {
-        ExitValue result;
-        result.m_kind = ExitValueInJSStackAsInt52;
-        UnionType u;
-        u.virtualRegister = reg.offset();
-        result.m_value = WTF::move(u);
-        return result;
-    }
-    
-    static ExitValue inJSStackAsDouble(VirtualRegister reg)
-    {
-        ExitValue result;
-        result.m_kind = ExitValueInJSStackAsDouble;
-        UnionType u;
-        u.virtualRegister = reg.offset();
-        result.m_value = WTF::move(u);
-        return result;
-    }
+
+    static ExitValue inJSStack(VirtualRegister reg) { return inJSStack(ExitValueInJSStack, reg); }
+    static ExitValue inJSStackAsInt32(VirtualRegister reg) { return inJSStack(ExitValueInJSStackAsInt32, reg); }
+    static ExitValue inJSStackAsInt52(VirtualRegister reg) { return inJSStack(ExitValueInJSStackAsInt52, reg); }
+    static ExitValue inJSStackAsDouble(VirtualRegister reg) { return inJSStack(ExitValueInJSStackAsDouble, reg); }
     
     static ExitValue constant(JSValue value)
     {

--- a/Source/JavaScriptCore/ftl/FTLJITCode.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.cpp
@@ -29,7 +29,9 @@
 #if ENABLE(FTL_JIT)
 
 #include "FTLState.h"
+#include "JSCJSValueInlines.h"
 #include "JSCPtrTag.h"
+#include "TrackedReferences.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -141,6 +143,7 @@ void JITCode::shrinkToFit()
     common.shrinkToFit();
     m_osrExit.shrinkToFit();
     osrExitDescriptors.shrinkToFit();
+    osrExitConstants.shrinkToFit();
     lazySlowPaths.shrinkToFit();
 }
 
@@ -148,6 +151,8 @@ void JITCode::validateReferences(const TrackedReferences& trackedReferences)
 {
     common.validateReferences(trackedReferences);
     
+    for (EncodedJSValue constant : osrExitConstants)
+        trackedReferences.check(JSValue::decode(constant));
     for (OSRExit& exit : m_osrExit)
         exit.m_descriptor->validateReferences(trackedReferences);
 }

--- a/Source/JavaScriptCore/ftl/FTLJITCode.h
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.h
@@ -77,6 +77,9 @@ public:
 
     const RegisterAtOffsetList* calleeSaveRegisters() const LIFETIME_BOUND { return &m_calleeSaveRegisters; }
 
+    int osrExitLocalsOffset() const { return m_osrExitLocalsOffset; }
+    void setOSRExitLocalsOffset(int offset) { m_osrExitLocalsOffset = offset; }
+
     unsigned numberOfCompiledDFGNodes() const { return m_numberOfCompiledDFGNodes; }
     void setNumberOfCompiledDFGNodes(unsigned numberOfCompiledDFGNodes)
     {
@@ -87,6 +90,7 @@ public:
     Vector<OSRExit> m_osrExit;
     RegisterAtOffsetList m_calleeSaveRegisters;
     SegmentedVector<OSRExitDescriptor, 8> osrExitDescriptors;
+    Vector<EncodedJSValue> osrExitConstants;
     Vector<std::unique_ptr<LazySlowPath>> lazySlowPaths;
     
 private:
@@ -95,6 +99,7 @@ private:
     CodePtr<JSEntryPtrTag> m_addressForArityCheck;
     size_t m_size { 1000 };
     unsigned m_numberOfCompiledDFGNodes { 0 };
+    int m_osrExitLocalsOffset { 0 };
 };
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -27163,11 +27163,7 @@ IGNORE_CLANG_WARNINGS_END
                 }
             }
         }
-        return &m_ftlState.jitCode->osrExitDescriptors.alloc(
-            lowValue.format(), profile,
-            availabilityMap().m_locals.numberOfArguments(),
-            availabilityMap().m_locals.numberOfLocals(),
-            availabilityMap().m_locals.numberOfTmps());
+        return &m_ftlState.jitCode->osrExitDescriptors.alloc(lowValue.format(), profile);
     }
 
     void appendOSRExit(
@@ -27307,8 +27303,9 @@ IGNORE_CLANG_WARNINGS_END
                 }
             });
 
-        for (unsigned i = 0; i < exitDescriptor->m_values.size(); ++i) {
-            Operand operand = exitDescriptor->m_values.operandForIndex(i);
+        Operands<ExitValue> exitValues(OperandsLike, availabilityMap.m_locals);
+        for (unsigned i = 0; i < exitValues.size(); ++i) {
+            Operand operand = exitValues.operandForIndex(i);
 
             Availability availability = availabilityMap.m_locals[i];
 
@@ -27322,8 +27319,9 @@ IGNORE_CLANG_WARNINGS_END
             ExitValue exitValue = exitValueForAvailability(arguments, map, availability);
             if (exitValue.hasIndexInStackmapLocations())
                 exitValue.adjustStackmapLocationsIndexByOffset(offsetOfExitArgumentsInStackmapLocations);
-            exitDescriptor->m_values[i] = exitValue;
+            exitValues[i] = exitValue;
         }
+        exitDescriptor->m_values.encode(exitValues, exitDescriptor->m_materializations, *m_ftlState.jitCode);
 
         for (auto& heapPair : availabilityMap.m_heap) {
             Node* node = heapPair.key.base();
@@ -27341,7 +27339,7 @@ IGNORE_CLANG_WARNINGS_END
 
         if (verboseCompilationEnabled()) [[unlikely]] {
             WTF::dataFile().atomically([&](auto&) {
-                dataLogLn("        Exit values: ", exitDescriptor->m_values);
+                dataLogLn("        Exit values: ", exitValues);
                 if (!exitDescriptor->m_materializations.isEmpty()) {
                     dataLogLn("        Materializations:");
                     for (ExitTimeObjectMaterialization* materialization : exitDescriptor->m_materializations)

--- a/Source/JavaScriptCore/ftl/FTLOSRExit.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExit.cpp
@@ -32,26 +32,181 @@
 #include "FTLJITCode.h"
 #include "FTLSlowPathCall.h"
 #include "FTLState.h"
+#include "JSCJSValueInlines.h"
+#include <wtf/LEBDecoder.h>
 
 namespace JSC { namespace FTL {
 
 using namespace B3;
 using namespace DFG;
 
-OSRExitDescriptor::OSRExitDescriptor(
-    DataFormat profileDataFormat, MethodOfGettingAValueProfile valueProfile,
-    unsigned numberOfArguments, unsigned numberOfLocals, unsigned numberOfTmps)
+namespace {
+
+constexpr uint8_t maxDeadRunLength = 0x40;
+constexpr uint8_t inJSStackAtOwnRegisterTag = 0x40;
+constexpr uint8_t inJSStackTag = 0x44;
+constexpr uint8_t constantTag = 0x48;
+constexpr uint8_t materializationTag = 0x49;
+constexpr uint8_t argumentTag = 0x4A;
+
+static_assert(ExitValueInJSStackAsInt32 == ExitValueInJSStack + 1);
+static_assert(ExitValueInJSStackAsInt52 == ExitValueInJSStack + 2);
+static_assert(ExitValueInJSStackAsDouble == ExitValueInJSStack + 3);
+static_assert(inJSStackAtOwnRegisterTag + 4 == inJSStackTag);
+static_assert(inJSStackTag + 4 == constantTag);
+
+void appendLEB(Vector<uint8_t, 128>& bytes, uint32_t value)
+{
+    while (value >= 0x80) {
+        bytes.append(static_cast<uint8_t>(value | 0x80));
+        value >>= 7;
+    }
+    bytes.append(static_cast<uint8_t>(value));
+}
+
+uint32_t readLEB(std::span<const uint8_t> bytes, size_t& offset)
+{
+    uint32_t result = 0;
+    bool success = WTF::LEBDecoder::decodeUInt32(bytes, offset, result);
+    RELEASE_ASSERT(success);
+    return result;
+}
+
+ExitValueKind inJSStackKind(uint8_t tag, uint8_t baseTag)
+{
+    return static_cast<ExitValueKind>(ExitValueInJSStack + (tag - baseTag));
+}
+
+Vector<ExitTimeObjectMaterialization*, 4> materializationTable(const Bag<ExitTimeObjectMaterialization>& materializations)
+{
+    Vector<ExitTimeObjectMaterialization*, 4> table;
+    for (ExitTimeObjectMaterialization* materialization : materializations)
+        table.append(materialization);
+    return table;
+}
+
+} // anonymous namespace
+
+void OSRExitValues::encode(const Operands<ExitValue>& values, const Bag<ExitTimeObjectMaterialization>& materializationBag, JITCode& jitCode)
+{
+    m_numberOfArguments = values.numberOfArguments();
+    m_numberOfLocals = values.numberOfLocals();
+    m_numberOfTmps = values.numberOfTmps();
+
+    Vector<ExitTimeObjectMaterialization*, 4> materializations = materializationTable(materializationBag);
+    Vector<EncodedJSValue>& constants = jitCode.osrExitConstants;
+    Vector<uint8_t, 128> bytes;
+    for (unsigned index = 0; index < values.size(); ++index) {
+        const ExitValue& value = values[index];
+        switch (value.kind()) {
+        case ExitValueDead: {
+            unsigned runLength = 1;
+            while (runLength < maxDeadRunLength && index + runLength < values.size() && values[index + runLength].isDead())
+                ++runLength;
+            bytes.append(static_cast<uint8_t>(runLength - 1));
+            index += runLength - 1;
+            break;
+        }
+        case ExitValueInJSStack:
+        case ExitValueInJSStackAsInt32:
+        case ExitValueInJSStackAsInt52:
+        case ExitValueInJSStackAsDouble: {
+            Operand operand = values.operandForIndex(index);
+            VirtualRegister reg = value.virtualRegister();
+            if (!operand.isTmp() && operand.virtualRegister() == reg) {
+                bytes.append(inJSStackAtOwnRegisterTag + (value.kind() - ExitValueInJSStack));
+                break;
+            }
+            bytes.append(inJSStackTag + (value.kind() - ExitValueInJSStack));
+            int32_t offset = reg.offset();
+            appendLEB(bytes, (static_cast<uint32_t>(offset) << 1) ^ static_cast<uint32_t>(offset >> 31));
+            break;
+        }
+        case ExitValueConstant: {
+            bytes.append(constantTag);
+            EncodedJSValue constant = JSValue::encode(value.constant());
+            size_t constantIndex = constants.find(constant);
+            if (constantIndex == notFound) {
+                constantIndex = constants.size();
+                constants.append(constant);
+            }
+            appendLEB(bytes, constantIndex);
+            break;
+        }
+        case ExitValueMaterializeNewObject: {
+            bytes.append(materializationTag);
+            size_t materializationIndex = materializations.find(value.objectMaterialization());
+            ASSERT(materializationIndex != notFound);
+            appendLEB(bytes, materializationIndex);
+            break;
+        }
+        case ExitValueArgument:
+            bytes.append(argumentTag);
+            bytes.append(static_cast<uint8_t>(value.exitArgument().format()));
+            appendLEB(bytes, value.exitArgument().argument());
+            break;
+        case InvalidExitValue:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+    m_bytes = FixedVector<uint8_t>(bytes);
+}
+
+FixedOperands<ExitValue> OSRExitValues::decode(const JITCode& jitCode, const Bag<ExitTimeObjectMaterialization>& materializationBag) const
+{
+    FixedOperands<ExitValue> values(m_numberOfArguments, m_numberOfLocals, m_numberOfTmps, ExitValue::dead());
+    int localsOffset = jitCode.osrExitLocalsOffset();
+    Vector<ExitTimeObjectMaterialization*, 4> materializations = materializationTable(materializationBag);
+
+    std::span<const uint8_t> bytes = m_bytes.span();
+    size_t offset = 0;
+    for (unsigned index = 0; index < values.size(); ++index) {
+        uint8_t tag = bytes[offset++];
+        if (tag < maxDeadRunLength) {
+            index += tag;
+            continue;
+        }
+        if (tag < constantTag) {
+            bool atOwnRegister = tag < inJSStackTag;
+            VirtualRegister reg;
+            if (atOwnRegister)
+                reg = values.operandForIndex(index).virtualRegister();
+            else {
+                uint32_t zigzag = readLEB(bytes, offset);
+                reg = VirtualRegister(static_cast<int32_t>(zigzag >> 1) ^ -static_cast<int32_t>(zigzag & 1));
+            }
+            values[index] = ExitValue::inJSStack(inJSStackKind(tag, atOwnRegister ? inJSStackAtOwnRegisterTag : inJSStackTag), reg).withLocalsOffset(localsOffset);
+            continue;
+        }
+        switch (tag) {
+        case constantTag:
+            values[index] = ExitValue::constant(JSValue::decode(jitCode.osrExitConstants[readLEB(bytes, offset)]));
+            break;
+        case materializationTag:
+            values[index] = ExitValue::materializeNewObject(materializations[readLEB(bytes, offset)]);
+            break;
+        case argumentTag: {
+            DataFormat format = static_cast<DataFormat>(bytes[offset++]);
+            values[index] = ExitValue::exitArgument(ExitArgument(format, readLEB(bytes, offset)));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+    RELEASE_ASSERT(offset == bytes.size());
+    return values;
+}
+
+OSRExitDescriptor::OSRExitDescriptor(DataFormat profileDataFormat, MethodOfGettingAValueProfile valueProfile)
     : m_profileDataFormat(profileDataFormat)
     , m_valueProfile(valueProfile)
-    , m_values(numberOfArguments, numberOfLocals, numberOfTmps)
 {
 }
 
 void OSRExitDescriptor::validateReferences(const TrackedReferences& trackedReferences)
 {
-    for (unsigned i = m_values.size(); i--;)
-        m_values[i].validateReferences(trackedReferences);
-    
     for (ExitTimeObjectMaterialization* materialization : m_materializations)
         materialization->validateReferences(trackedReferences);
 }

--- a/Source/JavaScriptCore/ftl/FTLOSRExit.h
+++ b/Source/JavaScriptCore/ftl/FTLOSRExit.h
@@ -68,13 +68,39 @@ class State;
 struct OSRExitDescriptorImpl;
 struct OSRExitHandle;
 
+class JITCode;
+
+// Stores one ExitValue per operand of the exit (arguments, then locals, then tmps) as
+// a byte stream: a tag byte followed by an optional payload.
+//
+//   0x00-0x3F  (tag + 1) consecutive dead values
+//   0x40-0x43  InJSStack / AsInt32 / AsInt52 / AsDouble, flushed to the operand's own virtual register
+//   0x44-0x47  the same, flushed to another virtual register: zigzag LEB128 register offset follows
+//   0x48       Constant: LEB128 index into JITCode::osrExitConstants follows
+//   0x49       MaterializeNewObject: LEB128 index into OSRExitDescriptor::m_materializations follows
+//   0x4A       Argument: DataFormat byte and LEB128 stackmap index follow
+//
+// Virtual registers are stored before the localsOffset adjustment; decode() applies it.
+class OSRExitValues {
+    WTF_MAKE_NONCOPYABLE(OSRExitValues);
+public:
+    OSRExitValues() = default;
+
+    void encode(const Operands<ExitValue>&, const Bag<ExitTimeObjectMaterialization>&, JITCode&);
+    FixedOperands<ExitValue> decode(const JITCode&, const Bag<ExitTimeObjectMaterialization>&) const;
+
+private:
+    FixedVector<uint8_t> m_bytes;
+    unsigned m_numberOfArguments { 0 };
+    unsigned m_numberOfLocals { 0 };
+    unsigned m_numberOfTmps { 0 };
+};
+
 struct OSRExitDescriptor {
 private:
     WTF_MAKE_NONCOPYABLE(OSRExitDescriptor);
 public:
-    OSRExitDescriptor(
-        DataFormat profileDataFormat, MethodOfGettingAValueProfile,
-        unsigned numberOfArguments, unsigned numberOfLocals, unsigned numberOfTmps);
+    OSRExitDescriptor(DataFormat profileDataFormat, MethodOfGettingAValueProfile);
 
     // The first argument to the exit call may be a value we wish to profile.
     // If that's the case, the format will be not Invalid and we'll have a
@@ -83,9 +109,11 @@ public:
     // correct them.
     DataFormat m_profileDataFormat;
     MethodOfGettingAValueProfile m_valueProfile;
-    
-    FixedOperands<ExitValue> m_values;
+
+    OSRExitValues m_values;
     Bag<ExitTimeObjectMaterialization> m_materializations;
+
+    FixedOperands<ExitValue> values(const JITCode& jitCode) const { return m_values.decode(jitCode, m_materializations); }
 
     void validateReferences(const TrackedReferences&);
 

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -144,7 +144,7 @@ static void compileRecovery(
         value.dataFormat(), jit, GPRInfo::regT0, GPRInfo::regT1, GPRInfo::regT2);
 }
 
-static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit, CodeBlock* codeBlock)
+static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit, const FixedOperands<ExitValue>& exitValues, CodeBlock* codeBlock)
 {
     // This code requires framePointerRegister is the same as callFrameRegister
     static_assert(MacroAssembler::framePointerRegister == GPRInfo::callFrameRegister, "MacroAssembler::framePointerRegister and GPRInfo::callFrameRegister must be the same");
@@ -191,12 +191,12 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
     }
     
     const size_t scratchBufferSize =
-        sizeof(EncodedJSValue) * (exit.m_descriptor->m_values.size() + numMaterializations + maxMaterializationNumArguments) +
+        sizeof(EncodedJSValue) * (exitValues.size() + numMaterializations + maxMaterializationNumArguments) +
         requiredScratchMemorySizeInBytes() +
         codeBlock->jitCode()->calleeSaveRegisters()->sizeOfAreaInBytes();
     ScratchBuffer* scratchBuffer = vm.scratchBufferForSize(scratchBufferSize);
     EncodedJSValue* scratch = scratchBuffer ? static_cast<EncodedJSValue*>(scratchBuffer->dataBuffer()) : nullptr;
-    EncodedJSValue* materializationPointers = scratch + exit.m_descriptor->m_values.size();
+    EncodedJSValue* materializationPointers = scratch + exitValues.size();
     EncodedJSValue* materializationArguments = materializationPointers + numMaterializations;
     char* registerScratch = std::bit_cast<char*>(materializationArguments + maxMaterializationNumArguments);
     uint64_t* unwindScratch = std::bit_cast<uint64_t*>(registerScratch + requiredScratchMemorySizeInBytes());
@@ -383,8 +383,8 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         std::optional<GPRReg> undefinedGPR;
         jit.move(CCallHelpers::TrustedImmPtr(scratch), GPRInfo::regT3);
         CCallHelpers::CopySpooler spooler(jit, CCallHelpers::framePointerRegister, GPRInfo::regT3, GPRInfo::regT0, GPRInfo::regT1);
-        for (unsigned index = exit.m_descriptor->m_values.size(); index--;) {
-            auto& value = exit.m_descriptor->m_values[index];
+        for (unsigned index = exitValues.size(); index--;) {
+            auto& value = exitValues[index];
             if (value.dataFormat() == DataFormatJS) {
                 switch (value.kind()) {
                 case ExitValueDead:
@@ -455,7 +455,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
 
     // Henceforth we make it look like the exiting function was called through a register
     // preservation wrapper. This implies that FP must be nudged down by a certain amount. Then
-    // we restore the various things according to either exit.m_descriptor->m_values or by copying from the
+    // we restore the various things according to either exitValues or by copying from the
     // old frame, and finally we save the various callee-save registers into where the
     // restoration thunk would restore them from.
     
@@ -479,7 +479,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
 
     // First set up SP so that our data doesn't get clobbered by signals.
     unsigned conservativeStackDelta =
-        (exit.m_descriptor->m_values.numberOfLocals() + CodeBlock::calleeSaveSpaceAsVirtualRegisters(*baselineCodeBlock->jitCode()->calleeSaveRegisters())) * sizeof(Register) +
+        (exitValues.numberOfLocals() + CodeBlock::calleeSaveSpaceAsVirtualRegisters(*baselineCodeBlock->jitCode()->calleeSaveRegisters())) * sizeof(Register) +
         maxFrameExtentForSlowPathCall;
     conservativeStackDelta = WTF::roundUpToMultipleOf(
         stackAlignmentBytes(), conservativeStackDelta);
@@ -608,7 +608,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
     }
 
     if (exit.m_codeOrigin.inlineStackContainsActiveCheckpoint()) {
-        EncodedJSValue* tmpScratch = scratch + exit.m_descriptor->m_values.tmpIndex(0);
+        EncodedJSValue* tmpScratch = scratch + exitValues.tmpIndex(0);
         jit.setupArguments<decltype(operationMaterializeOSRExitSideState)>(CCallHelpers::TrustedImmPtr(&vm), CCallHelpers::TrustedImmPtr(&exit), CCallHelpers::TrustedImmPtr(tmpScratch));
         jit.prepareCallOperation(vm);
         jit.move(AssemblyHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationMaterializeOSRExitSideState)), GPRInfo::nonArgGPR0);
@@ -623,8 +623,8 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         jit.move(CCallHelpers::TrustedImmPtr(scratch), srcBufferGPR);
         jit.move(GPRInfo::callFrameRegister, destBufferGPR);
         CCallHelpers::CopySpooler spooler(CCallHelpers::CopySpooler::BufferRegs::AllowModification, jit, srcBufferGPR, destBufferGPR, GPRInfo::regT0, GPRInfo::regT1);
-        for (unsigned index = exit.m_descriptor->m_values.size(); index--;) {
-            Operand operand = exit.m_descriptor->m_values.operandForIndex(index);
+        for (unsigned index = exitValues.size(); index--;) {
+            Operand operand = exitValues.operandForIndex(index);
 
             if (operand.isTmp())
                 continue;
@@ -654,7 +654,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         "FTL OSR exit #%u (D@%u, %s, %s) from %s, with operands = %s",
             exitID, exit.m_dfgNodeIndex, toCString(exit.m_codeOrigin).data(),
             toCString(exit.m_kind).data(), toCString(*codeBlock).data(),
-            toCString(ignoringContext<DumpContext>(exit.m_descriptor->m_values)).data()
+            toCString(ignoringContext<DumpContext>(exitValues)).data()
         );
 }
 
@@ -685,6 +685,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame*
 
     JITCode* jitCode = codeBlock->jitCode()->ftl();
     OSRExit& exit = jitCode->m_osrExit[exitID];
+    FixedOperands<ExitValue> exitValues = exit.m_descriptor->values(*jitCode);
     
     if (shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseFTLOSRExit()) {
         dataLogLn(
@@ -696,7 +697,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame*
             "    Current call site index: ", callFrame->callSiteIndex().bits(), "\n",
             "    Exit is exception handler: ", exit.isExceptionHandler(), "\n",
             "    Is unwind handler: ", exit.isGenericUnwindHandler(), "\n",
-            "    Exit values: ", exit.m_descriptor->m_values, "\n",
+            "    Exit values: ", exitValues, "\n",
             "    Value reps: ", listDump(exit.m_valueReps));
         if (!exit.m_descriptor->m_materializations.isEmpty()) {
             dataLogLn("    Materializations:");
@@ -705,7 +706,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame*
         }
     }
 
-    compileStub(vm, exitID, jitCode, exit, codeBlock);
+    compileStub(vm, exitID, jitCode, exit, exitValues, codeBlock);
 
     MacroAssembler::repatchJump(
         exit.codeLocationForRepatch(codeBlock), CodeLocationLabel<OSRExitPtrTag>(exit.m_code.code()));


### PR DESCRIPTION
#### 580b6dade24924fbe758fc530211de0faf00fb43
<pre>
[JSC] Store `OSRExitDescriptor` exit values as a compact byte stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=322369">https://bugs.webkit.org/show_bug.cgi?id=322369</a>

Reviewed by Yusuke Suzuki.

FTL::OSRExitDescriptor::m_values is a FixedOperands&lt;ExitValue&gt; with one 9 byte
entry per argument, local and tmp of the whole inline stack, and it is kept for
as long as the FTL code lives. Most entries carry almost no information. On
JetStream3 (5,455 FTL compiles, 161,428 descriptors, 60 entries per descriptor
on average) 83% of the entries are Dead, 4% are arguments flushed to their own
stack slot, and 4% are constants of which only 7% are distinct within one
JITCode. The dense arrays hold 86 MB over the run, 15.5 KB per FTL compile,
which makes them the largest part of the per-CodeBlock footprint of FTL code.

This patch replaces the dense array with OSRExitValues, which stores the same
information as a tag + payload byte stream; the format is described in the
comment above the class in FTLOSRExit.h. Dead values are run-length encoded
and constants are shared through a per-JITCode table. LowerDFGToB3 builds the
Operands&lt;ExitValue&gt; as before and encodes it once. operationCompileFTLOSRExit
decodes the stream into a stack-local FixedOperands&lt;ExitValue&gt; and passes it to
compileStub; this runs once per exit site, so the rest of the exit compiler is
unchanged. The localsOffset adjustment that FTL::compile applied to every entry
of every descriptor is now stored once in FTL::JITCode and applied while
decoding.

On the same JetStream3 run the byte streams and constant tables total 4.77 MB
(0.50 bytes per entry, -94.5%), 0.85 KB per FTL compile. Encoding takes 122 ns
per descriptor (0.3% of the FTL lowering time) and decoding 104 ns per exit stub
(1.3% of compileStub).

* Source/JavaScriptCore/ftl/FTLCompile.cpp:
* Source/JavaScriptCore/ftl/FTLExitValue.h:
* Source/JavaScriptCore/ftl/FTLJITCode.cpp:
* Source/JavaScriptCore/ftl/FTLJITCode.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* Source/JavaScriptCore/ftl/FTLOSRExit.cpp:
* Source/JavaScriptCore/ftl/FTLOSRExit.h:
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:

Canonical link: <a href="https://commits.webkit.org/319934@main">https://commits.webkit.org/319934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa44077cfc8d8ffc8dafb672e96df9330cd7f121

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142353 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98868 "2 flakes 18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43015 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4752 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11580 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42637 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43653 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55987 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151782 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40867 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151483 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46062 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128962 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124924 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17636 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->