### PR TITLE
[JSC] `DFGFixupPhase` should not clear `NodeMustGenerate` on checked arith nodes

### DIFF
--- a/JSTests/stress/arith-checked-int-must-generate-dce.js
+++ b/JSTests/stress/arith-checked-int-must-generate-dce.js
@@ -1,0 +1,73 @@
+//@ requireOptions("--useConcurrentJIT=0", "--thresholdForFTLOptimizeAfterWarmUp=1000")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("FAIL: got " + actual + ", expected " + expected);
+}
+
+function mulOverflow(k) {
+    let y = k;
+    y = y * y;
+    return (y | 0) === y;
+}
+noInline(mulOverflow);
+
+function mulNegativeZero(a, b) {
+    let y = a;
+    y = y * b;
+    return Object.is(y | 0, y);
+}
+noInline(mulNegativeZero);
+
+function divNonInteger(a, b) {
+    let y = a;
+    y = y / b;
+    return (y | 0) === y;
+}
+noInline(divNonInteger);
+
+function modNegativeZero(a, b) {
+    let y = a;
+    y = y % b;
+    return Object.is(y | 0, y);
+}
+noInline(modNegativeZero);
+
+function negateOverflow(k) {
+    let y = k;
+    y = -y;
+    return (y | 0) === y;
+}
+noInline(negateOverflow);
+
+function negateNegativeZero(k) {
+    let y = k;
+    y = -y;
+    return Object.is(y | 0, y);
+}
+noInline(negateNegativeZero);
+
+function absOverflow(k) {
+    let y = k;
+    y = Math.abs(y);
+    return (y | 0) === y;
+}
+noInline(absOverflow);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    mulOverflow(3);
+    mulNegativeZero(3, 2);
+    divNonInteger(6, 3);
+    modNegativeZero(7, 3);
+    negateOverflow(3);
+    negateNegativeZero(3);
+    absOverflow(-3);
+}
+
+shouldBe(mulOverflow(65536), false);
+shouldBe(mulNegativeZero(0, -1), false);
+shouldBe(divNonInteger(7, 2), false);
+shouldBe(modNegativeZero(-3, 3), false);
+shouldBe(negateOverflow(-2147483648), false);
+shouldBe(negateNegativeZero(0), false);
+shouldBe(absOverflow(-2147483648), false);

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -89,16 +89,13 @@ private:
             fixIntOrBooleanEdge(rightChild);
             // We need to be careful about skipping overflow check because div / mod can generate non integer values
             // from (Int32, Int32) inputs. For now, we always check non-zero divisor.
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) && bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) && bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags())) {
                 node->setArithMode(Arith::Unchecked);
-            else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                node->clearFlags(NodeMustGenerate);
+            } else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
-            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
-            // we do not need to perform checks and keep this node.
-            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
-            node->clearFlags(NodeMustGenerate);
             return;
         }
 
@@ -143,16 +140,13 @@ private:
         if ((node->op() == ArithMod || node->op() == ValueMod) && m_graph.modShouldSpeculateInt52(node)) {
             fixEdge<Int52RepUse>(leftChild);
             fixEdge<Int52RepUse>(rightChild);
-            if (bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+            if (bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags())) {
                 node->setArithMode(Arith::Unchecked);
-            else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                node->clearFlags(NodeMustGenerate);
+            } else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
-            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
-            // we do not need to perform checks and keep this node.
-            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
-            node->clearFlags(NodeMustGenerate);
             node->setResult(NodeResultInt52);
             return;
         }
@@ -168,16 +162,13 @@ private:
         if (m_graph.binaryArithShouldSpeculateInt32(node, FixupPass)) {
             fixIntOrBooleanEdge(leftChild);
             fixIntOrBooleanEdge(rightChild);
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags())) {
                 node->setArithMode(Arith::Unchecked);
-            else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()) || leftChild.node() == rightChild.node())
+                node->clearFlags(NodeMustGenerate);
+            } else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()) || leftChild.node() == rightChild.node())
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
-            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
-            // we do not need to perform checks and keep this node.
-            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
-            node->clearFlags(NodeMustGenerate);
             return;
         }
         if (m_graph.binaryArithShouldSpeculateInt52(node, FixupPass)) {
@@ -187,10 +178,6 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
-            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
-            // we do not need to perform checks and keep this node.
-            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
-            node->clearFlags(NodeMustGenerate);
             node->setResult(NodeResultInt52);
             return;
         }
@@ -498,14 +485,14 @@ private:
             if (node->child1()->shouldSpeculateInt32OrBoolean() && node->canSpeculateInt32(FixupPass)) {
                 node->setOp(ArithNegate);
                 fixIntOrBooleanEdge(node->child1());
-                if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+                if (bytecodeCanTruncateInteger(node->arithNodeFlags())) {
                     node->setArithMode(Arith::Unchecked);
-                else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                    node->clearFlags(NodeMustGenerate);
+                } else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                     node->setArithMode(Arith::CheckOverflow);
                 else
                     node->setArithMode(Arith::CheckOverflowAndNegativeZero);
                 node->setResult(NodeResultInt32);
-                node->clearFlags(NodeMustGenerate);
                 break;
             }
             
@@ -517,7 +504,6 @@ private:
                 else
                     node->setArithMode(Arith::CheckOverflowAndNegativeZero);
                 node->setResult(NodeResultInt52);
-                node->clearFlags(NodeMustGenerate);
                 break;
             }
             if (node->child1()->shouldSpeculateNotCellNorBigInt()) {
@@ -652,14 +638,14 @@ private:
         case ArithNegate: {
             if (node->child1()->shouldSpeculateInt32OrBoolean() && node->canSpeculateInt32(FixupPass)) {
                 fixIntOrBooleanEdge(node->child1());
-                if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+                if (bytecodeCanTruncateInteger(node->arithNodeFlags())) {
                     node->setArithMode(Arith::Unchecked);
-                else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                    node->clearFlags(NodeMustGenerate);
+                } else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                     node->setArithMode(Arith::CheckOverflow);
                 else
                     node->setArithMode(Arith::CheckOverflowAndNegativeZero);
                 node->setResult(NodeResultInt32);
-                node->clearFlags(NodeMustGenerate);
                 break;
             }
             if (m_graph.unaryArithShouldSpeculateInt52(node, FixupPass)) {
@@ -669,7 +655,6 @@ private:
                 else
                     node->setArithMode(Arith::CheckOverflowAndNegativeZero);
                 node->setResult(NodeResultInt52);
-                node->clearFlags(NodeMustGenerate);
                 break;
             }
 
@@ -859,11 +844,11 @@ private:
             if (node->child1()->shouldSpeculateInt32OrBoolean()
                 && node->canSpeculateInt32(FixupPass)) {
                 fixIntOrBooleanEdge(node->child1());
-                if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+                if (bytecodeCanTruncateInteger(node->arithNodeFlags())) {
                     node->setArithMode(Arith::Unchecked);
-                else
+                    node->clearFlags(NodeMustGenerate);
+                } else
                     node->setArithMode(Arith::CheckOverflow);
-                node->clearFlags(NodeMustGenerate);
                 node->setResult(NodeResultInt32);
                 break;
             }


### PR DESCRIPTION
#### 9f3eea6f466175106d4e9073964cd4bb000895dc
<pre>
[JSC] `DFGFixupPhase` should not clear `NodeMustGenerate` on checked arith nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322371">https://bugs.webkit.org/show_bug.cgi?id=322371</a>

Reviewed by Yusuke Suzuki.

DFGFixupPhase cleared NodeMustGenerate on these nodes even when it had just
selected Arith::CheckOverflow or Arith::CheckOverflowAndNegativeZero. The
abstract interpreter then proves the result is Int32 (and not -0) on the
strength of that check, folds users such as `(y | 0) === y` to constants, and
MovHintRemoval + DCE delete the node together with the check that justified the
proof. This is the same shape as bug 315213 for Inc / Dec.

Clear NodeMustGenerate only on the Arith::Unchecked branches, which DFGMayExit
already treats as non-exiting, so the DCE introduced for unused unchecked
div / mod is preserved. Int52 ArithMul / ArithNegate have no unchecked mode and
keep NodeMustGenerate unconditionally.

Test: JSTests/stress/arith-checked-int-must-generate-dce.js

* JSTests/stress/arith-checked-int-must-generate-dce.js: Added.
(shouldBe):
(mulOverflow):
(mulNegativeZero):
(divNonInteger):
(modNegativeZero):
(negateOverflow):
(negateNegativeZero):
(absOverflow):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDivInt32):
(JSC::DFG::FixupPhase::fixupArithDiv):
(JSC::DFG::FixupPhase::fixupArithMul):
(JSC::DFG::FixupPhase::fixupNode):

Canonical link: <a href="https://commits.webkit.org/319935@main">https://commits.webkit.org/319935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99db189a74c23a41ddbbbcb9691cefea6ada1d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146702 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142357 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98870 "2 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43020 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4756 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11582 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42639 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3765 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43657 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55991 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40866 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56682 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151487 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46064 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128966 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55193 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17638 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54813 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->