### PR TITLE
AudioBufferSourceNode does not clamp out-of-range loopStart/loopEnd

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
@@ -12,6 +12,6 @@ FAIL AudioBufferSourceNode handles out-of-bounds start offset correctly assert_e
 PASS AudioBufferSourceNode performs sub-sample interpolation backwards
 PASS AudioBufferSourceNode ran successfully with zero delta and playbackRate 0
 PASS AudioBufferSourceNode loops backwards using entire buffer when loopStart > loopEnd
-FAIL AudioBufferSourceNode loops backwards using clamped loopStart when loopStart < 0 assert_array_equals: expected property 4 to be 2 but got 4 (expected array [4, 3, 2, 1, 2, 1, 2, 1] got object "4,3,2,1,4,3,2,1")
+PASS AudioBufferSourceNode loops backwards using clamped loopStart when loopStart < 0
 PASS AudioBufferSourceNode loops backwards using entire buffer when loopEnd < 0
 

--- a/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt
+++ b/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt
@@ -32,8 +32,8 @@ PASS   Case 12: illegal loop: loopStartFrame > loopEndFrame is identical to the 
 PASS   Case 12: illegal loop: loopStartFrame > loopEndFrame: tail contains only the constant 0.
 PASS   Case 13: illegal loop: loopStartFrame == loopEndFrame is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
 PASS   Case 13: illegal loop: loopStartFrame == loopEndFrame: tail contains only the constant 0.
-PASS   Case 14: illegal loop: loopStartFrame < 0 is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
-PASS   Case 14: illegal loop: loopStartFrame < 0: tail contains only the constant 0.
+PASS   Case 14: illegal loop: loopStartFrame < 0 (clamps to 0) is identical to the array [0,1,2,0,1,2,0,1,2,0,1,2,0,1,2,0...].
+PASS   Case 14: illegal loop: loopStartFrame < 0 (clamps to 0): tail contains only the constant 0.
 PASS   Case 15: illegal loop: loopEndFrame > bufferLength is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
 PASS   Case 15: illegal loop: loopEndFrame > bufferLength: tail contains only the constant 0.
 PASS   Case 16: loop from 3 -> 6 with offset 1 for 20 frames is identical to the array [1,2,3,4,5,3,4,5,3,4,5,3,4,5,3,4...].

--- a/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html
+++ b/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html
@@ -154,12 +154,12 @@
         },
 
         {
-          description: 'illegal loop: loopStartFrame < 0',
+          description: 'illegal loop: loopStartFrame < 0 (clamps to 0)',
           loopStartFrame: -8,
           loopEndFrame: 3,
           renderFrames: 16,
           playbackRate: 1,
-          expected: [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]
+          expected: [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
         },
 
         {

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -240,20 +240,26 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     if (maxFrame > bufferLength)
         maxFrame = bufferLength;
 
-    // If the .loop attribute is true, then values of m_loopStart == 0 && m_loopEnd == 0 implies
-    // that we should use the entire buffer as the loop, otherwise use the loop values in m_loopStart and m_loopEnd.
+    // Defaults to the entire buffer, which is also the fallback when the loop points below do not
+    // describe a usable range.
     double virtualMaxFrame = maxFrame;
     double virtualMinFrame = 0;
     double virtualDeltaFrames = maxFrame;
 
-    if (m_isLooping && (m_loopStart || m_loopEnd) && m_loopStart >= 0 && m_loopEnd > 0 && m_loopStart < m_loopEnd) {
-        // Convert from seconds to sample-frames.
-        double loopMinFrame = m_loopStart * m_buffer->sampleRate();
-        double loopMaxFrame = m_loopEnd * m_buffer->sampleRate();
+    // Compute the effective loop points by clamping both endpoints into the buffer, then falling
+    // back to looping the entire buffer unless what is left is a range of positive length. Clamping
+    // before validating keeps an out-of-range endpoint from producing an inverted range.
+    // https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode
+    if (m_isLooping) {
+        double bufferDuration = m_buffer->duration();
+        double loopStart = std::clamp(m_loopStart, 0.0, bufferDuration);
+        double loopEnd = m_loopEnd <= 0 ? 0 : std::min(m_loopEnd, bufferDuration);
 
-        virtualMaxFrame = std::min(loopMaxFrame, virtualMaxFrame);
-        virtualMinFrame = std::max(loopMinFrame, virtualMinFrame);
-        virtualDeltaFrames = virtualMaxFrame - virtualMinFrame;
+        if (loopStart < loopEnd) {
+            virtualMinFrame = loopStart * bufferSampleRate;
+            virtualMaxFrame = std::min(loopEnd * bufferSampleRate, virtualMaxFrame);
+            virtualDeltaFrames = virtualMaxFrame - virtualMinFrame;
+        }
     }
 
     if (!reverse) {
@@ -263,8 +269,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
                 return false;
 
             // Wrap back to the beginning of the loop.
-            m_virtualReadIndex = (m_loopStart < 0) ? 0 : (m_loopStart * m_buffer->sampleRate());
-            m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast<double>(bufferLength) - 1);
+            m_virtualReadIndex = virtualMinFrame;
         }
     } else if (m_isLooping && m_virtualReadIndex < virtualMinFrame) {
         // https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode


### PR DESCRIPTION
#### c2c8b0cb3b0def5b71c991462d7b3714c46a8d62
<pre>
AudioBufferSourceNode does not clamp out-of-range loopStart/loopEnd
<a href="https://bugs.webkit.org/show_bug.cgi?id=322372">https://bugs.webkit.org/show_bug.cgi?id=322372</a>

Reviewed by Jean-Yves Avenard and Darin Adler.

renderFromBuffer() rejected out-of-range loop points and fell back to looping the
entire buffer, which is what the spec&apos;s playback algorithm says. But the
loopStart/loopEnd attribute definitions say those values are clamped into the
buffer instead, and the two readings give different output. The Audio WG resolved
the contradiction in favour of clamping in
<a href="https://github.com/WebAudio/web-audio-api/issues/2689">https://github.com/WebAudio/web-audio-api/issues/2689</a>: clamp both endpoints
first, then fall back to the entire buffer only if what is left is not a range of
positive length. The spec PR has not landed yet, so index.bs still shows the old
guard. Blink already does this in
AudioBufferSourceHandler::UpdateEffectiveLoopPoints(), and we now match it for a
negative loopStart, a loopStart past the buffer duration, loopStart &gt;= loopEnd, a
negative loopEnd, a loopEnd past the duration, and the loopStart == loopEnd == 0
default.

Two configurations change. A negative loopStart looped the whole buffer and now
loops [0, loopEnd), the case the WPT test already asserted. A loopStart past the
buffer duration used to *pass* the old guard, since 0 &lt;= loopStart &lt; loopEnd
holds, leaving virtualMinFrame above virtualMaxFrame and a negative
virtualDeltaFrames; the playback-rate check then bailed out and rendered silence.
Clamping makes that range empty rather than inverted, so it falls back to the
whole buffer.

The forward wrap recomputed its target from the raw m_loopStart rather than the
effective loop points, so it wrapped to loopStart even when playback had fallen
back to the whole buffer. It now uses virtualMinFrame.

One difference from Blink remains, unchanged by this patch: Blink resolves a
loopEnd of exactly 0 to the buffer duration and loops [loopStart, duration),
while the resolution maps any loopEnd &lt;= 0 to 0 and falls back to the entire
buffer.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt:
Rebaselined: &quot;loops backwards using clamped loopStart when loopStart &lt; 0&quot; passes.
The two remaining failures are out-of-bounds start offsets, unrelated.

* LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html:
* LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt:
Case 14 expected loopStart = -8 with loopEnd = 3 to loop the whole buffer,
contradicting the WPT test. Updated to the clamped loop [0, 3), matching
Chromium&apos;s updated copy of this test.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Canonical link: <a href="https://commits.webkit.org/319755@main">https://commits.webkit.org/319755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a235987e0dfbf36fb85a44b74aaa3210bfb415fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d0a198a-e761-46b2-90fe-66d26be9ae7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3873626f-1f25-4d79-bb6f-35c1134abb7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43021 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42643 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3767 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194531 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40725 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56684 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151489 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46066 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128968 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17642 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54643 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->