### PR TITLE
[Site Isolation] UI-process crash in MediaSessionManagerCocoa::audioOutputDeviceChanged() after the last media session is removed

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -756,7 +756,8 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
 void MediaSessionManagerCocoa::audioOutputDeviceChanged()
 {
-    ASSERT(m_audioHardwareListener);
+    if (!m_audioHardwareListener)
+        return;
     m_supportedAudioHardwareBufferSizes = m_audioHardwareListener->supportedBufferSizes();
     m_defaultBufferSize = AudioSession::singleton().preferredBufferSize();
     AudioSession::singleton().audioOutputDeviceChanged();

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
@@ -30,6 +30,12 @@
 #include <wtf/Logger.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if PLATFORM(MAC)
+#include <WebCore/AudioHardwareListener.h>
+#include <WebCore/MediaSessionManagerCocoa.h>
+#include <wtf/RefCounted.h>
+#endif
+
 namespace TestWebKitAPI {
 using namespace WebCore;
 
@@ -109,5 +115,65 @@ TEST(PlatformMediaSessionManager, PausingFrontSessionDemotesItInCurrentSession)
     // With the bug, the reorder hits a copy and currentSession() is still A.
     EXPECT_EQ(manager->currentSession().get(), static_cast<PlatformMediaSessionInterface*>(sessionB.ptr()));
 }
+
+#if PLATFORM(MAC)
+
+// Stands in for the audio-hardware listener the UI-process proxy retains under site isolation:
+// kept alive by the test and fired manually after the manager has dropped its own reference.
+class TestFiringAudioHardwareListener final : public AudioHardwareListener, public RefCounted<TestFiringAudioHardwareListener> {
+public:
+    static Ref<TestFiringAudioHardwareListener> create(Client& client) { return adoptRef(*new TestFiringAudioHardwareListener(client)); }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    void fireOutputDeviceChanged() { m_client.audioOutputDeviceChanged(); }
+
+private:
+    explicit TestFiringAudioHardwareListener(Client& client)
+        : AudioHardwareListener(client)
+    {
+    }
+};
+
+class TestMediaSessionManagerCocoa final : public MediaSessionManagerCocoa {
+public:
+    static Ref<TestMediaSessionManagerCocoa> create() { return adoptRef(*new TestMediaSessionManagerCocoa()); }
+
+private:
+    TestMediaSessionManagerCocoa()
+        : MediaSessionManagerCocoa(std::nullopt)
+    {
+    }
+};
+
+TEST(PlatformMediaSessionManager, AudioOutputDeviceChangeAfterLastSessionRemovedDoesNotCrash)
+{
+    RefPtr<TestFiringAudioHardwareListener> listener;
+    AudioHardwareListener::setCreationFunction([&](AudioHardwareListener::Client& client) -> Ref<AudioHardwareListener> {
+        Ref newListener = TestFiringAudioHardwareListener::create(client);
+        listener = newListener.ptr();
+        return newListener;
+    });
+
+    auto manager = TestMediaSessionManagerCocoa::create();
+    auto client = makeUnique<TestMediaSessionClient>(manager.get());
+    auto session = PlatformMediaSession::create(*client);
+
+    // Registering the first session creates MediaSessionManagerCocoa::m_audioHardwareListener.
+    session->setActive(true);
+    ASSERT_TRUE(listener);
+
+    // Removing the last session clears m_audioHardwareListener; the listener object survives here
+    // (as the proxy keeps it alive under site isolation) and can still deliver a device change.
+    session->setActive(false);
+
+    // Before the fix this dereferenced the now-null m_audioHardwareListener and crashed.
+    listener->fireOutputDeviceChanged();
+
+    AudioHardwareListener::resetCreationFunction();
+}
+
+#endif // PLATFORM(MAC)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### dc6ce247faeea6c6466018559b5177314ac1d667
<pre>
[Site Isolation] UI-process crash in MediaSessionManagerCocoa::audioOutputDeviceChanged() after the last media session is removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=322355">https://bugs.webkit.org/show_bug.cgi?id=322355</a>
<a href="https://rdar.apple.com/183466855">rdar://183466855</a>

Reviewed by Jer Noble.

MediaSessionManagerCocoa::audioOutputDeviceChanged() dereferenced m_audioHardwareListener
unconditionally, guarded only by an ASSERT. That listener is created in addSession() and cleared
in removeSession() once the last session is gone.

Under site isolation the UI-process RemoteMediaSessionManagerProxy keeps its audio-hardware
listener proxy alive for the lifetime of the process, so an audio-output-device change relayed
from the GPU process after the last session was removed still reached audioOutputDeviceChanged()
- now with a null m_audioHardwareListener - and crashed the UI process in release builds.

A device change arriving while no media session exists is a valid condition, not a
programming error, so return early when there is no listener and drop the ASSERT.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::audioOutputDeviceChanged):
* Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp:
(TestWebKitAPI::TestFiringAudioHardwareListener::create):
(TestWebKitAPI::TestFiringAudioHardwareListener::fireOutputDeviceChanged):
(TestWebKitAPI::TestMediaSessionManagerCocoa::create):
(TestWebKitAPI::TEST): Added a regression test that fires a device change after the last
session is removed.

Canonical link: <a href="https://commits.webkit.org/319716@main">https://commits.webkit.org/319716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/956b4c81862deb453b38b539c4df7d35e5650561

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146708 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f714565-d255-4d31-851a-bd826607c165) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03b8cf81-ca57-4eb0-949c-8e3b6ed4c961) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122794 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a59d584-4eac-44bc-aea3-b5a26c835b23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43023 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42645 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3771 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194535 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55997 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151790 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56688 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151491 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46070 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128972 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124938 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55199 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17644 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54819 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->