### PR TITLE
AudioBufferSourceNode renders only silence for an out-of-bounds start() offset with a negative playbackRate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
@@ -7,8 +7,8 @@ PASS AudioBufferSourceNode supports very low negative playbackRate (-0.02)
 PASS AudioBufferSourceNode enters loop backwards from offset > loopEnd
 PASS AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0
 PASS AudioBufferSourceNode loops backwards with negative rate (offset in loop)
-FAIL AudioBufferSourceNode handles offset exactly at duration with negative rate assert_equals: Frame 1 should be 4 expected 4 but got 0
-FAIL AudioBufferSourceNode handles out-of-bounds start offset correctly assert_equals: Frame 1 should be 4.0 expected 4 but got 0
+PASS AudioBufferSourceNode handles offset exactly at duration with negative rate
+PASS AudioBufferSourceNode handles out-of-bounds start offset correctly
 PASS AudioBufferSourceNode performs sub-sample interpolation backwards
 PASS AudioBufferSourceNode ran successfully with zero delta and playbackRate 0
 PASS AudioBufferSourceNode loops backwards using entire buffer when loopStart > loopEnd

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -276,11 +276,6 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         // For a negative playback rate, only an offset before the loop start is clamped, to the
         // loop start. An offset past the loop end is left alone so playback descends into the loop.
         m_virtualReadIndex = virtualMinFrame;
-    } else if (m_virtualReadIndex >= bufferLength) {
-        // The playhead starts past the end of the buffer, e.g. for an offset at the buffer
-        // duration. There is nothing to read, so output silence rather than a partially
-        // written bus.
-        return false;
     }
 
     // Sanity check that our playback rate isn't larger than the loop size.
@@ -297,6 +292,20 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     if (startFrameOffset < 0 && pitchRate) {
         double skippedFrames = std::abs(startFrameOffset * pitchRate);
         virtualReadIndex += reverse ? -skippedFrames : skippedFrames;
+    }
+
+    // With a negative playback rate the playhead can start at or past the end of the buffer, since
+    // offset is only clamped to [0, duration]. Those frames are outside the buffer and so are
+    // silent; playback picks up once the playhead descends into the buffer.
+    // https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode
+    if (reverse) {
+        while (framesToProcess > 0 && virtualReadIndex >= bufferLength) {
+            for (unsigned i = 0; i < numberOfChannels; ++i)
+                m_destinationChannels[i][writeIndex] = 0;
+            ++writeIndex;
+            --framesToProcess;
+            virtualReadIndex += pitchRate;
+        }
     }
 
     bool needsInterpolation = virtualReadIndex != floor(virtualReadIndex)


### PR DESCRIPTION
#### 268a25f376b16d07e316f099693025f2b61615cc
<pre>
AudioBufferSourceNode renders only silence for an out-of-bounds start() offset with a negative playbackRate
<a href="https://bugs.webkit.org/show_bug.cgi?id=322373">https://bugs.webkit.org/show_bug.cgi?id=322373</a>

Reviewed by Jean-Yves Avenard.

start() silently clamps offset to [0, duration], so a negative playbackRate can
leave the playhead exactly at the end of the buffer. renderFromBuffer() decided
once per render quantum whether the playhead was usable and returned false when
it was not, making process() zero the whole bus. But only the first frame is
outside the buffer: the playhead immediately descends back into it. A 4-frame
buffer started at offset == duration with rate -1 therefore rendered four silent
frames instead of one silent frame followed by 4, 3, 2.

This aligns us with the spec, which makes that decision per frame rather than
per quantum:
```
    if (bufferTime &gt;= 0 &amp;&amp; bufferTime &lt; buffer.duration)
        output.push(playbackSignal(bufferTime));
    else
        output.push(0); // past end of buffer, so output silent frame
```
Unlike bugs 320870 and 322372, no spec ambiguity is involved: the existing text
already specifies this, and we simply did not implement it.

It also aligns us with Blink, whose &quot;Reverse Out-Of-Bounds Playhead Catch-up&quot;
loop in AudioBufferSourceHandler::RenderFromBuffer() is equivalent, added for the
same reason.

Forward playback is unaffected. With a positive rate the playhead only moves
further past the end of the buffer, so bailing out and rendering silence was
already the correct result and still is.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt:
Rebaselined: &quot;handles offset exactly at duration with negative rate&quot; and
&quot;handles out-of-bounds start offset correctly&quot; now pass. The one remaining
failure is a negative loopStart, addressed separately in bug 322372.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Canonical link: <a href="https://commits.webkit.org/319779@main">https://commits.webkit.org/319779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff65b54420ac907135d6195df001d89ab4d0e4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147016 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb370b35-8585-4403-b1f1-6bd1fe296f8a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142606 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5544160-b952-40fb-bc34-632a4beb870e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46333 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123041 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86d67fac-a59a-43ca-b83a-7819b52b39a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45016 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42897 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4116 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194887 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56321 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151760 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46334 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129293 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125323 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55533 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17900 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->