### PR TITLE
[JSC] Use `objectCloneFast` for object rest destructuring in `@copyDataProperties`

### DIFF
--- a/JSTests/microbenchmarks/object-rest-clone.js
+++ b/JSTests/microbenchmarks/object-rest-clone.js
@@ -1,0 +1,8 @@
+var cities = ["a", "b", "c", "d", "e", "f", "g", "h"];
+var state = { id: 1, name: "x", age: 3, city: "z", zip: 0, flag: true, score: 1.5, tag: "t" };
+for (var i = 0; i < 1e4; ++i) {
+    var { ...next } = state;
+    next.city = cities[i & 7];
+    next.zip = i;
+    state = next;
+}

--- a/JSTests/stress/object-rest-clone.js
+++ b/JSTests/stress/object-rest-clone.js
@@ -1,0 +1,202 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function makeState(count) {
+    var state = {};
+    for (var i = 0; i < count; ++i)
+        state["k" + i] = i;
+    return state;
+}
+
+function restOnly(object) {
+    var { ...rest } = object;
+    return rest;
+}
+noInline(restOnly);
+
+function restParameter({ ...rest }) {
+    return rest;
+}
+noInline(restParameter);
+
+function restAssignment(object) {
+    var rest;
+    ({ ...rest } = object);
+    return rest;
+}
+noInline(restAssignment);
+
+function restExcluding(object) {
+    var { k0, ...rest } = object;
+    return rest;
+}
+noInline(restExcluding);
+
+function spreadThenGetter(object) {
+    return { ...object, get extra() { return 42; } };
+}
+noInline(spreadThenGetter);
+
+function protoThenSpread(object) {
+    return { __proto__: Object.prototype, ...object };
+}
+noInline(protoThenSpread);
+
+function nullProtoThenSpread(object) {
+    return { __proto__: null, ...object };
+}
+noInline(nullProtoThenSpread);
+
+class WithPrivateField {
+    #secret = 1;
+    constructor(count) {
+        for (var i = 0; i < count; ++i)
+            this["k" + i] = i;
+    }
+    static hasSecret(object) { return #secret in object; }
+}
+
+class WithPrivateMethod {
+    #m() { return 1; }
+    constructor(count) {
+        for (var i = 0; i < count; ++i)
+            this["k" + i] = i;
+    }
+    static hasBrand(object) { return #m in object; }
+}
+
+var sym = Symbol("s");
+var proto = { inherited: 1 };
+var otherGlobal = createGlobalObject();
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var count = [4, 8, 20][i % 3];
+    var state = makeState(count);
+    var keys = Object.keys(state);
+
+    for (var copy of [restOnly(state), restParameter(state), restAssignment(state)]) {
+        shouldBeArray(Object.keys(copy), keys);
+        shouldBe(copy.k0, 0);
+        shouldBe(copy["k" + (count - 1)], count - 1);
+        shouldBe(Object.getPrototypeOf(copy), Object.prototype);
+        shouldBe(Object.isExtensible(copy), true);
+        copy.k0 = "changed";
+        copy.added = i;
+        shouldBe(state.k0, 0);
+        shouldBe(state.added, undefined);
+        shouldBe(copy.added, i);
+    }
+
+    var excluded = restExcluding(state);
+    shouldBeArray(Object.keys(excluded), keys.slice(1));
+    shouldBe(excluded.k0, undefined);
+
+    state.afterCopy = "x";
+    var copyBeforeMutation = restOnly(state);
+    state.k1 = "mutated";
+    shouldBe(copyBeforeMutation.k1, 1);
+    shouldBe(copyBeforeMutation.afterCopy, "x");
+
+    var withGetter = spreadThenGetter(makeState(count));
+    shouldBeArray(Object.keys(withGetter), keys.concat(["extra"]));
+    shouldBe(withGetter.extra, 42);
+
+    var frozen = Object.freeze(makeState(count));
+    var fromFrozen = restOnly(frozen);
+    shouldBe(Object.isFrozen(fromFrozen), false);
+    fromFrozen.k0 = "y";
+    shouldBe(fromFrozen.k0, "y");
+    shouldBe(frozen.k0, 0);
+
+    var withSymbol = makeState(count);
+    withSymbol[sym] = "sym";
+    Object.defineProperty(withSymbol, "hidden", { value: 1, enumerable: false });
+    var copied = restOnly(withSymbol);
+    shouldBe(copied[sym], "sym");
+    shouldBe(Object.getOwnPropertyDescriptor(copied, "hidden"), undefined);
+
+    var getterCalls = 0;
+    var withAccessor = makeState(count);
+    Object.defineProperty(withAccessor, "accessor", { get() { return ++getterCalls; }, enumerable: true });
+    var fromAccessor = restOnly(withAccessor);
+    shouldBe(getterCalls, 1);
+    shouldBe(fromAccessor.accessor, 1);
+    shouldBe(Object.getOwnPropertyDescriptor(fromAccessor, "accessor").writable, true);
+
+    var withIndex = makeState(count);
+    withIndex[0] = "zero";
+    var fromIndexed = restOnly(withIndex);
+    shouldBe(fromIndexed[0], "zero");
+    shouldBe(Object.keys(fromIndexed).length, count + 1);
+
+    var withProto = Object.create(proto);
+    for (var j = 0; j < count; ++j)
+        withProto["k" + j] = j;
+    var fromProto = restOnly(withProto);
+    shouldBe(Object.getPrototypeOf(fromProto), Object.prototype);
+    shouldBe(fromProto.inherited, undefined);
+    shouldBeArray(Object.keys(fromProto), keys);
+
+    var dictionary = makeState(count);
+    dictionary.extra = 1;
+    delete dictionary.extra;
+    var fromDictionary = restOnly(dictionary);
+    shouldBeArray(Object.keys(fromDictionary), keys);
+
+    var readOnly = makeState(count);
+    Object.defineProperty(readOnly, "k1", { writable: false });
+    var fromReadOnly = restOnly(readOnly);
+    shouldBe(Object.getOwnPropertyDescriptor(fromReadOnly, "k1").writable, true);
+    fromReadOnly.k1 = "w";
+    shouldBe(fromReadOnly.k1, "w");
+    shouldBe(readOnly.k1, 1);
+
+    var nonConfigurable = makeState(count);
+    Object.defineProperty(nonConfigurable, "k2", { configurable: false });
+    var fromNonConfigurable = restOnly(nonConfigurable);
+    shouldBe(Object.getOwnPropertyDescriptor(fromNonConfigurable, "k2").configurable, true);
+    shouldBe(delete fromNonConfigurable.k2, true);
+    shouldBe(nonConfigurable.k2, 2);
+
+    var sealed = Object.seal(makeState(count));
+    var fromSealed = restOnly(sealed);
+    shouldBe(Object.isSealed(fromSealed), false);
+    fromSealed.added = 1;
+    shouldBe(fromSealed.added, 1);
+
+    var withPrivateField = new WithPrivateField(count);
+    var fromPrivateField = restOnly(withPrivateField);
+    shouldBeArray(Object.keys(fromPrivateField), keys);
+    shouldBe(WithPrivateField.hasSecret(withPrivateField), true);
+    shouldBe(WithPrivateField.hasSecret(fromPrivateField), false);
+
+    var withPrivateMethod = new WithPrivateMethod(count);
+    var fromPrivateMethod = restOnly(withPrivateMethod);
+    shouldBeArray(Object.keys(fromPrivateMethod), keys);
+    shouldBe(WithPrivateMethod.hasBrand(fromPrivateMethod), false);
+
+    var otherRealm = otherGlobal.Function("count", "var o = {}; for (var i = 0; i < count; ++i) o['k' + i] = i; return o;")(count);
+    var fromOtherRealm = restOnly(otherRealm);
+    shouldBe(Object.getPrototypeOf(fromOtherRealm), Object.prototype);
+    shouldBeArray(Object.keys(fromOtherRealm), keys);
+
+    var withProtoLiteral = protoThenSpread(makeState(count));
+    shouldBe(Object.getPrototypeOf(withProtoLiteral), Object.prototype);
+    shouldBeArray(Object.keys(withProtoLiteral), keys);
+
+    var withNullProtoLiteral = nullProtoThenSpread(makeState(count));
+    shouldBe(Object.getPrototypeOf(withNullProtoLiteral), null);
+    shouldBeArray(Object.keys(withNullProtoLiteral), keys);
+
+    shouldBeArray(Object.keys(restOnly({})), []);
+    shouldBeArray(Object.keys(restOnly("ab")), ["0", "1"]);
+    shouldBeArray(Object.keys(restOnly([1, 2])), ["0", "1"]);
+}

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -898,6 +898,9 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
 
     auto sourceStructure = source->structure();
     if (canPerformFastPropertyEnumerationForCopyDataProperties(sourceStructure)) [[likely]] {
+        if ((!excludedSet || excludedSet->isEmpty()) && objectCloneFast(vm, target, source))
+            return JSValue::encode(target);
+
         EnsureStillAliveScope sourceStructureScope(sourceStructure);
         Vector<UniquedStringImpl*, 8> properties; // sourceStructure ensures the lifetimes of these strings.
         MarkedArgumentBuffer values;


### PR DESCRIPTION
#### c9740e5b2bb94d45875c64d3ee4da528f534aeea
<pre>
[JSC] Use `objectCloneFast` for object rest destructuring in `@copyDataProperties`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322374">https://bugs.webkit.org/show_bug.cgi?id=322374</a>

Reviewed by Yusuke Suzuki.

Object rest destructuring (`const { ...rest } = object`) creates an empty object and
calls @copyDataProperties, which replays the source&apos;s shape one property at a time
via putOwnDataPropertyBatching even when nothing is excluded. This is the situation
319645@main fixed for Object.assign&apos;s batching path.

Try objectCloneFast before enumerating properties when the excluded set is empty.
The preconditions of the fast enumeration block already satisfy what objectCloneFast
requires, and a non-empty target fails its first check.

                                             Baseline                  Patched

object-rest-clone                         0.8409+-0.0355     ^      0.5708+-0.0369        ^ definitely 1.4733x faster

Tests: JSTests/microbenchmarks/object-rest-clone.js
       JSTests/stress/object-rest-clone.js

* JSTests/microbenchmarks/object-rest-clone.js: Added.
* JSTests/stress/object-rest-clone.js: Added.
(shouldBe):
(shouldBeArray):
(makeState):
(restOnly):
(restParameter):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/319745@main">https://commits.webkit.org/319745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f21eb19a62d762c780dab6b65ea73d812f2b0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146714 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44757 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43030 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4767 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11595 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42652 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3777 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43669 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194541 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56003 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151798 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40715 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56694 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151499 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128978 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55205 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->