### PR TITLE
CanvasBase::postProcessPixelBufferResults() takes an rvalue Ref<PixelBuffer> it never moves

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -307,10 +307,10 @@ void CanvasBase::removeCanvasNeedingPreparationForDisplayOrFlush()
     // FIXME: WorkerGlobalContext does not have prepare phase yet.
 }
 
-bool CanvasBase::postProcessPixelBufferResults(Ref<PixelBuffer>&& pixelBuffer) const
+bool CanvasBase::postProcessPixelBufferResults(PixelBuffer& pixelBuffer) const
 {
     if (m_canvasNoiseHashSalt)
-        return m_canvasNoiseInjection.postProcessPixelBufferResults(std::forward<Ref<PixelBuffer>>(pixelBuffer), *m_canvasNoiseHashSalt);
+        return m_canvasNoiseInjection.postProcessPixelBufferResults(pixelBuffer, *m_canvasNoiseHashSalt);
     return false;
 }
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -117,7 +117,7 @@ public:
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
 
-    bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
+    bool postProcessPixelBufferResults(PixelBuffer&) const;
     void recordLastFillText(const String&);
 
     void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }


### PR DESCRIPTION
#### cc9c3b0efd451fe6af9db9ff55dc20ad660cabe3
<pre>
CanvasBase::postProcessPixelBufferResults() takes an rvalue Ref&lt;PixelBuffer&gt; it never moves
<a href="https://bugs.webkit.org/show_bug.cgi?id=322376">https://bugs.webkit.org/show_bug.cgi?id=322376</a>
<a href="https://rdar.apple.com/185660088">rdar://185660088</a>

Reviewed by Gerald Squelart.

postProcessPixelBufferResults() took Ref&lt;PixelBuffer&gt;&amp;&amp; but never moved or
stored it: it forwarded to CanvasNoiseInjection::postProcessPixelBufferResults(),
which takes PixelBuffer&amp;. std::forward on the non-deduced Ref&lt;PixelBuffer&gt; was
just a cast to rvalue reference. The sole caller passes a PixelBuffer&amp;, so
every WebGL getImageData() materialized a temporary Ref for the duration of
the call, paying a ref()/deref() pair for nothing.

Take PixelBuffer&amp; instead. No behavior change.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::postProcessPixelBufferResults const):
* Source/WebCore/html/CanvasBase.h:

Canonical link: <a href="https://commits.webkit.org/319739@main">https://commits.webkit.org/319739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9f68c9ce291d4a4ecfcd113545978755ef7412f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146722 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4877127-c0fc-4771-8416-9300cbbf6601) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/270dabd5-7a51-4cb1-b3f2-c7ba5f9c8fb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122807 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34ff73fc-63ac-48ef-8777-ba98e0b397e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43037 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42659 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3787 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56011 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40709 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56702 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39284 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151505 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128986 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124957 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55213 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17658 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->