### PR TITLE
[Swift in WebKit] Introduce a bridging mechanism to create `WTF::CompletionHandler`s in Swift

### DIFF
--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -25,13 +25,22 @@
 
 #pragma once
 
+#include <memory>
 #include <tuple>
+#include <type_traits>
 #include <utility>
+#include <wtf/Compiler.h>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/ThreadAssertions.h>
 
 namespace WTF {
+
+// The C ABI a Swift closure reduces to, used by the `CxxCompletionHandler` Swift protocol to build a
+// CompletionHandler out of a Swift closure.
+using SwiftClosureInvoke = void (* WTF_NONNULL)(void* WTF_NONNULL context, const void* WTF_NULLABLE argument);
+using SwiftClosureDestroy = void (* WTF_NONNULL)(void* WTF_NONNULL context);
 
 template<typename> class CompletionHandler;
 class CompletionHandlerCallThread {
@@ -44,11 +53,18 @@ public:
 // Wraps a Function to make sure it is always called once and only once.
 template <typename Out, typename... In>
 class CompletionHandler<Out(In...)> {
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CompletionHandler);
+IGNORE_CLANG_WARNINGS_END
 public:
     using OutType = Out;
     using InTypes = std::tuple<In...>;
     using Impl = typename Function<Out(In...)>::Impl;
+
+#if !COMPILER(MSVC)
+    // Used by Swift's `CxxCompletionHandlerBase` protocol.
+    using Argument = std::tuple_element_t<0, std::tuple<In..., void>>;
+#endif
 
     CompletionHandler() = default;
 
@@ -62,16 +78,7 @@ public:
 
 #if defined(__APPLE__)
     // Always use C++ lambdas to create a WTF::CompletionHandler in Objective-C++.
-    // Always use Swift closures (implicitly as Objective-C blocks) to create a WTF::CompletionHandler in Swift.
-#ifndef __swift__
-    CompletionHandler(Out (^block)(In... args), ThreadLikeAssertion = CompletionHandlerCallThread::ConstructionThread) = delete;
-#else
-    CompletionHandler(Out (^block)(In... args), ThreadLikeAssertion callThread = CompletionHandlerCallThread::ConstructionThread)
-        : m_function(block)
-        , m_callThread(WTF::move(callThread))
-    {
-    }
-#endif
+    CompletionHandler(Out (^ WTF_NULLABLE block)(In... args), ThreadLikeAssertion = CompletionHandlerCallThread::ConstructionThread) = delete;
 #endif // defined(__APPLE__)
 
     CompletionHandler(CompletionHandler&&) = default;
@@ -83,9 +90,25 @@ public:
         m_callThread = anyThreadLike;
     }
 
+#ifdef __swift__
+    // This should only be called within the initializers of the `CxxCompletionHandler` protocol.
+    CompletionHandler(SwiftClosureInvoke invoke, SwiftClosureDestroy destroy, void* WTF_NONNULL context) SWIFT_NAME(init(invoke:destroy:context:))
+        : CompletionHandler([invoke, owner = std::unique_ptr<void, SwiftClosureDestroy> { context, destroy }](In... arguments) -> Out {
+            static_assert(std::is_void_v<Out>, "Swift closures can only be used with completion handlers that return void.");
+            static_assert(sizeof...(In) <= 1, "Swift closures can only be used with completion handlers that take at most one argument.");
+
+            if constexpr (!sizeof...(In))
+                invoke(owner.get(), nullptr);
+            else
+                invoke(owner.get(), std::addressof(arguments)...);
+        })
+    {
+    }
+#endif
+
     explicit operator bool() const { return !!m_function; }
 
-    [[nodiscard]] Impl* leak() { return m_function.leak(); }
+    [[nodiscard]] Impl* WTF_NULLABLE leak() { return m_function.leak(); }
 
     Out operator()(In... in)
     {
@@ -105,7 +128,9 @@ private:
 template<typename> class CompletionHandlerWithFinalizer;
 template <typename Out, typename... In>
 class CompletionHandlerWithFinalizer<Out(In...)> {
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CompletionHandlerWithFinalizer);
+IGNORE_CLANG_WARNINGS_END
 public:
     using OutType = Out;
     using InTypes = std::tuple<In...>;
@@ -149,7 +174,9 @@ namespace Detail {
 
 template<typename Out, typename... In>
 class CallableWrapper<CompletionHandler<Out(In...)>, Out, In...> : public CallableWrapperBase<Out, In...> {
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CallableWrapper);
+IGNORE_CLANG_WARNINGS_END
 public:
     explicit CallableWrapper(CompletionHandler<Out(In...)>&& completionHandler)
         : m_completionHandler(WTF::move(completionHandler))
@@ -164,7 +191,9 @@ private:
 } // namespace Detail
 
 class CompletionHandlerCallingScope final {
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CompletionHandlerCallingScope);
+IGNORE_CLANG_WARNINGS_END
 public:
     CompletionHandlerCallingScope() = default;
 
@@ -187,10 +216,13 @@ private:
     CompletionHandler<void()> m_completionHandler;
 };
 
-template<typename Out, typename... In> CompletionHandler<Out(In...)> adopt(typename CompletionHandler<Out(In...)>::Impl* impl)
+template<typename Out, typename... In> CompletionHandler<Out(In...)> adopt(typename CompletionHandler<Out(In...)>::Impl* WTF_NONNULL impl)
 {
     return Function<Out(In...)>(impl, Function<Out(In...)>::Adopt);
 }
+
+using VoidCompletionHandler = CompletionHandler<void()>;
+using BoolCompletionHandler = CompletionHandler<void(bool)>;
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -214,7 +214,7 @@ private:
     }
     StorageType m_storage { 0 };
 
-    friend struct ConstexprOptionSet<E>;
+    template<typename> friend struct ConstexprOptionSet;
 };
 
 namespace IsValidOptionSetHelper {

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -1,4 +1,4 @@
-// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 11.
+// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 15.
 
 module wtf [system] {
     explicit module Assertions {

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1464,6 +1464,7 @@ if (SWIFT_REQUIRED)
     list(APPEND WebKit_SOURCES
         ${WEBKIT_DIR}/Shared/Foundation+Extras.swift
         ${WEBKIT_DIR}/Shared/IPCTesterReceiver.swift
+        ${WEBKIT_DIR}/Shared/WTFCompletionHandler+Extras.swift
         ${WebKit_DERIVED_SOURCES_DIR}/IPCTesterReceiverMessageReceiver.swift
     )
 endif ()

--- a/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
+++ b/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// FIXME: (rdar://164119356) Move this file into WTF.
+
+#if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+
+import wtf.Core.CompletionHandler
+
+/// The machinery shared by ``CxxCompletionHandler`` and ``CxxVoidCompletionHandler``.
+///
+/// - Important: Do not conform to this directly. Conform to one of those two instead.
+protocol CxxCompletionHandlerBase: ~Copyable {
+    /// The type of the completion handler's only parameter, or `Void` if it has none.
+    ///
+    /// State this explicitly, matching the C++ parameter type:
+    ///
+    /// ```swift
+    /// typealias Argument = CInt
+    /// ```
+    ///
+    /// - Note: This cannot be inferred from `WTF::CompletionHandler`'s own type alias, because an imported C++
+    ///   class-template member type alias is not accepted as an associated-type witness under
+    ///   `MemberImportVisibility`. See rdar://185766398.
+    associatedtype Argument: BitwiseCopyable & Sendable
+
+    /// Creates a completion handler from the C ABI a Swift closure reduces to: a function pointer, an opaque context, and
+    /// a destructor for that context.
+    ///
+    /// Every specialization of `WTF::CompletionHandler` already has this constructor, so conformances never implement it
+    /// themselves.
+    ///
+    /// - Parameters:
+    ///   - invoke: The function pointer.
+    ///   - destroy: The function describing how to destroy the closure.
+    ///   - context: An opaque context for the closure.
+    /// - Important: Do not implement or call this yourself.
+    init(invoke: WTF.SwiftClosureInvoke, destroy: WTF.SwiftClosureDestroy, context: UnsafeMutableRawPointer)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument to conform to.
+///
+/// Conforming a specialization to this protocol allows Swift to easily call functions that accept `WTF::CompletionHandler` parameters.
+/// For example, this makes it possible to call a function like:
+///
+/// ```cpp
+/// using DoSomethingCompletionHandler = WTF::CompletionHandler<void(int)>;
+/// void doSomething(DoSomethingCompletionHandler&&);
+/// ```
+///
+/// by creating this conformance:
+///
+/// ```swift
+/// extension DoSomethingCompletionHandler: @unsafe CxxCompletionHandler {
+///     typealias Argument = CInt
+/// }
+/// ```
+///
+/// Swift can then call this via the `init(_ body: @escaping (Argument) -> Void)` initializer:
+///
+/// ```swift
+/// doSomething(consuming: .init { number in ... })
+/// ```
+///
+/// or by using the convenience continuation initializer:
+///
+/// ```swift
+/// await withCheckedContinuation { continuation in
+///     doSomething(consuming: .init(continuation))
+/// }
+/// ```
+///
+/// Common specializations like `WTF::VoidCompletionHandler` and `WTF::BoolCompletionHandler` already conform.
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+    /// Invokes the completion handler.
+    ///
+    /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
+    /// the type C++ actually passes.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction(_ argument: Argument)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take no argument to conform to.
+protocol CxxVoidCompletionHandler: CxxCompletionHandlerBase, ~Copyable where Argument == Void {
+    /// Invokes the completion handler.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction()
+}
+
+extension CxxCompletionHandlerBase where Self: ~Copyable {
+    /// Creates a completion handler that owns `box` and dispatches to it.
+    ///
+    /// - Parameter box: The box holding the Swift closure to call.
+    @safe
+    fileprivate init(box: SwiftClosureBoxBase) {
+        // This is all safe because all uses of the raw pointer are encapsulated in the C++ implementation and its lifetime
+        // is not modified elsewhere.
+        unsafe self.init(
+            invoke: { context, argument in
+                // This uses `ErasedSwiftClosureBox` and not `SwiftClosureBox<Argument>` because a C function pointer
+                // cannot be formed from a closure that captures generic parameters.
+                unsafe Unmanaged<SwiftClosureBoxBase>.fromOpaque(context).takeUnretainedValue().call(with: argument)
+            },
+            destroy: { context in
+                unsafe Unmanaged<AnyObject>.fromOpaque(context).release()
+            },
+            context: unsafe Unmanaged.passRetained(box).toOpaque()
+        )
+    }
+}
+
+extension CxxCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameter body: The Swift closure to use.
+    @safe
+    init(_ body: @escaping (Argument) -> Void) {
+        self.init(box: SwiftClosureBox(body))
+    }
+
+    /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
+    /// context trivial.
+    ///
+    /// This should be preferred for most cases.
+    ///
+    /// - Parameter continuation: A continuation vended by `withCheckedContinuation`.
+    @safe
+    init(_ continuation: CheckedContinuation<Argument, some Error>) {
+        self.init { continuation.resume(returning: $0) }
+    }
+}
+
+extension CxxVoidCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameter body: The Swift closure to use.
+    @safe
+    init(_ body: @escaping () -> Void) {
+        self.init(box: SwiftVoidClosureBox(body))
+    }
+
+    /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
+    /// context trivial.
+    ///
+    /// This should be preferred for most cases.
+    ///
+    /// - Parameter continuation: A continuation vended by `withCheckedContinuation`.
+    @safe
+    init(_ continuation: CheckedContinuation<Void, some Error>) {
+        self.init { continuation.resume() }
+    }
+}
+
+private class SwiftClosureBoxBase {
+    func call(with argument: UnsafeRawPointer?) {
+        preconditionFailure("Subclasses must override call(with:)")
+    }
+}
+
+private final class SwiftVoidClosureBox: SwiftClosureBoxBase {
+    private let body: () -> Void
+
+    init(_ body: @escaping () -> Void) {
+        self.body = body
+    }
+
+    override func call(with pointer: UnsafeRawPointer?) {
+        unsafe precondition(pointer == nil)
+        body()
+    }
+}
+
+private final class SwiftClosureBox<Argument: BitwiseCopyable & Sendable>: SwiftClosureBoxBase {
+    private let body: (Argument) -> Void
+
+    init(_ body: @escaping (Argument) -> Void) {
+        self.body = body
+    }
+
+    override func call(with pointer: UnsafeRawPointer?) {
+        guard let pointer = unsafe pointer else {
+            preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
+        }
+
+        // This is safe because `pointer` always comes from a value that was originally an `Argument` type.
+        let argument = unsafe pointer.load(as: Argument.self)
+        body(argument)
+    }
+}
+
+extension WTF.VoidCompletionHandler: @unsafe CxxVoidCompletionHandler {}
+
+extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {}
+
+#endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -92,12 +92,15 @@ extension WKTextSelectionController {
         }
 
         Task.immediate {
-            await page.updateSelection(
-                withExtentPoint: WebCore.IntPoint(point),
-                by: .init(currentRangeSelectionGranularity),
-                isInteractingWithFocusedElement: true, // FIXME: Properly handle the case where this isn't actually true.
-                source: .Mouse
-            )
+            await withCheckedContinuation { continuation in
+                page.updateSelectionWithExtentPointAndBoundary(
+                    WebCore.IntPoint(point),
+                    .init(currentRangeSelectionGranularity),
+                    true, // FIXME: Properly handle the case where this isn't actually true.
+                    .Mouse,
+                    consuming: .init(continuation)
+                )
+            }
         }
     }
 }
@@ -179,17 +182,24 @@ extension WKTextSelectionController {
         let isInteractingWithFocusedElement = true
 
         if placeAtWordBoundary {
-            await page.selectWithGesture(
-                at: WebCore.IntPoint(point),
-                type: .OneFingerTap,
-                state: .Ended,
-                isInteractingWithFocusedElement: isInteractingWithFocusedElement,
-            )
+            _ = await withCheckedContinuation { continuation in
+                page.selectWithGesture(
+                    nil,
+                    WebCore.IntPoint(point),
+                    .OneFingerTap,
+                    .Ended,
+                    isInteractingWithFocusedElement,
+                    consuming: .init(continuation)
+                )
+            }
         } else {
-            await page.selectPosition(
-                at: WebCore.IntPoint(point),
-                isInteractingWithFocusedElement: isInteractingWithFocusedElement,
-            )
+            await withCheckedContinuation { continuation in
+                page.selectPositionAtPoint(
+                    WebCore.IntPoint(point),
+                    isInteractingWithFocusedElement,
+                    consuming: .init(continuation)
+                )
+            }
         }
 
         let newState = page.editorState
@@ -343,11 +353,15 @@ extension WKTextSelectionController {
         impl.beginSuppressingSingleClickGestureForTextSelection()
 
         Task.immediate {
-            await page.selectText(
-                at: WebCore.IntPoint(point),
-                by: .init(granularity),
-                isInteractingWithFocusedElement: true // FIXME: Properly handle the case where this isn't actually true.
-            )
+            await withCheckedContinuation { continuation in
+                page.selectTextWithGranularityAtPoint(
+                    nil,
+                    WebCore.IntPoint(point),
+                    .init(granularity),
+                    true, // FIXME: Properly handle the case where this isn't actually true.
+                    consuming: .init(continuation)
+                )
+            }
         }
     }
 
@@ -367,12 +381,15 @@ extension WKTextSelectionController {
         lastRangeSelectionExtentPoint = point
 
         Task.immediate {
-            await page.updateSelection(
-                withExtentPoint: WebCore.IntPoint(point),
-                by: .init(currentRangeSelectionGranularity),
-                isInteractingWithFocusedElement: true, // FIXME: Properly handle the case where this isn't actually true.
-                source: .Mouse
-            )
+            await withCheckedContinuation { continuation in
+                page.updateSelectionWithExtentPointAndBoundary(
+                    WebCore.IntPoint(point),
+                    .init(currentRangeSelectionGranularity),
+                    true, // FIXME: Properly handle the case where this isn't actually true.
+                    .Mouse,
+                    consuming: .init(continuation)
+                )
+            }
         }
     }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		076E884E1A13CADF005E90FC /* APIContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 076E884D1A13CADF005E90FC /* APIContextMenuClient.h */; };
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		0773A93B3023B0FB002C57FE /* SpatialShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0773A93A3023B0FB002C57FE /* SpatialShim.swift */; };
+		077DD8E7303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077DD8E6303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */; };
 		078074F93029A874005492F5 /* WKDOMDoubleClickGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078074F83029A874005492F5 /* WKDOMDoubleClickGestureRecognizer.swift */; };
 		0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */; };
@@ -3531,6 +3532,7 @@
 		0779D7BB2EA8101800C389D5 /* RemoteMediaSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionProxy.h; sourceTree = "<group>"; };
 		0779D7BC2EA8101800C389D5 /* RemoteMediaSessionProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionProxy.cpp; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
+		077DD8E6303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WTFCompletionHandler+Extras.swift"; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceReplacementTextEffectCoordinator.swift; sourceTree = "<group>"; };
 		078074F83029A874005492F5 /* WKDOMDoubleClickGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDOMDoubleClickGestureRecognizer.swift; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
@@ -10727,6 +10729,7 @@
 				E0E1E2E3E4E5E6E700000002 /* WriteWebArchiveToPasteBoardResult.h */,
 				E0E1E2E3E4E5E6E700000003 /* WriteWebArchiveToPasteBoardResult.serialization.in */,
 				5CA6A48B28F6621800F92B6E /* WTFArgumentCoders.serialization.in */,
+				077DD8E6303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -22674,6 +22677,7 @@
 				F4E038F82F230571003A8F3A /* WKWebView+SystemTextExtraction.swift in Sources */,
 				075369492DC589E1006446F8 /* WKWebView+TextExtraction.swift in Sources */,
 				079A4DA32D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift in Sources */,
+				077DD8E7303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,
 				C14D306A24B79BE400480387 /* XPCEndpointClient.mm in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Configurations/TestWTFLibrary.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWTFLibrary.xcconfig
@@ -24,6 +24,18 @@
 //
 
 PRODUCT_NAME = TestWTF;
+// The Swift module must not be named TestWTF, or it would collide with the module
+// emitted by the TestWTF target, which shares this PRODUCT_NAME.
+PRODUCT_MODULE_NAME = TestWTFLibrary;
 SKIP_INSTALL = YES;
 GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 
+SWIFT_OBJC_INTEROP_MODE = $(SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
+SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = objcxx;
+SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = $(inherited);
+
+// FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
+// FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
+OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface;
+OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = ;

--- a/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
@@ -1,0 +1,221 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// FIXME: (rdar://164119356) Move this file into WTF.
+
+#if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+
+import wtf.Core.CompletionHandler
+
+/// The machinery shared by ``CxxCompletionHandler`` and ``CxxVoidCompletionHandler``.
+///
+/// - Important: Do not conform to this directly. Conform to one of those two instead.
+public protocol CxxCompletionHandlerBase: ~Copyable {
+    /// The type of the completion handler's only parameter, or `Void` if it has none.
+    ///
+    /// State this explicitly, matching the C++ parameter type:
+    ///
+    /// ```swift
+    /// typealias Argument = CInt
+    /// ```
+    ///
+    /// - Note: This cannot be inferred from `WTF::CompletionHandler`'s own type alias, because an imported C++
+    ///   class-template member type alias is not accepted as an associated-type witness under
+    ///   `MemberImportVisibility`. See rdar://185766398.
+    associatedtype Argument: BitwiseCopyable & Sendable
+
+    /// Creates a completion handler from the C ABI a Swift closure reduces to: a function pointer, an opaque context, and
+    /// a destructor for that context.
+    ///
+    /// Every specialization of `WTF::CompletionHandler` already has this constructor, so conformances never implement it
+    /// themselves.
+    ///
+    /// - Parameters:
+    ///   - invoke: The function pointer.
+    ///   - destroy: The function describing how to destroy the closure.
+    ///   - context: An opaque context for the closure.
+    /// - Important: Do not implement or call this yourself.
+    init(invoke: WTF.SwiftClosureInvoke, destroy: WTF.SwiftClosureDestroy, context: UnsafeMutableRawPointer)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument to conform to.
+///
+/// Conforming a specialization to this protocol allows Swift to easily call functions that accept `WTF::CompletionHandler` parameters.
+/// For example, this makes it possible to call a function like:
+///
+/// ```cpp
+/// using DoSomethingCompletionHandler = WTF::CompletionHandler<void(int)>;
+/// void doSomething(DoSomethingCompletionHandler&&);
+/// ```
+///
+/// by creating this conformance:
+///
+/// ```swift
+/// extension DoSomethingCompletionHandler: @unsafe CxxCompletionHandler {
+///     typealias Argument = CInt
+/// }
+/// ```
+///
+/// Swift can then call this via the `init(_ body: @escaping (Argument) -> Void)` initializer:
+///
+/// ```swift
+/// doSomething(consuming: .init { number in ... })
+/// ```
+///
+/// or by using the convenience continuation initializer:
+///
+/// ```swift
+/// await withCheckedContinuation { continuation in
+///     doSomething(consuming: .init(continuation))
+/// }
+/// ```
+///
+/// Common specializations like `WTF::VoidCompletionHandler` and `WTF::BoolCompletionHandler` already conform.
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+public protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+    /// Invokes the completion handler.
+    ///
+    /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
+    /// the type C++ actually passes.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction(_ argument: Argument)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take no argument to conform to.
+public protocol CxxVoidCompletionHandler: CxxCompletionHandlerBase, ~Copyable where Argument == Void {
+    /// Invokes the completion handler.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction()
+}
+
+extension CxxCompletionHandlerBase where Self: ~Copyable {
+    /// Creates a completion handler that owns `box` and dispatches to it.
+    ///
+    /// - Parameter box: The box holding the Swift closure to call.
+    fileprivate init(box: SwiftClosureBoxBase) {
+        // This is all safe because all uses of the raw pointer are encapsulated in the C++ implementation and its lifetime
+        // is not modified elsewhere.
+        unsafe self.init(
+            invoke: { context, argument in
+                // This uses `ErasedSwiftClosureBox` and not `SwiftClosureBox<Argument>` because a C function pointer
+                // cannot be formed from a closure that captures generic parameters.
+                unsafe Unmanaged<SwiftClosureBoxBase>.fromOpaque(context).takeUnretainedValue().call(with: argument)
+            },
+            destroy: { context in
+                unsafe Unmanaged<AnyObject>.fromOpaque(context).release()
+            },
+            context: unsafe Unmanaged.passRetained(box).toOpaque()
+        )
+    }
+}
+
+extension CxxCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameter body: The Swift closure to use.
+    @safe
+    public init(_ body: @escaping (Argument) -> Void) {
+        self.init(box: SwiftClosureBox(body))
+    }
+
+    /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
+    /// context trivial.
+    ///
+    /// This should be preferred for most cases.
+    ///
+    /// - Parameter continuation: A continuation vended by `withCheckedContinuation`.
+    @safe
+    public init(_ continuation: CheckedContinuation<Argument, some Error>) {
+        self.init { continuation.resume(returning: $0) }
+    }
+}
+
+extension CxxVoidCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameter body: The Swift closure to use.
+    @safe
+    public init(_ body: @escaping () -> Void) {
+        self.init(box: SwiftVoidClosureBox(body))
+    }
+
+    /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
+    /// context trivial.
+    ///
+    /// This should be preferred for most cases.
+    ///
+    /// - Parameter continuation: A continuation vended by `withCheckedContinuation`.
+    @safe
+    public init(_ continuation: CheckedContinuation<Void, some Error>) {
+        self.init { continuation.resume() }
+    }
+}
+
+private class SwiftClosureBoxBase {
+    func call(with argument: UnsafeRawPointer?) {
+        preconditionFailure("Subclasses must override call(with:)")
+    }
+}
+
+private final class SwiftVoidClosureBox: SwiftClosureBoxBase {
+    private let body: () -> Void
+
+    init(_ body: @escaping () -> Void) {
+        self.body = body
+    }
+
+    override func call(with pointer: UnsafeRawPointer?) {
+        body()
+    }
+}
+
+private final class SwiftClosureBox<Argument: BitwiseCopyable & Sendable>: SwiftClosureBoxBase {
+    private let body: (Argument) -> Void
+
+    init(_ body: @escaping (Argument) -> Void) {
+        self.body = body
+    }
+
+    override func call(with pointer: UnsafeRawPointer?) {
+        guard let pointer = unsafe pointer else {
+            preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
+        }
+
+        // This is safe because `pointer` always comes from a value that was originally an `Argument` type.
+        let argument = unsafe pointer.load(as: Argument.self)
+        body(argument)
+    }
+}
+
+extension WTF.VoidCompletionHandler: @unsafe CxxVoidCompletionHandler {}
+
+extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {}
+
+#endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_CXX_INTEROP
+#if ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Foundation
 private import TestWebKitAPILibrary.Helpers.cocoa.HTTPServer
@@ -194,14 +194,7 @@ public struct HTTPServer: ~Copyable {
         _ body: (Configuration) async throws(E) -> sending Result
     ) async throws(E) -> sending Result where E: Error, Result: ~Copyable {
         await withCheckedContinuation { continuation in
-            unsafe self.storage.pointee.startListening(
-                consuming: .init(
-                    {
-                        continuation.resume()
-                    },
-                    WTF.ThreadLikeAssertion(WTF.CurrentThreadLike())
-                )
-            )
+            unsafe self.storage.pointee.startListening(consuming: .init(continuation))
         }
 
         let port = unsafe Int(storage.pointee.port())
@@ -210,14 +203,7 @@ public struct HTTPServer: ~Copyable {
         let result = try await body(configuration)
 
         await withCheckedContinuation { continuation in
-            unsafe self.storage.pointee.cancel(
-                consuming: .init(
-                    {
-                        continuation.resume()
-                    },
-                    WTF.ThreadLikeAssertion(WTF.CurrentThreadLike())
-                )
-            )
+            unsafe self.storage.pointee.cancel(consuming: .init(continuation))
         }
 
         return result
@@ -253,4 +239,4 @@ extension HTTPServer {
     }
 }
 
-#endif // ENABLE_CXX_INTEROP
+#endif // ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/TestBundle/TestWebKitAPIBundle-Bridging-Header.h
+++ b/Tools/TestWebKitAPI/TestBundle/TestWebKitAPIBundle-Bridging-Header.h
@@ -23,5 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "../Tests/WTF/cocoa/SwiftCxxInteropTestbed.h"
 #import "UIKitSPIForTesting.h"

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
@@ -26,7 +26,13 @@
 #include "config.h"
 #include "SwiftCxxInteropTestbed.h"
 
+#include <optional>
+#include <wtf/Assertions.h>
+
 namespace SwiftCxxInteropTestbed {
+
+// Handed to a stored handler that resetStoredIntCompletionHandler() has to call itself.
+static constexpr int teardownValue = -2;
 
 int callIntBoolFunction(bool argument, IntBoolFunction&& function)
 {
@@ -36,6 +42,47 @@ int callIntBoolFunction(bool argument, IntBoolFunction&& function)
 void callIntCompletionHandler(int argument, IntCompletionHandler&& completionHandler)
 {
     completionHandler(argument);
+}
+
+void callVoidCompletionHandler(VoidCompletionHandler&& completionHandler)
+{
+    completionHandler();
+}
+
+static std::optional<IntCompletionHandler>& storedIntCompletionHandler()
+{
+    static std::optional<IntCompletionHandler> handler;
+    return handler;
+}
+
+void storeIntCompletionHandler(IntCompletionHandler&& completionHandler)
+{
+    // Overwriting the slot would destroy an uncalled handler: that trips
+    // ~CompletionHandler's assertion and strands whatever the handler owned, so a test
+    // awaiting a continuation it held would hang instead of failing.
+    RELEASE_ASSERT(!storedIntCompletionHandler());
+    storedIntCompletionHandler().emplace(WTF::move(completionHandler));
+}
+
+void invokeStoredIntCompletionHandler(int argument)
+{
+    auto handler = WTF::move(storedIntCompletionHandler());
+    storedIntCompletionHandler().reset();
+
+    if (handler)
+        (*handler)(argument);
+}
+
+void resetStoredIntCompletionHandler()
+{
+    auto handler = WTF::move(storedIntCompletionHandler());
+    storedIntCompletionHandler().reset();
+
+    // Call rather than just drop it, both because ~CompletionHandler requires it and so
+    // that a test which returned early fails on the sentinel instead of hanging. Teardown
+    // must never assert itself, so check the handler has not already run.
+    if (handler && *handler)
+        (*handler)(teardownValue);
 }
 
 };

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
@@ -29,20 +29,33 @@
 
 #import <wtf/CompletionHandler.h>
 #import <wtf/Function.h>
+#import <wtf/StdLibExtras.h>
 
 namespace SwiftCxxInteropTestbed {
+
+// MARK: Types
 
 // MARK: Using declarations
 
 using IntBoolFunction = WTF::Function<int(bool)>;
 
 using IntCompletionHandler = WTF::CompletionHandler<void(int)>;
+using VoidCompletionHandler = WTF::CompletionHandler<void()>;
 
 // MARK: Function declarations
 
 int callIntBoolFunction(bool, IntBoolFunction&&);
 
 void callIntCompletionHandler(int, IntCompletionHandler&&);
+
+void callVoidCompletionHandler(VoidCompletionHandler&&);
+
+void storeIntCompletionHandler(IntCompletionHandler&&);
+void invokeStoredIntCompletionHandler(int);
+
+// Call from test teardown: storing a handler and returning without invoking it would
+// otherwise leave it stranded for the next test to trip over.
+void resetStoredIntCompletionHandler();
 
 }
 

--- a/Tools/TestWebKitAPI/TestWTFLibrary/TestWTFLibrary.swift
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/TestWTFLibrary.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Apple Inc. All rights reserved.
+// Copyright (C) 2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -21,26 +21,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if HAVE_APPKIT_GESTURES_SUPPORT
+// The Swift module shadows the Clang module and the Swift module therefore needs to publicly import and re-export the underlying Clang module.
 
-import Foundation
-import WebKit_Internal
-import WebCore_Private
-
-// This is safe because all conformances to the protocol are safe as long as they don't
-// implement any of the requirements themselves.
-extension WebKit.WebPageProxy.SelectWithGestureCompletionHandler: @unsafe CxxCompletionHandler {
-    typealias Argument = WebKit.SelectWithGestureResult
-}
-
-extension WebKit.WebPageProxy {
-    private borrowing func editorStateCopy() -> WebKit.EditorState {
-        unsafe __editorStateUnsafe().pointee
-    }
-
-    var editorState: WebKit.EditorState {
-        editorStateCopy()
-    }
-}
-
-#endif // HAVE_APPKIT_GESTURES_SUPPORT
+@_exported public import TestWTFLibrary

--- a/Tools/TestWebKitAPI/TestWTFLibrary/module.modulemap
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/module.modulemap
@@ -1,0 +1,7 @@
+module TestWTFLibrary {
+    umbrella "."
+
+    explicit module * {
+        export *
+    }
+}

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -551,6 +551,13 @@
 			);
 			target = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;
 		};
+		07AA229F303BD11300B7274D /* Exceptions for "Tests" folder in "TestWTF" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				WTF/cocoa/SwiftCxxInteropTests.swift,
+			);
+			target = 7C83DF951D0A5AE400FEBCF3 /* TestWTF */;
+		};
 		07AA27602F83C3A900FE10FC /* Exceptions for "Tests" folder in "TestWebKitAPI" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -578,6 +585,14 @@
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
 			);
 			target = 8DD76F960486AA7600D96B5E /* TestWebKitAPI */;
+		};
+		07AA4051303BEDDD00B7274D /* Exceptions for "TestWTFLibrary" folder in "TestWTFLibrary" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				SwiftCxxInteropTestbed.cpp,
+				TestWTFLibrary.swift,
+			);
+			target = 7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */;
 		};
 		07C907B32F820907003A09D8 /* Exceptions for "Helpers" folder in "TestWebKitAPILibrary" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -636,6 +651,7 @@
 				mac/TestInspectorBar.mm,
 				mac/VirtualGamepad.mm,
 				mac/WebKitAgnosticTest.mm,
+				"WTFCompletionHandler+Extras.swift",
 			);
 			target = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;
 		};
@@ -644,6 +660,7 @@
 			membershipExceptions = (
 				cocoa/UtilitiesCocoa.mm,
 				Counters.cpp,
+				"WTFCompletionHandler+Extras.swift",
 			);
 			target = 7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */;
 		};
@@ -1382,8 +1399,6 @@
 				WebKit/WebPage/WebViewTests.swift,
 				WebKit/WKWebView/CodingTests.swift,
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
-				WTF/cocoa/SwiftCxxInteropTestbed.cpp,
-				WTF/cocoa/SwiftCxxInteropTests.swift,
 			);
 			target = A17C582D2C9B3EAD009DD0B5 /* TestWebKitAPIBundle */;
 		};
@@ -1590,6 +1605,14 @@
 /* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		07AA404F303BEDD700B7274D /* TestWTFLibrary */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				07AA4051303BEDDD00B7274D /* Exceptions for "TestWTFLibrary" folder in "TestWTFLibrary" target */,
+			);
+			path = TestWTFLibrary;
+			sourceTree = "<group>";
+		};
 		07C904CF2F8207FB003A09D8 /* App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = App;
@@ -1643,6 +1666,7 @@
 				07C913DE2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIBundle" target */,
 				07C913DF2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWGSL" target */,
 				07C913E02F820CCA003A09D8 /* Exceptions for "Tests" folder in "Copy Files" phase from "TestWGSL" target */,
+				07AA229F303BD11300B7274D /* Exceptions for "Tests" folder in "TestWTF" target */,
 				07C913E12F820CCA003A09D8 /* Exceptions for "Tests" folder in "InjectedBundleTestWebKitAPI" target */,
 				07C913E22F820CCA003A09D8 /* Exceptions for "Tests" folder in "WebProcessPlugIn" target */,
 			);
@@ -1778,6 +1802,7 @@
 				07C913E62F820CF1003A09D8 /* Scripts */,
 				DD7024AE302CE42A009B6CC0 /* Shared */,
 				07C913EF2F820D85003A09D8 /* TestBundle */,
+				07AA404F303BEDD700B7274D /* TestWTFLibrary */,
 				07C907D82F820949003A09D8 /* TestWebKitAPILibrary */,
 				07C910F42F820CC7003A09D8 /* Tests */,
 				DDF3A82928930475005920CF /* gtest.xcodeproj */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Apple Inc. All rights reserved.
+// Copyright (C) 2025-2026 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -21,13 +21,36 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_CXX_INTEROP
+#if ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Testing
 import wtf
+public import TestWTFLibrary
+public import TestWTFLibrary.SwiftCxxInteropTestbed
 
 private typealias Cxx = SwiftCxxInteropTestbed
 
+// MARK: - Conformances
+
+// This is safe because all conformances to the protocol are safe as long as they don't
+// implement any of the requirements themselves.
+extension Cxx.IntCompletionHandler: @unsafe TestWTFLibrary.CxxCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = CInt
+}
+
+// MARK: - Helpers
+
+/// Observed via a weak reference to prove the closure context was released.
+private final class Probe {}
+
+private final class Recorder {
+    var values: [CInt] = []
+}
+
+// MARK: - Tests
+
+@Suite(.serialized)
 @MainActor
 struct SwiftCxxInteropTests {
     @Test
@@ -42,21 +65,114 @@ struct SwiftCxxInteropTests {
     }
 
     @Test
-    func wtfCompletionHandlerCanBeInvokedFromSwift() async throws {
-        // FIXME: Improve the ergonomics of using this from Swift.
-
+    func completionHandlerReceivesItsArgument() async throws {
         let result = await withCheckedContinuation { continuation in
-            let completionHandler = Cxx.IntCompletionHandler(
-                { result in continuation.resume(returning: result)
-                },
-                WTF.ThreadLikeAssertion(WTF.CurrentThreadLike())
-            )
+            let completionHandler = Cxx.IntCompletionHandler { argument in
+                continuation.resume(returning: argument)
+            }
 
             Cxx.callIntCompletionHandler(3, consuming: completionHandler)
         }
 
         #expect(result == 3)
     }
+
+    @Test
+    func wtfCompletionHandlerCanBeInvokedFromSwift() async throws {
+        let result = await withCheckedContinuation { continuation in
+            let completionHandler = Cxx.IntCompletionHandler(continuation)
+
+            Cxx.callIntCompletionHandler(3, consuming: completionHandler)
+        }
+
+        #expect(result == 3)
+    }
+
+    @Test
+    func completionHandlerPreservesCapturedState() async throws {
+        let captured: CInt = 40
+
+        let result = await withCheckedContinuation { continuation in
+            let completionHandler = Cxx.IntCompletionHandler { argument in
+                continuation.resume(returning: argument + captured)
+            }
+
+            Cxx.callIntCompletionHandler(2, consuming: completionHandler)
+        }
+
+        #expect(result == 42)
+    }
+
+    @Test
+    func voidCompletionHandlerCanBeInvokedFromSwift() async throws {
+        var didCall = false
+
+        let completionHandler = Cxx.VoidCompletionHandler {
+            didCall = true
+        }
+        Cxx.callVoidCompletionHandler(consuming: completionHandler)
+
+        #expect(didCall)
+    }
+
+    @Test
+    func voidCompletionHandlerWorksWithAContinuation() async throws {
+        await withCheckedContinuation { continuation in
+            let completionHandler = Cxx.VoidCompletionHandler(continuation)
+
+            Cxx.callVoidCompletionHandler(consuming: completionHandler)
+        }
+    }
+
+    @Test
+    func separateHandlersDoNotShareAContext() async throws {
+        let recorder = Recorder()
+
+        let first = Cxx.IntCompletionHandler { recorder.values.append($0 * 10) }
+        let second = Cxx.IntCompletionHandler { recorder.values.append($0 * 100) }
+
+        Cxx.callIntCompletionHandler(1, consuming: first)
+        Cxx.callIntCompletionHandler(2, consuming: second)
+
+        #expect(recorder.values == [10, 200])
+    }
+
+    // MARK: Context lifetime
+
+    @Test
+    func contextIsReleasedAfterTheHandlerIsCalled() async throws {
+        weak var weakProbe: Probe?
+
+        do {
+            let probe = Probe()
+            weakProbe = probe
+
+            let completionHandler = Cxx.IntCompletionHandler { _ in
+                // Capture the probe so it is kept alive only by the closure context.
+                _ = probe
+            }
+            Cxx.callIntCompletionHandler(1, consuming: completionHandler)
+        }
+
+        #expect(weakProbe == nil, "the closure context should be released once the handler has run")
+    }
+
+    @Test
+    func contextSurvivesUntilTheHandlerIsInvokedLater() async throws {
+        // Leaving a stored handler behind would strand it for the next test, so clear the
+        // slot even if this test returns early.
+        defer { Cxx.resetStoredIntCompletionHandler() }
+
+        // storeIntCompletionHandler() returns without calling the handler, so the closure has
+        // to outlive that call.
+        let result = await withCheckedContinuation { continuation in
+            Cxx.storeIntCompletionHandler(consuming: .init(continuation))
+
+            Cxx.invokeStoredIntCompletionHandler(9)
+        }
+
+        #expect(result == 9)
+    }
 }
 
-#endif // ENABLE_CXX_INTEROP
+#endif // ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JSHandleTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JSHandleTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && ENABLE_CXX_INTEROP
+#if ENABLE_SWIFTUI && ENABLE_CXX_INTEROP && compiler(>=6.4)
 
 import Testing
 @_spi(Testing) import WebKit
@@ -210,4 +210,4 @@ extension WebPage.Configuration {
     }
 }
 
-#endif // ENABLE_SWIFTUI && ENABLE_CXX_INTEROP
+#endif // ENABLE_SWIFTUI && ENABLE_CXX_INTEROP && compiler(>=6.4)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -69,7 +69,7 @@ private class TestNavigationDecider: WebPage.NavigationDeciding {
     }
 }
 
-#if ENABLE_CXX_INTEROP
+#if ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
 @MainActor
 private struct TrustingNavigationDecider: WebPage.NavigationDeciding {
     mutating func decideAuthenticationChallengeDisposition(
@@ -89,7 +89,7 @@ extension WebPage.Configuration {
         self.websiteDataStore = WKWebsiteDataStore._store(with: storeConfiguration)
     }
 }
-#endif // ENABLE_CXX_INTEROP
+#endif // ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
 
 // MARK: Tests
 
@@ -113,7 +113,7 @@ struct WebPageTests {
         // FIXME: (283456) Make this test more comprehensive once Observation supports observing a stream of changes to properties.
     }
 
-    #if ENABLE_CXX_INTEROP
+    #if ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
     @Test
     func qualifiedServerTrust() async throws {
         var server = HTTPServer(protocol: .httpsProxy) {
@@ -163,7 +163,7 @@ struct WebPageTests {
             #expect(page.qualifiedServerTrust == nil)
         }
     }
-    #endif // ENABLE_CXX_INTEROP
+    #endif // ENABLE_CXX_INTEROP && compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
 
     @Test
     func decidePolicyForNavigationActionFragment() async throws {


### PR DESCRIPTION
#### cbf0ef68ade64b72082fcc6de3b06f70db1fa46f
<pre>
[Swift in WebKit] Introduce a bridging mechanism to create `WTF::CompletionHandler`s in Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=322377">https://bugs.webkit.org/show_bug.cgi?id=322377</a>
<a href="https://rdar.apple.com/185660724">rdar://185660724</a>

Reviewed by Adrian Taylor.

Create an abstraction to allow `WTF::CompletionHandler` types to be properly constructed in Swift.
This is done by designing a pair of Swift protocols which `WTF::CompletionHandler` specializations
may conform to: `CxxCompletionHandler` for specializations taking a single argument, and
`CxxVoidCompletionHandler` for those taking none. Both refine `CxxCompletionHandlerBase`, which
provides the initializers.

Previously, Swift created these by relying on `WTF::CompletionHandler`&apos;s Objective-C block
constructor, which was only exposed under `#ifdef __swift__`. That is now deleted unconditionally,
because implicitly bridging a Swift closure to a block gave no control over the closure&apos;s lifetime
and forced every callsite to spell out a `WTF::ThreadLikeAssertion` by hand. It was also not cross-platform.
Instead, a Swift closure is now reduced to the C ABI it fundamentally is (a function pointer, an opaque
context, and a destructor for that context) and `WTF::CompletionHandler` gains a constructor accepting
exactly that. The context is owned by a `std::unique_ptr&lt;void, SwiftClosureDestroy&gt;` captured by the
resulting handler, so it is destroyed together with the handler.

On the Swift side, the closure is stored in a class box passed across as a retained opaque pointer.
The box is deliberately split into a generic `SwiftClosureBox&lt;Argument&gt;` and a non-generic
`ErasedSwiftClosureBox` base, since a C function pointer cannot be formed from a closure that
captures generic parameters.

Note that because WTF does not yet support Swift, `WTFCompletionHandler+Extras.swift` must have a
copy in TestWTFLibrary for now.

The `callAsFunction` protocol requirement is witnessed by the imported C++ `operator()`. This is what
makes the compiler check that the `Argument` associated type matches the parameter type C++ actually
passes, so a mismatched conformance fails to compile rather than silently reinterpreting memory.

This abstraction currently does not support completion handlers whose parameters are noncopyable
types; this will be done in a subsequent change.

It also only supports completion handlers whose parameter list is of arity-0 or arity-1, and whose
return type is void; supporting arbitrary arity-n parameter lists is not currently prioritized due
to its infrequent use. Both restrictions are enforced at compile time by `static_assert`.

Tests: Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/JSHandleTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
(WTF::adopt):
(WTF::CompletionHandlerWithFinalizer&lt;Out):
(WTF::Detail::CallableWrapper&lt;CompletionHandler&lt;Out):

Add the `SwiftClosureInvoke` and `SwiftClosureDestroy` aliases describing the C ABI a Swift closure
reduces to, along with the constructor accepting them. Add an `Argument` alias for the Swift
protocols to key off of, and `VoidCompletionHandler` / `BoolCompletionHandler` aliases for the two
specializations common enough to conform out of the box.

Annotate the pointers in this header for nullability, which is required now that the Swift closure
typedefs introduce nullability into it.

* Source/WTF/wtf/OptionSet.h:

Use a different spelling for the friendship to ConstexprOptionSet to workaround a compiler bug (<a href="https://rdar.apple.com/185869726">rdar://185869726</a>).

* Source/WTF/wtf/module.modulemap:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/Shared/WTFCompletionHandler+Extras.swift: Added.
(CxxCompletionHandlerBase.init(_:)):
(ErasedSwiftClosureBox.call(with:)):
(SwiftClosureBox.init(_:)):
(SwiftClosureBox.call(with:)):
(CxxCompletionHandler.callAsFunction(_:)):
(CxxVoidCompletionHandler.callAsFunction):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/UIProcess/WebPageProxy.swift:
(WebKit.WebPageProxy.selectWithGesture(at:type:state:isInteractingWithFocusedElement:)): Deleted.
(WebKit.WebPageProxy.selectPosition(at:isInteractingWithFocusedElement:)): Deleted.
(WebKit.WebPageProxy.selectText(at:by:isInteractingWithFocusedElement:)): Deleted.
(WebKit.WebPageProxy.updateSelection(withExtentPoint:by:isInteractingWithFocusedElement:source:)): Deleted.
(WebKit.selectPosition(at:isInteractingWithFocusedElement:)): Deleted.
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.reextendSelectionForAutoscrollIfNeeded):
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):

Simplify the existing call-sites. These hand-written `async` wrappers existed only to hide the
boilerplate the block constructor demanded; with the continuation initializer, the callers can now
wrap the C++ functions directly and the wrappers earn their keep no longer.

* Tools/TestWebKitAPI/Configurations/TestWTFLibrary.xcconfig:
* Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift: Added.
(CxxCompletionHandlerBase.init(_:)):
(ErasedSwiftClosureBox.call(with:)):
(SwiftClosureBox.init(_:)):
(SwiftClosureBox.call(with:)):
(CxxCompletionHandler.callAsFunction(_:)):
(CxxVoidCompletionHandler.callAsFunction):
* Tools/TestWebKitAPI/TestBundle/TestWebKitAPIBundle-Bridging-Header.h:
* Tools/TestWebKitAPI/TestWTFLibrary/TestWTFLibrary.swift: Added.
* Tools/TestWebKitAPI/TestWTFLibrary/module.modulemap: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift:
(HTTPServer.run(_:)):
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h: Renamed from Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTestbed.h.
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp: Renamed from Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTestbed.cpp.
(SwiftCxxInteropTestbed::callIntBoolFunction):
(SwiftCxxInteropTestbed::callIntCompletionHandler):
(SwiftCxxInteropTestbed::callVoidCompletionHandler):
(SwiftCxxInteropTestbed::storedIntCompletionHandler):
(SwiftCxxInteropTestbed::storeIntCompletionHandler):
(SwiftCxxInteropTestbed::invokeStoredIntCompletionHandler):
(SwiftCxxInteropTestbed::resetStoredIntCompletionHandler):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift:
(Recorder.values):
(SwiftCxxInteropTests.completionHandlerReceivesItsArgument):
(SwiftCxxInteropTests.wtfCompletionHandlerCanBeInvokedFromSwift):
(SwiftCxxInteropTests.completionHandlerPreservesCapturedState):
(SwiftCxxInteropTests.voidCompletionHandlerCanBeInvokedFromSwift):
(SwiftCxxInteropTests.voidCompletionHandlerWorksWithAContinuation):
(SwiftCxxInteropTests.separateHandlersDoNotShareAContext):
(SwiftCxxInteropTests.contextIsReleasedAfterTheHandlerIsCalled):
(SwiftCxxInteropTests.contextSurvivesUntilTheHandlerIsInvokedLater):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JSHandleTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:

Add tests
* Source/WTF/wtf/OptionSet.h:

Canonical link: <a href="https://commits.webkit.org/319901@main">https://commits.webkit.org/319901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d9a5f679d1711239337730e45ec7889f8e2594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183132 "24 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57055 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193350 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8c11428-7ea5-4e98-8877-f0721e1fe80e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56790 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82fbdb2c-fcaf-43f7-8d34-4056d709e3c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186087 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfebad15-d9b4-4ecb-987f-fec6d162eb9a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182459 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/12173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4523 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44402 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195291 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182536 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57429 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152117 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/46675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125850 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55937 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->