### PR TITLE
[ANGLE] drawElements*BaseVertex* does not check baseVertex against the vertex buffer size

### DIFF
--- a/LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds-expected.txt
@@ -1,0 +1,16 @@
+drawElementsInstancedBaseVertexBaseInstanceWEBGL must reject out-of-range baseVertex
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.INVALID_OPERATION
+PASS gl.getError() is gl.INVALID_OPERATION
+PASS gl.getError() is gl.INVALID_OPERATION
+PASS gl.getError() is gl.INVALID_OPERATION
+PASS no GPU process crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html
+++ b/LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WebGLDraftExtensionsEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<canvas id="c" width="4" height="4"></canvas>
+<script>
+description("drawElementsInstancedBaseVertexBaseInstanceWEBGL must reject out-of-range baseVertex");
+
+if (window.internals)
+    window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
+var gl = document.getElementById('c').getContext('webgl2');
+var ext = gl.getExtension('WEBGL_draw_instanced_base_vertex_base_instance');
+var multiExt = gl.getExtension('WEBGL_multi_draw_instanced_base_vertex_base_instance');
+if (!ext) {
+    testPassed("WEBGL_draw_instanced_base_vertex_base_instance unavailable; skipping");
+} else {
+    var vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, "#version 300 es\nin vec2 p; void main(){ gl_Position = vec4(p,0.,1.); }");
+    gl.compileShader(vs);
+    var fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, "#version 300 es\nprecision highp float; out vec4 c; void main(){ c = vec4(1.); }");
+    gl.compileShader(fs);
+    var prog = gl.createProgram();
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.bindAttribLocation(prog, 0, "p");
+    gl.linkProgram(prog);
+    gl.useProgram(prog);
+
+    // 3-vertex VBO (24 bytes), index buffer [0,1,2].
+    gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, 0,1]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, gl.createBuffer());
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0,1,2]), gl.STATIC_DRAW);
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+
+    // In-range baseVertex=0 must succeed.
+    ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0, 1, 0, 0);
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+
+    // baseVertex=9999 makes the GPU fetch vertex 10001 from a 3-vertex buffer.
+    // ANGLE robust-buffer-access validation must reject this with INVALID_OPERATION
+    // rather than letting the backend read out-of-bounds GPU memory.
+    ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0, 1, 9999, 0);
+    shouldBe("gl.getError()", "gl.INVALID_OPERATION");
+
+    // Off-by-one boundary: baseVertex=1 puts max effective index at 3 (== vertex count) -> reject.
+    ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0, 1, 1, 0);
+    shouldBe("gl.getError()", "gl.INVALID_OPERATION");
+
+    // Negative baseVertex producing a negative effective index is undefined per spec -> reject.
+    ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0, 1, -1, 0);
+    shouldBe("gl.getError()", "gl.INVALID_OPERATION");
+
+    if (multiExt) {
+        multiExt.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+            gl.TRIANGLES, new Int32Array([3]), 0, gl.UNSIGNED_SHORT, new Int32Array([0]), 0,
+            new Int32Array([1]), 0, new Int32Array([9999]), 0, new Uint32Array([0]), 0, 1);
+        shouldBe("gl.getError()", "gl.INVALID_OPERATION");
+    } else {
+        testPassed("WEBGL_multi_draw_instanced_base_vertex_base_instance unavailable; skipping multiDraw case");
+    }
+
+    gl.finish();
+    testPassed("no GPU process crash");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2700,6 +2700,9 @@ http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscr
 webgl/webgl-draft-extensions-flag-default.html [ Skip ]
 webgl/webgl-draft-extensions-flag-on.html [ Skip ]
 
+# ANGLE disables base vertex/base instance on Linux.
+webkit.org/b/319507 fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html [ Skip ]
+
 # WEBGL2 failures
 webkit.org/b/251107 webgl/2.0.y/conformance2/extensions/ext-render-snorm.html [ Failure ]
 webkit.org/b/251107 webgl/2.0.y/conformance2/textures/video/tex-2d-r16f-red-half_float.html [ Timeout Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3158,6 +3158,9 @@ fast/canvas/webgl/texImage2D-mse-in-dom-flipY-true.html [ Skip ]
 fast/canvas/webgl/texImage2D-video-flipY-false.html [ Skip ]
 fast/canvas/webgl/texImage2D-video-flipY-true.html [ Skip ]
 
+# WEBGL_draw_instanced_base_vertex_base_instance is unavailable on the iOS simulator.
+webkit.org/b/319507 fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html [ Skip ]
+
 # No colorspaces in iOS WebGL yet.
 webkit.org/b/247166 fast/canvas/webgl/colorspaces-test.html [ Failure ]
 webkit.org/b/247166 fast/canvas/webgl/context-lost-restored-p3.html [ Failure ]

--- a/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
@@ -482,6 +482,8 @@ inline constexpr const char *kNegativeBufSize = "Negative bufSize.";
 inline constexpr const char *kNegativeCount = "Negative count.";
 inline constexpr const char *kNegativeDimensions = "One or more image dimensions are negative.";
 inline constexpr const char *kNegativeDrawcount = "Negative drawcount.";
+inline constexpr const char *kNegativeEffectiveVertexIndex =
+    "Effective vertex index (index + basevertex) is negative.";
 inline constexpr const char *kNegativeHeightWidthDepth = "Negative height, width, or depth.";
 inline constexpr const char *kNegativeLayer = "Negative layer.";
 inline constexpr const char *kNegativeLength = "Negative length.";

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
@@ -906,6 +906,7 @@ bool ValidateDrawElementsInstancedBase(const Context *context,
                                        DrawElementsType type,
                                        const void *indices,
                                        GLsizei primcount,
+                                       GLint basevertex,
                                        GLuint baseinstance)
 {
     if (primcount <= 0)
@@ -918,10 +919,11 @@ bool ValidateDrawElementsInstancedBase(const Context *context,
 
         // Early exit.
         return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices,
-                                          primcount);
+                                          primcount, basevertex);
     }
 
-    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, primcount))
+    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, primcount,
+                                    basevertex))
     {
         return false;
     }
@@ -4461,7 +4463,7 @@ bool ValidateDrawElementsInstancedANGLE(const Context *context,
                                         GLsizei primcount)
 {
     if (!ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                           primcount, 0))
+                                           primcount, 0, 0))
     {
         return false;
     }
@@ -4478,7 +4480,7 @@ bool ValidateDrawElementsInstancedEXT(const Context *context,
                                       GLsizei primcount)
 {
     if (!ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                           primcount, 0))
+                                           primcount, 0, 0))
     {
         return false;
     }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
@@ -420,6 +420,7 @@ bool ValidateDrawElementsInstancedBase(const Context *context,
                                        DrawElementsType type,
                                        const void *indices,
                                        GLsizei primcount,
+                                       GLint basevertex,
                                        GLuint baseinstance);
 
 bool ValidateDrawInstancedANGLE(const Context *context, angle::EntryPoint entryPoint);
@@ -1045,7 +1046,8 @@ ANGLE_INLINE bool ValidateDrawElementsCommon(const Context *context,
                                              GLsizei count,
                                              DrawElementsType type,
                                              const void *indices,
-                                             GLsizei primcount)
+                                             GLsizei primcount,
+                                             GLint basevertex)
 {
     if (ANGLE_UNLIKELY(!ValidateDrawElementsBase(context, entryPoint, mode, type)))
     {
@@ -1150,8 +1152,6 @@ ANGLE_INLINE bool ValidateDrawElementsCommon(const Context *context,
     if (ANGLE_UNLIKELY(context->isBufferAccessValidationEnabled()) && ANGLE_UNLIKELY(primcount > 0))
     {
         // Use the parameter buffer to retrieve and cache the index range.
-        // TODO: this calculation should take basevertex into account for
-        // glDrawElementsInstancedBaseVertexBaseInstanceEXT.  http://anglebug.com/41481166
         IndexRange indexRange{IndexRange::Undefined()};
         ANGLE_VALIDATION_TRY(vao->getIndexRange(context, type, count, indices,
                                                 context->getState().isPrimitiveRestartEnabled(),
@@ -1160,16 +1160,33 @@ ANGLE_INLINE bool ValidateDrawElementsCommon(const Context *context,
         // No op if there are no real indices in the index data (all are primitive restart).
         if (!indexRange.isEmpty())
         {
-            // If we use an index greater than our maximum supported index range, return an error.
-            // The ES3 spec does not specify behaviour here, it is undefined, but ANGLE should
-            // always return an error if possible here.
-            if (indexRange.end() >= context->getCaps().maxElementIndex)
+            // The effective vertex index fetched by the backend is index[i] + basevertex (GLES 3.2
+            // section 10.5).  indexRange.end() is uint32_t and basevertex is GLint, so the sum fits
+            // in int64_t without overflow.  basevertex may be negative; per spec the operation is
+            // undefined if the sum would be negative, so reject that case for robust buffer access.
+            int64_t maxVertex =
+                static_cast<int64_t>(indexRange.end()) + static_cast<int64_t>(basevertex);
+            int64_t minVertex =
+                static_cast<int64_t>(indexRange.start()) + static_cast<int64_t>(basevertex);
+
+            // MAX_ELEMENT_INDEX bounds the raw index value, before basevertex is added (GLES 3.2
+            // section 10.5).
+            if (ANGLE_UNLIKELY(indexRange.end() >= context->getCaps().maxElementIndex))
             {
                 ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, err::kExceedsMaxElement);
                 return false;
             }
 
-            if (!ValidateDrawAttribs(context, entryPoint, indexRange.end()))
+            // A negative effective index makes the vertex ID (index + basevertex) negative. The
+            // GLES 3.2 spec (section 10.5) leaves this undefined, to be handled as an out-of-bounds
+            // access (section 6.4); reject it rather than fetching before the start of the buffer.
+            if (ANGLE_UNLIKELY(minVertex < 0))
+            {
+                ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, err::kNegativeEffectiveVertexIndex);
+                return false;
+            }
+
+            if (!ValidateDrawAttribs(context, entryPoint, maxVertex))
             {
                 return false;
             }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES2.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES2.h
@@ -565,7 +565,7 @@ ANGLE_INLINE bool ValidateDrawElements(const Context *context,
                                        DrawElementsType type,
                                        const void *indices)
 {
-    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1);
+    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1, 0);
 }
 
 ANGLE_INLINE bool ValidateVertexAttribPointer(const Context *context,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp
@@ -1657,7 +1657,7 @@ bool ValidateDrawRangeElements(const Context *context,
         return false;
     }
 
-    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1))
+    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1, 0))
     {
         return false;
     }
@@ -3185,7 +3185,7 @@ bool ValidateDrawElementsInstanced(const Context *context,
                                    GLsizei instanceCount)
 {
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instanceCount, 0);
+                                             instanceCount, 0, 0);
 }
 
 bool ValidateMultiDrawArraysInstancedANGLE(const Context *context,
@@ -3262,7 +3262,7 @@ bool ValidateMultiDrawElementsInstancedANGLE(const Context *context,
     {
         if (ANGLE_UNSAFE_TODO(
                 !ValidateDrawElementsInstancedBase(context, entryPoint, mode, counts[drawID], type,
-                                                   indices[drawID], instanceCounts[drawID], 0)))
+                                                   indices[drawID], instanceCounts[drawID], 0, 0)))
         {
             return false;
         }
@@ -3304,7 +3304,7 @@ bool ValidateDrawElementsInstancedBaseVertexBaseInstanceANGLE(const Context *con
                                                               GLuint baseInstance)
 {
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instanceCount, baseInstance);
+                                             instanceCount, baseVertex, baseInstance);
 }
 
 bool ValidateMultiDrawArraysInstancedBaseInstanceANGLE(const Context *context,
@@ -3370,7 +3370,7 @@ bool ValidateMultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(const Context
     {
         if (!ANGLE_UNSAFE_TODO(ValidateDrawElementsInstancedBase(
                 context, entryPoint, modePacked, counts[drawID], typePacked, indices[drawID],
-                instanceCounts[drawID], baseInstances[drawID])))
+                instanceCounts[drawID], baseVertices[drawID], baseInstances[drawID])))
         {
             return false;
         }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES32.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES32.cpp
@@ -252,7 +252,8 @@ bool ValidateDrawElementsBaseVertex(const Context *context,
                                     const void *indices,
                                     GLint basevertex)
 {
-    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1);
+    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1,
+                                      basevertex);
 }
 
 bool ValidateDrawElementsInstancedBaseVertex(const Context *context,
@@ -265,7 +266,7 @@ bool ValidateDrawElementsInstancedBaseVertex(const Context *context,
                                              GLint basevertex)
 {
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instancecount, 0);
+                                             instancecount, basevertex, 0);
 }
 
 bool ValidateDrawRangeElementsBaseVertex(const Context *context,
@@ -284,7 +285,7 @@ bool ValidateDrawRangeElementsBaseVertex(const Context *context,
         return false;
     }
 
-    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1))
+    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1, basevertex))
     {
         return false;
     }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationESEXT.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationESEXT.cpp
@@ -503,7 +503,8 @@ bool ValidateDrawElementsBaseVertexEXT(const Context *context,
                                        const void *indices,
                                        GLint basevertex)
 {
-    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1);
+    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1,
+                                      basevertex);
 }
 
 bool ValidateDrawElementsInstancedBaseVertexEXT(const Context *context,
@@ -524,7 +525,7 @@ bool ValidateDrawElementsInstancedBaseVertexEXT(const Context *context,
     }
 
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instancecount, 0);
+                                             instancecount, basevertex, 0);
 }
 
 bool ValidateDrawRangeElementsBaseVertexEXT(const Context *context,
@@ -549,7 +550,7 @@ bool ValidateDrawRangeElementsBaseVertexEXT(const Context *context,
         return false;
     }
 
-    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1))
+    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1, basevertex))
     {
         return false;
     }
@@ -706,7 +707,7 @@ bool ValidateDrawElementsInstancedBaseInstanceEXT(const Context *context,
                                                   GLuint baseinstance)
 {
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instancecount, baseinstance);
+                                             instancecount, 0, baseinstance);
 }
 
 bool ValidateDrawElementsInstancedBaseVertexBaseInstanceEXT(const Context *context,
@@ -720,7 +721,7 @@ bool ValidateDrawElementsInstancedBaseVertexBaseInstanceEXT(const Context *conte
                                                             GLuint baseinstance)
 {
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, typePacked, indices,
-                                             instancecount, baseinstance);
+                                             instancecount, basevertex, baseinstance);
 }
 
 bool ValidateDrawElementsBaseVertexOES(const Context *context,
@@ -731,7 +732,8 @@ bool ValidateDrawElementsBaseVertexOES(const Context *context,
                                        const void *indices,
                                        GLint basevertex)
 {
-    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1);
+    return ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1,
+                                      basevertex);
 }
 
 bool ValidateDrawElementsInstancedBaseVertexOES(const Context *context,
@@ -752,7 +754,7 @@ bool ValidateDrawElementsInstancedBaseVertexOES(const Context *context,
     }
 
     return ValidateDrawElementsInstancedBase(context, entryPoint, mode, count, type, indices,
-                                             instancecount, 0);
+                                             instancecount, basevertex, 0);
 }
 
 bool ValidateDrawRangeElementsBaseVertexOES(const Context *context,
@@ -777,7 +779,7 @@ bool ValidateDrawRangeElementsBaseVertexOES(const Context *context,
         return false;
     }
 
-    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1))
+    if (!ValidateDrawElementsCommon(context, entryPoint, mode, count, type, indices, 1, basevertex))
     {
         return false;
     }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawElementsTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawElementsTest.cpp
@@ -1399,6 +1399,71 @@ TEST_P(DrawElementsTest, LargeIndexBufferSubData)
     EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, GLColor::green);
 }
 
+// Test that drawElements*BaseVertex* includes baseVertex in the vertex-buffer bounds check, so an
+// out-of-range baseVertex is rejected instead of fetching vertices past the end of the buffer.
+TEST_P(WebGLDrawElementsTest3, DrawElementsBaseVertexBaseInstanceValidatesBaseVertex)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_ANGLE_base_vertex_base_instance"));
+
+    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), essl3_shaders::fs::Red());
+    glUseProgram(program);
+    GLint positionLoc = glGetAttribLocation(program, essl3_shaders::PositionAttrib());
+    glEnableVertexAttribArray(positionLoc);
+
+    // Viewport-covering triangle drawn with indices [0,1,2], so baseVertex shifts the fetch window.
+    constexpr GLfloat kVertices[] = {-1.0f, -1.0f, 3.0f, -1.0f, -1.0f, 3.0f};
+    GLBuffer vertexBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(kVertices), kVertices, GL_STATIC_DRAW);
+    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+    constexpr GLushort kIndices[] = {0, 1, 2};
+    GLBuffer indexBuffer;
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(kIndices), kIndices, GL_STATIC_DRAW);
+
+    // In-range baseVertex draws and fills the viewport red.
+    glDrawElementsInstancedBaseVertexBaseInstanceANGLE(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT, nullptr,
+                                                       1, 0, 0);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, GLColor::red);
+
+    // baseVertex past the end (9999) or underflowing (-1) must be rejected instead of fetching out
+    // of bounds. Only backends without robust buffer access (Metal) perform this validation.
+    if (isMetalRenderer())
+    {
+        glDrawElementsInstancedBaseVertexBaseInstanceANGLE(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT,
+                                                           nullptr, 1, 9999, 0);
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+        glDrawElementsInstancedBaseVertexBaseInstanceANGLE(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT,
+                                                           nullptr, 1, -1, 0);
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+        // Off-by-one: baseVertex 1 makes the max effective index equal the vertex count (3), which
+        // is out of bounds and must be rejected.
+        glDrawElementsInstancedBaseVertexBaseInstanceANGLE(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT,
+                                                           nullptr, 1, 1, 0);
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+        // The multi-draw variant shares the same validator (and forwards baseVertices per draw), so
+        // it must reject an out-of-range baseVertex too.
+        if (EnsureGLExtensionEnabled("GL_ANGLE_multi_draw"))
+        {
+            const GLsizei counts[]         = {3};
+            const void *const indices[]    = {nullptr};
+            const GLsizei instanceCounts[] = {1};
+            const GLint baseVertices[]     = {9999};
+            const GLuint baseInstances[]   = {0};
+            glMultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GL_TRIANGLES, counts,
+                                                                    GL_UNSIGNED_SHORT, indices,
+                                                                    instanceCounts, baseVertices,
+                                                                    baseInstances, 1);
+            EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        }
+    }
+}
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DrawElementsTest);
 ANGLE_INSTANTIATE_TEST_ES3(DrawElementsTest);
 


### PR DESCRIPTION
#### bb5740819e68ae4a2d5c60613861f559f05e7b4b
<pre>
[ANGLE] drawElements*BaseVertex* does not check baseVertex against the vertex buffer size
<a href="https://bugs.webkit.org/show_bug.cgi?id=319507">https://bugs.webkit.org/show_bug.cgi?id=319507</a>
<a href="https://rdar.apple.com/177955302">rdar://177955302</a>

Reviewed by Dan Glastonbury.

When drawing indexed geometry with a base vertex, the GPU reads each vertex at
(index + baseVertex), but validation only checks the index against the size of the
bound vertex buffers and ignores baseVertex. A small, in-range index buffer combined
with a large baseVertex therefore passes validation while the GPU reads past the end
of the buffer, an out-of-bounds read in the GPU process. This is only reachable when
the WebGL draft extensions setting is enabled, which is off by default.

Fix by passing baseVertex into the shared draw-elements validation and checking the
effective range (index + baseVertex), rejecting a draw whose largest effective index
is past the buffer or whose smallest effective index is negative. Every base-vertex
entry point now forwards its baseVertex and the others pass 0, so ordinary draws are
unchanged.

Test: fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html

* LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/draw-elements-base-vertex-out-of-bounds.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h:
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp:
(gl::ValidateDrawElementsInstancedBase):
(gl::ValidateDrawElementsInstancedANGLE):
(gl::ValidateDrawElementsInstancedEXT):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.h:
(gl::ValidateDrawElementsCommon):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES2.h:
(gl::ValidateDrawElements):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp:
(gl::ValidateDrawRangeElements):
(gl::ValidateDrawElementsInstanced):
(gl::ValidateMultiDrawElementsInstancedANGLE):
(gl::ValidateDrawElementsInstancedBaseVertexBaseInstanceANGLE):
(gl::ValidateMultiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES32.cpp:
(gl::ValidateDrawElementsBaseVertex):
(gl::ValidateDrawElementsInstancedBaseVertex):
(gl::ValidateDrawRangeElementsBaseVertex):
* Source/ThirdParty/ANGLE/src/libANGLE/validationESEXT.cpp:
(gl::ValidateDrawElementsBaseVertexEXT):
(gl::ValidateDrawElementsInstancedBaseVertexEXT):
(gl::ValidateDrawRangeElementsBaseVertexEXT):
(gl::ValidateDrawElementsInstancedBaseInstanceEXT):
(gl::ValidateDrawElementsInstancedBaseVertexBaseInstanceEXT):
(gl::ValidateDrawElementsBaseVertexOES):
(gl::ValidateDrawElementsInstancedBaseVertexOES):
(gl::ValidateDrawRangeElementsBaseVertexOES):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawElementsTest.cpp:

Originally-landed-as: 305413.1122@safari-7624.5-branch (e21200a08a7a). <a href="https://rdar.apple.com/185366919">rdar://185366919</a>
Canonical link: <a href="https://commits.webkit.org/319735@main">https://commits.webkit.org/319735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05fff291b3f8ba669e2eac7ca3d2b90823ab3a35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192848 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142521 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46243 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44927 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42807 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4019 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162779 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40705 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56930 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151676 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46242 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55438 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17807 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->