### PR TITLE
Hold AudioHardwareListener client weakly and stop caching listener proxies across clients

### DIFF
--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() { window.testRunner?.notifyDone(); }
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const pageID = IPC.pageID;
+
+    const state = {
+        pageIdentifier: pageID,
+        sessionIdentifier: 1234,
+        logIdentifier: 0,
+        mediaType: 0,
+        presentationType: 0,
+        displayType: 0,
+        state: 0,
+        stateToRestore: 0,
+        interruptionType: 0,
+        duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { },
+        nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false,
+        isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false,
+        hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false,
+        isNowPlayingEligible: false,
+        canProduceAudio: false,
+        isSuspended: false,
+        isPlaying: false,
+        isAudible: false,
+        isEnded: false,
+        canReceiveRemoteControlCommands: false,
+        supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false,
+        isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false,
+        activeAudioSessionRequired: false,
+        preparingToPlay: false,
+        isActiveNowPlayingSession: false,
+    };
+
+    // AddMediaSession creates the AudioHardwareListener; RemoveMediaSession (last
+    // session) clears MediaSessionManagerCocoa::m_audioHardwareListener while
+    // RemoteMediaSessionManagerProxy used to retain a stale listener proxy whose
+    // raw Client& dispatched into a manager with a null m_audioHardwareListener.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageID, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageID, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageID, { });
+
+    // Let the async IPC drain before finishing.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    done();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    done();
+else
+    run().catch(done);
+</script>

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+let finished = false;
+function finish() {
+    if (finished)
+        return;
+    finished = true;
+    window.testRunner?.notifyDone();
+}
+
+function makeState(pageID) {
+    return {
+        pageIdentifier: pageID, sessionIdentifier: 1234, logIdentifier: 0,
+        mediaType: 0, presentationType: 0, displayType: 0, state: 0, stateToRestore: 0,
+        interruptionType: 0, duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { }, nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false, isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false, hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false, isNowPlayingEligible: false,
+        canProduceAudio: false, isSuspended: false, isPlaying: false, isAudible: false,
+        isEnded: false, canReceiveRemoteControlCommands: false, supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false, isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false, activeAudioSessionRequired: false,
+        preparingToPlay: false, isActiveNowPlayingSession: false,
+    };
+}
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    // With RemoteMediaSessionManagerEnabled=true each WebPageProxy creates its
+    // RemoteMediaSessionManagerProxy eagerly, so the last-opened page (B) owns
+    // the process-global AudioHardwareListener factory.
+    const winA = window.open("about:blank", "A");
+    const winB = window.open("about:blank", "B");
+    await wait(0);
+
+    if (!winA?.IPC || !winB?.IPC) {
+        finish();
+        return;
+    }
+    const pageA = winA.IPC.pageID;
+    const pageB = winB.IPC.pageID;
+
+    // A.AddMediaSession -> AudioHardwareListener::create(*A) -> B's factory ->
+    // B caches a listener whose raw Client& was A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageA, { session: makeState(pageA) });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageA, { session: makeState(pageA) });
+
+    // Destroy A's WebPageProxy; B's listener used to keep a dangling Client& to A.
+    winA.close();
+    for (let i = 0; i < 8; ++i)
+        await wait(50);
+    if (window.GCController)
+        GCController.collect();
+    await wait(100);
+
+    // RemoteAudioOutputDeviceChanged on B used to dispatch on freed A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageB, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageB, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageB, { });
+
+    await wait(100);
+    finish();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+// The watchdog also finishes the test if an opened window never populates window.IPC.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    finish();
+else {
+    setTimeout(finish, 8000);
+    run().catch(finish);
+}
+</script>

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -25,11 +25,12 @@
 
 #pragma once
 
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-    
+
 enum class AudioHardwareActivityType {
     Unknown,
     IsActive,
@@ -38,7 +39,7 @@ enum class AudioHardwareActivityType {
 
 class AudioHardwareListener : public AbstractRefCounted {
 public:
-    class Client {
+    class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:
         virtual ~Client() = default;
         virtual void audioHardwareDidBecomeActive() = 0;
@@ -66,10 +67,12 @@ public:
 protected:
     WEBCORE_EXPORT AudioHardwareListener(Client&);
 
+    Client* client() const { return m_client.get(); }
     void setHardwareActivity(AudioHardwareActivityType activity) { m_activity = activity; }
     void setSupportedBufferSizes(BufferSizeRange sizes) { m_supportedBufferSizes = sizes; }
 
-    Client& m_client;
+private:
+    WeakPtr<Client> m_client;
     AudioHardwareActivityType m_activity { AudioHardwareActivityType::Unknown };
     BufferSizeRange m_supportedBufferSizes;
 };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -756,8 +756,10 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
 void MediaSessionManagerCocoa::audioOutputDeviceChanged()
 {
-    ASSERT(m_audioHardwareListener);
-    m_supportedAudioHardwareBufferSizes = m_audioHardwareListener->supportedBufferSizes();
+    RefPtr audioHardwareListener = m_audioHardwareListener;
+    if (!audioHardwareListener)
+        return;
+    m_supportedAudioHardwareBufferSizes = audioHardwareListener->supportedBufferSizes();
     m_defaultBufferSize = AudioSession::singleton().preferredBufferSize();
     AudioSession::singleton().audioOutputDeviceChanged();
     updateSessionState();

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -761,9 +761,10 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
 void MediaSessionManagerCocoa::audioOutputDeviceChanged()
 {
-    if (!m_audioHardwareListener)
+    RefPtr audioHardwareListener = m_audioHardwareListener;
+    if (!audioHardwareListener)
         return;
-    m_supportedAudioHardwareBufferSizes = m_audioHardwareListener->supportedBufferSizes();
+    m_supportedAudioHardwareBufferSizes = audioHardwareListener->supportedBufferSizes();
     m_defaultBufferSize = AudioSession::singleton().preferredBufferSize();
     AudioSession::singleton().audioOutputDeviceChanged();
     updateSessionState();

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -157,17 +157,21 @@ void AudioHardwareListenerMac::processIsRunningChanged()
     if (activity == hardwareActivity())
         return;
     setHardwareActivity(activity);
-    
+
+    RefPtr client = this->client();
+    if (!client)
+        return;
     if (hardwareActivity() == AudioHardwareActivityType::IsActive)
-        m_client.audioHardwareDidBecomeActive();
+        client->audioHardwareDidBecomeActive();
     else if (hardwareActivity() == AudioHardwareActivityType::IsInactive)
-        m_client.audioHardwareDidBecomeInactive();
+        client->audioHardwareDidBecomeInactive();
 }
 
 void AudioHardwareListenerMac::outputDeviceChanged()
 {
     setSupportedBufferSizes(currentDeviceSupportedBufferSizes());
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -955,7 +955,7 @@ RemoteMediaEngineConfigurationFactoryProxy& GPUConnectionToWebProcess::mediaEngi
 void GPUConnectionToWebProcess::createAudioHardwareListener(RemoteAudioHardwareListenerIdentifier identifier)
 {
     auto addResult = m_remoteAudioHardwareListenerMap.ensure(identifier, [&]() {
-        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTF::move(identifier));
+        return RemoteAudioHardwareListenerProxy::create(*this, WTF::move(identifier));
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -996,7 +996,7 @@ RemoteMediaEngineConfigurationFactoryProxy& GPUConnectionToWebProcess::mediaEngi
 void GPUConnectionToWebProcess::createAudioHardwareListener(RemoteAudioHardwareListenerIdentifier identifier)
 {
     auto addResult = m_remoteAudioHardwareListenerMap.ensure(identifier, [&]() {
-        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTF::move(identifier));
+        return RemoteAudioHardwareListenerProxy::create(*this, WTF::move(identifier));
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -447,7 +447,7 @@ private:
     HashMap<std::pair<WebPageProxyIdentifier, WebCore::PageIdentifier>, std::unique_ptr<LayerHostingContext>> m_visibilityPropagationContexts;
 #endif
 
-    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, std::unique_ptr<RemoteAudioHardwareListenerProxy>>;
+    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, Ref<RemoteAudioHardwareListenerProxy>>;
     RemoteAudioHardwareListenerMap m_remoteAudioHardwareListenerMap;
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -451,7 +451,7 @@ private:
     HashMap<std::pair<WebPageProxyIdentifier, WebCore::PageIdentifier>, std::unique_ptr<LayerHostingContext>> m_visibilityPropagationContexts;
 #endif
 
-    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, std::unique_ptr<RemoteAudioHardwareListenerProxy>>;
+    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, Ref<RemoteAudioHardwareListenerProxy>>;
     RemoteAudioHardwareListenerMap m_remoteAudioHardwareListenerMap;
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
@@ -43,13 +44,21 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 
-class RemoteAudioHardwareListenerProxy final : private WebCore::AudioHardwareListener::Client {
+class RemoteAudioHardwareListenerProxy final : public RefCounted<RemoteAudioHardwareListenerProxy>, private WebCore::AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioHardwareListenerProxy);
 public:
-    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+    static Ref<RemoteAudioHardwareListenerProxy> create(GPUConnectionToWebProcess& connection, RemoteAudioHardwareListenerIdentifier&& identifier)
+    {
+        return adoptRef(*new RemoteAudioHardwareListenerProxy(connection, WTF::move(identifier)));
+    }
     virtual ~RemoteAudioHardwareListenerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+
     // AudioHardwareListener::Client
     void audioHardwareDidBecomeActive() final;
     void audioHardwareDidBecomeInactive() final;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -65,19 +65,22 @@ public:
     void audioHardwareDidBecomeActive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsActive);
-        m_client.audioHardwareDidBecomeActive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeActive();
     }
 
     void audioHardwareDidBecomeInactive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsInactive);
-        m_client.audioHardwareDidBecomeInactive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeInactive();
     }
 
     void audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
     {
         setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-        m_client.audioOutputDeviceChanged();
+        if (RefPtr client = this->client())
+            client->audioOutputDeviceChanged();
     }
 };
 #endif
@@ -115,8 +118,10 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy()
 #endif
 
 #if PLATFORM(COCOA)
-    WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
-        return protectedThis->ensureAudioHardwareListenerProxy(client);
+    WebCore::AudioHardwareListener::setCreationFunction([weakThis = ThreadSafeWeakPtr { *this }] (WebCore::AudioHardwareListener::Client& client) -> Ref<WebCore::AudioHardwareListener> {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->ensureAudioHardwareListenerProxy(client);
+        return RemoteMediaSessionManagerAudioHardwareListener::create(client);
     });
 #endif
 }
@@ -278,27 +283,33 @@ void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)
 #if PLATFORM(COCOA)
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeActive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeActive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeInactive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeInactive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
 }
 
 Ref<RemoteMediaSessionManagerAudioHardwareListener> RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy(WebCore::AudioHardwareListener::Client& client)
 {
-    if (!m_audioHardwareListenerProxy)
-        m_audioHardwareListenerProxy = RemoteMediaSessionManagerAudioHardwareListener::create(client);
-    return *m_audioHardwareListenerProxy;
+    if (&client == static_cast<WebCore::AudioHardwareListener::Client*>(this)) {
+        if (RefPtr existing = m_audioHardwareListenerProxy.get())
+            return existing.releaseNonNull();
+        auto listener = RemoteMediaSessionManagerAudioHardwareListener::create(client);
+        m_audioHardwareListenerProxy = listener.get();
+        return listener;
+    }
+
+    return RemoteMediaSessionManagerAudioHardwareListener::create(client);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -69,19 +69,22 @@ public:
     void audioHardwareDidBecomeActive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsActive);
-        m_client.audioHardwareDidBecomeActive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeActive();
     }
 
     void audioHardwareDidBecomeInactive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsInactive);
-        m_client.audioHardwareDidBecomeInactive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeInactive();
     }
 
     void audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
     {
         setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-        m_client.audioOutputDeviceChanged();
+        if (RefPtr client = this->client())
+            client->audioOutputDeviceChanged();
     }
 };
 #endif
@@ -119,8 +122,10 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy()
 #endif
 
 #if PLATFORM(COCOA)
-    WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
-        return protectedThis->ensureAudioHardwareListenerProxy(client);
+    WebCore::AudioHardwareListener::setCreationFunction([weakThis = ThreadSafeWeakPtr { *this }] (WebCore::AudioHardwareListener::Client& client) -> Ref<WebCore::AudioHardwareListener> {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->ensureAudioHardwareListenerProxy(client);
+        return RemoteMediaSessionManagerAudioHardwareListener::create(client);
     });
 #endif
 }
@@ -318,27 +323,33 @@ void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)
 #if PLATFORM(COCOA)
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeActive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeActive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeInactive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeInactive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
 }
 
 Ref<RemoteMediaSessionManagerAudioHardwareListener> RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy(WebCore::AudioHardwareListener::Client& client)
 {
-    if (!m_audioHardwareListenerProxy)
-        m_audioHardwareListenerProxy = RemoteMediaSessionManagerAudioHardwareListener::create(client);
-    return *m_audioHardwareListenerProxy;
+    if (&client == static_cast<WebCore::AudioHardwareListener::Client*>(this)) {
+        if (RefPtr existing = m_audioHardwareListenerProxy.get())
+            return existing.releaseNonNull();
+        auto listener = RemoteMediaSessionManagerAudioHardwareListener::create(client);
+        m_audioHardwareListenerProxy = listener.get();
+        return listener;
+    }
+
+    return RemoteMediaSessionManagerAudioHardwareListener::create(client);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -39,6 +39,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -157,7 +158,7 @@ private:
     HashMap<WebCore::ProcessQualified<WebCore::PageIdentifier>, uint64_t> m_audioCaptureSourceCountsByPage;
 
 #if PLATFORM(COCOA)
-    RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
+    ThreadSafeWeakPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
 #endif
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -39,6 +39,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -166,7 +167,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
+    ThreadSafeWeakPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
 #endif
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -77,19 +77,22 @@ void RemoteAudioHardwareListener::gpuProcessConnectionDidClose(GPUProcessConnect
 void RemoteAudioHardwareListener::audioHardwareDidBecomeActive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsActive);
-    m_client.audioHardwareDidBecomeActive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeActive();
 }
 
 void RemoteAudioHardwareListener::audioHardwareDidBecomeInactive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsInactive);
-    m_client.audioHardwareDidBecomeInactive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeInactive();
 }
 
 void RemoteAudioHardwareListener::audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
     setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
@@ -127,7 +127,11 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void fireOutputDeviceChanged() { m_client.audioOutputDeviceChanged(); }
+    void fireOutputDeviceChanged()
+    {
+        if (RefPtr client = this->client())
+            client->audioOutputDeviceChanged();
+    }
 
 private:
     explicit TestFiringAudioHardwareListener(Client& client)


### PR DESCRIPTION
#### d147fe73cf325652651f542a234f60897daf0480
<pre>
Hold AudioHardwareListener client weakly and stop caching listener proxies across clients
<a href="https://rdar.apple.com/177436036">rdar://177436036</a>

Reviewed by Jean-Yves Avenard.

AudioHardwareListener stored its Client as a raw reference, while
RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy()
cached the first listener it created and reused it (with the original
client) for every subsequent caller, in addition to holding it
strongly via m_audioHardwareListenerProxy. Because each
RemoteMediaSessionManagerProxy also overwrites the process-global
AudioHardwareListener factory with a lambda capturing Ref{*this}, two
WebPageProxy instances could end up with B&apos;s cached listener bound to
A; closing A&apos;s page then made B&apos;s RemoteAudioOutputDeviceChanged
dispatch a virtual call on a freed proxy (UI-process heap-use-after-
free). Within a single page, removing the last media session cleared
MediaSessionManagerCocoa::m_audioHardwareListener but left the
strongly-held m_audioHardwareListenerProxy, so the same IPC message
null-dereferenced m_audioHardwareListener in audioOutputDeviceChanged.

Make AudioHardwareListener::Client an AbstractRefCountedAndCanMakeWeakPtr
(matching NowPlayingManagerClient), store m_client as a WeakPtr, and
upgrade to a protecting RefPtr before dispatching in every listener
subclass. In RemoteMediaSessionManagerProxy, capture *this weakly in
the creation lambda (also removing a leak of the last-constructed
proxy), always create a fresh listener per call, only stash a
ThreadSafeWeakPtr to it when the client is *this*, and dispatch IPC
through that weak pointer so the listener&apos;s lifetime is governed
solely by MediaSessionManagerCocoa::m_audioHardwareListener. Also
guard MediaSessionManagerCocoa::audioOutputDeviceChanged() against a
null m_audioHardwareListener for defense in depth, and make
RemoteAudioHardwareListenerProxy ref-counted to satisfy the new Client
contract.

Tests: ipc/remote-media-session-manager-audio-hardware-listener-crash.html
       ipc/remote-media-session-manager-audio-hardware-listener-uaf.html

* LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt: Added.
* LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html: Added.
* LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt: Added.
* LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html: Added.
* Source/WebCore/platform/audio/AudioHardwareListener.h:
(WebCore::AudioHardwareListener::client const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::audioOutputDeviceChanged):
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
(WebCore::AudioHardwareListenerMac::processIsRunningChanged):
(WebCore::AudioHardwareListenerMac::outputDeviceChanged):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::createAudioHardwareListener):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged):
(WebKit::RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
(WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeActive):
(WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeInactive):
(WebKit::RemoteAudioHardwareListener::audioOutputDeviceChanged):

Originally-landed-as: 305413.1115@safari-7624.5-branch (ddf732bdf8b3). <a href="https://rdar.apple.com/185368109">rdar://185368109</a>
Canonical link: <a href="https://commits.webkit.org/320953@main">https://commits.webkit.org/320953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0709f897db8602a854fdca4da69bbcc33b7b2d1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145523 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45908 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45648 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7606 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41586 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154734 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49169 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132757 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129935 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20627 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->