### PR TITLE
Avoid redundant URL copies on Cache API query paths

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -73,13 +73,13 @@ static inline bool matchURLs(const ResourceRequest& request, const URL& cachedUR
 {
     ASSERT(options.ignoreMethod || request.httpMethod() == "GET"_s);
 
+    if (!options.ignoreSearch)
+        return equalIgnoringFragmentIdentifier(request.url(), cachedURL);
+
     URL requestURL = request.url();
     URL cachedRequestURL = cachedURL;
-
-    if (options.ignoreSearch) {
-        requestURL.setQuery({ });
-        cachedRequestURL.setQuery({ });
-    }
+    requestURL.setQuery({ });
+    cachedRequestURL.setQuery({ });
     return equalIgnoringFragmentIdentifier(requestURL, cachedRequestURL);
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -46,9 +46,7 @@ String CacheStorageCache::computeKeyURL(const URL& url)
 {
     RELEASE_ASSERT(url.isValid());
     RELEASE_ASSERT(!url.isEmpty());
-    URL keyURL { url };
-    keyURL.removeQueryAndFragmentIdentifier();
-    auto keyURLString = keyURL.string();
+    auto keyURLString = url.string().left(url.pathEnd());
     RELEASE_ASSERT(RecordsMap::isValidKey(keyURLString));
     return keyURLString;
 }


### PR DESCRIPTION
#### b4f60d6c8f3d1ba9b7c3096264c09de05e747f3d
<pre>
Avoid redundant URL copies on Cache API query paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=322383">https://bugs.webkit.org/show_bug.cgi?id=322383</a>
<a href="https://rdar.apple.com/185665260">rdar://185665260</a>

Reviewed by Chris Dumez.

Two spots on the Cache API lookup path copied a URL only to throw the copy
away.

DOMCacheEngine::matchURLs() copied both the request URL and the cached record
URL into locals before comparing them, but the copies only exist so that
setQuery({ }) can strip the query strings when CacheQueryOptions::ignoreSearch
is set. When ignoreSearch is false -- the common case -- both copies are
discarded unmodified. Take that path first and compare in place.

CacheStorageCache::computeKeyURL() built a whole URL just to call
removeQueryAndFragmentIdentifier() on it and read back the string. Truncate
the URL&apos;s string directly instead, which is what
removeQueryAndFragmentIdentifier() does internally, and which also skips the
substring allocation entirely for URLs that have no query or fragment.

Together these run once per bucket lookup plus once per record examined, for
every match(), matchAll(), keys(), delete() and put(), as well as addAll()&apos;s
duplicate-request check.

No change in behavior.

* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::matchURLs):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::computeKeyURL):

Canonical link: <a href="https://commits.webkit.org/319765@main">https://commits.webkit.org/319765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c10b2fa09bdf72c04ebe8ce2164d711b83af49e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146744 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bddae569-2811-459a-b9bb-5198492615c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142383 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3c2de6f-67f9-4c67-b5e5-481693bcad25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46098 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163148 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122816 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ba82d07-4ac5-4061-a448-106a264c920b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43043 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42673 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3809 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56033 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151813 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40733 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151514 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46090 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129008 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55235 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17672 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54616 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->