### PR TITLE
Resync domparsing WPT tests from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt
@@ -1,0 +1,8 @@
+
+PASS parseFromString as HTML, appendChild
+PASS parseFromString as HTML, append importNode result
+PASS parseFromString as HTML, svg script, appendChild
+PASS parseFromString as HTML, svg script, append importNode result
+PASS parseFromString as XML, svg script, appendChild
+FAIL parseFromString as XML, svg script, append importNode result assert_equals: expected 0 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+<head>
+<title>DOMParser: script already started</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// The DOMParser parserFromString method wants an XML parser with
+// XML scripting support disabled. This test tests that various
+// parseFromString-parsed script elements are inactive ("already started").
+//
+// See:
+//   https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+//   step 3, "Otherwise: [...] "with XML scripting support disabled."
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<div><script>window.mark = 1;</sc" + "ript></div>", "text/html");
+  document.body.appendChild(d.body);
+  assert_equals(window.mark, 0);
+}, "parseFromString as HTML, appendChild");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<div><script>window.mark = 1;</sc" + "ript></div>", "text/html");
+  document.body.appendChild(document.importNode(d.body, true));
+  assert_equals(window.mark, 0);
+}, "parseFromString as HTML, append importNode result");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<svg><script>window.mark = 1;</sc" + "ript></svg>", "text/html");
+  document.body.appendChild(d.body);
+  assert_equals(window.mark, 0);
+}, "parseFromString as HTML, svg script, appendChild");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<svg><script>window.mark = 1;</sc" + "ript></svg>", "text/html");
+  document.body.appendChild(document.importNode(d.body, true));
+  assert_equals(window.mark, 0);
+}, "parseFromString as HTML, svg script, append importNode result");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<svg xmlns='http://www.w3.org/2000/svg'><script>window.mark = 1;</sc" + "ript></svg>", "text/xml");
+  document.body.appendChild(d.rootElement);
+  assert_equals(window.mark, 0);
+}, "parseFromString as XML, svg script, appendChild");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<svg xmlns='http://www.w3.org/2000/svg'><script>window.mark = 1;</sc" + "ript></svg>", "text/xml");
+  document.body.appendChild(document.importNode(d.rootElement, true));
+  assert_equals(window.mark, 0);
+}, "parseFromString as XML, svg script, append importNode result");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+rules:
+- DOMParser-*: [domparser]
+- "*domparser*": [domparser]
+- style_attribute_html.html: [domparser]
+- xml-parse-serialize-roundtrip.html: [domparser]
+- XMLSerializer-serializeToString.html: [xml-serializer]
+- xml-serialization.xhtml: [xml-serializer]

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt
@@ -13,7 +13,11 @@ FAIL Check if an attribute with namespace and no prefix is serialized with the n
 PASS Check if the prefix of an attribute is replaced with another existing prefix mapped to the same namespace URI.
 FAIL Check if the prefix of an attribute is NOT preserved in a case where neither its prefix nor its namespace URI is not already used. assert_equals: expected "<r xmlns:xx=\"uri\" xmlns:ns1=\"uri2\" ns1:name=\"value\"/>" but got "<r xmlns:xx=\"uri\" xmlns:p=\"uri2\" p:name=\"value\"/>"
 PASS Check if the prefix of an attribute is replaced with a generated one in a case where the prefix is already mapped to a different namespace URI.
-PASS check XMLSerializer.serializeToString escapes attribute values for roundtripping
+PASS Attribute value escapes: lt
+PASS Attribute value escapes: gt
+PASS Attribute value escapes: quot
+PASS Attribute value escapes: apos
+PASS [TENTATIVE] check XMLSerializer.serializeToString escapes attribute values for roundtripping
 FAIL Check if attribute serialization takes into account of following xmlns:* attributes assert_equals: expected "<root xmlns:ns1=\"uri1\" ns1:foobar=\"value1\" xmlns:p=\"uri2\"/>" but got "<root xmlns:p=\"uri1\" p:foobar=\"value1\" xmlns:p=\"uri2\"/>"
 PASS Check if attribute serialization takes into account of the same prefix declared in an ancestor element
 FAIL Check if start tag serialization drops element prefix if the namespace is same as inherited default namespace. assert_equals: expected "<root xmlns=\"u1\"><child xmlns:p=\"u1\"/></root>" but got "<root xmlns=\"u1\"><p:child xmlns:p=\"u1\"/></root>"

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
@@ -152,6 +152,28 @@ test(function() {
                 '<r xmlns:xx="uri" xmlns:ns1="uri2" ns1:name="value"/>');
 }, 'Check if the prefix of an attribute is replaced with a generated one in a case where the prefix is already mapped to a different namespace URI.');
 
+// https://w3c.github.io/DOM-Parsing/#dfn-serializing-an-attribute-value
+test(function() {
+  var root = parse('<root attr="&lt;"/>');
+  assert_equals(serialize(root), '<root attr="&lt;"/>');
+}, 'Attribute value escapes: lt');
+
+test(function() {
+  var root = parse('<root attr=">"/>');
+  assert_equals(serialize(root), '<root attr="&gt;"/>');
+}, 'Attribute value escapes: gt');
+
+test(function() {
+  var root = parse('<root attr=\'"\'/>');
+  assert_equals(serialize(root), '<root attr="&quot;"/>');
+}, 'Attribute value escapes: quot');
+
+test(function() {
+  var root = parse('<root attr="\'"/>');
+  assert_equals(serialize(root), '<root attr="\'"/>');
+}, 'Attribute value escapes: apos');
+
+// This does not match the specification; see <https://github.com/w3c/DOM-Parsing/issues/59>.
 test(function() {
   var root = parse('<root />');
   root.setAttribute('attr', '\t');
@@ -163,7 +185,7 @@ test(function() {
   root.setAttribute('attr', '\r');
   assert_in_array(serialize(root), [
     '<root attr="&#xD;"/>', '<root attr="&#13;"/>']);
-}, 'check XMLSerializer.serializeToString escapes attribute values for roundtripping');
+}, '[TENTATIVE] check XMLSerializer.serializeToString escapes attribute values for roundtripping');
 
 test(function() {
   const root = (new Document()).createElement('root');

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08-expected.txt
@@ -1,0 +1,4 @@
+
+PASS innerHTML on html element with trailing comment
+PASS innerHTML on html element with trailing comment (no explicit head)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>innerHTML on html element</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/11023">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  const html = document.createElement('html');
+  html.innerHTML = '<head></head><body></body><!-- comment -->';
+  assert_equals(html.childNodes.length, 3);
+  assert_equals(html.childNodes[0].nodeName, 'HEAD');
+  assert_equals(html.childNodes[1].nodeName, 'BODY');
+  assert_equals(html.childNodes[2].nodeType, Node.COMMENT_NODE);
+  assert_equals(html.childNodes[2].data, ' comment ');
+}, "innerHTML on html element with trailing comment")
+
+test(function() {
+  const html = document.createElement('html');
+  html.innerHTML = '<body></body><!-- comment -->';
+  assert_equals(html.childNodes.length, 3);
+  assert_equals(html.childNodes[0].nodeName, 'HEAD');
+  assert_equals(html.childNodes[1].nodeName, 'BODY');
+  assert_equals(html.childNodes[2].nodeType, Node.COMMENT_NODE);
+  assert_equals(html.childNodes[2].data, ' comment ');
+}, "innerHTML on html element with trailing comment (no explicit head)")
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/resources/domparser-iframe-base-pushstate.html

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/w3c-import.log
@@ -10,12 +10,11 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-encoding.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-html.html
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html
@@ -24,10 +23,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-doctype.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-internal-subset.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror.html
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-in-detached-xml-document-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/domparser-spurious-attributes.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-01.xhtml
@@ -36,6 +38,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-05.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-06.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-07.html
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08.html
+/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-mxss.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/insert-adjacent.html
 /LayoutTests/imported/w3c/web-platform-tests/domparsing/insert_adjacent_html-001-crash.html


### PR DESCRIPTION
#### 2bf5b6e2d9f34ba4114af97d0f6cabcc7caa4aeb
<pre>
Resync domparsing WPT tests from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=322382">https://bugs.webkit.org/show_bug.cgi?id=322382</a>

Reviewed by Tim Nguyen.

Resync domparsing WPT tests from upstream@83b63594532f89d8949a.

* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html:
* LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-08.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/domparsing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/319753@main">https://commits.webkit.org/319753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d94fb26c39bcb9a523816ae3d21c7f1b18fb3414

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146746 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bcf2a88-5fd1-41d9-ba29-62760f9a6060) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142385 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec0fa8c2-0196-4437-aba1-caa19e713292) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46096 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163141 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122818 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ee2a874-a21e-4db7-86ee-0485ff02bbeb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44780 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43046 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42666 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3811 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194576 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40722 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151518 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46092 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55237 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17665 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54618 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54857 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->