### PR TITLE
REGRESSION(315609@main): Stack overflow in NetworkProcess aborting the queued transactions of a suspended process

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -229,7 +229,7 @@ void IDBConnectionToClient::setClientProcessSuspended(bool isSuspended)
     // in-progress transactions, which cannot finish while the client is suspended.
     m_databaseConnections.forEach([](UniqueIDBDatabaseConnection& connection) {
         if (CheckedPtr database = connection.database())
-            database->abortInProgressTransactionsBlockedOnSuspendedClients();
+            database->didSuspendClientProcess();
     });
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1403,7 +1403,32 @@ void UniqueIDBDatabase::enqueueTransaction(Ref<UniqueIDBDatabaseTransaction>&& t
 
 void UniqueIDBDatabase::handleTransactions()
 {
-    LOG(IndexedDB, "UniqueIDBDatabase::handleTransactions - There are %zu pending", m_pendingTransactions.size());
+    // Starting transactions can abort the in-progress transactions of a suspended client, which in
+    // turn makes more transactions runnable. Drive that from a single loop instead of letting the
+    // nested calls recurse: with enough queued transactions the recursion overflows the stack.
+    if (m_isHandlingTransactions) {
+        m_shouldHandleTransactionsAgain = true;
+        return;
+    }
+
+    SetForScope handlingTransactionsScope(m_isHandlingTransactions, true);
+    do {
+        m_shouldHandleTransactionsAgain = false;
+        startRunnableTransactions();
+
+        // In-progress transactions of a suspended client process can never finish while the client
+        // stays suspended, so transactions queued behind them would be blocked indefinitely.
+        if (abortInProgressTransactionsBlockedOnSuspendedClients() == DidAbortTransactions::Yes) {
+            // Previously blocked operations and transactions might be runnable.
+            handleDatabaseOperations();
+            m_shouldHandleTransactionsAgain = true;
+        }
+    } while (m_shouldHandleTransactionsAgain);
+}
+
+void UniqueIDBDatabase::startRunnableTransactions()
+{
+    LOG(IndexedDB, "UniqueIDBDatabase::startRunnableTransactions - There are %zu pending", m_pendingTransactions.size());
 
     bool hadDeferredTransactions = false;
     RefPtr transaction = takeNextRunnableTransaction(hadDeferredTransactions);
@@ -1423,11 +1448,7 @@ void UniqueIDBDatabase::handleTransactions()
             break;
         transaction = takeNextRunnableTransaction(hadDeferredTransactions);
     }
-    LOG(IndexedDB, "UniqueIDBDatabase::handleTransactions - There are %zu pending after this round of handling", m_pendingTransactions.size());
-
-    // In-progress transactions of a suspended client process can never finish while the client
-    // stays suspended, so transactions queued behind them would be blocked indefinitely.
-    abortInProgressTransactionsBlockedOnSuspendedClients();
+    LOG(IndexedDB, "UniqueIDBDatabase::startRunnableTransactions - There are %zu pending after this round of handling", m_pendingTransactions.size());
 }
 
 void UniqueIDBDatabase::activateTransactionInBackingStore(UniqueIDBDatabaseTransaction& transaction)
@@ -1639,14 +1660,17 @@ bool UniqueIDBDatabase::transactionBlocksPendingTransactions(UniqueIDBDatabaseTr
     return false;
 }
 
-void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
+void UniqueIDBDatabase::didSuspendClientProcess()
+{
+    // handleTransactions() aborts the in-progress transactions of suspended clients and starts the
+    // transactions those aborts unblock.
+    handleTransactions();
+}
+
+auto UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients() -> DidAbortTransactions
 {
     if (m_pendingTransactions.isEmpty() || m_inProgressTransactions.isEmpty())
-        return;
-
-    SetForScope recursionScope(m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth, m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth + 1);
-    if (m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth > 5)
-        RELEASE_LOG_ERROR(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients - recursion depth reaches %u", m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth);
+        return DidAbortTransactions::No;
 
     Vector<Ref<UniqueIDBDatabaseTransaction>> transactionsToAbort;
     for (auto& transaction : m_inProgressTransactions.values()) {
@@ -1691,10 +1715,7 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
         abortedAnyTransaction = true;
     }
 
-    if (abortedAnyTransaction) {
-        handleDatabaseOperations();
-        handleTransactions();
-    }
+    return abortedAnyTransaction ? DidAbortTransactions::Yes : DidAbortTransactions::No;
 }
 
 void UniqueIDBDatabase::close()

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -121,7 +121,7 @@ public:
 
     bool NODELETE hasActiveTransactions() const;
     WEBCORE_EXPORT void abortActiveTransactions();
-    void abortInProgressTransactionsBlockedOnSuspendedClients();
+    void didSuspendClientProcess();
     WEBCORE_EXPORT bool tryClose();
 
     WEBCORE_EXPORT String filePath() const;
@@ -147,10 +147,14 @@ private:
     void notifyCurrentRequestConnectionClosedOrFiredVersionChangeEvent(IDBDatabaseConnectionIdentifier);
 
     void handleTransactions();
+    void startRunnableTransactions();
     RefPtr<UniqueIDBDatabaseTransaction> takeNextRunnableTransaction(bool& hadDeferredTransactions);
     bool transactionBlocksPendingTransactions(UniqueIDBDatabaseTransaction&);
 
     void activateTransactionInBackingStore(UniqueIDBDatabaseTransaction&);
+
+    enum class DidAbortTransactions : bool { No, Yes };
+    DidAbortTransactions abortInProgressTransactionsBlockedOnSuspendedClients();
 
     enum class ShouldStartRunnableWork : bool { No, Yes };
     void transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&&, ShouldStartRunnableWork = ShouldStartRunnableWork::Yes);
@@ -189,7 +193,9 @@ private:
     // These sets help to decide which transactions can be started and which must be deferred.
     HashCountedSet<IDBObjectStoreIdentifier> m_objectStoreTransactionCounts;
     HashSet<IDBObjectStoreIdentifier> m_objectStoreWriteTransactions;
-    unsigned m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth { 0 };
+
+    bool m_isHandlingTransactions { false };
+    bool m_shouldHandleTransactionsAgain { false };
 };
 
 } // namespace IDBServer

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -535,3 +535,90 @@ TEST(IndexedDB, AbortMultipleTransactionsOfSuspendedProcess)
     EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
     EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"all first transactions aborted");
 }
+
+TEST(IndexedDB, AbortManyQueuedTransactionsOfSuspendedProcess)
+{
+    // Every queued transaction of the suspended client gets started and then immediately aborted,
+    // which used to happen recursively, one nested scheduling pass per transaction, and overflowed
+    // the network process's stack.
+    static NSString *firstClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var transactionCount = 2000; \
+        var request = indexedDB.open('ManyQueuedSuspendedTransactionsDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('Store'); \
+        }; \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var db = event.target.result; \
+            var firstTransaction = db.transaction('Store', 'readwrite'); \
+            var objectStore = firstTransaction.objectStore('Store'); \
+            function keepTransactionAlive() { \
+                objectStore.get('TestKey').onsuccess = keepTransactionAlive; \
+            } \
+            keepTransactionAlive(); \
+            for (var i = 1; i < transactionCount; i++) { \
+                var transaction = db.transaction('Store', 'readwrite'); \
+                transaction.objectStore('Store').put('Value' + i, 'Key' + i); \
+            } \
+            objectStore.get('TestKey').onsuccess = function() { \
+                post('first transactions queued'); \
+            }; \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('ManyQueuedSuspendedTransactionsDatabase'); \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('Store', 'readwrite'); \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore('Store').put('OtherValue', 'OtherKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    // The final request is sent after every queued transaction, so its reply means the server has
+    // them all.
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transactions queued");
+    pid_t networkProcessIdentifier = [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier];
+    EXPECT_NE(networkProcessIdentifier, 0);
+
+    // One transaction of the first client is in progress and the rest are queued behind it. They all
+    // block the second client, so suspending the first client aborts them one after another.
+    [firstWebView _setThrottleStateForTesting:0];
+
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+
+    // Aborting the queued transactions must not have taken down the network process.
+    EXPECT_EQ(networkProcessIdentifier, [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier]);
+}


### PR DESCRIPTION
#### 30b9f00154ac753a4ff2315903cfc165418fd5af
<pre>
REGRESSION(<a href="https://commits.webkit.org/315609@main">315609@main</a>): Stack overflow in NetworkProcess aborting the queued transactions of a suspended process
<a href="https://bugs.webkit.org/show_bug.cgi?id=322386">https://bugs.webkit.org/show_bug.cgi?id=322386</a>
<a href="https://rdar.apple.com/184669941">rdar://184669941</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/318222@main">318222@main</a> was meant to fix this crash by batching the aborts so that
transactionCompleted() no longer re-entered handleTransactions() once per aborted
transaction. It only moved the recursion: the batch now ends with its own call
back into the scheduler, so the chain became
```
  handleTransactions()
    -&gt; abortInProgressTransactionsBlockedOnSuspendedClients()
          -&gt; handleDatabaseOperations() / handleTransactions()
                -&gt; abortInProgressTransactionsBlockedOnSuspendedClients()
                      -&gt; ...
```
Batching only helps when a pass can abort many transactions at once. When the
suspended client has many *queued* transactions with overlapping scopes, each
pass starts exactly one of them (takeNextRunnableTransaction() defers the rest
and the loop breaks on hadDeferredTransactions), aborts it, and re-enters, so
the depth is still one frame pair per queued transaction. The reported crash
recursed over 3000 levels; the RELEASE_LOG_ERROR that <a href="https://commits.webkit.org/318222@main">318222@main</a> added at depth
&gt; 5 runs at every level, and its os_log buffers are what finally touch the stack
guard page.

Make the cycle iterative instead. Split the scheduling body out of
handleTransactions() into startRunnableTransactions(), and turn
handleTransactions() into a re-entrancy-guarded driver loop: a nested call sets
m_shouldHandleTransactionsAgain and returns, so the outer loop picks the work up
rather than growing the stack.
abortInProgressTransactionsBlockedOnSuspendedClients() now reports whether it
aborted anything and no longer calls back into the scheduler, and the
recursion-depth counter and its log are gone since recursion is no longer
possible.

IDBConnectionToClient::setClientProcessSuspended() needs the abort pass *and*
the reschedule it used to trigger, so it calls the new didSuspendClientProcess()
entry point, which drives the same loop.

API test: IndexedDB.AbortManyQueuedTransactionsOfSuspendedProcess

The test checks the network process identifier is unchanged, because a network
process crash otherwise goes unnoticed here: it relaunches, and the contending
client&apos;s transaction then succeeds against a fresh server.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm

* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::setClientProcessSuspended):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::handleTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::startRunnableTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::didSuspendClientProcess):
(WebCore::IDBServer::UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm:
(AbortManyQueuedTransactionsOfSuspendedProcess)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b9f00154ac753a4ff2315903cfc165418fd5af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146760 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/640c19f3-1172-496f-85c8-c5ff1c3c8978) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142398 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98889 "2 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6768a637-be94-4709-8bca-2197b27ba46c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122831 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32dba28f-0739-4be8-a008-acfa1d007e34) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44786 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43057 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42681 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3825 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56049 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56740 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39306 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151527 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46104 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129024 "Found 773 new failures in testing/Internals.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125007 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55251 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54699 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->