### PR TITLE
Descendant and dynamic module script fetches send the wrong Referer header

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url-expected.txt
@@ -1,0 +1,4 @@
+
+PASS The document's base URL differs from the document URL
+PASS Static imports from inline modules in a document with a base URL override
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Referrer for imports from an inline module script with a base URL override</title>
+<base href="/html/semantics/scripting-1/the-script-element/module/resources/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>setup({ explicit_done: true })</script>
+</head>
+<body>
+<script type="module">
+
+// The referrer of a descendant fetch is the importing module script's base URL, which for an inline
+// module script is the document's base URL. The <base> element above moves that away from the document
+// URL, so a referrer of the document URL cannot pass by coincidence.
+import { referrer } from "/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name=inline-base-url";
+
+test(t => {
+  assert_not_equals(document.baseURI, document.URL,
+    "The <base> element should move the base URL away from the document URL");
+}, "The document's base URL differs from the document URL");
+
+test(t => {
+  assert_equals(referrer, document.baseURI,
+    "Referrer should be the inline module script's base URL");
+}, "Static imports from inline modules in a document with a base URL override");
+
+done();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Static imports from inline modules in the HTML document
 PASS Dynamic imports from inline modules in the HTML document
-FAIL Static imports from external modules assert_equals: Referrer should be the importer module URL expected "http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/module/module-import-referrer.js" but got "http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html"
-FAIL Dynamic imports from external modules assert_equals: Referrer should be the document URL expected "http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/module/module-import-referrer.js" but got "http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html"
+PASS Static imports from external modules
+PASS Dynamic imports from external modules
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The strict-* referrer policies compare the trustworthiness of a request's referrer string against its URL assert_equals: A document with the strict-origin referrer policy served over HTTP, imports an module script over HTTPS, that imports a descendant script over HTTP. The request for the descendant script is sent with no `Referer` header expected "" but got "http://web-platform.test:8800/"
+PASS The strict-* referrer policies compare the trustworthiness of a request's referrer string against its URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
@@ -11,10 +11,10 @@ PASS Importing a same-origin script from a remote-origin worklet script that has
 PASS Importing a remote-origin script from a remote-origin worklet script that has "no-referrer" referrer policy should not send referrer.
 PASS Importing a same-origin script from a same-origin worklet script that has "origin" referrer policy should send referrer.
 PASS Importing a remote-origin script from a same-origin worklet script that has "origin" referrer policy should send referrer.
-FAIL Importing a same-origin script from a remote-origin worklet script that has "origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
-FAIL Importing a remote-origin script from a remote-origin worklet script that has "origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Cross-origin script load denied by Cross-Origin Resource Sharing policy."
-FAIL Importing a same-origin script from a same-origin worklet script that has "same-origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
+PASS Importing a same-origin script from a remote-origin worklet script that has "origin" referrer policy should send referrer.
+PASS Importing a remote-origin script from a remote-origin worklet script that has "origin" referrer policy should send referrer.
+PASS Importing a same-origin script from a same-origin worklet script that has "same-origin" referrer policy should send referrer.
 PASS Importing a remote-origin script from a same-origin worklet script that has "same-origin" referrer policy should not send referrer.
-FAIL Importing a same-origin script from a remote-origin worklet script that has "same-origin" referrer policy should not send referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
-FAIL Importing a remote-origin script from a remote-origin worklet script that has "same-origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Cross-origin script load denied by Cross-Origin Resource Sharing policy."
+PASS Importing a same-origin script from a remote-origin worklet script that has "same-origin" referrer policy should not send referrer.
+PASS Importing a remote-origin script from a remote-origin worklet script that has "same-origin" referrer policy should send referrer.
 

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.h
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.h
@@ -61,7 +61,7 @@ private:
 
     static JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSModuleLoader*, JSString* moduleNameValue, RefPtr<ScriptFetchParameters>, const SourceOrigin&, bool deferred);
     static Identifier moduleLoaderResolve(JSGlobalObject*, JSModuleLoader*, JSValue keyValue, JSValue referrerValue, RefPtr<ScriptFetcher>, bool useImportMap);
-    static JSPromise* moduleLoaderFetch(JSGlobalObject*, JSModuleLoader*, JSValue, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
+    static JSPromise* moduleLoaderFetch(JSGlobalObject*, JSModuleLoader*, JSValue, const String&, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     static JSObject* moduleLoaderCreateImportMetaProperties(JSGlobalObject*, JSModuleLoader*, JSValue, JSModuleRecord*, RefPtr<ScriptFetcher>);
     static JSValue moduleLoaderEvaluate(JSGlobalObject*, JSModuleLoader*, JSValue, JSValue, RefPtr<ScriptFetcher>, JSValue, JSValue);
 };

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -161,7 +161,7 @@ JSPromise* JSAPIGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObj
     return result;
 }
 
-JSPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModuleLoader*, JSValue key, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>)
+JSPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModuleLoader*, JSValue key, const String&, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -956,7 +956,7 @@ private:
 
     static JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSModuleLoader*, JSString*, RefPtr<ScriptFetchParameters>, const SourceOrigin&, bool deferred);
     static Identifier moduleLoaderResolve(JSGlobalObject*, JSModuleLoader*, JSValue, JSValue, RefPtr<ScriptFetcher>, bool useImportMap);
-    static JSPromise* moduleLoaderFetch(JSGlobalObject*, JSModuleLoader*, JSValue, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
+    static JSPromise* moduleLoaderFetch(JSGlobalObject*, JSModuleLoader*, JSValue, const String&, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     static JSObject* moduleLoaderCreateImportMetaProperties(JSGlobalObject*, JSModuleLoader*, JSValue, JSModuleRecord*, RefPtr<ScriptFetcher>);
 
 #if ENABLE(FUZZILLI)
@@ -1475,7 +1475,7 @@ static bool fetchModuleFromLocalFileSystem(const URL& fileURL, Vector& buffer)
     return result;
 }
 
-JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModuleLoader*, JSValue key, RefPtr<ScriptFetchParameters> attributes, RefPtr<ScriptFetcher>)
+JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModuleLoader*, JSValue key, const String&, RefPtr<ScriptFetchParameters> attributes, RefPtr<ScriptFetcher>)
 {
     VM& vm = globalObject->vm();
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -63,7 +63,7 @@ struct GlobalObjectMethodTable {
 
     JSPromise* (*moduleLoaderImportModule)(JSGlobalObject*, JSModuleLoader*, JSString*, RefPtr<ScriptFetchParameters>, const SourceOrigin&, bool deferred);
     Identifier (*moduleLoaderResolve)(JSGlobalObject*, JSModuleLoader*, JSValue, JSValue, RefPtr<ScriptFetcher>, bool useImportMap);
-    JSPromise* (*moduleLoaderFetch)(JSGlobalObject*, JSModuleLoader*, JSValue, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
+    JSPromise* (*moduleLoaderFetch)(JSGlobalObject*, JSModuleLoader*, JSValue key, const String& referrer, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     JSObject* (*moduleLoaderCreateImportMetaProperties)(JSGlobalObject*, JSModuleLoader*, JSValue, JSModuleRecord*, RefPtr<ScriptFetcher>);
     JSValue (*moduleLoaderEvaluate)(JSGlobalObject*, JSModuleLoader*, JSValue key, JSValue moduleRecordValue, RefPtr<ScriptFetcher>, JSValue awaitedValue, JSValue resumeMode);
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -345,7 +345,7 @@ void JSModuleLoader::provideFetch(JSGlobalObject* globalObject, const Identifier
         entry->provideFetch(globalObject, jsSourceCode); // can throw
 }
 
-JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identifier& specifier, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher, OptionSet<ModuleLoadFlag> flags)
+JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identifier& specifier, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher, OptionSet<ModuleLoadFlag> flags, const String& referrer)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -369,7 +369,7 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identi
     }
 
     if (!promise) {
-        promise = fetch(globalObject, identifierToJSValue(vm, specifier), WTF::move(parameters), scriptFetcher);
+        promise = fetch(globalObject, identifierToJSValue(vm, specifier), referrer, WTF::move(parameters), scriptFetcher);
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
@@ -431,6 +431,16 @@ JSPromise* JSModuleLoader::linkAndEvaluateModule(JSGlobalObject* globalObject, c
     return promise;
 }
 
+// The referrer of a module fetch is the referring script's base URL, i.e. its module key. An inline
+// module's key is a Symbol: it has no URL of its own, so we return the empty string and let the host
+// substitute its base URL. A null key means there is no referring script at all.
+static String moduleReferrer(const Identifier& referrerKey)
+{
+    if (referrerKey.isSymbol())
+        return emptyString();
+    return referrerKey.string();
+}
+
 JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, const Identifier& moduleName, const Identifier& referrer, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher, bool deferred)
 {
     VM& vm = globalObject->vm();
@@ -442,7 +452,8 @@ JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, con
     OptionSet<ModuleLoadFlag> flags { ModuleLoadFlag::Evaluate, ModuleLoadFlag::Dynamic };
     if (deferred)
         flags.add(ModuleLoadFlag::Deferred);
-    JSPromise* promise = loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), flags);
+    // Per "fetch an import() module script graph", the referring script's base URL is the fetch's referrer.
+    JSPromise* promise = loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), flags, moduleReferrer(referrer));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -504,7 +515,7 @@ Identifier JSModuleLoader::resolve(JSGlobalObject* globalObject, const Identifie
     RELEASE_AND_RETURN(scope, resolve(globalObject, nameValue, referrerValue, WTF::move(scriptFetcher), useImportMap));
 }
 
-JSPromise* JSModuleLoader::fetch(JSGlobalObject* globalObject, JSValue key, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher)
+JSPromise* JSModuleLoader::fetch(JSGlobalObject* globalObject, JSValue key, const String& referrer, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher)
 {
     dataLogLnIf(Options::dumpModuleLoadingState(), "Loader [fetch] ", printableModuleKey(globalObject, key));
 
@@ -512,7 +523,7 @@ JSPromise* JSModuleLoader::fetch(JSGlobalObject* globalObject, JSValue key, RefP
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (globalObject->globalObjectMethodTable()->moduleLoaderFetch)
-        RELEASE_AND_RETURN(scope, globalObject->globalObjectMethodTable()->moduleLoaderFetch(globalObject, this, key, WTF::move(parameters), WTF::move(scriptFetcher)));
+        RELEASE_AND_RETURN(scope, globalObject->globalObjectMethodTable()->moduleLoaderFetch(globalObject, this, key, referrer, WTF::move(parameters), WTF::move(scriptFetcher)));
 
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     String moduleKey = key.toWTFString(globalObject);
@@ -702,7 +713,8 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
     }
 
     if (mapEntry->status() == ModuleRegistryEntry::Status::New) {
-        JSPromise* promise = fetch(globalObject, identifierToJSValue(vm, resolved), moduleRequest.m_attributes, scriptFetcher);
+        // Per "fetch the descendants of a module script", the referrer is the referring module's base URL.
+        JSPromise* promise = fetch(globalObject, identifierToJSValue(vm, resolved), moduleReferrer(referrerKey), moduleRequest.m_attributes, scriptFetcher);
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         mapEntry->setStatus(ModuleRegistryEntry::Status::Fetching);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -92,7 +92,7 @@ public:
     // APIs to control the module loader.
     void provideFetch(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type, SourceCode&&);
     void provideFetch(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type, JSSourceCode*);
-    JSPromise* loadModule(JSGlobalObject*, const Identifier& moduleName, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>, OptionSet<ModuleLoadFlag>);
+    JSPromise* loadModule(JSGlobalObject*, const Identifier& moduleName, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>, OptionSet<ModuleLoadFlag>, const String& referrer = { });
     JSPromise* linkAndEvaluateModule(JSGlobalObject*, const Identifier& moduleKey, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     JSPromise* requestImportModule(JSGlobalObject*, const Identifier& moduleName, const Identifier& referrer, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>, bool deferred = false);
 
@@ -100,7 +100,7 @@ public:
     JSPromise* importModule(JSGlobalObject*, JSString* moduleName, JSValue parameters, const SourceOrigin& referrer, bool deferred = false);
     Identifier resolve(JSGlobalObject*, JSValue name, JSValue referrer, RefPtr<ScriptFetcher>, bool useImportMap);
     Identifier resolve(JSGlobalObject*, const Identifier& name, const Identifier& referrer, RefPtr<ScriptFetcher>, bool useImportMap);
-    JSPromise* fetch(JSGlobalObject*, JSValue key, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
+    JSPromise* fetch(JSGlobalObject*, JSValue key, const String& referrer, RefPtr<ScriptFetchParameters>, RefPtr<ScriptFetcher>);
     JSObject* createImportMetaProperties(JSGlobalObject*, JSValue key, JSModuleRecord*, RefPtr<ScriptFetcher>);
 
     // Additional platform dependent hooked APIs.

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -58,7 +58,7 @@ CachedModuleScriptLoader::~CachedModuleScriptLoader()
     }
 }
 
-bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::optional<ServiceWorkersMode> serviceWorkersMode)
+bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer)
 {
     ASSERT(m_promise);
     ASSERT(!m_cachedScript);
@@ -76,7 +76,7 @@ bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::op
             break;
         }
     }
-    m_cachedScript = protect(scriptFetcher())->requestModuleScript(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode);
+    m_cachedScript = protect(scriptFetcher())->requestModuleScript(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode, referrer);
     if (!m_cachedScript)
         return false;
     m_sourceURL = WTF::move(sourceURL);

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -55,7 +55,7 @@ public:
     void ref() const final { ModuleScriptLoader::ref(); }
     void deref() const final { ModuleScriptLoader::deref(); }
 
-    bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>);
+    bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>, const URL& referrer);
 
     CachedScript* cachedScript() { return m_cachedScript.get(); }
     CachedScriptFetcher& scriptFetcher() { return static_cast<CachedScriptFetcher&>(ModuleScriptLoader::scriptFetcher()); }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -41,12 +41,12 @@ Ref<CachedScriptFetcher> CachedScriptFetcher::create(const AtomString& charset)
     return adoptRef(*new CachedScriptFetcher(charset));
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
-    return requestScriptWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode);
+    return requestScriptWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode, referrer);
 }
 
-RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
     if (!document.settings().isScriptEnabled())
         return nullptr;
@@ -68,6 +68,11 @@ RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& docum
     request.upgradeInsecureRequestIfNeeded(document);
     request.setCharset(m_charset);
     request.setPriority(WTF::move(resourceLoadPriority));
+    // Only an HTTP(S) fetch appends a Referer header, and CachedResourceLoader applies the referrer
+    // policy to the request only for those. Setting it for any other scheme would send the importing
+    // script's URL unfiltered, e.g. to a URL scheme handler.
+    if (!referrer.isEmpty() && request.resourceRequest().url().protocolIsInHTTPFamily())
+        request.resourceRequest().setHTTPReferrer(referrer.strippedForUseAsReferrer().string);
     if (!m_initiatorType.isNull())
         request.setInitiatorType(m_initiatorType);
 

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -42,7 +42,7 @@ enum class FetchOptionsDestination : uint8_t;
 
 class CachedScriptFetcher : public JSC::ScriptFetcher {
 public:
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
+    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
 
     static Ref<CachedScriptFetcher> create(const AtomString& charset);
 
@@ -62,7 +62,7 @@ protected:
     {
     }
 
-    RefPtr<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
+    RefPtr<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>, const URL& referrer = { }) const;
 
 private:
     bool isCachedScriptFetcher() const final { return true; }

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -737,13 +737,13 @@ JSC::Identifier JSDOMGlobalObject::moduleLoaderResolve(JSC::JSGlobalObject* glob
     return { };
 }
 
-JSC::JSPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleKey, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> scriptFetcher)
+JSC::JSPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleKey, const String& referrer, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> scriptFetcher)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
-        RELEASE_AND_RETURN(scope, loader->fetch(globalObject, moduleLoader, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher)));
+        RELEASE_AND_RETURN(scope, loader->fetch(globalObject, moduleLoader, moduleKey, referrer, WTF::move(parameters), WTF::move(scriptFetcher)));
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     scope.release();
     promise->reject(vm, jsUndefined());

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -148,7 +148,7 @@ protected:
 #endif
 
     static JSC::Identifier moduleLoaderResolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSValue, RefPtr<JSC::ScriptFetcher>, bool useImportMap);
-    static JSC::JSPromise* moduleLoaderFetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, RefPtr<JSC::ScriptFetchParameters>, RefPtr<JSC::ScriptFetcher>);
+    static JSC::JSPromise* moduleLoaderFetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, const String&, RefPtr<JSC::ScriptFetchParameters>, RefPtr<JSC::ScriptFetcher>);
     static JSC::JSValue moduleLoaderEvaluate(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSValue, RefPtr<JSC::ScriptFetcher>, JSC::JSValue, JSC::JSValue);
     static JSC::JSPromise* moduleLoaderImportModule(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString*, RefPtr<JSC::ScriptFetchParameters>, const JSC::SourceOrigin&, bool deferred);
     static JSC::JSObject* moduleLoaderCreateImportMetaProperties(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSModuleRecord*, RefPtr<JSC::ScriptFetcher>);

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -200,7 +200,7 @@ static void rejectWithFetchError(ScriptExecutionContext& context, Ref<DeferredPr
     });
 }
 
-JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleKeyValue, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> scriptFetcher)
+JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleKeyValue, const String& referrer, RefPtr<JSC::ScriptFetchParameters> parameters, RefPtr<JSC::ScriptFetcher> scriptFetcher)
 {
     JSC::VM& vm = jsGlobalObject->vm();
 
@@ -229,6 +229,16 @@ JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, J
         return jsPromise;
     }
 
+    // The referrer is the referring script's base URL, the same URL resolve() resolved the specifier
+    // against: a descendant fetch is handed the importing module's key, which the map turns into its
+    // response URL, while import() is handed its calling script's base URL, already a response URL and
+    // not a key in the map, so it comes back unchanged. An empty referrer means the referring script has
+    // no URL of its own (an inline module), and a null one that there is no referring script at all — a
+    // script element or worker top-level fetch — which uses the fetch client's referrer.
+    URL referrerURL;
+    if (!referrer.isNull())
+        referrerURL = referrer.isEmpty() ? baseURLForScriptWithoutURL() : responseURLFromRequestURL(referrer);
+
     if (m_ownerType == OwnerType::Document) {
         Ref loader = CachedModuleScriptLoader::create(*this, deferred.get(), *downcast<CachedScriptFetcher>(scriptFetcher.get()), WTF::move(parameters));
         m_loaders.add(loader.copyRef());
@@ -236,7 +246,7 @@ JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, J
         // Prevent non-normal worlds from loading with a service worker.
         auto serviceWorkersMode = currentWorld(*jsGlobalObject).isNormal() ? ServiceWorkersMode::All : ServiceWorkersMode::None;
 
-        if (!loader->load(protect(downcast<Document>(*m_context)), WTF::move(completedURL), serviceWorkersMode)) {
+        if (!loader->load(protect(downcast<Document>(*m_context)), WTF::move(completedURL), serviceWorkersMode, referrerURL)) {
             loader->clearClient();
             m_loaders.remove(WTF::move(loader));
             rejectToPropagateNetworkError(*protect(m_context), WTF::move(deferred), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
@@ -245,7 +255,7 @@ JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, J
     } else {
         Ref loader = WorkerModuleScriptLoader::create(*this, deferred.get(), *downcast<WorkerScriptFetcher>(scriptFetcher.get()), WTF::move(parameters));
         m_loaders.add(loader.copyRef());
-        loader->load(*protect(m_context), WTF::move(completedURL));
+        loader->load(*protect(m_context), WTF::move(completedURL), referrerURL);
     }
 
     return jsPromise;
@@ -265,18 +275,27 @@ URL ScriptModuleLoader::responseURLFromRequestURL(JSC::JSGlobalObject& jsGlobalO
     JSC::VM& vm = jsGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (isRootModule(moduleKeyValue)) {
-        if (!m_context)
-            return URL();
-        if (m_ownerType == OwnerType::Document)
-            return downcast<Document>(*m_context).baseURL();
-        return protect(m_context)->url();
-    }
+    if (isRootModule(moduleKeyValue))
+        return baseURLForScriptWithoutURL();
 
-    ASSERT(!isRootModule(moduleKeyValue));
     ASSERT(moduleKeyValue.isString());
     String requestURL = asString(moduleKeyValue)->value(&jsGlobalObject);
     RETURN_IF_EXCEPTION(scope, { });
+    return responseURLFromRequestURL(requestURL);
+}
+
+// The base URL of a script that has no URL of its own, i.e. an inline module script.
+URL ScriptModuleLoader::baseURLForScriptWithoutURL()
+{
+    if (!m_context)
+        return URL();
+    if (m_ownerType == OwnerType::Document)
+        return downcast<Document>(*m_context).baseURL();
+    return protect(m_context)->url();
+}
+
+URL ScriptModuleLoader::responseURLFromRequestURL(const String& requestURL)
+{
     ASSERT_WITH_MESSAGE(URL(requestURL).isValid(), "Invalid module referrer never starts importing dependent modules.");
 
     auto iterator = m_requestURLToResponseURLMap.find(requestURL);

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -68,7 +68,7 @@ public:
     ScriptExecutionContext* context();
 
     JSC::Identifier resolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleName, JSC::JSValue importerModuleKey, RefPtr<JSC::ScriptFetcher>, bool useImportMap);
-    JSC::JSPromise* fetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleKey, RefPtr<JSC::ScriptFetchParameters>, RefPtr<JSC::ScriptFetcher>);
+    JSC::JSPromise* fetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleKey, const String& referrer, RefPtr<JSC::ScriptFetchParameters>, RefPtr<JSC::ScriptFetcher>);
     JSC::JSValue evaluate(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleKey, JSC::JSValue moduleRecord, RefPtr<JSC::ScriptFetcher>, JSC::JSValue awaitedValue, JSC::JSValue resumeMode);
     JSC::JSPromise* importModule(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString*, RefPtr<JSC::ScriptFetchParameters>, const JSC::SourceOrigin&, bool deferred);
     JSC::JSObject* createImportMetaProperties(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSModuleRecord*, RefPtr<JSC::ScriptFetcher>);
@@ -78,6 +78,8 @@ private:
 
     URL moduleURL(JSC::JSGlobalObject&, JSC::JSValue);
     URL responseURLFromRequestURL(JSC::JSGlobalObject&, JSC::JSValue);
+    URL responseURLFromRequestURL(const String& requestURL);
+    URL baseURLForScriptWithoutURL();
 
     WeakPtr<ScriptExecutionContext> m_context;
     MemoryCompactRobinHoodHashMap<String, URL> m_requestURLToResponseURLMap;

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -60,7 +60,7 @@ WorkerModuleScriptLoader::~WorkerModuleScriptLoader()
     m_scriptLoader->cancel();
 }
 
-void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourceURL)
+void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourceURL, const URL& referrer)
 {
     m_sourceURL = WTF::move(sourceURL);
 
@@ -127,7 +127,11 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
             fetchOptions.mode = FetchOptions::Mode::SameOrigin;
     }
 
-    m_scriptLoader->loadAsynchronously(context, WTF::move(request), WorkerScriptLoader::Source::ModuleScript, WTF::move(fetchOptions), contentSecurityPolicyEnforcement, ServiceWorkersMode::All, *this, taskMode());
+    String referrerForRequest;
+    if (!referrer.isEmpty())
+        referrerForRequest = referrer.strippedForUseAsReferrer().string;
+
+    m_scriptLoader->loadAsynchronously(context, WTF::move(request), WorkerScriptLoader::Source::ModuleScript, WTF::move(fetchOptions), contentSecurityPolicyEnforcement, ServiceWorkersMode::All, *this, taskMode(), std::nullopt, WTF::move(referrerForRequest));
 }
 
 ReferrerPolicy WorkerModuleScriptLoader::referrerPolicy()

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
@@ -54,7 +54,7 @@ public:
     void ref() const final { ModuleScriptLoader::ref(); }
     void deref() const final { ModuleScriptLoader::deref(); }
 
-    void load(ScriptExecutionContext&, URL&& sourceURL);
+    void load(ScriptExecutionContext&, URL&& sourceURL, const URL& referrer);
 
     WorkerScriptLoader& scriptLoader() { return m_scriptLoader.get(); }
 

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 
 const ASCIILiteral ScriptElementCachedScriptFetcher::defaultCrossOriginModeForModule { "anonymous"_s };
 
-CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
     // If the fetcher is not module script, credential mode is always "same-origin" ("anonymous").
     // This code is for dynamic module import (`import` operator).
 
-    return requestScriptWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode);
+    return requestScriptWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode, referrer);
 }
 
 }

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -35,7 +35,7 @@ class ScriptElementCachedScriptFetcher : public CachedScriptFetcher {
 public:
     static const ASCIILiteral defaultCrossOriginModeForModule;
 
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>) const;
+    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
 
     virtual ScriptType scriptType() const = 0;
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -130,7 +130,7 @@ std::optional<Exception> WorkerScriptLoader::loadSynchronously(ScriptExecutionCo
     return std::nullopt;
 }
 
-void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecutionContext, ResourceRequest&& scriptRequest, Source source, FetchOptions&& fetchOptions, ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement, ServiceWorkersMode serviceWorkerMode, WorkerScriptLoaderClient& client, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier)
+void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecutionContext, ResourceRequest&& scriptRequest, Source source, FetchOptions&& fetchOptions, ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement, ServiceWorkersMode serviceWorkerMode, WorkerScriptLoaderClient& client, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier, String&& referrer)
 {
     m_client = client;
     m_url = scriptRequest.url();
@@ -182,7 +182,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
 
     // During create, callbacks may happen which remove the last reference to this object.
     Ref<WorkerScriptLoader> protectedThis(*this);
-    m_threadableLoader = ThreadableLoader::create(scriptExecutionContext, *this, WTF::move(*request), options, { }, WTF::move(taskMode));
+    m_threadableLoader = ThreadableLoader::create(scriptExecutionContext, *this, WTF::move(*request), options, WTF::move(referrer), WTF::move(taskMode));
 }
 
 const URL& WorkerScriptLoader::responseURL() const

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -68,7 +68,7 @@ public:
     enum class Source : uint8_t { ClassicWorkerScript, ClassicWorkerImport, ModuleScript };
 
     std::optional<Exception> loadSynchronously(ScriptExecutionContext*, const URL&, Source, FetchOptions::Mode, FetchOptions::Cache, ContentSecurityPolicyEnforcement, const String& initiatorIdentifier);
-    void loadAsynchronously(ScriptExecutionContext&, ResourceRequest&&, Source, FetchOptions&&, ContentSecurityPolicyEnforcement, ServiceWorkersMode, WorkerScriptLoaderClient&, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier = std::nullopt);
+    void loadAsynchronously(ScriptExecutionContext&, ResourceRequest&&, Source, FetchOptions&&, ContentSecurityPolicyEnforcement, ServiceWorkersMode, WorkerScriptLoaderClient&, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier = std::nullopt, String&& referrer = { });
 
     void notifyError(std::optional<ScriptExecutionContextIdentifier>);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
@@ -1851,3 +1851,41 @@ TEST(URLSchemeHandler, Redirect302FromHTTPToHandledScheme)
 {
     runRedirectToHandledSchemeTest(302);
 }
+
+TEST(URLSchemeHandler, ModuleDescendantFetchDoesNotSendReferrer)
+{
+    __block RetainPtr<NSString> dependencyReferrer;
+    __block bool fetchedDependency = false;
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        NSString *mimeType = @"text/javascript";
+        NSString *body = @"";
+        if ([path isEqualToString:@"/index.html"]) {
+            mimeType = @"text/html";
+            body = @"<meta name='referrer' content='no-referrer'><script type='module' src='/importer.js'></script>";
+        } else if ([path isEqualToString:@"/importer.js"])
+            body = @"import '/dependency.js';";
+        else {
+            EXPECT_WK_STREQ("/dependency.js", path);
+            dependencyReferrer = [task.request valueForHTTPHeaderField:@"Referer"];
+            fetchedDependency = true;
+        }
+
+        NSData *data = [body dataUsingEncoding:NSUTF8StringEncoding];
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data];
+        [task didFinish];
+    }];
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"module-referrer"];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"module-referrer://webkit.org/index.html"]]];
+    TestWebKitAPI::Util::run(&fetchedDependency);
+
+    // The descendant fetch of a module script sends the importing script's URL as its referrer, but only
+    // an HTTP(S) fetch gets a Referer header, and only those have the referrer policy applied to them.
+    EXPECT_NULL(dependencyReferrer.get());
+}


### PR DESCRIPTION
#### c8fdf5eb819d6b75b99ab2288ce2887d33326d27
<pre>
Descendant and dynamic module script fetches send the wrong Referer header
<a href="https://bugs.webkit.org/show_bug.cgi?id=322392">https://bugs.webkit.org/show_bug.cgi?id=322392</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

When fetching a module script, we never set a referrer on the request, so the load fell back to the
fetch client&apos;s outgoing referrer: the document URL for documents, and the global scope URL for
workers and worklets (which, for a threaded worklet, is the URL of the window that created it).

Per HTML, the referrer of a module fetch is the referring script&apos;s base URL: &quot;fetch the descendants
of a module script&quot; passes &quot;module script&apos;s base URL&quot; as the referrer for each descendant, and
HostLoadImportedModule likewise uses the referencing script&apos;s base URL for dynamic import(). Only a
fetch with no referring script — a script element or worker top-level fetch — uses the fetch client&apos;s
referrer. Both Blink and Gecko implement this.

The referrer was not available where the fetch happens, because JSC&apos;s moduleLoaderFetch hook only
receives the module key. Pass the referring script&apos;s base URL through the hook as a String:
JSModuleLoader::hostLoadImportedModule already resolves the specifier against the referring module&apos;s
key, and requestImportModule() has the importing script&apos;s base URL for dynamic import(). Both now
forward it to JSModuleLoader::fetch(), which hands it to the host.

ScriptModuleLoader::fetch() maps a module key through responseURLFromRequestURL(), so a redirected
importer contributes its response URL. A dynamic import&apos;s base URL is already a response URL and is
not a key in that map, so it comes back unchanged. An inline module script has no URL of its own, its
key being a Symbol, so the hook passes the empty string and ScriptModuleLoader substitutes the
script&apos;s base URL — the same URL resolve() resolves its specifiers against, and not necessarily the
document URL, since a &lt;base&gt; element can move it. A null referrer means there is no referring script
and keeps the previous behavior of falling back to the fetch client&apos;s outgoing referrer.

The two loaders apply it differently. WorkerModuleScriptLoader passes it as the ThreadableLoader
referrer rather than setting it on the ResourceRequest, since referrer and origin headers are only
set after a preflight and DocumentThreadableLoader asserts the request carries neither.
CachedScriptFetcher sets it on the request directly, but only for an HTTP(S) URL, because
CachedResourceLoader::requestResource() calls updateHTTPRequestHeaders() only for those: on any other
scheme the referrer would never have the referrer policy applied to it and would be sent unfiltered,
e.g. to a URL scheme handler, even under Referrer-Policy: no-referrer. For an HTTP(S) request,
CachedResourceRequest::updateReferrerAndOriginHeaders() prefers the pre-set referrer and applies the
referrer policy to it.

Tests: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url.html
       imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html
       URLSchemeHandler.ModuleDescendantFetchDoesNotSendReferrer

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-base-url.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-import-referrer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt:
* Source/JavaScriptCore/API/JSAPIGlobalObject.h:
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::moduleReferrer):
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::requestImportModule):
(JSC::JSModuleLoader::fetch):
(JSC::JSModuleLoader::hostLoadImportedModule):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
(WebCore::CachedModuleScriptLoader::load):
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestModuleScript const):
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
(WebCore::CachedScriptFetcher::requestScriptWithCache):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::moduleLoaderFetch):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::fetch):
(WebCore::ScriptModuleLoader::responseURLFromRequestURL):
(WebCore::ScriptModuleLoader::baseURLForScriptWithoutURL):
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.h:
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp:
(WebCore::ScriptElementCachedScriptFetcher::requestModuleScript const):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebCore/workers/WorkerScriptLoader.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm:
((URLSchemeHandler, ModuleDescendantFetchDoesNotSendReferrer)):

Canonical link: <a href="https://commits.webkit.org/319921@main">https://commits.webkit.org/319921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a91846d38bc528ebadd2e3bf5835979edfc7b87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147293 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0158a649-0371-49a4-a808-a7a4087fb27c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c16af1fb-75e5-4721-afee-1fa9b730ccbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57a6a399-74eb-4ef3-859e-e830d701fbd3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45253 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43499 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5238 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12073 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43133 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4395 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44275 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40854 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57302 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152006 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46561 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129571 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125683 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55810 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55418 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->