### PR TITLE
[JSC] Fix BackwardsGraph for loops with multiple back-edge sources

### DIFF
--- a/JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
+++ b/JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
@@ -1,0 +1,109 @@
+//@ runDefaultWasm("--useConcurrentJIT=0", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+
+load("wast.js", "caller relative");
+
+const moduleBytes = WebAssemblyText.encode(`
+(module
+  (type $sink (struct (field i64)))
+  (type $probe
+    (struct
+      (field i64)
+      (field (ref $sink))
+      (field (ref $sink))
+      (field (ref $sink))))
+  (type $small
+    (struct
+      (field i64)
+      (field i64)
+      (field i64)
+      (field i64)))
+  (global $keep (mut i32) (i32.const 0))
+
+  (func (export "makeSink") (param $value i64) (result (ref $sink))
+    (struct.new $sink (local.get $value)))
+
+  (func (export "makeProbe")
+    (param $value i64)
+    (param $sink (ref $sink))
+    (result (ref $probe))
+    (struct.new $probe
+      (local.get $value)
+      (local.get $sink)
+      (local.get $sink)
+      (local.get $sink)))
+
+  (func (export "makeSmall") (result (ref $small))
+    (struct.new $small
+      (i64.const 0)
+      (i64.const 0)
+      (i64.const 0)
+      (i64.const 0)))
+
+  (func (export "readAfterCast")
+    (param $source anyref)
+    (param $valid (ref $sink))
+    (param $bit i64)
+    (param $forceBit i32)
+    (param $useLoaded i32)
+    (param $lateLoop i32)
+    (result i64)
+    (local $probeLocal (ref $probe))
+    (loop $loop (result i64)
+      (block $castSucceeded (result (ref $probe))
+        (br_on_cast $castSucceeded
+          (ref null any)
+          (ref $probe)
+          (local.get $source))
+        (global.set $keep (i32.const 1))
+        (br $loop))
+      (local.set $probeLocal)
+
+      (struct.get $probe 2 (local.get $probeLocal))
+      (struct.get $probe 3 (local.get $probeLocal))
+      (struct.get $probe 2 (local.get $probeLocal))
+      (local.get $valid)
+      (struct.get $probe 1 (local.get $probeLocal))
+      (struct.get $sink 0)
+      (local.get $bit)
+      i64.shr_u
+      i32.wrap_i64
+      i32.const 1
+      i32.and
+      (local.get $forceBit)
+      (local.get $useLoaded)
+      (select (result i32))
+      i32.eqz
+      (select (result (ref $sink)))
+      (struct.get $sink 0)
+      i64.const 1
+      i64.and
+      i32.wrap_i64
+      (select (result (ref $sink)))
+      (struct.get $sink 0)
+      (br_if $loop (local.get $lateLoop))))
+)
+`);
+
+const { makeProbe, makeSink, makeSmall, readAfterCast } =
+    new WebAssembly.Instance(new WebAssembly.Module(moduleBytes)).exports;
+const sink = makeSink(0x5152535455565758n);
+const probe = makeProbe(0x1111111111111111n, sink);
+
+for (let iteration = 0; iteration < 1000; ++iteration)
+    readAfterCast(probe, sink, 0n, 0, 1, 0);
+
+// Correct semantics: cast failure loops forever before any control-dependent
+// struct.get executes. OMG-compiled Wasm loops have no watchdog poll (rdar://103455312), so bound
+// the test by exiting from a helper thread once the main thread has had time to
+// reach the loop.
+$.agent.start(`
+    $.agent.sleep(10); // 10 ms
+    quit();
+`);
+
+try {
+    readAfterCast(makeSmall(), sink, 0n, 0, 1, 0);
+    throw new Error("readAfterCast on a failed cast should not return");
+} catch (e) {
+    throw new Error("B3 LICM hoisted control-dependent struct.get past br_on_cast: " + e);
+}

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -201,7 +201,7 @@ public:
     Dominators& dominators();
     JS_EXPORT_PRIVATE NaturalLoops& naturalLoops();
     BackwardsCFG& backwardsCFG();
-    BackwardsDominators& backwardsDominators();
+    JS_EXPORT_PRIVATE BackwardsDominators& backwardsDominators();
 
     void addFastConstant(const ValueKey&);
     bool NODELETE isFastConstant(const ValueKey&);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1292,6 +1292,7 @@ void testShuffleDoesntTrashCalleeSaves();
 void testDemotePatchpointTerminal();
 void testReportUsedRegistersLateUseFollowedByEarlyDefDoesNotMarkUseAsDead();
 void testInfiniteLoopDoesntCauseBadHoisting();
+void testBackwardsDominatorsWithMultipleBackEdges();
 void testDivImmArgFloat(float, float);
 void testDivImmsFloat(float, float);
 void testModArgDouble(double);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1190,6 +1190,7 @@ void run(const TestConfig* config)
     RUN(testLoopWithMultipleHeaderEdges());
 
     RUN(testInfiniteLoopDoesntCauseBadHoisting());
+    RUN(testBackwardsDominatorsWithMultipleBackEdges());
 
     RUN(testFloatMaxMin());
     RUN(testDoubleMaxMin());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "testb3.h"
+#include "B3BackwardsDominators.h"
 #include <wtf/WasmSIMD128.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -2307,6 +2308,70 @@ void testInfiniteLoopDoesntCauseBadHoisting()
     auto code = compileProc(proc);
     RELEASE_ASSERT(!proc.calleeSaveRegisterAtOffsetList().registerCount());
     invoke<void>(*code, static_cast<intptr_t>(55)); // Shouldn't crash dereferncing 55.
+}
+
+void testBackwardsDominatorsWithMultipleBackEdges()
+{
+    // A loop whose header has two latches (back-edge sources), where only one
+    // of them also exits the loop:
+    //
+    //   root    --> header
+    //   header  --> success | failure          (branch)
+    //   success --> header (back edge) | exit   (branch)   // latch that can exit
+    //   failure --> header (back edge)                     // latch with no exit
+    //   exit    --> Return                                 // the only terminal
+    //
+    // `success` and `failure` are both back-edge sources. The `failure` latch
+    // has no exit of its own, so control that keeps taking it loops forever.
+    // BackwardsGraph treats that as a form of terminality: it computes
+    // post-dominators by reversing the CFG and giving the synthetic reverse
+    // root a successor for every terminal and every back-edge source.
+    //
+    // The property B3 LICM (and the control-equivalence consumers) rely on is
+    // the post-dominator relation: `success` must NOT post-dominate the header
+    // or the loop entry, because control can stay in the loop forever via the
+    // exit-less `failure` latch without ever reaching `success`. If `failure`
+    // is missing from the reverse root's successors, the header is reachable in
+    // the reverse CFG only through `success`, so `success` falsely
+    // post-dominates the header (and `root`) -- the false relationship that
+    // would let LICM hoist a control-dependent read out of the loop.
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* header = proc.addBlock();
+    BasicBlock* success = proc.addBlock();
+    BasicBlock* failure = proc.addBlock();
+    BasicBlock* exit = proc.addBlock();
+    auto arguments = cCallArgumentValues<intptr_t>(proc, root);
+    Value* arg = arguments[0];
+
+    root->appendNewControlValue(proc, Jump, Origin(), header);
+    header->appendNewControlValue(
+        proc, Branch, Origin(),
+        header->appendNew<Value>(proc, Equal, Origin(), arg,
+            header->appendNew<ConstPtrValue>(proc, Origin(), 10)),
+        success, failure);
+    success->appendNewControlValue(
+        proc, Branch, Origin(),
+        success->appendNew<Value>(proc, Equal, Origin(), arg,
+            success->appendNew<ConstPtrValue>(proc, Origin(), 20)),
+        header, exit);
+    failure->appendNewControlValue(proc, Jump, Origin(), header);
+    exit->appendNewControlValue(proc, Return, Origin());
+
+    proc.resetReachability();
+
+    BackwardsDominators& backwardsDominators = proc.backwardsDominators();
+
+    // Sanity: `header` genuinely post-dominates the entry (root's only successor
+    // is header), so the checks below are not vacuously true.
+    CHECK(backwardsDominators.dominates(header, root));
+
+    // The actual property: `success` must not post-dominate the header or the
+    // loop entry, because the exit-less `failure` latch is an escape that
+    // bypasses `success`. A dropped `failure` back-edge source makes both of
+    // these falsely true.
+    CHECK(!backwardsDominators.dominates(success, header));
+    CHECK(!backwardsDominators.dominates(success, root));
 }
 
 static void testSimpleTuplePair(unsigned first, int64_t second)

--- a/Source/WTF/wtf/BackwardsGraph.h
+++ b/Source/WTF/wtf/BackwardsGraph.h
@@ -50,9 +50,9 @@ public:
         GraphNodeWorklist<typename Graph::Node, typename Graph::Set> worklist;
 
         auto addRootSuccessor = [&] (typename Graph::Node node) {
-            if (worklist.push(node)) {
+            if (m_rootSuccessorSet.add(node))
                 m_rootSuccessorList.append(node);
-                m_rootSuccessorSet.add(node);
+            if (worklist.push(node)) {
                 while (typename Graph::Node node = worklist.pop())
                     worklist.pushAll(graph.predecessors(node));
             }
@@ -77,8 +77,10 @@ public:
 
         for (unsigned i = 0; i < graph.numNodes(); ++i) {
             if (typename Graph::Node node = graph.node(i)) {
-                if (!graph.successors(node).size())
+                if (!graph.successors(node).size()) {
+                    ASSERT(!worklist.saw(node));
                     addRootSuccessor(node);
+                }
             }
         }
 
@@ -88,8 +90,10 @@ public:
         // edges. That would require thinking, so we just use a rough heuristic: add the highest
         // numbered nodes first, which is totally fine if the input program is already sorted nicely.
         for (unsigned i = graph.numNodes(); i--;) {
-            if (typename Graph::Node node = graph.node(i))
-                addRootSuccessor(node);
+            if (typename Graph::Node node = graph.node(i)) {
+                if (!worklist.saw(node))
+                    addRootSuccessor(node);
+            }
         }
     }
 


### PR DESCRIPTION
#### d6a04ce33593d35998cf948b4c0901406055372b
<pre>
[JSC] Fix BackwardsGraph for loops with multiple back-edge sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=317603">https://bugs.webkit.org/show_bug.cgi?id=317603</a>
<a href="https://rdar.apple.com/178735697">rdar://178735697</a>

Reviewed by Marcus Plutowski.

The addRootSuccessor lambda in WTF::BackwardsGraph used a single
GraphNodeWorklist both to decide synthetic-root membership and to drive
the predecessor-coverage flood. Depending on the order that back-edges
were processed, this would cause some back-edge sources to not be
included as backwards root successors.

B3::BackwardsDominators, built on the resulting incomplete reverse CFG, can
then report that a block post-dominates the loop pre-header even though a
potentially-infinite loop between them means the block may never execute.
B3HoistLoopInvariantValues uses post-dominators to conclude a control-dependent
value always runs once the loop is entered, and hoists it into the pre-header,
so the value can execute on paths where it should not.

Decouple the two roles: addRootSuccessor now records every distinct back-edge
source and terminal in m_rootSuccessorSet unconditionally, and uses the
worklist only to bound the predecessor flood.

Tests: JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js: Added.
(catch):
* Source/JavaScriptCore/b3/B3Procedure.h:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testBackwardsDominatorsWithMultipleBackEdges):
* Source/WTF/wtf/BackwardsGraph.h:
(WTF::BackwardsGraph::BackwardsGraph):

Originally-landed-as: 305413.1019@safari-7624.5-branch (dec21f1baf1f). <a href="https://rdar.apple.com/185366847">rdar://185366847</a>
Canonical link: <a href="https://commits.webkit.org/319700@main">https://commits.webkit.org/319700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1190e049766da13e366eac37acf6c221e35dc47d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146792 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142426 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44814 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43085 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4824 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11652 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42709 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3857 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43747 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56081 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151859 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40680 "Failed to push commit to Webkit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56772 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151557 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129056 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125047 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55283 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->