### PR TITLE
[JSC] Fix B3 ReduceStrength Select specialization when a Check appears between the Select and triggering Check

### DIFF
--- a/Source/JavaScriptCore/b3/B3PureCSE.cpp
+++ b/Source/JavaScriptCore/b3/B3PureCSE.cpp
@@ -44,6 +44,19 @@ void PureCSE::clear()
     m_map.clear();
 }
 
+void PureCSE::remove(const ValueKey& key, Value* value)
+{
+    if (!key)
+        return;
+
+    auto iter = m_map.find(key);
+    if (iter == m_map.end())
+        return;
+
+    Matches& matches = iter->value;
+    matches.removeAll(value);
+}
+
 Value* PureCSE::findMatch(const ValueKey& key, BasicBlock* block, Dominators& dominators)
 {
     if (!key)

--- a/Source/JavaScriptCore/b3/B3PureCSE.h
+++ b/Source/JavaScriptCore/b3/B3PureCSE.h
@@ -48,6 +48,8 @@ public:
 
     void clear();
 
+    void remove(const ValueKey&, Value*);
+
     Value* NODELETE findMatch(const ValueKey&, BasicBlock*, Dominators&);
 
     bool process(Value*, Dominators&);

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -4398,14 +4398,17 @@ private:
         // Now handle all values between the source and the check.
         for (unsigned i = startIndex + 1; i < predecessor->size(); ++i) {
             Value* value = predecessor->at(i);
+            ValueKey key = value->key(); // Compute before cloneValue mutates the Value
             value->owner = nullptr;
 
             cloneValue(value);
 
             if (value->type() != Void)
                 m_insertionSet.insertValue(m_index, value);
-            else
+            else {
+                m_pureCSE.remove(key, value);
                 m_proc.deleteValue(value);
+            }
         }
 
         // Finally, deal with the check.

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -663,6 +663,7 @@ void testSelectInvert();
 void testCheckSelect();
 void testCheckSelectCheckSelect();
 void testCheckSelectAndCSE();
+void testCheckSelectAndDeadCheckCSE();
 void testPowDoubleByIntegerLoop(double xOperand, int32_t yOperand);
 double b3Pow(double x, int y);
 void testTruncOrHigh();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -987,6 +987,7 @@ void run(const TestConfig* config)
     RUN(testCheckSelect());
     RUN(testCheckSelectCheckSelect());
     RUN(testCheckSelectAndCSE());
+    RUN(testCheckSelectAndDeadCheckCSE());
     RUN_BINARY(testPowDoubleByIntegerLoop, floatingPointOperands<double>(), int64Operands());
 
     RUN(testTruncOrHigh());

--- a/Source/JavaScriptCore/b3/testb3_6.cpp
+++ b/Source/JavaScriptCore/b3/testb3_6.cpp
@@ -960,6 +960,81 @@ void testCheckSelectAndCSE()
     CHECK_EQ(invoke<int>(*code, false), 666);
 }
 
+void testCheckSelectAndDeadCheckCSE()
+{
+    // Exercises B3 strength reduction's "select specialization" (specializeSelect) together with pure CSE.
+    //
+    // When a Check is reached (within selectSpecializationBound) from a Select that has a constant arm,
+    // reduceStrength specializes the Select: it splits the block at the Check, clones the values between
+    // the Select and the Check into a then/else pair of blocks -- substituting the Select's then/else
+    // value in each -- and replaces the originals with Phis at the merge. Void values in that range (such
+    // as an intermediate Check) are removed from the original block and re-emitted in both arms.
+    //
+    // The IR (single block):
+    //
+    //   @cond = arg1
+    //   @sel  = Select(arg0, -42, 35)   ; Select with a constant arm
+    //           Check(@cond)            ; intermediate Check
+    //   @add  = Add(@sel, 42)
+    //           Check(@add)             ; triggering Check (reaches @sel within the bound)
+    //           Check(@cond)            ; later Check on the same condition (CSE)
+    //           Return(@add)
+    //
+    Procedure proc;
+    if (proc.optLevel() < 1)
+        return;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t>(proc, root);
+
+    // Condition shared by the intermediate and later Checks, so the later Check is a CSE candidate. A
+    // plain argument: each Check is kept (the condition isn't a known constant) and doesn't lead back to
+    // the Select.
+    Value* condition = arguments[1];
+
+    auto appendCheck = [&] (Value* predicate, int32_t exitValue) {
+        CheckValue* check = root->appendNew<CheckValue>(proc, Check, Origin(), predicate);
+        check->setGenerator(
+            [exitValue] (CCallHelpers& jit, const StackmapGenerationParams&) {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+                jit.move(CCallHelpers::TrustedImm32(exitValue), GPRInfo::returnValueGPR);
+                jit.emitFunctionEpilogue();
+                jit.ret();
+            });
+    };
+
+    // Defined before the Select so the Select -> triggering-Check run stays within
+    // selectSpecializationBound (== 3): Select, intermediate Check, Add, triggering Check.
+    auto* constant = root->appendNew<ConstPtrValue>(proc, Origin(), 42);
+
+    // (1) The Select to specialize: at least one data arm is constant.
+    auto* selectValue = root->appendNew<Value>(
+        proc, Select, Origin(),
+        arguments[0],
+        root->appendNew<ConstPtrValue>(proc, Origin(), -42),
+        root->appendNew<ConstPtrValue>(proc, Origin(), 35));
+
+    // (2) An intermediate Check between the Select and the triggering Check. Specialization moves it out
+    //     of this block and clones it into both arms.
+    appendCheck(condition, 1);
+
+    // (3) Add consuming the Select, feeding (4); keeps the Select within bound 3 of the triggering Check.
+    auto* addValue = root->appendNew<Value>(proc, Add, Origin(), selectValue, constant);
+
+    // (4) The Check that triggers specialization: it reaches the Select within selectSpecializationBound.
+    appendCheck(addValue, 2);
+
+    // (5) A later Check on the SAME condition as (2), so pure CSE relates the two across the specialized
+    //     region.
+    appendCheck(condition, 3);
+
+    root->appendNewControlValue(proc, Return, Origin(), addValue);
+
+    // After specialization the merged value is unchanged: select(true, -42, 35) + 42 == 0, with no Check
+    // firing for these inputs.
+    auto code = compileProc(proc);
+    CHECK_EQ(invoke<intptr_t>(*code, 1, 0), 0);
+}
+
 double NODELETE b3Pow(double x, int y)
 {
     if (y < 0 || y > 1000)


### PR DESCRIPTION
#### 74ad57a915ac7b7a7d25bc2b148428233e3424a6
<pre>
[JSC] Fix B3 ReduceStrength Select specialization when a Check appears between the Select and triggering Check
<a href="https://bugs.webkit.org/show_bug.cgi?id=316347">https://bugs.webkit.org/show_bug.cgi?id=316347</a>
<a href="https://rdar.apple.com/177687354">rdar://177687354</a>

Reviewed by Marcus Plutowski.

In B3ReduceStrength, specializeSelect() specializes a Select that has a constant
arm and is reached, within selectSpecializationBound, from a Check: it splits the
block at the Check, clones the values between the Select and the Check into the
then/else arms, and deleteValue()s the Void ones in that range.

PureCSE records pure Values in a per-iteration map (m_pureCSE) and assumes they
stay present. Checks, though Void, are also recorded (to enable removing redundant
Branches), so an intermediate Check in that range is recorded too; specializeSelect
then deleteValue()s it without updating the map.

Keep the map consistent: remove the value from m_pureCSE before specializeSelect
deletes it.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_6.cpp

* Source/JavaScriptCore/b3/B3PureCSE.cpp:
(JSC::B3::PureCSE::clear):
(JSC::B3::PureCSE::remove):
* Source/JavaScriptCore/b3/B3PureCSE.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_6.cpp:
(testCheckSelectAndDeadCheckCSE):

Originally-landed-as: 305413.977@safari-7624.5-branch (353f0e1145bf). <a href="https://rdar.apple.com/185369088">rdar://185369088</a>
Canonical link: <a href="https://commits.webkit.org/319718@main">https://commits.webkit.org/319718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5b9fa0cf23c66311903461296a85e5904521900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182565 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57828 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185520 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43849 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194722 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40692 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55385 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->