### PR TITLE
REGRESSION(317964@main): [macOS iOS] ASSERTION FAILED: bytesSent >= m_pendingStreamBytesSentByNetwork in imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -3,6 +3,7 @@ PASS global setup
 PASS The streaming request body is readable in the service worker.
 PASS Network fallback for streaming upload.
 PASS When the streaming request body is used, network fallback fails.
-PASS Running clone() in the service worker does not prevent network fallback.
+PASS Running clone() in the service worker does not prevent network fallback, and the service worker can read the request body via the clone.
+PASS Cloning the request after leaving the fetch event unhandled throws because the request body was canceled.
 PASS restore global state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html
@@ -8,6 +8,8 @@
 <body>
 <script>
 const worker = 'resources/fetch-event-test-worker.js';
+const messageChannel = new MessageChannel();
+const serviceWorkerPort = messageChannel.port1;
 
 const method = 'POST';
 const duplex = 'half';
@@ -28,7 +30,12 @@ promise_test(async t => {
   const scope = 'resources/';
   const registration =
     await service_worker_unregister_and_register(t, worker, scope);
-  await wait_for_state(t, registration.installing, 'activated');
+  const installing = registration.installing;
+  await wait_for_state(t, installing, 'activated');
+
+  installing.postMessage({ port: messageChannel.port2 }, [messageChannel.port2]);
+  const postResult = await new Promise(resolve => serviceWorkerPort.onmessage = e => resolve(e.data));
+  assert_equals(postResult, "ok");
 
   // This will happen after all other tests
   promise_test(t => {
@@ -89,7 +96,8 @@ promise_test(async t => {
 }, 'When the streaming request body is used, network fallback fails.');
 
 // When the streaming body is used by clone() in the service worker, network
-// fallback succeeds.
+// fallback succeeds, and the service worker can read the full body from the
+// clone even though it does not handle the fetch event itself.
 promise_test(async t => {
   const body = createBody(t);
   // Set page_url to "?ignore" so the service worker falls back to network
@@ -101,12 +109,36 @@ promise_test(async t => {
   // Add "?clone-and-ignore" so that the service worker falls back to
   // echo-content.h2.py.
   const echo_url = '/fetch/api/resources/echo-content.h2.py?clone-and-ignore';
+  const clonedBodyFromWorker = new Promise(resolve => {
+    serviceWorkerPort.onmessage = e => resolve(e.data);
+  });
   const response = await frame.contentWindow.fetch(echo_url, {
     method, body, duplex});
   assert_equals(response.status, 200, 'status');
   const text = await response.text();
   assert_equals(text, 'i am the request body', 'body');
-}, 'Running clone() in the service worker does not prevent network fallback.');
+  assert_equals(await clonedBodyFromWorker, 'i am the request body',
+    'body read by the service worker from the cloned request');
+}, 'Running clone() in the service worker does not prevent network fallback, and the service worker can read the request body via the clone.');
 
+promise_test(async t => {
+  const body = createBody(t);
+  const page_url = `resources/simple.html?ignore&id=${token()}`;
+  const frame = await with_iframe(page_url);
+  t.add_cleanup(() => { frame.remove(); });
+  const echo_url =
+    '/fetch/api/resources/echo-content.h2.py?clone-after-ignore';
+  const cloneResultFromWorker = new Promise(resolve => {
+    serviceWorkerPort.onmessage = e => resolve(e.data);
+  });
+  const response = await frame.contentWindow.fetch(echo_url, {
+    method, body, duplex});
+  assert_equals(response.status, 200, 'status');
+  const text = await response.text();
+  assert_equals(text, 'i am the request body', 'body');
+  assert_equals(await cloneResultFromWorker, 'TypeError',
+    'cloning the request after leaving the fetch event unhandled should ' +
+    'throw a TypeError, since its body was canceled');
+}, 'Cloning the request after leaving the fetch event unhandled throws because the request body was canceled.');
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-event-test-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-event-test-worker.js
@@ -162,7 +162,25 @@ function handleUseAndIgnore(event) {
 
 function handleCloneAndIgnore(event) {
   const request = event.request;
-  request.clone().text();
+  request.clone().text().then(t => {
+    if (self.port)
+      self.port.postMessage(t);
+  });
+  return;
+}
+
+function handleCloneAfterIgnore(event) {
+  const request = event.request;
+  setTimeout(() => {
+    try {
+      request.clone();
+      if (self.port)
+        self.port.postMessage('no error');
+    } catch (e) {
+      if (self.port)
+        self.port.postMessage(e.name);
+    }
+  }, 0);
   return;
 }
 
@@ -176,6 +194,13 @@ function handleStatus(event) {
       {"status": new URL(event.request.url).searchParams.get("status")});
   }());
 }
+
+self.addEventListener('message', function(event) {
+  if (event.data.port) {
+    self.port = event.data.port;
+    self.port.postMessage("ok");
+  }
+});
 
 self.addEventListener('fetch', function(event) {
     var url = event.request.url;
@@ -204,6 +229,7 @@ self.addEventListener('fetch', function(event) {
       { pattern: '?isHistoryNavigation', fn: handleIsHistoryNavigation },
       { pattern: '?use-and-ignore', fn: handleUseAndIgnore },
       { pattern: '?clone-and-ignore', fn: handleCloneAndIgnore },
+      { pattern: '?clone-after-ignore', fn: handleCloneAfterIgnore },
       { pattern: '?status', fn: handleStatus },
     ];
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -3,6 +3,7 @@ PASS global setup
 PASS The streaming request body is readable in the service worker.
 FAIL Network fallback for streaming upload. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS When the streaming request body is used, network fallback fails.
-FAIL Running clone() in the service worker does not prevent network fallback. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+FAIL Running clone() in the service worker does not prevent network fallback, and the service worker can read the request body via the clone. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: TypeError: Load failed"
+FAIL Cloning the request after leaving the fetch event unhandled throws because the request body was canceled. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS restore global state
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2431,8 +2431,6 @@ webkit.org/b/321103 [ Debug ] imported/w3c/web-platform-tests/uievents/textInput
 
 webkit.org/b/321185 [ Debug ] imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html [ Pass Timeout ]
 
-webkit.org/b/321191 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html [ Pass Crash Failure ]
-
 webkit.org/b/321312 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Pass Failure ]
 
 # webkit.org/b/321298 [ Release ] REGRESSION(316423@main): [macOS Release] imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html is a flaky crash

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -406,6 +406,8 @@ FetchBodyConsumer& FetchBody::consumer()
 
 FetchBody FetchBody::clone(JSDOMGlobalObject& globalObject)
 {
+    ASSERT(!isFormData() || !protect(formDataBody())->isPendingStream());
+
     FetchBody clone(protect(consumer())->clone());
 
     if (isArrayBuffer())

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -104,6 +104,11 @@ public:
         ASSERT(!m_readableStream);
         m_readableStream = WTF::move(stream);
     }
+    void setAsReadableStream()
+    {
+        ASSERT(m_readableStream);
+        m_data = Ref { *m_readableStream };
+    }
 
     void convertReadableStreamToArrayBuffer(FetchBodyOwner&, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
@@ -113,6 +118,7 @@ public:
 
     bool isBlob() const { return std::holds_alternative<Ref<Blob>>(m_data); }
     bool isFormData() const { return std::holds_alternative<Ref<FormData>>(m_data); }
+    bool isPendingStreamFormData() const { return std::holds_alternative<Ref<FormData>>(m_data) && formDataBody().pendingStreamState(); }
     bool isReadableStream() const { return std::holds_alternative<Ref<ReadableStream>>(m_data); }
 
 private:

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -41,6 +41,7 @@
 #include "JSDOMFormData.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
+#include "Logging.h"
 #include "ResourceError.h"
 #include "ResourceResponse.h"
 #include "Settings.h"
@@ -167,12 +168,26 @@ void FetchBodyOwner::bytes(Ref<DeferredPromise>&& promise)
     m_body->bytes(*this, WTF::move(promise));
 }
 
-void FetchBodyOwner::cloneBody(JSDOMGlobalObject& globalObject, FetchBodyOwner& owner)
+std::optional<Exception> FetchBodyOwner::cloneBody(JSDOMGlobalObject& globalObject, FetchBodyOwner& owner)
 {
     m_loadingError = owner.m_loadingError;
     if (owner.isBodyNull())
-        return;
+        return { };
+
+    if (owner.m_body->isPendingStreamFormData()) {
+        // We cannot clone a PendingStream directly, we create a ReadableStream from it to ensure cloning works as expected.
+        auto streamOrException = owner.readableStream(globalObject);
+        if (streamOrException.hasException()) {
+            RELEASE_LOG_ERROR(ServiceWorker, "Unable to clone pending stream body");
+            return streamOrException.releaseException();
+        }
+        ASSERT(owner.m_body->readableStream());
+        if (owner.m_body->readableStream())
+            owner.m_body->setAsReadableStream();
+    }
+
     m_body = owner.m_body->clone(globalObject);
+    return { };
 }
 
 ExceptionOr<void> FetchBodyOwner::extractBody(FetchBody::Init&& value)
@@ -497,6 +512,16 @@ void FetchBodyOwner::setLoadingError(ResourceError&& error)
         return;
 
     m_loadingError = WTF::move(error);
+}
+
+bool FetchBodyOwner::hasClonedReadableStream() const
+{
+    if (isBodyNull())
+        return false;
+
+    RefPtr readableStreamSource = m_readableStreamSource;
+    RefPtr readableStream = body().readableStream();
+    return readableStreamSource && readableStream && readableStream->controller() != readableStreamSource->controller();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -70,6 +70,7 @@ public:
     ExceptionOr<RefPtr<ReadableStream>> readableStream(JSC::JSGlobalObject&);
     bool hasReadableStreamBody() const { return m_body && m_body->hasReadableStream(); }
     bool isReadableStreamBody() const { return m_body && m_body->isReadableStream(); }
+    bool hasClonedReadableStream() const;
 
     virtual void consumeBodyAsStream();
     virtual void feedStream() { }
@@ -90,7 +91,7 @@ protected:
     const FetchBody& body() const LIFETIME_BOUND { return *m_body; }
     bool isBodyNull() const { return !m_body; }
     bool isBodyNullOrOpaque() const { return !m_body || m_isBodyOpaque; }
-    void cloneBody(JSDOMGlobalObject&, FetchBodyOwner&);
+    std::optional<Exception> cloneBody(JSDOMGlobalObject&, FetchBodyOwner&);
 
     ExceptionOr<void> extractBody(FetchBody::Init&&);
     void consumeOnceLoadingFinished(FetchBodyConsumer::Type, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -60,6 +60,8 @@ public:
     void detach();
 
     void setByteController(ReadableByteStreamController&);
+    const ReadableByteStreamController* controller() const { return m_byteController.get(); }
+
     Ref<DOMPromise> pull(JSDOMGlobalObject&, ReadableByteStreamController&);
     Ref<DOMPromise> cancel(JSDOMGlobalObject&, ReadableByteStreamController&, std::optional<JSC::JSValue>&&);
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -401,7 +401,9 @@ ExceptionOr<Ref<FetchRequest>> FetchRequest::clone(JSDOMGlobalObject& globalObje
     auto clone = adoptRef(*new FetchRequest(*context, std::nullopt, FetchHeaders::create(m_headers.get()), ResourceRequest { m_request }, FetchOptions { m_options }, String { m_referrer }));
     clone->suspendIfNeeded();
     clone->m_duplex = m_duplex;
-    clone->cloneBody(globalObject, *this);
+    if (auto exception = clone->cloneBody(globalObject, *this))
+        return { WTF::move(*exception) };
+
     clone->setNavigationPreloadIdentifier(m_navigationPreloadIdentifier);
     clone->m_enableContentExtensionsCheck = m_enableContentExtensionsCheck;
     if (auto* document = dynamicDowncast<Document>(*context); document && document->settings().localNetworkAccessEnabled())

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -96,6 +96,8 @@ public:
     bool shouldEnableContentExtensionsCheck() const { return m_enableContentExtensionsCheck; }
     void disableContentExtensionsCheck() { m_enableContentExtensionsCheck = false; }
 
+    void markAsUnhandled() { setDisturbed(); }
+
 private:
     FetchRequest(ScriptExecutionContext&, std::optional<FetchBody>&&, Ref<FetchHeaders>&&, ResourceRequest&&, FetchOptions&&, String&& referrer);
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -218,7 +218,9 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone(JSDOMGlobalObject& globalOb
 
     Ref headers = FetchHeaders::create(this->headers());
     auto clone = FetchResponse::create(context.get(), std::nullopt, WTF::move(headers), ResourceResponse { m_internalResponse });
-    clone->cloneBody(globalObject, *this);
+    if (auto exception = clone->cloneBody(globalObject, *this))
+        return { WTF::move(*exception) };
+
     clone->m_opaqueLoadIdentifier = m_opaqueLoadIdentifier;
     clone->m_bodySizeWithPadding = m_bodySizeWithPadding;
     clone->m_resourceLoaderIdentifier = m_resourceLoaderIdentifier;

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -115,6 +115,7 @@ public:
 
     bool hasByteStreamController() { return !!m_controller; }
     ReadableByteStreamController* controller() { return m_controller.get(); }
+    const ReadableByteStreamController* controller() const { return m_controller.get(); }
 
     void setByobReader(ReadableStreamBYOBReader*);
     ReadableStreamBYOBReader* NODELETE byobReader();

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -97,6 +97,13 @@ ExceptionOr<void> FetchEvent::respondWith(Ref<DOMPromise>&& promise)
     if (m_respondWithEntered)
         return Exception { ExceptionCode::InvalidStateError, "Event respondWith flag is set"_s };
 
+    processRespondWithPromise(WTF::move(promise));
+    return { };
+}
+
+void FetchEvent::processRespondWithPromise(Ref<DOMPromise>&& promise)
+{
+    ASSERT(!m_respondWithEntered);
     m_respondPromise = promise.copyRef();
     addExtendLifetimePromise(promise.get());
 
@@ -112,8 +119,6 @@ ExceptionOr<void> FetchEvent::respondWith(Ref<DOMPromise>&& promise)
 
     if (isRegistered == DOMPromise::IsCallbackRegistered::No)
         respondWithError(createResponseError(m_request->url(), "FetchEvent unable to handle respondWith promise."_s, ResourceError::IsSanitized::Yes));
-
-    return { };
 }
 
 void FetchEvent::onResponse(ResponseCallback&& callback)

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -72,6 +72,7 @@ public:
     const String& resultingClientId() const LIFETIME_BOUND { return m_resultingClientId; }
     DOMPromise& handled() const { return m_handled.get(); }
 
+    void processRespondWithPromise(Ref<DOMPromise>&&);
     bool respondWithEntered() const { return m_respondWithEntered; }
 
     static ResourceError createResponseError(const URL&, const String&, ResourceError::IsSanitized = ResourceError::IsSanitized::No);

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -26,13 +26,16 @@
 #include "config.h"
 #include "ServiceWorkerFetch.h"
 
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "CrossOriginAccessControl.h"
 #include "EventNames.h"
 #include "FetchEvent.h"
 #include "FetchRequest.h"
 #include "FetchResponse.h"
+#include "JSDOMConvertInterface.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSFetchResponse.h"
 #include "MIMETypeRegistry.h"
 #include "ResourceRequest.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -237,12 +240,27 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
             return;
         }
 
-        if (isPendingStream && protect(event->request())->isDisturbed()) {
-            errorCallback({ errorDomainWebKitInternal, 0, requestURL, "Fetch request body is disturbed"_s, ResourceError::Type::General, ResourceError::IsSanitized::Yes });
-            return;
+        Ref eventRequest = event->request();
+        bool isHandled = false;
+        if (isPendingStream) {
+            if (eventRequest->isDisturbed()) {
+                errorCallback({ errorDomainWebKitInternal, 0, requestURL, "Fetch request body is disturbed"_s, ResourceError::Type::General, ResourceError::IsSanitized::Yes });
+                return;
+            }
+            if (eventRequest->hasClonedReadableStream()) {
+                auto [promise, deferred] = createPromiseAndWrapper(jsDOMGlobalObject);
+                FetchResponse::fetch(globalScope, eventRequest.get(), [deferred = DOMPromiseDeferred<IDLInterface<FetchResponse>> { WTF::move(deferred) }](auto&& result) mutable {
+                    deferred.settle(WTF::move(result));
+                }, cachedResourceRequestInitiatorTypes().fetch);
+                event->processRespondWithPromise(WTF::move(promise));
+                isHandled = true;
+            }
         }
-        client->didNotHandle();
-        deferredPromise->resolve();
+        if (!isHandled) {
+            eventRequest->markAsUnhandled();
+            client->didNotHandle();
+            deferredPromise->resolve();
+        }
     }
 
     globalScope.updateExtendedEventsSet(event.ptr());


### PR DESCRIPTION
#### b5aef3f0e4fc73299ec9f998007de512019041d3
<pre>
REGRESSION(317964@main): [macOS iOS] ASSERTION FAILED: bytesSent &gt;= m_pendingStreamBytesSentByNetwork in imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html
<a href="https://rdar.apple.com/184253301">rdar://184253301</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321191">https://bugs.webkit.org/show_bug.cgi?id=321191</a>

Reviewed by Chris Dumez.

318042@main started failing the load when the fetch event request body is disturbed,
since a body backed by a ReadableStream can no longer be provided

We need to support a service worker reading a clone of the request, even if the original request gets to the network.
PendingStreamState cannot have multiple consumers and we keep it this way for simplicity.

To implement the correct functional behavior, in case a fetch event request that has a pending stream body, the request is cloned
and the fetch event is not handled, we make the service worker do the fetch itself and we use this fetch for the fetch event.
This ensures that all request body data gets to the service worker and to the network, through the readable stream tee algorithm.
This also ensures that backward pressure is applied properly on the original readable stream.

 We now convert a pending stream FormData body into a ReadableStream before cloning it,
so that FetchBody::clone tees it as it does for any other stream body.
The original request keeps one branch and the clone gets the other, and each can be consumed independently.

Finally, when the fetch event is left unhandled, the request body is canceled, so the request is marked as disturbed to make it unusable afterwards, as per specification.

Covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-event-test-worker.js:
(handleCloneAndIgnore):
(handleCloneAfterIgnore):
(async self):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::clone):
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::setAsReadableStream):
(WebCore::FetchBody::isPendingStreamFormData const):
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::cloneBody):
(WebCore::FetchBodyOwner::hasClonedReadableStream const):
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::clone):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::clone):
* Source/WebCore/Modules/streams/ReadableStream.h:
(WebCore::ReadableStream::controller const):
* Source/WebCore/workers/service/FetchEvent.cpp:
(WebCore::FetchEvent::respondWith):
(WebCore::FetchEvent::processRespondWithPromise):
* Source/WebCore/workers/service/FetchEvent.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):

Canonical link: <a href="https://commits.webkit.org/319788@main">https://commits.webkit.org/319788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f94ce0e0569b587e42cc4a8033ab380babb69724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192987 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56429 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46364 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123074 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42927 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4161 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194930 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152099 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40750 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57068 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151799 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46365 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129336 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55576 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17930 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54948 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->