### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WOFFFileFormat

### DIFF
--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -47,9 +47,8 @@ static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
-    value = ntohl(*reinterpret_cast_ptr<const uint32_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(asMutableByteSpan(value), buffer.span().subspan(offset, sizeof(value)));
+    value = ntohl(value);
     offset += sizeof(value);
 
     return true;
@@ -61,9 +60,8 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
-    value = ntohs(*reinterpret_cast_ptr<const uint16_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(asMutableByteSpan(value), buffer.span().subspan(offset, sizeof(value)));
+    value = ntohs(value);
     offset += sizeof(value);
 
     return true;
@@ -259,13 +257,11 @@ bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
             return false;
 
         // Write an sfnt table directory entry.
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        uint32_t* sfntTableDirectoryPtr = reinterpret_cast_ptr<uint32_t*>(sfnt.mutableSpan().subspan(sfntTableDirectoryCursor).data());
-        *sfntTableDirectoryPtr++ = htonl(tableTag);
-        *sfntTableDirectoryPtr++ = htonl(tableOrigChecksum);
-        *sfntTableDirectoryPtr++ = htonl(sfnt.size());
-        *sfntTableDirectoryPtr++ = htonl(tableOrigLength);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto sfntTableDirectoryEntry = spanReinterpretCast<uint32_t>(sfnt.mutableSubspan(sfntTableDirectoryCursor, 4 * sizeof(uint32_t)));
+        sfntTableDirectoryEntry[0] = htonl(tableTag);
+        sfntTableDirectoryEntry[1] = htonl(tableOrigChecksum);
+        sfntTableDirectoryEntry[2] = htonl(sfnt.size());
+        sfntTableDirectoryEntry[3] = htonl(tableOrigLength);
         sfntTableDirectoryCursor += 4 * sizeof(uint32_t);
 
         if (tableCompLength == tableOrigLength) {


### PR DESCRIPTION
#### 24f73019156c8d7adaf0955545971b3f1c72b839
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WOFFFileFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=283899">https://bugs.webkit.org/show_bug.cgi?id=283899</a>

Reviewed by NOBODY (OOPS!).

The readers were not just suppressing a warning: loading a uint32_t
through a pointer into an arbitrary buffer offset is an unaligned
access, and undefined regardless of the annotation. Copying the bytes
out is well-defined and lowers to the same instruction.

The table directory entry keeps a reinterpret cast because its cursor is
provably four-byte aligned (it starts at 12 and advances by 16); making
it a span only bounds the four stores.

* Source/WebCore/platform/graphics/WOFFFileFormat.cpp:
(WebCore::readUInt32):
(WebCore::readUInt16):
(WebCore::convertWOFFToSfnt):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24f73019156c8d7adaf0955545971b3f1c72b839

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56147 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46141 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44825 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155226 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3871 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194634 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56095 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56786 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151565 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46141 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55297 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->