### PR TITLE
[EWS] Don't mark the build as exception when extract-test-results is killed on the buildmaster

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6496,10 +6496,26 @@ class ExtractTestResults(master.MasterShellCommand):
         step.addURL('view layout test results', self.resultDirectoryURL() + 'results.html')
         step.addURL('download layout test results', self.resultsDownloadURL())
 
+    def archiveSizeText(self):
+        try:
+            size = os.path.getsize(self.zipFile)
+        except OSError:
+            return ''
+        return f' ({size / (1024 * 1024):.1f} MB archive)'
+
     @defer.inlineCallbacks
     def run(self):
-        rc = yield super().run()
+        size_text = self.archiveSizeText()
+        try:
+            rc = yield super().run()
+        except Exception as e:
+            # Extraction just unzips the already-uploaded results archive on the buildmaster; a
+            # stall or kill here (e.g. disk pressure) shouldn't fail the build, the tests already ran.
+            if getattr(self, 'stdio_log', None) is not None:
+                yield self.stdio_log.addStdout(f'\nFailed to extract test results{size_text}: {e}\n')
+            rc = FAILURE
         self.addCustomURLs()
+        self.descriptionDone = [f'Extracted test results{size_text}' if rc == SUCCESS else f'Failed to extract test results{size_text}']
         defer.returnValue(rc)
 
 


### PR DESCRIPTION
#### 09003477a258cf761878ac2cee0e1ac3247ae1fc
<pre>
[EWS] Don&apos;t mark the build as exception when extract-test-results is killed on the buildmaster
<a href="https://bugs.webkit.org/show_bug.cgi?id=322398">https://bugs.webkit.org/show_bug.cgi?id=322398</a>
&lt;<a href="https://rdar.apple.com/problem/185686807">rdar://problem/185686807</a>&gt;

Reviewed by Ryan Haddad.

The extract-test-results step unzips the results archive on the buildmaster.
Under disk pressure the unzip can exceed buildbot&apos;s 5-minute no-output timeout
and then survive SIGKILL, which surfaces as a build exception and an
unnecessary retry, even though the results archive has already been uploaded to
the buildmaster and the tests have already run.

Treat an extraction failure as a non-fatal step failure instead of a build
exception, and include the archive size in the step summary so oversized
archives are easy to spot.

* Tools/CISupport/ews-build/steps.py:
(ExtractTestResults.archiveSizeText):
(ExtractTestResults.run):

Canonical link: <a href="https://commits.webkit.org/319826@main">https://commits.webkit.org/319826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db02771c68022560f30484b6945500df8a6e4786

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146834 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8199043-d4d6-4369-b6ee-e8de83dcc63c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142459 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98923 "4 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f479433-5eda-4510-beda-38961816c866) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122892 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/053177ee-6071-45f5-85e9-513a7bba1493) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43121 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42749 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3899 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194662 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181906 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56123 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56814 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39375 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151589 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46170 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125111 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55325 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->