### PR TITLE
Remove ReadableByteStreamFetchSourceEnabled flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7168,20 +7168,6 @@ ReadableByteStreamAPIEnabled:
     WebKit:
       default: true
 
-ReadableByteStreamFetchSourceEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "ReadableByteStream for fetch API"
-  humanReadableDescription: "Enable Readable Byte Streams for fetch API"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-
 ReadableStreamFromEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -414,34 +414,21 @@ ExceptionOr<void> FetchBodyOwner::createReadableStream(JSC::JSGlobalObject& stat
     }
 
     RefPtr context = scriptExecutionContext();
-    if (context && context->settingsValues().readableByteStreamFetchSourceEnabled) {
-        Ref readableStreamSource = FetchBodySource::createByteSource(*this);
-        Ref readableStream = ReadableStream::createReadableByteStream(globalObject, [readableStreamSource](auto& globalObject, auto& controller) {
-            return readableStreamSource->pull(globalObject, controller);
-        }, [readableStreamSource](auto& globalObject, auto& controller, auto&& value) {
-            return readableStreamSource->cancel(globalObject, controller, WTF::move(value));
-        }, {
-            .highwaterMark = 1,
-            .startSynchronously = ReadableStream::StartSynchronously::Yes,
-            .isSourceReachableFromOpaqueRoot = ReadableStream::IsSourceReachableFromOpaqueRoot::Yes
-        });
+    Ref readableStreamSource = FetchBodySource::create(*this);
+    Ref readableStream = ReadableStream::createReadableByteStream(globalObject, [readableStreamSource](auto& globalObject, auto& controller) {
+        return readableStreamSource->pull(globalObject, controller);
+    }, [readableStreamSource](auto& globalObject, auto& controller, auto&& value) {
+        return readableStreamSource->cancel(globalObject, controller, WTF::move(value));
+    }, {
+        .highwaterMark = 1,
+        .startSynchronously = ReadableStream::StartSynchronously::Yes,
+        .isSourceReachableFromOpaqueRoot = ReadableStream::IsSourceReachableFromOpaqueRoot::Yes
+    });
 
-        m_readableStreamSource = readableStreamSource.ptr();
-        readableStreamSource->setByteController(*readableStream->controller());
-        m_body->setReadableStream(WTF::move(readableStream));
+    m_readableStreamSource = readableStreamSource.ptr();
+    readableStreamSource->setByteController(*readableStream->controller());
+    m_body->setReadableStream(WTF::move(readableStream));
 
-        return { };
-    }
-
-    auto [fetchBodySource, readableStreamSource] = FetchBodySource::createNonByteSource(*this);
-    m_readableStreamSource = WTF::move(fetchBodySource);
-
-    auto streamOrException = ReadableStream::create(downcast<JSDOMGlobalObject>(state), readableStreamSource);
-    if (streamOrException.hasException()) [[unlikely]] {
-        m_readableStreamSource = nullptr;
-        return streamOrException.releaseException();
-    }
-    m_body->setReadableStream(streamOrException.releaseReturnValue());
     return { };
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -39,21 +39,13 @@
 
 namespace WebCore {
 
-std::pair<Ref<FetchBodySource>, Ref<RefCountedReadableStreamSource>> FetchBodySource::createNonByteSource(FetchBodyOwner& bodyOwner)
-{
-    Ref nonByteSource = NonByteSource::create(bodyOwner);
-    Ref source = adoptRef(*new FetchBodySource(bodyOwner, nonByteSource.ptr()));
-    return { WTF::move(source), WTF::move(nonByteSource) };
-}
-
-Ref<FetchBodySource> FetchBodySource::createByteSource(FetchBodyOwner& bodyOwner)
+Ref<FetchBodySource> FetchBodySource::create(FetchBodyOwner& bodyOwner)
 {
     return adoptRef(*new FetchBodySource(bodyOwner));
 }
 
-FetchBodySource::FetchBodySource(FetchBodyOwner& bodyOwner, RefPtr<NonByteSource>&& nonByteSource)
+FetchBodySource::FetchBodySource(FetchBodyOwner& bodyOwner)
     : m_bodyOwner(bodyOwner)
-    , m_nonByteSource(WTF::move(nonByteSource))
 {
 }
 
@@ -61,7 +53,6 @@ FetchBodySource::~FetchBodySource() = default;
 
 void FetchBodySource::setByteController(ReadableByteStreamController& controller)
 {
-    ASSERT(!m_nonByteSource);
     ASSERT(!m_byteController);
     m_byteController = controller;
 
@@ -110,9 +101,6 @@ static JSDOMGlobalObject* globalObjectFromBodyOwner(RefPtr<FetchBodyOwner>&& bod
 // FIXME: We should be able to take a FragmentedSharedBuffer
 bool FetchBodySource::enqueue(RefPtr<JSC::ArrayBuffer>&& chunk)
 {
-    if (m_nonByteSource)
-        return m_nonByteSource->enqueue(WTF::move(chunk));
-
     if (!chunk)
         return false;
 
@@ -131,11 +119,6 @@ bool FetchBodySource::enqueue(RefPtr<JSC::ArrayBuffer>&& chunk)
 
 void FetchBodySource::close()
 {
-    if (m_nonByteSource) {
-        m_nonByteSource->close();
-        return;
-    }
-
     RefPtr controller = m_byteController.get();
     if (!controller)
         return;
@@ -149,11 +132,6 @@ void FetchBodySource::close()
 
 void FetchBodySource::error(const Exception& exception)
 {
-    if (m_nonByteSource) {
-        m_nonByteSource->error(exception);
-        return;
-    }
-
     RefPtr controller = m_byteController.get();
     if (!controller)
         return;
@@ -167,107 +145,22 @@ void FetchBodySource::error(const Exception& exception)
 
 bool FetchBodySource::isPulling() const
 {
-    if (m_nonByteSource)
-        return m_nonByteSource->isPulling();
     if (m_formDataConsumer)
         return m_formDataConsumer->hasPendingPull();
     return !!m_pullPromise;
 }
 
-bool FetchBodySource::isCancelling() const
-{
-    return m_nonByteSource ? m_nonByteSource->isCancelling() : m_isCancelling;
-}
-
 void FetchBodySource::resolvePullPromise()
 {
-    if (m_nonByteSource) {
-        m_nonByteSource->resolvePullPromise();
-        return;
-    }
-
     if (auto pullPromise = std::exchange(m_pullPromise, { }))
         pullPromise->resolve();
 }
 
 void FetchBodySource::detach()
 {
-    if (m_nonByteSource) {
-        m_nonByteSource->detach();
-        return;
-    }
-
     m_bodyOwner = nullptr;
     m_byteController = nullptr;
     m_pullPromise = nullptr;
-}
-
-FetchBodySource::NonByteSource::NonByteSource(FetchBodyOwner& owner)
-    : m_bodyOwner(owner)
-{
-}
-
-void FetchBodySource::NonByteSource::setActive()
-{
-    ASSERT(m_bodyOwner);
-    ASSERT(!m_pendingActivity);
-    if (RefPtr bodyOwner = m_bodyOwner.get())
-        m_pendingActivity = bodyOwner->makePendingActivity(*bodyOwner);
-}
-
-void FetchBodySource::NonByteSource::setInactive()
-{
-    ASSERT(m_bodyOwner);
-    ASSERT(m_pendingActivity);
-    m_pendingActivity = nullptr;
-}
-
-void FetchBodySource::NonByteSource::doStart()
-{
-    ASSERT(m_bodyOwner);
-    if (RefPtr bodyOwner = m_bodyOwner.get())
-        bodyOwner->consumeBodyAsStream();
-}
-
-void FetchBodySource::NonByteSource::doPull()
-{
-    ASSERT(m_bodyOwner);
-    if (RefPtr bodyOwner = m_bodyOwner.get())
-        bodyOwner->feedStream();
-}
-
-void FetchBodySource::NonByteSource::doCancel(JSC::JSValue)
-{
-    auto scope = makeScopeExit([&] {
-        cancelFinished();
-    });
-
-    m_isCancelling = true;
-    RefPtr bodyOwner = m_bodyOwner.get();
-    if (!bodyOwner)
-        return;
-
-    bodyOwner->cancel();
-    m_bodyOwner = nullptr;
-}
-
-void FetchBodySource::NonByteSource::close()
-{
-#if ASSERT_ENABLED
-    ASSERT(!m_isClosed);
-    m_isClosed = true;
-#endif
-
-    controller().close();
-    clean();
-    m_bodyOwner = nullptr;
-}
-
-void FetchBodySource::NonByteSource::error(const Exception& value)
-{
-    controller().error(value);
-    clean();
-    m_bodyOwner = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -44,8 +44,7 @@ class ReadableByteStreamController;
 
 class FetchBodySource final : public RefCountedAndCanMakeWeakPtr<FetchBodySource> {
 public:
-    static std::pair<Ref<FetchBodySource>, Ref<RefCountedReadableStreamSource>> createNonByteSource(FetchBodyOwner&);
-    static Ref<FetchBodySource> createByteSource(FetchBodyOwner&);
+    static Ref<FetchBodySource> create(FetchBodyOwner&);
 
     ~FetchBodySource();
 
@@ -54,7 +53,7 @@ public:
     void error(const Exception&);
 
     bool NODELETE isPulling() const;
-    bool NODELETE isCancelling() const;
+    bool NODELETE isCancelling() const { return m_isCancelling; }
 
     void resolvePullPromise();
     void detach();
@@ -68,44 +67,10 @@ public:
     void setFormDataConsumer(Ref<FormDataConsumer>&&);
 
 private:
-    class NonByteSource;
-    FetchBodySource(FetchBodyOwner&, RefPtr<NonByteSource>&& = { });
-
-    class NonByteSource : public RefCountedReadableStreamSource {
-    public:
-        static Ref<NonByteSource> create(FetchBodyOwner& owner) { return adoptRef(*new NonByteSource(owner)); }
-
-        bool enqueue(RefPtr<JSC::ArrayBuffer>&& chunk) { return controller().enqueue(WTF::move(chunk)); }
-        void close();
-        void error(const Exception&);
-
-        bool isCancelling() const { return m_isCancelling; }
-
-        void resolvePullPromise() { pullFinished(); }
-        void detach() { m_bodyOwner = nullptr; }
-
-    private:
-        explicit NonByteSource(FetchBodyOwner&);
-
-        void doStart() final;
-        void doPull() final;
-        void doCancel(JSC::JSValue) final;
-        void setActive() final;
-        void setInactive() final;
-
-        WeakPtr<FetchBodyOwner> m_bodyOwner;
-
-        bool m_isCancelling { false };
-#if ASSERT_ENABLED
-        bool m_isClosed { false };
-#endif
-        RefPtr<ActiveDOMObject::PendingActivity<FetchBodyOwner>> m_pendingActivity;
-    };
+    explicit FetchBodySource(FetchBodyOwner&);
 
     WeakPtr<FetchBodyOwner> m_bodyOwner;
     bool m_isCancelling { false };
-
-    const RefPtr<NonByteSource> m_nonByteSource;
 
     WeakPtr<ReadableByteStreamController> m_byteController;
     RefPtr<DeferredPromise> m_pullPromise;


### PR DESCRIPTION
#### cb138473ae6a19d20367d13b40228c30320461f5
<pre>
Remove ReadableByteStreamFetchSourceEnabled flag
<a href="https://rdar.apple.com/185689807">rdar://185689807</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322401">https://bugs.webkit.org/show_bug.cgi?id=322401</a>

Reviewed by Chris Dumez.

ReadableByteStreamFetchSourceEnabled is on by default.
We remove this flag and the related code.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::createReadableStream):
* Source/WebCore/Modules/fetch/FetchBodySource.cpp:
(WebCore::FetchBodySource::create):
(WebCore::FetchBodySource::FetchBodySource):
(WebCore::FetchBodySource::setByteController):
(WebCore::FetchBodySource::enqueue):
(WebCore::FetchBodySource::close):
(WebCore::FetchBodySource::error):
(WebCore::FetchBodySource::isPulling const):
(WebCore::FetchBodySource::resolvePullPromise):
(WebCore::FetchBodySource::detach):
(WebCore::FetchBodySource::createNonByteSource): Deleted.
(WebCore::FetchBodySource::createByteSource): Deleted.
(WebCore::FetchBodySource::isCancelling const): Deleted.
(WebCore::FetchBodySource::NonByteSource::NonByteSource): Deleted.
(WebCore::FetchBodySource::NonByteSource::setActive): Deleted.
(WebCore::FetchBodySource::NonByteSource::setInactive): Deleted.
(WebCore::FetchBodySource::NonByteSource::doStart): Deleted.
(WebCore::FetchBodySource::NonByteSource::doPull): Deleted.
(WebCore::FetchBodySource::NonByteSource::doCancel): Deleted.
(WebCore::FetchBodySource::NonByteSource::close): Deleted.
(WebCore::FetchBodySource::NonByteSource::error): Deleted.
* Source/WebCore/Modules/fetch/FetchBodySource.h:

Canonical link: <a href="https://commits.webkit.org/319790@main">https://commits.webkit.org/319790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ffaf312bdd28e1f8e704ece17c2f978c4ea3176

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146822 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d6a727f-e2a4-4972-bd72-8904a9f19a81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142447 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1afaf9af-5f9a-4644-8138-3038b6015247) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122880 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44840 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43109 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4845 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11680 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42737 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3887 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43777 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56111 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40752 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56802 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151577 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46160 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129086 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55313 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17736 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->