### PR TITLE
[Skia] Test fast/writing-mode/vertical-subst-font-vert-no-dflt.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2400,8 +2400,6 @@ webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]
 
-webkit.org/b/273477 fast/writing-mode/vertical-subst-font-vert-no-dflt.html [ ImageOnlyFailure ]
-
 webkit.org/b/273480 imported/w3c/web-platform-tests/css/geometry/DOMMatrix2DInit-validate-fixup.html [ Failure ]
 
 webkit.org/b/273481 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/draw-generic-family/2d.text.draw.generic.family.html [ Failure ]

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -183,6 +183,27 @@ static void forEachHBRun(const std::span<const char16_t>& characters, Function<v
     }
 }
 
+static hb_script_t findScriptForVerticalGlyphSubstitution(hb_face_t* face)
+{
+    static const unsigned maxCount = 32;
+
+    unsigned scriptCount = maxCount;
+    std::array<hb_tag_t, maxCount> scriptTags;
+    hb_ot_layout_table_get_script_tags(face, HB_OT_TAG_GSUB, 0, &scriptCount, scriptTags.data());
+    for (unsigned scriptIndex = 0; scriptIndex < scriptCount; ++scriptIndex) {
+        unsigned languageCount = maxCount;
+        std::array<hb_tag_t, maxCount> languageTags;
+        hb_ot_layout_script_get_language_tags(face, HB_OT_TAG_GSUB, scriptIndex, 0, &languageCount, languageTags.data());
+        for (unsigned languageIndex = 0; languageIndex < languageCount; ++languageIndex) {
+            unsigned featureIndex;
+            if (hb_ot_layout_language_find_feature(face, HB_OT_TAG_GSUB, scriptIndex, languageIndex, HB_TAG('v', 'e', 'r', 't'), &featureIndex)
+                || hb_ot_layout_language_find_feature(face, HB_OT_TAG_GSUB, scriptIndex, languageIndex, HB_TAG('v', 'r', 't', '2'), &featureIndex))
+                return hb_ot_tag_to_script(scriptTags[scriptIndex]);
+        }
+    }
+    return HB_SCRIPT_INVALID;
+}
+
 void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const char16_t> characters, unsigned stringLocation, const Font* font)
 {
     ASSERT(!characters.empty());
@@ -194,23 +215,37 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     }
 
     const auto& fontPlatformData = font->platformData();
+    const bool isVertical = fontPlatformData.orientation() == FontOrientation::Vertical;
     auto* hbFont = fontPlatformData.hbFont();
     RELEASE_ASSERT(hbFont);
 
     const auto& features = fontPlatformData.features();
-    // Kerning is not handled as font features, so only in case it's explicitly disabled
-    // we need to create a new vector to include kern feature.
-    const hb_feature_t* featuresData = features.isEmpty() ? nullptr : features.span().data();
     unsigned featuresSize = features.size();
-    Vector<hb_feature_t> featuresWithKerning;
-    if (!m_fontCascade->enableKerning()) {
-        featuresWithKerning.reserveInitialCapacity(featuresSize + 1);
-        static hb_feature_t kernFeature { HB_TAG('k', 'e', 'r', 'n'), 0, 0, static_cast<unsigned>(-1) };
-        featuresWithKerning.append(kernFeature);
-        featuresWithKerning.appendVector(features);
-        featuresData = featuresWithKerning.span().data();
-        featuresSize = featuresWithKerning.size();
+    const hb_feature_t* featuresData = featuresSize > 0 ? features.span().data() : nullptr;
+
+    // Kerning and vertical text are not handled as font features, so we only need to build a new
+    // features vector when kerning is explicitly disabled or the font is vertically oriented.
+    Vector<hb_feature_t> extraFeatures;
+    if (!m_fontCascade->enableKerning() || isVertical) {
+        extraFeatures.reserveInitialCapacity(featuresSize + 3);
+        if (!m_fontCascade->enableKerning()) {
+            static hb_feature_t kernFeature { HB_TAG('k', 'e', 'r', 'n'), 0, 0, static_cast<unsigned>(-1) };
+            extraFeatures.append(kernFeature);
+        }
+        if (isVertical) {
+            static hb_feature_t vertFeature { HB_TAG('v', 'e', 'r', 't'), 1, 0, static_cast<unsigned>(-1) };
+            static hb_feature_t vrt2Feature { HB_TAG('v', 'r', 't', '2'), 1, 0, static_cast<unsigned>(-1) };
+            extraFeatures.append(vertFeature);
+            extraFeatures.append(vrt2Feature);
+        }
+        extraFeatures.appendVector(features);
+        featuresData = extraFeatures.span().data();
+        featuresSize = extraFeatures.size();
     }
+
+    auto verticalGlyphSubstitutionScript = HB_SCRIPT_INVALID;
+    if (isVertical)
+        verticalGlyphSubstitutionScript = findScriptForVerticalGlyphSubstitution(hb_font_get_face(hbFont));
 
     static thread_local HbUniquePtr<hb_buffer_t> buffer(hb_buffer_create());
 
@@ -223,7 +258,10 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         hb_buffer_set_cluster_level(buffer.get(), HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);
         hb_buffer_set_language(buffer.get(), language);
 
-        hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));
+        if (verticalGlyphSubstitutionScript != HB_SCRIPT_INVALID)
+            hb_buffer_set_script(buffer.get(), verticalGlyphSubstitutionScript);
+        else
+            hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));
 
         if (!m_mayUseNaturalWritingDirection || m_run->directionalOverride())
             hb_buffer_set_direction(buffer.get(), m_run->rtl() ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);


### PR DESCRIPTION
#### a562b34e5386c35648835584439534662ce6b4a2
<pre>
[Skia] Test fast/writing-mode/vertical-subst-font-vert-no-dflt.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=273477">https://bugs.webkit.org/show_bug.cgi?id=273477</a>

Reviewed by Carlos Garcia Campos.

WebKit shapes vertical writing-mode text as an ordinary horizontal HarfBuzz
buffer (LTR/RTL direction) and relies on the font&apos;s OpenType &apos;vert&apos;/&apos;vrt2&apos;
GSUB features to substitute glyphs with their vertical forms. HarfBuzz only
auto-enables &apos;vert&apos;/&apos;vrt2&apos; for buffers shaped in a vertical direction (TTB/BTT),
which WebKit never uses. Thus, &apos;ComplexTextControllerSkia&apos; must request
these features explicitly (otherwise vertical glyph substitution won&apos;t happen).

Fix by explicitly requesting &apos;vert&apos;/&apos;vrt2&apos; whenever the font is vertically
oriented. Also add &apos;findScriptForVerticalGlyphSubstitution()&apos;, almost
identical to Harfbuzz&apos;s implementation, which looks up in which script the font
actually registers &apos;vert&apos; and &apos;vrt2&apos; and uses that script for shaping.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::findScriptForVerticalGlyphSubstitution):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):

Canonical link: <a href="https://commits.webkit.org/319783@main">https://commits.webkit.org/319783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e05ad1dadc59737645cc4f7e1c7d7e4fa2e5e549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56678 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56413 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4145 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49318 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194914 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57052 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27747 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/46354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129320 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55560 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54932 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->