### PR TITLE
HTML parser should not insert an element into its own subtree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Template content should throw when its ancestor is being appended.
-FAIL Template content should throw exception when its ancestor in a different document but connected via host is being append. assert_equals: expected Document node with 0 children but got Document node with 2 children
+PASS Template content should throw exception when its ancestor in a different document but connected via host is being append.
+PASS Template content should throw when an ancestor across two template boundaries is being appended.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
@@ -45,11 +45,10 @@ test(() => {
   assert_not_equals(new_doc, tmpl_doc);
 
   // Try moving tmpl.content to new_doc and check the results.
-  const tmplContentNodeDocument = tmpl.content.ownerDocument;
   const tmplContentAdoptResult = new_doc.adoptNode(tmpl.content);
   assert_equals(tmpl.content, tmplContentAdoptResult);
   assert_equals(tmpl.ownerDocument, document);
-  assert_equals(tmpl.content.ownerDocument, tmplContentNodeDocument);
+  assert_equals(tmpl.content.ownerDocument, new_doc);
 
   // Hierarchy checks at various combinations.
   assert_throws_dom('HierarchyRequestError', () => {
@@ -78,4 +77,31 @@ test(() => {
                 'moving its children.');
 }, 'Template content should throw exception when its ancestor in ' +
    'a different document but connected via host is being append.');
+
+test(() => {
+  const outer = document.createElement('template');
+  const inner = document.createElement('template');
+  const div = document.createElement('div');
+  const span = document.createElement('span');
+  outer.content.appendChild(inner);
+  inner.content.appendChild(div);
+  div.appendChild(span);
+
+  // outer is a host-including inclusive ancestor of everything in inner's
+  // contents, reached through two template content boundaries.
+  assert_throws_dom('HierarchyRequestError', () => {
+    inner.content.appendChild(outer);
+  }, 'Template content should throw if a template two boundaries up is being appended.');
+  assert_throws_dom('HierarchyRequestError', () => {
+    span.appendChild(outer);
+  }, 'Template content descendant should throw if a template two boundaries up is being appended.');
+  assert_throws_dom('HierarchyRequestError', () => {
+    span.appendChild(inner);
+  }, 'Template content descendant should throw if its own host is being appended.');
+
+  // A node that is not an ancestor is still accepted.
+  inner.content.appendChild(document.createElement('p'));
+  assert_equals(inner.content.lastChild.localName, 'p');
+}, 'Template content should throw when an ancestor across two template ' +
+   'boundaries is being appended.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Baseline: a custom element that does not reparent anything
+PASS attributeChangedCallback gives the element a parent before it is inserted
+PASS attributeChangedCallback detaches the intended parent before the element is inserted
+PASS Custom element constructor attaches an unrelated shadow root
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-shadow-cycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-shadow-cycle-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Custom element constructor moves the intended parent into its own shadow root
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-shadow-cycle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-shadow-cycle.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion: a custom element constructor creates a cycle through its own shadow root</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// The constructor runs before the element is inserted. It cannot append the
+// intended parent to itself -- "create an element" rejects a constructed
+// element with children -- but it can move it into a shadow root, which makes
+// the element a host-including inclusive ancestor of the adjusted insertion
+// location. The element is dropped, but stays on the stack of open elements.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); if (window.el) return; window.el = this; window.b = document.body; window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(window.b) } })<\/script><body><x-a><p>x</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_array_equals([...d.documentElement.children].map(e => e.localName), ["head"],
+    "the document element is left with only its head child");
+  assert_equals(w.el.parentNode, null, "the custom element was dropped on the floor");
+  assert_equals(w.root.firstChild, w.b, "body stayed in the custom element's shadow root");
+  assert_equals(tree(w.b), ``, "the custom element was not inserted into body");
+  assert_equals(tree(w.el), `<p>["x"]`, "following content went into the dropped element");
+}, "Custom element constructor moves the intended parent into its own shadow root");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-template-cycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-template-cycle-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Custom element constructor moves the intended parent into a template element's contents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-template-cycle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-template-cycle.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion: a custom element constructor creates a cycle through a template element's contents</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// Like the shadow root case, but the loop is closed through a template
+// element's contents. Kept separate because insertion-time subtree traversal
+// descends into shadow trees and not into template contents, so the two are not
+// equivalent for implementations.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); if (window.el) return; window.el = this; window.b = document.body; window.t = document.createElement('template'); window.t.content.appendChild(window.b); window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(window.t) } })<\/script><body><x-a><p>x</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_array_equals([...d.documentElement.children].map(e => e.localName), ["head"],
+    "the document element is left with only its head child");
+  assert_equals(w.el.parentNode, null, "the custom element was dropped on the floor");
+  assert_equals(w.b.parentNode, w.t.content, "body stayed in the template element's contents");
+  assert_equals(tree(w.b), ``, "the custom element was not inserted into body");
+  assert_equals(tree(w.el), `<p>["x"]`, "following content went into the dropped element");
+}, "Custom element constructor moves the intended parent into a template element's contents");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion when a custom element reaction reparents nodes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// The custom element constructor, and attributeChangedCallback for the token's
+// attributes, both run before the element is inserted. These are the cases
+// where the resulting tree stays well-formed; the cycle-inducing variants live
+// in custom-element-reparenting-*-cycle.html.
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement {})<\/script><body><x-a><p>y</p></x-a>`);
+  assert_equals(tree(iframe.contentDocument.body), `<x-a>[<p>["y"]]`);
+}, "Baseline: a custom element that does not reparent anything");
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { static get observedAttributes() { return ['x'] } attributeChangedCallback() { if (window.el) return; window.el = this; document.head.appendChild(this) } })<\/script><body><x-a x=1><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(w.el.parentNode, d.head, "the custom element stayed where the callback put it");
+  assert_equals(tree(d.body), ``, "the custom element was not also inserted into body");
+  assert_equals(tree(w.el), `<p>["y"]`, "following content went into the custom element");
+}, "attributeChangedCallback gives the element a parent before it is inserted");
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { static get observedAttributes() { return ['x'] } attributeChangedCallback() { if (window.el) return; window.el = this; window.b = document.body; window.b.remove() } })<\/script><body><x-a x=1><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_equals(w.b.parentNode, null, "body stayed detached");
+  assert_equals(tree(w.b), `<x-a>[<p>["y"]]`, "the element was inserted into the detached body");
+}, "attributeChangedCallback detaches the intended parent before the element is inserted");
+
+// A shadow root that does not contain the intended parent must not prevent the
+// insertion; this is what an over-broad cycle guard would break.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); window.el = this; window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(document.createElement('span')) } })<\/script><body><x-a><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(tree(d.body), `<x-a>[<p>["y"]]`, "the element was inserted normally");
+  assert_equals(w.root.firstChild.localName, "span", "its shadow root is untouched");
+}, "Custom element constructor attaches an unrelated shadow root");
+</script>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -542,21 +542,33 @@ static inline bool NODELETE isChildTypeAllowed(ContainerNode& newParent, Node& c
     return true;
 }
 
+static inline const ContainerNode* NODELETE hostIncludingParent(const Node& node)
+{
+    if (auto* parent = node.parentNode())
+        return parent;
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(node))
+        return shadowRoot->host();
+    if (auto* fragment = dynamicDowncast<TemplateContentDocumentFragment>(node))
+        return fragment->host();
+    return nullptr;
+}
+
+// https://dom.spec.whatwg.org/#concept-tree-host-including-inclusive-ancestor
 bool containsIncludingHostElements(const Node& possibleAncestor, const Node& node)
 {
-    const Node* currentNode = &node;
-    do {
+    if (&possibleAncestor == &node)
+        return true;
+
+    if (!possibleAncestor.hasChildNodes() && !possibleAncestor.shadowRoot() && !possibleAncestor.hasTagName(HTMLNames::templateTag))
+        return false;
+
+    auto* possibleAncestorRoot = &possibleAncestor.shadowIncludingRoot();
+    for (auto* currentNode = &node; currentNode; currentNode = hostIncludingParent(*currentNode)) {
         if (currentNode == &possibleAncestor)
             return true;
-        const ContainerNode* parent = currentNode->parentNode();
-        if (!parent) {
-            if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*currentNode))
-                parent = shadowRoot->host();
-            else if (auto* fragment = dynamicDowncast<TemplateContentDocumentFragment>(*currentNode))
-                parent = fragment->host();
-        }
-        currentNode = WTF::move(parent);
-    } while (currentNode);
+        if (auto* currentRoot = &currentNode->shadowIncludingRoot(); currentRoot != possibleAncestorRoot)
+            currentNode = currentRoot;
+    }
 
     return false;
 }

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -148,11 +148,17 @@ static inline void insert(HTMLConstructionSiteTask& task)
         }
     }
 
-    ASSERT(!task.child->parentNode());
+    Ref child = *task.child;
+    Ref parent = *task.parent;
+
+    if (containsIncludingHostElements(child, parent)) [[unlikely]]
+        return;
+
+    ASSERT(!child->parentNode());
     if (task.nextChild)
-        SUPPRESS_UNCOUNTED_ARG task.parent->parserInsertBefore(protect(*task.child), protect(*task.nextChild));
+        parent->parserInsertBefore(child, protect(*task.nextChild));
     else
-        SUPPRESS_UNCOUNTED_ARG task.parent->parserAppendChild(protect(*task.child));
+        parent->parserAppendChild(child);
 }
 
 static inline void executeInsertTask(HTMLConstructionSiteTask& task)
@@ -192,7 +198,7 @@ static inline void executeInsertAlreadyParsedChildTask(HTMLConstructionSiteTask&
     if (RefPtr parent = child->parentNode())
         parent->parserRemoveChild(child);
 
-    if (child->parentNode() || containsIncludingHostElements(child, *protect(task.parent)))
+    if (child->parentNode())
         return;
 
     insert(task);


### PR DESCRIPTION
#### 3dff3fac8c47236b7cab34e2f9239ef83f7f2df9
<pre>
HTML parser should not insert an element into its own subtree
<a href="https://bugs.webkit.org/show_bug.cgi?id=322403">https://bugs.webkit.org/show_bug.cgi?id=322403</a>

Reviewed by Ryosuke Niwa.

Unfortunately the changes in 319453@main were insufficient due to custom elements.
The constructor cannot append the parent to the element, since creating an element
rejects a constructed element that has children, but it can move the parent into a
shadow root, or into the contents of a template element inside one. Check for that
with containsIncludingHostElements() and drop the element on the floor, as the
adoption agency already does.

Make containsIncludingHostElements() consult the cached shadow-including root to
skip over a tree that cannot contain possibleAncestor, so the ancestor walk is
avoided entirely when the two nodes are in different trees. That is the common
case both for parser insertion and for appending a newly created node from
script.

The cycle check in executeInsertAlreadyParsedChildTask() is now redundant with
the one in insert(). Its parentNode() check is not: script run by
parserRemoveChild() can give the node a parent again without creating a cycle.

Spec changes: <a href="https://github.com/whatwg/html/pull/12830">https://github.com/whatwg/html/pull/12830</a>

Tests: imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-shadow-cycle.html
       imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting-template-cycle.html
       imported/w3c/web-platform-tests/html/syntax/parsing/custom-element-reparenting.html

Tests upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62174">https://github.com/web-platform-tests/wpt/pull/62174</a>

Canonical link: <a href="https://commits.webkit.org/319844@main">https://commits.webkit.org/319844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6474a9b4f30f1507ab2cf284beb5f190224005aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147110 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8add19f-f18a-42a8-83ef-2c0ef95148f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142687 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f31dace-fb23-4c41-b421-14caafc24663) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46404 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163447 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7749b9e5-f131-4c62-9b41-dfea67d31ed2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43348 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42976 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4211 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152143 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40792 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57119 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151840 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46406 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129388 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125465 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17986 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->