### PR TITLE
[JSC] Refresh AI state when folding GetScope to Identity

### DIFF
--- a/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
+++ b/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
@@ -1,0 +1,29 @@
+function opt(a1, a2, a3, a4, a5) {
+    try {
+        class Trans extends Array {
+        };
+        function inline() {
+            try {
+                a2(["Āሴ￿", a5]);
+            } catch (x) {
+            };
+        };
+        inline();
+    } catch (x) {
+    };
+    function foo(a, b) {
+        for (var x = 0; x < 10000; x++) {
+        };
+        return a == b;
+    }
+    foo(-1, a5);
+    class C {
+    };
+}
+
+for (let i = 0; i < 10000; i++) {
+    try {
+        opt(Function.prototype.apply, Function.prototype.toString, 1.1, '💩', Object.defineProperty);
+    } catch (e) {
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1719,6 +1719,7 @@ private:
                 case NewAsyncFunction: {
                     node->convertToIdentityOn(node->child1()->child1().node());
                     node->child1().setUseKind(KnownCellUse);
+                    m_interpreter.execute(indexInBlock); // Catch the fact that we may overwrite a stale AbstractValue.
                     eliminated = true;
                     break;
                 }


### PR DESCRIPTION
#### cb05a6083ae0246da0eeee815a7ba5daf3b20c25
<pre>
[JSC] Refresh AI state when folding GetScope to Identity
<a href="https://bugs.webkit.org/show_bug.cgi?id=316803">https://bugs.webkit.org/show_bug.cgi?id=316803</a>
<a href="https://rdar.apple.com/178423757">rdar://178423757</a>

Reviewed by Yusuke Suzuki.

A GetScope could be constant folded to Identity. When this happens, the
abstract interpreter isn&apos;t re-executed on the Identity node. If a previous run
of the AI left the abstract value corresponding to the pre-replacement GetScope
node as bottom, this stale bottom value can cause downstream consumers to
assume the Identity is unreachable when it is.

This PR re-executes AI after folding to Identity.

Test: JSTests/stress/dfg-getscope-fold-stale-cfa-state.js

* JSTests/stress/dfg-getscope-fold-stale-cfa-state.js: Added.
(try.Trans):
(try.inline):
(foo):
(C):
(opt):
(i.catch):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Originally-landed-as: 305413.1012@safari-7624.5-branch (3efb180e50d2). <a href="https://rdar.apple.com/185369111">rdar://185369111</a>
Canonical link: <a href="https://commits.webkit.org/319719@main">https://commits.webkit.org/319719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18bab2afe3a5083e5a4cb51c3433d6eb7c68e54e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142455 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43117 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4853 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11691 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42748 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3895 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43785 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56119 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40695 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56810 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151585 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46166 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129094 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125106 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55321 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17747 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->