### PR TITLE
[ews-build] Remove Bugzilla patch workflow support from ews-build.webkit.org - Part 3

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1464,10 +1464,6 @@ class GetTestExpectationsBaseline(shell.ShellCommand, ShellMixin):
         platform = self.getProperty('platform')
         self.command += customBuildFlag(platform, self.getProperty('fullPlatform'))
 
-        patch_author = self.getProperty('patch_author')
-        if patch_author in ['webkit-wpt-import-bot@igalia.com']:
-            self.command += ['imported/w3c/web-platform-tests']
-
         additionalArguments = self.getProperty('additionalArguments', '')
         if additionalArguments:
             self.command += additionalArguments
@@ -1495,10 +1491,6 @@ class GetUpdatedTestExpectations(steps.ShellSequence, ShellMixin):
         configuration_flag = [f"--{self.getProperty('configuration')}"] if self.getProperty('configuration') else []
         platform_flag = customBuildFlag(self.getProperty('platform'), self.getProperty('fullPlatform'))
         run_webkit_command = ['python3', 'Tools/Scripts/run-webkit-tests', '--print-expectations'] + configuration_flag + platform_flag
-
-        patch_author = self.getProperty('patch_author')
-        if patch_author in ['webkit-wpt-import-bot@igalia.com']:
-            run_webkit_command += ['imported/w3c/web-platform-tests']
 
         additionalArguments = self.getProperty('additionalArguments', '')
         if additionalArguments:
@@ -3937,10 +3929,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         self.command += ['--results-directory', self.resultDirectory]
         self.command += ['--debug-rwt-logging']
 
-        patch_author = self.getProperty('patch_author')
-        if patch_author in ['webkit-wpt-import-bot@igalia.com']:
-            self.command += ['imported/w3c/web-platform-tests']
-        elif GitHub.NO_FAILURE_LIMITS_LABEL in self.getProperty('github_labels', []):
+        if GitHub.NO_FAILURE_LIMITS_LABEL in self.getProperty('github_labels', []):
             self.command += ['--no-retry']
             self.maxTime = 60 * 90
         else:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2177,23 +2177,6 @@ ts","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM o
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         return self.run_step()
 
-    def test_success_wpt_import_bot(self):
-        self.configureStep()
-        self.setProperty('fullPlatform', 'ios-simulator')
-        self.setProperty('configuration', 'release')
-        self.setProperty('patch_author', 'webkit-wpt-import-bot@igalia.com')
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        logfiles={'json': self.jsonFileName},
-                        log_environ=False,
-                        timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging imported/w3c/web-platform-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
-                        )
-            .exit(0),
-        )
-        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
-        return self.run_step()
-
     def test_failure_no_failure_limits(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')


### PR DESCRIPTION
#### ff0937cb73c708dc1727feae377b5f917572b635
<pre>
[ews-build] Remove Bugzilla patch workflow support from ews-build.webkit.org - Part 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=322402">https://bugs.webkit.org/show_bug.cgi?id=322402</a>
<a href="https://rdar.apple.com/185690788">rdar://185690788</a>

Reviewed by Carlos Alberto Lopez Perez.

Remove the WPT import bot special case, which keyed off the Bugzilla-only
patch_author build property. Its only producer was removed in 319303@main,
so the branch can no longer be reached.

* Tools/CISupport/ews-build/steps.py:
(GetTestExpectationsBaseline.run):
(GetUpdatedTestExpectations.run):
(RunWebKitTests.setLayoutTestCommand):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTests.test_success_wpt_import_bot): Deleted.

Canonical link: <a href="https://commits.webkit.org/319722@main">https://commits.webkit.org/319722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f6adf406c0fdd855751126512449d83e775795f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146832 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6b52851-618b-4a21-b1ac-ad1f49e1e6cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56173 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142457 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185458 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46165 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163221 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122890 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/356ddefb-457f-4990-b082-850665de8bcc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44849 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43119 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155250 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42746 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3897 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194660 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181904 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56121 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151889 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56812 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39372 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151587 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46171 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125109 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55323 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->