### PR TITLE
[JSC][Wasm] Growing a shared memory reads its instances' sibling memory handles across threads

### DIFF
--- a/JSTests/wasm/stress/multimemory-shared-grow-refreshes-only-its-own-slots.js
+++ b/JSTests/wasm/stress/multimemory-shared-grow-refreshes-only-its-own-slots.js
@@ -1,0 +1,49 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+const wat = `
+(module
+  (import "env" "shared" (memory $shared 1 8 shared))
+  (import "env" "plain" (memory $plain 1 8))
+  (func (export "sizeShared") (result i32) (memory.size $shared))
+  (func (export "sizePlain") (result i32) (memory.size $plain))
+  (func (export "storePlain") (param $a i32) (i32.store $plain (local.get $a) (i32.const 0xaa)))
+  (func (export "loadPlain") (param $a i32) (result i32) (i32.load $plain (local.get $a))))`;
+
+const shared = new WebAssembly.Memory({ initial: 1, maximum: 8, shared: true });
+const plain = new WebAssembly.Memory({ initial: 1, maximum: 8 });
+
+const { exports } = await instantiate(wat, { env: { shared, plain } }, { multi_memory: true, threads: true });
+
+const secondPage = 65536;
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    exports.sizeShared();
+    exports.sizePlain();
+}
+
+assert.eq(shared.grow(1), 1);
+assert.eq(exports.sizeShared(), 2);
+
+assert.eq(exports.sizePlain(), 1);
+assert.throws(() => exports.storePlain(secondPage), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+assert.eq(plain.grow(1), 1);
+assert.eq(exports.sizePlain(), 2);
+exports.storePlain(secondPage);
+assert.eq(exports.loadPlain(secondPage), 0xaa);
+assert.eq(exports.sizeShared(), 2);
+
+assert.eq(shared.grow(0), 2);
+assert.eq(exports.sizeShared(), 2);
+assert.eq(exports.sizePlain(), 2);
+assert.eq(exports.loadPlain(secondPage), 0xaa);
+
+const otherPlain = new WebAssembly.Memory({ initial: 1, maximum: 8 });
+const other = await instantiate(wat, { env: { shared, plain: otherPlain } }, { multi_memory: true, threads: true });
+assert.eq(shared.grow(1), 2);
+assert.eq(other.exports.sizeShared(), 3);
+assert.eq(exports.sizeShared(), 3);
+assert.eq(other.exports.sizePlain(), 1);

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -748,7 +748,7 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::tryGrow(const Abstr
     for (Ref anchor : memoryHandle->anchors(locker)) {
         Locker locker { anchor->m_lock };
         if (JSWebAssemblyInstance* instance = anchor->instance())
-            instance->updateCachedMemories();
+            instance->updateMatchingCachedMemoriesConcurrently(*this);
     }
 #endif
     return deltaByteLength;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -233,6 +233,20 @@ public:
         }
     }
 
+    void updateMatchingCachedMemoriesConcurrently(const SharedArrayBufferContents& grownMemory)
+    {
+        if (!m_wasmMemory)
+            return;
+
+        for (unsigned i = 0; i < m_moduleInformation->memoryCount(); i++) {
+            if (!m_memories[i] || m_memories[i]->memory().shared() != &grownMemory)
+                continue;
+            updateCachedMemoryBaseSizePair(i);
+            if (!i)
+                m_cachedMemory0Size = m_memories[i]->memory().size();
+        }
+    }
+
     uint32_t cachedTable0Length() const { return m_cachedTable0Length; }
     Wasm::FuncRefTable::Function* cachedTable0Buffer() const { return m_cachedTable0Buffer; }
 


### PR DESCRIPTION
#### 4002a938c8699bcd479e7b3cb998a9675738c8a1
<pre>
[JSC][Wasm] Growing a shared memory reads its instances&apos; sibling memory handles across threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=322405">https://bugs.webkit.org/show_bug.cgi?id=322405</a>
<a href="https://rdar.apple.com/183462752">rdar://183462752</a>

Reviewed by Yusuke Suzuki.

setMemory() anchors an instance on every imported memory&apos;s BufferMemoryHandle, so
growing a shared memory reaches every instance that imported it, on every thread,
and updateCachedMemories() reloaded all of that instance&apos;s memories -- including
its non-shared siblings. Those belong to the thread that owns the instance, whose
own Memory::grow() frees the old handle when it swaps it in BoundsChecking mode.
The two share no lock, so the refresh reads a freed handle, and what it caches is
the {base, boundsCheckingSize} pair the JIT bounds every access with.

Refresh only the slots backed by the memory that grew, matched on
Wasm::Memory::shared(), which is fixed at creation -- so the comparison reads
immutable state instead of a sibling handle.

Memory::grow() keeps the full refresh for the non-shared case: every anchor on a
non-shared handle is an instance on the growing thread, and the shared memories
those instances also import are safe to read concurrently, since growing a shared
memory never frees its handle.

Test: JSTests/wasm/stress/multimemory-shared-grow-refreshes-only-its-own-slots.js

* JSTests/wasm/stress/multimemory-shared-grow-refreshes-only-its-own-slots.js: Added.
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::SharedArrayBufferContents::tryGrow):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/319937@main">https://commits.webkit.org/319937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b335deb7d06ff5d11617ff8feab42db37aabc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147453 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5cbdf2d9-13eb-46df-892b-36f81eace5f0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142961 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df8f8398-decd-4781-9b85-768df283a852) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fe84d1f-cb53-4089-a0cc-95a4e00a02b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43634 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5358 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12196 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43256 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4556 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44434 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56756 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40870 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152142 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46699 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129731 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55969 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18267 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55340 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->