### PR TITLE
Clean up ScopedLambda API for modern C++

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -16,7 +16,7 @@ ftl/FTLFormattedValue.h
 ftl/FTLState.h
 heap/AbstractSlotVisitor.h
 heap/Heap.h
-heap/HeapInlines.h
+[ macOS ] heap/HeapInlines.h
 heap/HeapProfiler.h
 heap/HeapSnapshotBuilder.h
 heap/SlotVisitor.h

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -786,7 +786,7 @@ writeH("OpcodeUtils") {
             outp.puts "case Opcode::#{opcode.name}:"
         end
     }
-    outp.puts "forEachArgCustom(scopedLambdaRef<EachArgCallback>(functor));"
+    outp.puts "forEachArgCustom(functor);"
     outp.puts "return;"
     outp.puts "default:"
     outp.puts "forEachArgSimple(functor);"

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.h
@@ -42,13 +42,13 @@ void computeUsesForBytecodeIndex(Block* codeBlock, const JSInstruction* instruct
     if (opcodeID != op_enter && codeBlock->wasCompiledWithDebuggingOpcodes() && codeBlock->scopeRegister().isValid())
         functor(codeBlock->scopeRegister());
 
-    computeUsesForBytecodeIndexImpl(instruction, checkpoint, scopedLambda<void(VirtualRegister)>(functor));
+    computeUsesForBytecodeIndexImpl(instruction, checkpoint, functor);
 }
 
 template<typename Block, typename Functor>
 void computeDefsForBytecodeIndex(Block* codeBlock, const JSInstruction* instruction, Checkpoint checkpoint, const Functor& functor)
 {
-    computeDefsForBytecodeIndexImpl(codeBlock->numVars(), instruction, checkpoint, scopedLambda<void(VirtualRegister)>(functor));
+    computeDefsForBytecodeIndexImpl(codeBlock->numVars(), instruction, checkpoint, functor);
 }
 
 #undef CALL_FUNCTOR

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -45,7 +45,7 @@ struct ArrayBufferViewWatchpointAdaptor;
 class VM;
 
 class FireDetail {
-    void* operator new(size_t) = delete;
+    WTF_FORBID_HEAP_ALLOCATION;
     
 public:
     virtual ~FireDetail() = default;
@@ -69,17 +69,18 @@ private:
     const char* m_string;
 };
 
+template<ConstInvocable<void(PrintStream&)> Functor>
 class LazyFireDetail final : public FireDetail {
 public:
-    LazyFireDetail(ScopedLambda<void(PrintStream&)>& lambda)
-        : m_lambda(lambda)
+    LazyFireDetail(Functor functor)
+        : m_functor(WTF::move(functor))
     {
     }
 
-    void dump(PrintStream& out) const final { m_lambda(out); }
+    void dump(PrintStream& out) const final { m_functor(out); }
 
 private:
-    ScopedLambda<void(PrintStream&)>& m_lambda;
+    Functor m_functor;
 };
 
 class WatchpointSet;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -530,7 +530,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
     if (shouldCaptureAllOfTheThings)
         functionNode->varDeclarations().markAllVariablesAsCaptured();
     
-    auto captures = scopedLambda<bool (UniquedStringImpl*)>([&] (UniquedStringImpl* uid) -> bool {
+    auto captures = [&] (UniquedStringImpl* uid) -> bool {
         if (!shouldCaptureSomeOfTheThings)
             return false;
         if (m_needsArguments && uid == propertyNames().arguments.impl()) {
@@ -541,7 +541,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
             return true;
         }
         return functionNode->captures(uid);
-    });
+    };
     auto varKind = [&] (UniquedStringImpl* uid) -> VarKind {
         return captures(uid) ? VarKind::Scope : VarKind::Stack;
     };
@@ -4974,12 +4974,12 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
             emitLabel(loopStart.get());
             emitLoopHint();
 
-            emitTryWithFinallyThatDoesNotShadowException(finallyContext, scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+            emitTryWithFinallyThatDoesNotShadowException(finallyContext, [&](BytecodeGenerator& generator) {
                 callBack(generator, value.get());
                 generator.emitJump(*scope->continueTarget());
-            }), scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+            }, [&](BytecodeGenerator& generator) {
                 generator.emitIteratorGenericClose(iterator.get(), node, EmitAwait::Yes);
-            }));
+            });
 
             emitLabel(*scope->continueTarget());
             RELEASE_ASSERT(forLoopNode->isForOfNode());
@@ -5058,12 +5058,12 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
             emitJumpIfTrue(done.get(), loopDone.get());
         }
 
-        emitTryWithFinallyThatDoesNotShadowException(finallyContext, scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        emitTryWithFinallyThatDoesNotShadowException(finallyContext, [&](BytecodeGenerator& generator) {
             callBack(generator, value.get());
             generator.emitJump(loopStart.get());
-        }), scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        }, [&](BytecodeGenerator& generator) {
             generator.emitIteratorGenericClose(iterator.get(), node);
-        }));
+        });
 
         bool breakLabelIsBound = scope->breakTargetMayBeBound();
         if (breakLabelIsBound)

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -528,11 +528,11 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
     
 handleSpread:
     RefPtr<RegisterID> index = generator.emitLoad(generator.newTemporary(), jsNumber(length));
-    auto spreader = scopedLambda<void(BytecodeGenerator&, RegisterID*)>([array, index](BytecodeGenerator& generator, RegisterID* value)
+    auto spreader = [array, index](BytecodeGenerator& generator, RegisterID* value)
     {
         generator.emitDirectPutByVal(array.get(), index.get(), value);
         generator.emitInc(index.get());
-    });
+    };
     for (; n; n = n->next()) {
         if (n->elision())
             generator.emitBinaryOp<OpAdd>(index.get(), index.get(), generator.emitLoad(nullptr, jsNumber(n->elision())), OperandTypes(ResultType::numberTypeIsInt32(), ResultType::numberTypeIsInt32()));
@@ -2115,14 +2115,14 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_ifAbruptCloseIterator(Bytecode
     ASSERT(!node->m_next);
 
     Ref<Label> end = generator.newLabel();
-    auto emitSecondArgumentNode = scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+    auto emitSecondArgumentNode = [&](BytecodeGenerator& generator) {
         generator.emitNode(node);
         generator.emitJump(end.get());
-    });
+    };
 
-    auto emitIteratorClose = scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+    auto emitIteratorClose = [&](BytecodeGenerator& generator) {
         generator.emitIteratorGenericClose(iterator.get(), this);
-    });
+    };
 
     generator.emitTryWithFinallyThatDoesNotShadowException(emitSecondArgumentNode, emitIteratorClose);
     generator.emitLabel(end.get());
@@ -2440,7 +2440,7 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
                 RefPtr<RegisterID> thisRegister = generator.emitLoad(generator.newTemporary(), jsUndefined());
                 RefPtr<RegisterID> argumentsRegister = generator.emitLoad(generator.newTemporary(), jsUndefined());
                 
-                auto extractor = scopedLambda<void(BytecodeGenerator&, RegisterID*)>([&thisRegister, &argumentsRegister, &index](BytecodeGenerator& generator, RegisterID* value)
+                auto extractor = [&thisRegister, &argumentsRegister, &index](BytecodeGenerator& generator, RegisterID* value)
                 {
                     Ref<Label> haveThis = generator.newLabel();
                     Ref<Label> end = generator.newLabel();
@@ -2453,7 +2453,7 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
                     generator.move(argumentsRegister.get(), value);
                     generator.emitLoad(index.get(), jsNumber(2));
                     generator.emitLabel(end.get());
-                });
+                };
                 generator.emitEnumeration(this, spread->expression(), extractor);
                 generator.emitCallVarargsInTailPosition(returnValue.get(), realFunction.get(), thisRegister.get(), argumentsRegister.get(), generator.newTemporary(), 0, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
             } else if (m_args->m_listNode->m_next) {
@@ -4149,9 +4149,9 @@ void BlockNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested);
 
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-        scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        [&](BytecodeGenerator& generator) {
             m_statements->emitBytecode(generator, dst);
-        })
+        }
     );
 
     generator.popLexicalScope(this);
@@ -4365,7 +4365,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested, &forLoopSymbolTable);
 
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-        scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        [&](BytecodeGenerator& generator) {
             Ref<LabelScope> scope = generator.newLabelScope(LabelScope::Loop);
 
             if (m_expr1) {
@@ -4395,7 +4395,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
                 generator.emitJump(topOfLoop.get());
 
             generator.emitLabel(scope->breakTarget());
-        })
+        }
     );
 
     generator.popLexicalScope(this);
@@ -4588,7 +4588,7 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested, &forLoopSymbolTable);
     bool isUsingDeclaration = hasUsingDeclaration();
     bool isAwaitUsingDeclaration = hasAwaitUsingDeclaration();
-    auto extractor = scopedLambda<void(BytecodeGenerator&, RegisterID*)>([this, dst, isUsingDeclaration, isAwaitUsingDeclaration](BytecodeGenerator& generator, RegisterID* value)
+    auto extractor = [this, dst, isUsingDeclaration, isAwaitUsingDeclaration](BytecodeGenerator& generator, RegisterID* value)
     {
         auto emitBody = [&](BytecodeGenerator& generator) {
             if (m_lexpr->isResolveNode()) {
@@ -4638,11 +4638,11 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         };
 
         generator.emitBodyWithUsingIfNeeded(isUsingDeclaration ? 1 : 0, isAwaitUsingDeclaration,
-            scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+            [&](BytecodeGenerator& generator) {
                 emitBody(generator);
-            })
+            }
         );
-    });
+    };
     generator.emitEnumeration(this, m_expr, extractor, this, forLoopSymbolTable);
     generator.popLexicalScope(this);
     generator.emitProfileControlFlow(m_statement->endOffset() + (m_statement->isBlock() ? 1 : 0));
@@ -4928,9 +4928,9 @@ void SwitchNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::DoNotOptimize, BytecodeGenerator::NestedScopeType::IsNested);
 
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-        scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        [&](BytecodeGenerator& generator) {
             m_block->emitBytecodeForBlock(generator, r0.get(), dst);
-        })
+        }
     );
 
     generator.popLexicalScope(this);
@@ -5124,9 +5124,9 @@ static void emitProgramNodeBytecode(BytecodeGenerator& generator, ScopeNode& sco
     generator.emitProfileControlFlow(scopeNode.startStartOffset());
 
     generator.emitBodyWithUsingIfNeeded(scopeNode.usingDeclarationCount(), scopeNode.hasAwaitUsingDeclaration(),
-        scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        [&](BytecodeGenerator& generator) {
             scopeNode.emitStatementsBytecode(generator, dstRegister.get());
-        })
+        }
     );
 
     generator.emitDebugHook(DidExecuteProgram, JSTextPosition(scopeNode.lastLine(), scopeNode.startOffset(), scopeNode.lineStartOffset()));
@@ -5157,9 +5157,9 @@ void EvalNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
     generator.emitLoad(dstRegister.get(), jsUndefined());
 
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-        scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+        [&](BytecodeGenerator& generator) {
             emitStatementsBytecode(generator, dstRegister.get());
-        })
+        }
     );
 
     generator.emitDebugHook(DidExecuteProgram, JSTextPosition(lastLine(), startOffset(), lineStartOffset()));
@@ -5283,9 +5283,9 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
             Ref<Label> tryStartLabel = generator.newEmittedLabel();
             TryData* tryData = generator.pushTry(tryStartLabel.get(), catchLabel.get(), HandlerType::Finally);
             generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-                scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+                [&](BytecodeGenerator& generator) {
                     emitStatementsBytecode(generator, generator.ignoredResult());
-                })
+                }
             );
             generator.emitJump(finallyLabel.get());
             Ref<Label> tryEndLabel = generator.newEmittedLabel();
@@ -5453,9 +5453,9 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
     case SourceParseMode::AsyncArrowFunctionBodyMode:
     case SourceParseMode::AsyncFunctionBodyMode: {
         generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-            scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+            [&](BytecodeGenerator& generator) {
                 emitStatementsBytecode(generator, generator.ignoredResult());
-            })
+            }
         );
 
         generator.emitReturn(generator.emitLoad(nullptr, jsUndefined()));
@@ -5464,9 +5464,9 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
 
     default: {
         generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
-            scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+            [&](BytecodeGenerator& generator) {
                 emitStatementsBytecode(generator, generator.ignoredResult());
-            })
+            }
         );
 
         StatementNode* singleStatement = this->singleStatement();
@@ -5844,7 +5844,7 @@ void ArrayPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) 
 
     RefPtr<RegisterID> done = generator.newTemporary();
 
-    auto emitBindValue = scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+    auto emitBindValue = [&](BytecodeGenerator& generator) {
         for (size_t i = 0; i < this->m_targetPatterns.size(); i++) {
             const auto& target = this->m_targetPatterns[i];
 
@@ -5930,14 +5930,14 @@ void ArrayPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) 
             }
             }
         }
-    });
+    };
 
-    auto emitIteratorClose = scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
+    auto emitIteratorClose = [&](BytecodeGenerator& generator) {
         Ref<Label> iteratorClosed = generator.newLabel();
         generator.emitJumpIfTrue(done.get(), iteratorClosed.get());
         generator.emitIteratorGenericClose(iterator.get(), this);
         generator.emitLabel(iteratorClosed.get());
-    });
+    };
 
     if (bindValueOrDefaultValueCanThrow) {
         generator.emitLoad(done.get(), jsBoolean(false));

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
@@ -53,11 +53,9 @@ void AdaptiveInferredPropertyValueWatchpoint::handleFire(VM&, const FireDetail& 
 {
     dataLogLnIf(DFG::shouldDumpDisassembly(), "Firing watchpoint ", RawPointer(this), " (", key(), ") on ", *m_codeBlock);
 
-
-    auto lambda = scopedLambda<void(PrintStream&)>([&](PrintStream& out) {
+    LazyFireDetail lazyDetail([&](PrintStream& out) {
         out.print("Adaptation of ", key(), " failed: ", detail);
     });
-    LazyFireDetail lazyDetail(lambda);
     m_codeBlock->jettison(Profiler::JettisonDueToUnprofiledWatchpoint, CountReoptimization, &lazyDetail);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
@@ -76,10 +76,9 @@ void AdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail& detail)
     
     dataLogLnIf(DFG::shouldDumpDisassembly(), "Firing watchpoint ", RawPointer(this), " (", m_key, ") on ", *m_codeBlock);
 
-    auto lambda = scopedLambda<void(PrintStream&)>([&](PrintStream& out) {
+    LazyFireDetail lazyDetail([&](PrintStream& out) {
         out.print("Adaptation of ", m_key, " failed: ", detail);
     });
-    LazyFireDetail lazyDetail(lambda);
     m_codeBlock->jettison(Profiler::JettisonDueToUnprofiledWatchpoint, CountReoptimization, &lazyDetail);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGForAllKills.h
+++ b/Source/JavaScriptCore/dfg/DFGForAllKills.h
@@ -47,7 +47,7 @@ constexpr bool verbose = false;
 // This tells you those things that die on the boundary between nodeBefore and nodeAfter. It is
 // conservative in the sense that it might resort to telling you some things that are still live at
 // nodeAfter.
-template<WTF::ConstInvocable<void(Operand)> Functor>
+template<ConstInvocable<void(Operand)> Functor>
 void forAllKilledOperands(Graph& graph, Node* nodeBefore, Node* nodeAfter, const Functor& functor)
 {
     CodeOrigin before = nodeBefore->origin.forExit;
@@ -125,7 +125,7 @@ void forAllKilledOperands(Graph& graph, Node* nodeBefore, Node* nodeAfter, const
 }
     
 // Tells you all of the nodes that would no longer be live across the node at this nodeIndex.
-template<WTF::ConstInvocable<void(Node*)> Functor>
+template<ConstInvocable<void(Node*)> Functor>
 void forAllKilledNodesAtNodeIndex(
     Graph& graph, AvailabilityMap& availabilityMap, BasicBlock* block, unsigned nodeIndex,
     const Functor& functor)
@@ -173,7 +173,7 @@ void forAllKilledNodesAtNodeIndex(
 // Tells you all of the places to start searching from in a basic block. Gives you the node index at which
 // the value is either no longer live. This pretends that nodes are dead at the end of the block, so that
 // you can use this to do per-basic-block analyses.
-template<WTF::ConstInvocable<void(unsigned, Node*)> Functor>
+template<ConstInvocable<void(unsigned, Node*)> Functor>
 void forAllKillsInBlock(
     Graph& graph, const CombinedLiveness& combinedLiveness, BasicBlock* block,
     const Functor& functor)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14650,7 +14650,7 @@ void SpeculativeJIT::compileEnumeratorNextUpdateIndexAndMode(Node* node)
         Label incrementLoop;
         Jump done;
         constexpr bool preserveIndexReg = true;
-        compileHasIndexedProperty(node, operationHasEnumerableIndexedProperty, scopedLambda<std::tuple<GPRReg, GPRReg>()>([&] {
+        compileHasIndexedProperty(node, operationHasEnumerableIndexedProperty, [&]() -> std::tuple<GPRReg, GPRReg> {
             GPRReg newIndexGPR = newIndex.gpr();
             GPRReg scratchGPR = scratch.gpr();
 
@@ -14664,7 +14664,7 @@ void SpeculativeJIT::compileEnumeratorNextUpdateIndexAndMode(Node* node)
             initMode.link(this);
             done = branch32(AboveOrEqual, newIndexGPR, Address(enumeratorGPR, JSPropertyNameEnumerator::indexedLengthOffset()));
             return std::make_pair(newIndexGPR, scratchGPR);
-        }), preserveIndexReg);
+        }, preserveIndexReg);
         branchTest32(Zero, scratch.gpr()).linkTo(incrementLoop, this);
 
         done.link(this);
@@ -17382,7 +17382,7 @@ void SpeculativeJIT::compileEnumeratorGetByVal(Node* node)
         GPRReg enumeratorGPR;
         JumpList recoverGenericCase;
 
-        compileGetByVal(node, scopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat, bool)>([&](DataFormat preferredFormat, bool needsFlush) {
+        compileGetByVal(node, [&](DataFormat preferredFormat, bool needsFlush) -> std::tuple<JSValueRegs, DataFormat> {
             Edge storageEdge = m_graph.varArgChild(node, 2);
             StorageOperand storage;
             if (storageEdge)
@@ -17462,7 +17462,7 @@ void SpeculativeJIT::compileEnumeratorGetByVal(Node* node)
 
             notFastNamedCases.link(this);
             return std::tuple { resultRegs, DataFormatJS };
-        }));
+        });
 
         // We rely on compileGetByVal to call jsValueResult for us.
         // FIXME: This is kinda hacky...

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1415,7 +1415,7 @@ public:
     void compilePutByVal(Node*);
     void compilePutByValMegamorphic(Node*);
 
-    // We use a scopedLambda to placate register allocation validation.
+    // We use a ScopedLambda to placate register allocation validation.
     void compileGetByVal(Node*, const ScopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>& prefix);
 
     void compileMultiGetByVal(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1079,10 +1079,10 @@ void SpeculativeJIT::emitCall(Node* node)
             SuppressRegisterAllocationValidation suppressScope(*this);
             Label mainPath = label();
             emitStoreCallSiteIndex(callSite);
-            auto slowCases = callLinkInfo->emitDirectTailCallFastPath(*this, scopedLambda<void()>([&] {
+            auto slowCases = callLinkInfo->emitDirectTailCallFastPath(*this, [&] {
                 CallFrameShuffler shuffler { *this, shuffleData };
                 shuffler.prepareForTailCall();
-            }));
+            });
             Label slowPath = label();
             if (!callLinkInfo->isDataIC() || !slowCases.empty()) {
                 slowCases.link(this);
@@ -1122,7 +1122,7 @@ void SpeculativeJIT::emitCall(Node* node)
     if (m_graph.m_plan.isUnlinked())
         loadLinkableConstant(callLinkInfoConstant, callLinkInfoGPR);
     if (isTail) {
-        CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, scopedLambda<void()>([&] {
+        CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, [&] {
             if (node->op() == TailCall) {
                 CallFrameShuffler shuffler { *this, shuffleData };
                 shuffler.setCalleeJSValueRegs(BaselineJITRegisters::Call::calleeJSR);
@@ -1136,7 +1136,7 @@ void SpeculativeJIT::emitCall(Node* node)
                 preserved.add(BaselineJITRegisters::Call::calleeGPR, IgnoreVectors);
                 prepareForTailCallSlow(WTF::move(preserved));
             }
-        }));
+        });
         abortWithReason(JITDidReturnFromTailCall);
     } else {
         CallLinkInfo::emitFastPath(*this, callLinkInfo);
@@ -3906,14 +3906,14 @@ void SpeculativeJIT::compile(Node* node)
     case StringCharAt: {
         // Relies on StringCharAt and StringAt node having same basic layout as GetByVal
         JSValueRegsTemporary result;
-        compileGetByValOnString(node, scopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>([&] (DataFormat preferredFormat, bool needsFlush) {
+        compileGetByValOnString(node, [&] (DataFormat preferredFormat, bool needsFlush) {
             result = JSValueRegsTemporary(this);
             JSValueRegs resultRegs = result.regs();
             ASSERT(preferredFormat == DataFormatJS || preferredFormat == DataFormatCell);
             if (needsFlush)
                 flushRegisters();
             return std::tuple { resultRegs, preferredFormat };
-        }));
+        });
         break;
     }
 
@@ -3958,7 +3958,7 @@ void SpeculativeJIT::compile(Node* node)
     case GetByVal: {
         JSValueRegsTemporary result;
         std::optional<JSValueRegsFlushedCallResult> flushedResult;
-        compileGetByVal(node, scopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>([&](DataFormat preferredFormat, bool needsFlush) {
+        compileGetByVal(node, [&](DataFormat preferredFormat, bool needsFlush) {
             JSValueRegs resultRegs;
             switch (preferredFormat) {
             case DataFormatDouble:
@@ -3977,7 +3977,7 @@ void SpeculativeJIT::compile(Node* node)
             }
             };
             return std::tuple { resultRegs, preferredFormat };
-        }));
+        });
         break;
     }
 
@@ -6195,7 +6195,9 @@ void SpeculativeJIT::compile(Node* node)
             SpeculateStrictInt32Operand index(this, m_graph.varArgChild(node, 1));
             GPRTemporary result(this, Reuse, index);
 
-            compileHasIndexedProperty(node, operationHasIndexedProperty, scopedLambda<std::tuple<GPRReg, GPRReg>()>([&] { return std::make_pair(index.gpr(), result.gpr()); }));
+            compileHasIndexedProperty(node, operationHasIndexedProperty, [&] {
+                return std::make_pair(index.gpr(), result.gpr());
+            });
             unblessedBooleanResult(result.gpr(), node);
             break;
         }

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -396,10 +396,10 @@ void compile(State& state, Safepoint::Result& safepointResult)
         compilation->addDescription(Profiler::OriginStack(), out.toCString());
         out.reset();
 
-        state.dumpDisassembly(out, *state.b3CodeLinkBuffer, scopedLambda<void(DFG::Node*)>([&] (DFG::Node*) {
+        state.dumpDisassembly(out, *state.b3CodeLinkBuffer, [&] (DFG::Node*) {
             compilation->addDescription({ }, out.toCString());
             out.reset();
-        }));
+        });
         compilation->addDescription({ }, out.toCString());
         out.reset();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -14095,9 +14095,9 @@ IGNORE_CLANG_WARNINGS_END
                     jit.store32(
                         CCallHelpers::TrustedImm32(callSiteIndex.bits()),
                         CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
-                    callLinkInfo->emitDirectTailCallFastPath(jit, scopedLambda<void()>([&]{
+                    callLinkInfo->emitDirectTailCallFastPath(jit, [&] {
                         CallFrameShuffler(jit, shuffleData).prepareForTailCall();
-                    }));
+                    });
 
                     jit.abortWithReason(JITDidReturnFromTailCall);
 
@@ -14261,11 +14261,11 @@ IGNORE_CLANG_WARNINGS_END
                 auto* callLinkInfo = state->addCallLinkInfo(codeOrigin);
                 callLinkInfo->setUpCall(CallLinkInfo::TailCall);
 
-                CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, scopedLambda<void()>([&] {
+                CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, [&] {
                     CallFrameShuffler shuffler { jit, shuffleData };
                     shuffler.setCalleeJSValueRegs(BaselineJITRegisters::Call::calleeJSR);
                     shuffler.prepareForTailCall();
-                }));
+                });
                 jit.abortWithReason(JITDidReturnFromTailCall);
             });
     }
@@ -14589,14 +14589,14 @@ IGNORE_CLANG_WARNINGS_END
                 ASSERT(!usedRegisters.contains(GPRInfo::regT2, IgnoreVectors)); // Used on the slow path.
 
                 if (isTailCall) {
-                    CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, scopedLambda<void()>([&] {
+                    CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, [&] {
                         jit.emitRestoreCalleeSavesFor(state->jitCode->calleeSaveRegisters());
                         RegisterSet preserved;
                         preserved.add(BaselineJITRegisters::Call::calleeGPR, IgnoreVectors);
                         preserved.add(BaselineJITRegisters::Call::callLinkInfoGPR, IgnoreVectors);
                         preserved.add(BaselineJITRegisters::Call::callTargetGPR, IgnoreVectors);
                         jit.prepareForTailCallSlow(preserved);
-                    }));
+                    });
                     jit.abortWithReason(JITDidReturnFromTailCall);
                 } else {
                     CallLinkInfo::emitFastPath(jit, callLinkInfo);
@@ -14847,14 +14847,14 @@ IGNORE_CLANG_WARNINGS_END
                 bool isTailCall = CallLinkInfo::callModeFor(callType) == CallMode::Tail;
 
                 if (isTailCall) {
-                    CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, scopedLambda<void()>([&] {
+                    CallLinkInfo::emitTailCallFastPath(jit, callLinkInfo, [&] {
                         jit.emitRestoreCalleeSavesFor(state->jitCode->calleeSaveRegisters());
                         RegisterSet preserved;
                         preserved.add(BaselineJITRegisters::Call::calleeGPR, IgnoreVectors);
                         preserved.add(BaselineJITRegisters::Call::callLinkInfoGPR, IgnoreVectors);
                         preserved.add(BaselineJITRegisters::Call::callTargetGPR, IgnoreVectors);
                         jit.prepareForTailCallSlow(preserved);
-                    }));
+                    });
                     jit.abortWithReason(JITDidReturnFromTailCall);
                 } else {
                     CallLinkInfo::emitFastPath(jit, callLinkInfo);

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -155,12 +155,12 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
         };
 
         B3::Value* prevOrigin = nullptr;
-        auto forEachInst = scopedLambda<void(B3::Air::Inst&)>([&] (B3::Air::Inst& inst) {
+        auto forEachInst = [&] (B3::Air::Inst& inst) {
             if (inst.origin != prevOrigin) {
                 printB3Value(inst.origin);
                 prevOrigin = inst.origin;
             }
-        });
+        };
 
         disassembler->dump(proc->code(), out, linkBuffer, airPrefix, asmPrefix, forEachInst);
     });

--- a/Source/JavaScriptCore/ftl/FTLState.h
+++ b/Source/JavaScriptCore/ftl/FTLState.h
@@ -69,7 +69,7 @@ public:
 
     VM& vm() { return graph.m_vm; }
 
-    void dumpDisassembly(PrintStream&, LinkBuffer&, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback = scopedLambda<void(DFG::Node*)>([] (DFG::Node*) { }));
+    void dumpDisassembly(PrintStream&, LinkBuffer&, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback = [] (DFG::Node*) { });
 
     PropertyInlineCache* addPropertyInlineCache();
     OptimizingCallLinkInfo* addCallLinkInfo(CodeOrigin);

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2151,7 +2151,7 @@ NEVER_INLINE void Heap::collectInMutatorThread()
                     }
                 }
             };
-            callWithCurrentThreadState(scopedLambda<void(CurrentThreadState&)>(WTF::move(lambda)));
+            callWithCurrentThreadState(lambda);
             return;
         }
     }

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -132,12 +132,12 @@ inline void Heap::mutatorFence()
 
 template<typename Functor> inline void Heap::forEachCodeBlock(NOESCAPE const Functor& func)
 {
-    forEachCodeBlockImpl(scopedLambdaRef<void(CodeBlock*)>(func));
+    forEachCodeBlockImpl(func);
 }
 
 template<typename Functor> inline void Heap::forEachCodeBlockIgnoringJITPlans(const AbstractLocker& codeBlockSetLocker, NOESCAPE const Functor& func)
 {
-    forEachCodeBlockIgnoringJITPlansImpl(codeBlockSetLocker, scopedLambdaRef<void(CodeBlock*)>(func));
+    forEachCodeBlockIgnoringJITPlansImpl(codeBlockSetLocker, func);
 }
 
 template<typename Functor> inline void Heap::forEachProtectedCell(const Functor& functor)

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
@@ -86,12 +86,11 @@ void MarkingConstraintSolver::drain(BitVector& unexecuted)
     auto end = unexecuted.end();
     if (iter == end)
         return;
-    auto pickNext = scopedLambda<std::optional<unsigned>()>(
-        [&] () -> std::optional<unsigned> {
-            if (iter == end)
-                return std::nullopt;
-            return *iter++;
-        });
+    auto pickNext = [&] () -> std::optional<unsigned> {
+        if (iter == end)
+            return std::nullopt;
+        return *iter++;
+    };
     execute(NextConstraintFirst, pickNext);
     unexecuted.clearAll();
 }
@@ -123,17 +122,16 @@ void MarkingConstraintSolver::converge(const Vector<MarkingConstraint*>& order)
             return;
     }
     
-    auto pickNext = scopedLambda<std::optional<unsigned>()>(
-        [&] () -> std::optional<unsigned> {
-            if (didVisitSomething())
-                return std::nullopt;
-            
-            if (index >= order.size())
-                return std::nullopt;
-            
-            MarkingConstraint& constraint = *order[index++];
-            return constraint.index();
-        });
+    auto pickNext = [&] () -> std::optional<unsigned> {
+        if (didVisitSomething())
+            return std::nullopt;
+
+        if (index >= order.size())
+            return std::nullopt;
+
+        MarkingConstraint& constraint = *order[index++];
+        return constraint.index();
+    };
     
     execute(ParallelWorkFirst, pickNext);
 }

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -190,14 +190,14 @@ bool JIT::compileTailCall(const Op&, BaselineUnlinkedCallLinkInfo*, unsigned)
 template<>
 bool JIT::compileTailCall(const OpTailCall& bytecode, BaselineUnlinkedCallLinkInfo* callLinkInfo, unsigned callLinkInfoIndex)
 {
-    CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, scopedLambda<void()>([&] {
+    CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, [&] {
         CallFrameShuffleData shuffleData = CallFrameShuffleData::createForBaselineOrLLIntTailCall(bytecode, m_unlinkedCodeBlock->numParameters());
         CallFrameShuffler shuffler { *this, shuffleData };
         shuffler.setCalleeJSValueRegs(BaselineJITRegisters::Call::calleeJSR);
         shuffler.lockGPR(BaselineJITRegisters::Call::callLinkInfoGPR);
         shuffler.lockGPR(BaselineJITRegisters::Call::callTargetGPR);
         shuffler.prepareForTailCall();
-    }));
+    });
 
     auto doneLocation = label();
     m_callCompilationInfo[callLinkInfoIndex].doneLocation = doneLocation;
@@ -262,14 +262,14 @@ void JIT::compileOpCall(const JSInstruction* instruction)
         compileTailCall(bytecode, callLinkInfo, callLinkInfoIndex);
     else {
         if constexpr (Op::opcodeID == op_tail_call_varargs) {
-            CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, scopedLambda<void()>([&] {
+            CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, [&] {
                 emitRestoreCalleeSaves();
                 prepareForTailCallSlow(RegisterSet {
                     BaselineJITRegisters::Call::calleeJSR.payloadGPR(),
                     BaselineJITRegisters::Call::callLinkInfoGPR,
                     BaselineJITRegisters::Call::callTargetGPR,
                 });
-            }));
+            });
             auto doneLocation = label();
             m_callCompilationInfo[callLinkInfoIndex].doneLocation = doneLocation;
         } else {

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -1371,10 +1371,10 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JIT::generateOpGetFromScopeThunk(VM& vm)
             jit.load32(Address(metadataGPR, OpGetFromScope::Metadata::offsetOfStructureID()), scratch1GPR);
             slowCase.append(jit.branch32(NotEqual, Address(scopeGPR, JSCell::structureIDOffset()), scratch1GPR));
 
-            jit.jitAssert(scopedLambda<Jump(void)>([&] () -> Jump {
+            jit.jitAssert([&] () -> Jump {
                 loadGlobalObject(jit, scratch1GPR);
                 return jit.branchPtr(Equal, scopeGPR, scratch1GPR);
-            }));
+            });
 
             jit.loadPtr(Address(metadataGPR, Metadata::offsetOfOperand()), scratch1GPR);
 
@@ -1551,10 +1551,10 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
 
             emitGetVirtualRegister(value, valueJSR);
 
-            jitAssert(scopedLambda<Jump(void)>([&] () -> Jump {
+            jitAssert([&] () -> Jump {
                 loadGlobalObject(scratch1GPR2);
                 return branchPtr(Equal, scopeGPR, scratch1GPR2);
-            }));
+            });
 
             loadPtr(Address(scopeGPR, JSObject::butterflyOffset()), scratch1GPR2);
             loadPtr(operandAddress, scratch1GPR1);

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -3268,10 +3268,10 @@ MacroAssemblerCodeRef<JITThunkPtrTag> LOLJIT::generateOpGetFromScopeThunk(VM& vm
             jit.load32(Address(metadataGPR, OpGetFromScope::Metadata::offsetOfStructureID()), scratch1GPR);
             slowCase.append(jit.branch32(NotEqual, Address(scopeGPR, JSCell::structureIDOffset()), scratch1GPR));
 
-            jit.jitAssert(scopedLambda<Jump(void)>([&] () -> Jump {
+            jit.jitAssert([&] () -> Jump {
                 loadGlobalObject(jit, scratch1GPR);
                 return jit.branchPtr(Equal, scopeGPR, scratch1GPR);
-            }));
+            });
 
             jit.loadPtr(Address(metadataGPR, Metadata::offsetOfOperand()), scratch1GPR);
 
@@ -3439,10 +3439,10 @@ void LOLJIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             load32(structureIDAddress, s_scratch);
             addSlowCase(branch32(NotEqual, Address(scopeGPR, JSCell::structureIDOffset()), s_scratch));
 
-            jitAssert(scopedLambda<Jump(void)>([&] () -> Jump {
+            jitAssert([&] () -> Jump {
                 loadGlobalObject(s_scratch);
                 return branchPtr(Equal, scopeGPR, s_scratch);
-            }));
+            });
 
             loadPtr(Address(scopeGPR, JSObject::butterflyOffset()), s_scratch);
             loadPtr(operandAddress, metadataGPR);

--- a/Source/JavaScriptCore/runtime/InitializeThreading.h
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.h
@@ -39,7 +39,7 @@ JS_EXPORT_PRIVATE void initializeWithOptionsCustomization(const ScopedLambda<voi
 
 ALWAYS_INLINE void initialize(const Invocable<void()> auto& optionsCustomizationCallback)
 {
-    SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(scopedLambda<void()>(optionsCustomizationCallback));
+    SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(optionsCustomizationCallback);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -114,7 +114,7 @@ public:
 
     ALWAYS_INLINE static void initialize(const Invocable<void()> auto& optionsCustomizationCallback)
     {
-        SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(scopedLambda<void()>(optionsCustomizationCallback));
+        SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(optionsCustomizationCallback);
     }
 
     static void finalize();

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -93,14 +93,14 @@ VM* VMManager::findMatchingVMImpl(const ScopedLambda<VMManager::TestCallback>& t
         return s_recentVM;
 
     VM* result = nullptr;
-    iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+    iterateVMs([&] (VM& vm) {
         if (test(vm)) {
             result = &vm;
             s_recentVM = &vm;
             return IterationStatus::Done;
         }
         return IterationStatus::Continue;
-    }));
+    });
     return result;
 }
 
@@ -232,7 +232,7 @@ CONCURRENT_SAFE void VMManager::requestStopAllInternal(StopReason reason)
 
         // Have to use iterateVMs() instead of forEachVM() because we're already
         // holding the m_worldLock.
-        iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+        iterateVMs([&] (VM& vm) {
             vm.requestStop();
             WTF::storeLoadFence();
 
@@ -253,7 +253,7 @@ CONCURRENT_SAFE void VMManager::requestStopAllInternal(StopReason reason)
 #endif
             }
             return IterationStatus::Continue;
-        }));
+        });
     }
 }
 
@@ -312,11 +312,11 @@ void VMManager::resumeTheWorld() WTF_REQUIRES_LOCK(m_worldLock)
 
     // Have to use iterateVMs() instead of forEachVM() because we're already
     // holding the m_worldLock.
-    iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+    iterateVMs([&] (VM& vm) {
         vm.cancelStop();
         vm.traps().m_hasBeenCountedAsActive = false;
         return IterationStatus::Continue;
-    }));
+    });
 
     m_servingVM = nullptr;
     m_targetVM = nullptr;

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -293,17 +293,17 @@ public:
 
     static inline VM* findMatchingVM(const Invocable<TestCallback> auto& test)
     {
-        SUPPRESS_FORWARD_DECL_ARG return singleton().findMatchingVMImpl(scopedLambda<TestCallback>(test));
+        SUPPRESS_FORWARD_DECL_ARG return singleton().findMatchingVMImpl(test);
     }
 
     static inline void forEachVM(const Invocable<IteratorCallback> auto& functor)
     {
-        SUPPRESS_FORWARD_DECL_ARG singleton().forEachVMImpl(scopedLambda<IteratorCallback>(functor));
+        SUPPRESS_FORWARD_DECL_ARG singleton().forEachVMImpl(functor);
     }
 
     static inline Error forEachVMWithTimeout(Seconds timeout, const Invocable<IteratorCallback> auto& functor)
     {
-        SUPPRESS_FORWARD_DECL_ARG return singleton().forEachVMWithTimeoutImpl(timeout, scopedLambda<IteratorCallback>(functor));
+        SUPPRESS_FORWARD_DECL_ARG return singleton().forEachVMWithTimeoutImpl(timeout, functor);
     }
 
     JS_EXPORT_PRIVATE static void dumpVMs();

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -157,7 +157,7 @@ bool HeapVerifier::verifyCellList(Phase phase, CellList& list)
     auto& liveCells = list.cells();
 
     bool listNamePrinted = false;
-    auto printHeaderIfNeeded = scopedLambda<void()>([&] () {
+    auto printHeaderIfNeeded = [&] () {
         if (listNamePrinted)
             return;
         
@@ -165,7 +165,7 @@ bool HeapVerifier::verifyCellList(Phase phase, CellList& list)
         dataLog(" @ phase ", phaseName(phase), ": FAILED in cell list '", list.name(), "' (size ", liveCells.size(), ")\n");
         listNamePrinted = true;
         m_didPrintLogs = true;
-    });
+    };
     
     bool success = true;
     for (size_t i = 0; i < liveCells.size(); i++) {
@@ -186,7 +186,7 @@ bool HeapVerifier::verifyCellList(Phase phase, CellList& list)
 
 bool HeapVerifier::validateCell(HeapCell* cell, VM* expectedVM)
 {
-    auto printNothing = scopedLambda<void()>([] () { });
+    auto printNothing = [] () { };
 
     if (cell->isZapped()) {
         dataLog("    cell ", RawPointer(cell), " is ZAPPED\n");

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -267,10 +267,10 @@ inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentIn
         // these slots via positive-FP-offset ValueReps, so they must shift too.
         jit.move(MacroAssembler::stackPointerRegister, scratch1);
 
-        jit.jitAssert(scopedLambda<MacroAssembler::Jump()>([&] {
+        jit.jitAssert([&] {
             jit.addPtr(CCallHelpers::TrustedImm32(topSourceOffsetFromFP), GPRInfo::callFrameRegister, scratch2);
             return jit.branchPtr(CCallHelpers::AboveOrEqual, scratch2, MacroAssembler::stackPointerRegister);
-        }));
+        });
 
         JIT_COMMENT(jit, "Copy loop start");
         auto loop = jit.label();

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -88,7 +88,7 @@ void OMGPlan::dumpDisassembly(const Callee& callee, CompilationContext& context,
         const char* asmPrefix = "asm              ";
 
         B3::Value* prevOrigin = nullptr;
-        auto forEachInst = scopedLambda<void(B3::Air::Inst&)>([&] (B3::Air::Inst& inst) {
+        auto forEachInst = [&] (B3::Air::Inst& inst) {
             if (inst.origin && inst.origin != prevOrigin && context.procedure->code().shouldPreserveB3Origins()) {
                 if (String string = inst.origin->compilerConstructionSite(); !string.isNull())
                     out.println(string);
@@ -113,7 +113,7 @@ void OMGPlan::dumpDisassembly(const Callee& callee, CompilationContext& context,
 
                 prevOrigin = inst.origin;
             }
-        });
+        };
 
         disassembler->dump(context.procedure->code(), out, linkBuffer, airPrefix, asmPrefix, forEachInst);
         linkBuffer.didAlreadyDisassemble();

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -76,7 +76,7 @@ void OSREntryPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& link
         const char* asmPrefix = "asm              ";
 
         B3::Value* prevOrigin = nullptr;
-        auto forEachInst = scopedLambda<void(B3::Air::Inst&)>([&] (B3::Air::Inst& inst) {
+        auto forEachInst = [&] (B3::Air::Inst& inst) {
             if (inst.origin && inst.origin != prevOrigin && context.procedure->code().shouldPreserveB3Origins()) {
                 if (String string = inst.origin->compilerConstructionSite(); !string.isNull())
                     dataLogLn(string);
@@ -85,7 +85,7 @@ void OSREntryPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& link
                 dataLogLn();
                 prevOrigin = inst.origin;
             }
-        });
+        };
 
         disassembler->dump(context.procedure->code(), WTF::dataFile(), linkBuffer, airPrefix, asmPrefix, forEachInst);
         linkBuffer.didAlreadyDisassemble();

--- a/Source/WTF/wtf/ParkingLot.h
+++ b/Source/WTF/wtf/ParkingLot.h
@@ -81,8 +81,8 @@ public:
     {
         return parkConditionallyImpl(
             address,
-            scopedLambdaRef<bool()>(validation),
-            scopedLambdaRef<void()>(beforeSleep),
+            validation,
+            beforeSleep,
             timeout);
     }
 
@@ -135,7 +135,7 @@ public:
     template<typename Callback>
     static void unparkOne(const void* address, const Callback& callback)
     {
-        unparkOneImpl(address, scopedLambdaRef<intptr_t(UnparkResult)>(callback));
+        unparkOneImpl(address, callback);
     }
     
     WTF_EXPORT_PRIVATE static unsigned unparkCount(const void* address, unsigned count);
@@ -163,7 +163,7 @@ public:
     {
         // FIXME: Static analysis is complaining about `const ScopedLambda<void (uintptr_t, const void *)> &`
         // being forward-declared but ScopedLambda.h is included at the top of this file.
-        SUPPRESS_FORWARD_DECL_ARG forEachImpl(scopedLambdaRef<void(uintptr_t, const void*)>(func));
+        SUPPRESS_FORWARD_DECL_ARG forEachImpl(func);
     }
 
 private:

--- a/Source/WTF/wtf/ScopedLambda.h
+++ b/Source/WTF/wtf/ScopedLambda.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <concepts>
+#include <type_traits>
+#include <wtf/Compiler.h>
 #include <wtf/ForbidHeapAllocation.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WTF {
 
@@ -34,21 +38,43 @@ namespace WTF {
 //
 // void foo(const ScopedLambda<MyThings* (int, Stuff&)>&);
 //
-// The caller just does:
+// The caller just passes a lambda, which implicitly converts:
 //
-// void foo(scopedLambda<MyThings* (int, Stuff&)>([&] (int x, Stuff& y) -> MyThings* { blah }));
+// foo([&] (int x, Stuff& y) -> MyThings* { blah });
 //
-// Note that this relies on foo() not escaping the lambda. The lambda is only valid while foo() is
-// on the stack - hence the name ScopedLambda.
+// Note that this relies on foo() not escaping the lambda. A ScopedLambda points to its functor
+// rather than owning it, so in the call above the lambda is only valid until the end of the full
+// expression (hence the name ScopedLambda). To hold a ScopedLambda in a variable, keep the lambda in
+// a variable as well so that it outlives the ScopedLambda pointing at it:
+//
+// auto myLambda = [&] (int x, Stuff& y) -> MyThings* { blah };
+// ScopedLambda<MyThings* (int, Stuff&)> myScopedLambda = myLambda;
 
 template<typename FunctionType> class ScopedLambda;
 template<typename ResultType, typename... ArgumentTypes>
-class ScopedLambda<ResultType (ArgumentTypes...)> {
+class ScopedLambda<ResultType(ArgumentTypes...)> final {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
     ScopedLambda(ResultType (*impl)(void* arg, ArgumentTypes...) = nullptr, void* arg = nullptr)
         : m_impl(impl)
         , m_arg(arg)
+    {
+    }
+
+
+    template<typename Functor>
+    requires (!std::same_as<std::remove_cvref_t<Functor>, std::nullptr_t>
+        && Invocable<Functor, ResultType(ArgumentTypes...)>)
+    ScopedLambda(Functor&& functor LIFETIME_BOUND)
+        : m_impl([] (void* argument, ArgumentTypes... arguments) -> ResultType {
+            auto& boundFunctor = *static_cast<std::remove_reference_t<Functor>*>(argument);
+            // A functor may return a value that the signature discards, which Invocable permits.
+            if constexpr (std::is_void_v<ResultType>)
+                boundFunctor(arguments...);
+            else
+                return boundFunctor(arguments...);
+        })
+        , m_arg(const_cast<void*>(static_cast<const void*>(std::addressof(functor))))
     {
     }
 
@@ -63,134 +89,6 @@ private:
     void *m_arg;
 };
 
-template<typename FunctionType, typename Functor> class ScopedLambdaFunctor;
-template<typename ResultType, typename... ArgumentTypes, typename Functor>
-class ScopedLambdaFunctor<ResultType (ArgumentTypes...), Functor> : public ScopedLambda<ResultType (ArgumentTypes...)> {
-public:
-    template<typename PassedFunctor>
-    ScopedLambdaFunctor(PassedFunctor&& functor)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(std::forward<PassedFunctor>(functor))
-    {
-    }
-    
-    // We need to make sure that copying and moving ScopedLambdaFunctor results in a ScopedLambdaFunctor
-    // whose ScopedLambda supertype still points to this rather than other.
-    ScopedLambdaFunctor(const ScopedLambdaFunctor& other)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(other.m_functor)
-    {
-    }
-
-    ScopedLambdaFunctor(ScopedLambdaFunctor&& other)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(WTF::move(other.m_functor))
-    {
-    }
-    
-    ScopedLambdaFunctor& operator=(const ScopedLambdaFunctor& other)
-    {
-        m_functor = other.m_functor;
-        return *this;
-    }
-    
-    ScopedLambdaFunctor& operator=(ScopedLambdaFunctor&& other)
-    {
-        m_functor = WTF::move(other.m_functor);
-        return *this;
-    }
-
-private:
-    static ResultType implFunction(void* argument, ArgumentTypes... arguments)
-    {
-        return static_cast<ScopedLambdaFunctor*>(argument)->m_functor(arguments...);
-    }
-
-    Functor m_functor;
-};
-
-// Can't simply rely on perfect forwarding because then the ScopedLambdaFunctor would point to the functor
-// by const reference. This would be surprising in situations like:
-//
-// auto scopedLambda = scopedLambda<Foo(Bar)>([&] (Bar) -> Foo { ... });
-//
-// We expected scopedLambda to be valid for its entire lifetime, but if it computed the lambda by reference
-// then it would be immediately invalid.
-template<typename FunctionType, typename Functor>
-ScopedLambdaFunctor<FunctionType, Functor> scopedLambda(const Functor& functor)
-{
-    return ScopedLambdaFunctor<FunctionType, Functor>(functor);
-}
-
-template<typename FunctionType, typename Functor>
-ScopedLambdaFunctor<FunctionType, Functor> scopedLambda(Functor&& functor)
-{
-    return ScopedLambdaFunctor<FunctionType, Functor>(std::forward<Functor>(functor));
-}
-
-template<typename FunctionType, typename Functor> class ScopedLambdaRefFunctor;
-template<typename ResultType, typename... ArgumentTypes, typename Functor>
-class ScopedLambdaRefFunctor<ResultType (ArgumentTypes...), Functor> : public ScopedLambda<ResultType (ArgumentTypes...)> {
-public:
-    ScopedLambdaRefFunctor(const Functor& functor)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(&functor)
-    {
-    }
-    
-    // We need to make sure that copying and moving ScopedLambdaRefFunctor results in a
-    // ScopedLambdaRefFunctor whose ScopedLambda supertype still points to this rather than
-    // other.
-    ScopedLambdaRefFunctor(const ScopedLambdaRefFunctor& other)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(other.m_functor)
-    {
-    }
-
-    ScopedLambdaRefFunctor(ScopedLambdaRefFunctor&& other)
-        : ScopedLambda<ResultType (ArgumentTypes...)>(implFunction, this)
-        , m_functor(other.m_functor)
-    {
-    }
-    
-    ScopedLambdaRefFunctor& operator=(const ScopedLambdaRefFunctor& other)
-    {
-        m_functor = other.m_functor;
-        return *this;
-    }
-    
-    ScopedLambdaRefFunctor& operator=(ScopedLambdaRefFunctor&& other)
-    {
-        m_functor = other.m_functor;
-        return *this;
-    }
-
-private:
-    static ResultType implFunction(void* argument, ArgumentTypes... arguments)
-    {
-        return (*static_cast<ScopedLambdaRefFunctor*>(argument)->m_functor)(arguments...);
-    }
-
-    const Functor* m_functor;
-};
-
-// This is for when you already refer to a functor by reference, and you know its lifetime is
-// good. This just creates a ScopedLambda that points to your functor.
-//
-// Note that this is always wrong:
-//
-// auto ref = scopedLambdaRef([...] (...) {...});
-//
-// Because the scopedLambdaRef will refer to the lambda by reference, and the lambda will die after the
-// semicolon. Use scopedLambda() in that case.
-template<typename FunctionType, typename Functor>
-ScopedLambdaRefFunctor<FunctionType, Functor> scopedLambdaRef(const Functor& functor)
-{
-    return ScopedLambdaRefFunctor<FunctionType, Functor>(functor);
-}
-
 } // namespace WTF
 
 using WTF::ScopedLambda;
-using WTF::scopedLambda;
-using WTF::scopedLambdaRef;

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1683,6 +1683,7 @@ using WTF::weakOrderingCast;
 using WTF::zeroBytes;
 using WTF::secureZeroBytes;
 using WTF::zeroSpan;
+using WTF::ConstInvocable;
 using WTF::DerivedFromOrConvertibleTo;
 using WTF::IntegralOrEnum;
 using WTF::Invocable;

--- a/Source/WTF/wtf/ThreadMessage.h
+++ b/Source/WTF/wtf/ThreadMessage.h
@@ -48,8 +48,7 @@ WTF_EXPORT_PRIVATE MessageStatus sendMessageScoped(const ThreadSuspendLocker&, T
 template<typename Functor>
 MessageStatus sendMessage(const ThreadSuspendLocker& locker, Thread& targetThread, const Functor& func)
 {
-    auto lambda = scopedLambdaRef<void(PlatformRegisters&)>(func);
-    return sendMessageScoped(locker, targetThread, lambda);
+    return sendMessageScoped(locker, targetThread, func);
 }
 
 } // namespace WTF

--- a/Source/WebCore/bindings/js/JSDOMConvertSequences.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertSequences.h
@@ -87,11 +87,11 @@ struct GenericSequenceConverter {
     {
         auto& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        WebCore::forEachInIterable(&lexicalGlobalObject, object, scopedLambda<void(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue)>([&sequence](JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue nextValue) {
+        WebCore::forEachInIterable(&lexicalGlobalObject, object, [&sequence](JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue nextValue) {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             InnerConverter::convert(scope, *lexicalGlobalObject, nextValue, sequence);
-        }));
+        });
         RETURN_IF_EXCEPTION(scope, Result::exception());
 
         return Result { WTF::move(sequence) };
@@ -106,11 +106,11 @@ struct GenericSequenceConverter {
     {
         auto& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        WebCore::forEachInIterable(lexicalGlobalObject, object, method, scopedLambda<void(JSC::VM&, JSC::JSGlobalObject&, JSC::JSValue)>([&sequence](JSC::VM& vm, JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue nextValue) {
+        WebCore::forEachInIterable(lexicalGlobalObject, object, method, [&sequence](JSC::VM& vm, JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue nextValue) {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             InnerConverter::convert(scope, lexicalGlobalObject, nextValue, sequence);
-        }));
+        });
         RETURN_IF_EXCEPTION(scope, Result::exception());
 
         return Result { WTF::move(sequence) };

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -524,10 +524,10 @@ template<typename Source> static Vector<uint8_t> encodeToVector(Source&& source,
 {
     Vector<uint8_t> result;
 
-    bool success = encode(std::forward<Source>(source), mimeType, quality, scopedLambdaRef<PutBytesCallback>([&] (std::span<const uint8_t> data) {
+    bool success = encode(std::forward<Source>(source), mimeType, quality, [&] (std::span<const uint8_t> data) {
         result.append(data);
         return data.size();
-    }));
+    });
     if (!success)
         return { };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/ScopedLambda.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ScopedLambda.cpp
@@ -25,24 +25,46 @@
 
 #include "config.h"
 #include <wtf/ScopedLambda.h>
-#include <wtf/Vector.h>
 
 namespace TestWebKitAPI {
 
-// This test relies on this module being compiled with -fno-elide-constructors
-TEST(WTF_ScopedLambda, NoRVOLivenessBug)
+static int sumOverRange(unsigned count, const ScopedLambda<int(unsigned)>& mapper)
 {
-    Vector<int> vector;
-    for (unsigned i = 0; i < 10; ++i)
-        vector.append(i);
-    
-    auto lambda = scopedLambda<int(size_t)>(
-        [=] (size_t i) -> int {
-            return vector[i];
-        });
-    
-    for (unsigned i = 0; i < 10; ++i)
-        EXPECT_EQ(i, static_cast<unsigned>(lambda(i)));
+    int result = 0;
+    for (unsigned i = 0; i < count; ++i)
+        result += mapper(i);
+    return result;
+}
+
+TEST(WTF_ScopedLambda, ImplicitConversionFromTemporary)
+{
+    int scale = 3;
+    EXPECT_EQ(30, sumOverRange(5, [&] (unsigned i) -> int {
+        return i * scale;
+    }));
+}
+
+TEST(WTF_ScopedLambda, ImplicitConversionFromLValue)
+{
+    int scale = 3;
+    auto mapper = [&] (unsigned i) -> int {
+        return i * scale;
+    };
+    EXPECT_EQ(30, sumOverRange(5, mapper));
+
+    ScopedLambda<int(unsigned)> scopedMapper = mapper;
+    EXPECT_EQ(30, sumOverRange(5, scopedMapper));
+}
+
+TEST(WTF_ScopedLambda, ImplicitConversionCallsSameFunctorInstance)
+{
+    unsigned callCount = 0;
+    auto mapper = [&] (unsigned i) -> int {
+        ++callCount;
+        return i;
+    };
+    EXPECT_EQ(10, sumOverRange(5, mapper));
+    EXPECT_EQ(5u, callCount);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f057e7bc12bee1ce5870e2a290f3658bf186d477
<pre>
Clean up ScopedLambda API for modern C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=322406">https://bugs.webkit.org/show_bug.cgi?id=322406</a>
<a href="https://rdar.apple.com/185695582">rdar://185695582</a>

Reviewed by Yusuke Suzuki.

ScopedLambda required every caller to name the function signature at the
call site by wrapping the lambda in a scopedLambda&lt;Sig&gt;() call. This is
because ScopedLambda could only be constructed from a raw
(void*, Args...) thunk. Give ScopedLambda a converting constructor from
any invocable, so a callee declared as taking a const ScopedLambda&lt;Sig&gt;&amp;
can simply be passed a lambda. The parameter is marked LIFETIME_BOUND so
that clang diagnoses the cases where that does not hold: binding a
temporary lambda to a named ScopedLambda, returning one, or initializing
a member from one are all caught by -Wdangling, -Wreturn-stack-address,
and -Wdangling-field respectively.

Convert every caller to pass its lambda directly, which additionally
drops a needless copy of the functor at the sites that were wrapping an
already-live reference. This left scopedLambda(), ScopedLambdaFunctor,
scopedLambdaRef() and ScopedLambdaRefFunctor with no users, so I removed
them. The new constructor does what scopedLambdaRef() did and also
accepts functors whose call operator is not const, which
scopedLambdaRef() could not. The last user of the owning form was
LazyFireDetail, which stored a non-const ScopedLambda&amp; and so forced its
callers to keep one in a variable. I made it a template constrained on
ConstInvocable&lt;void(PrintStream&amp;)&gt; that owns its functor instead, which
is both simpler at its two call sites and removes the borrowed reference
altogether. opcode_generator.rb now emits forEachArgCustom(functor)
directly. Export ConstInvocable from StdLibExtras.h alongside Invocable
so it can be named unqualified, and drop the WTF:: qualification in
DFGForAllKills.h accordingly.

Test: Tools/TestWebKitAPI/Tests/WTF/ScopedLambda.cpp
Canonical link: <a href="https://commits.webkit.org/319727@main">https://commits.webkit.org/319727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/634ff42c9764c5e621f7fa888e38c827ba2958ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56510 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50316 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192798 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146876 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fbf025e-da04-48bb-b591-012d1448d76d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d178206b-0d0a-42ff-a0c9-dd5b988db43b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163258 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/122959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/124e3176-06f8-4386-94aa-78cdaf11f05a) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44897 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43151 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/4926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11728 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42785 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3957 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43847 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49141 "Build was cancelled. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Failed to build and analyze WebKit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194720 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56181 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151942 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56872 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151642 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46221 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129152 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125171 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17793 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54765 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55003 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54831 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
<!--EWS-Status-Bubble-End-->