### PR TITLE
[Text Extraction] iOS: Automatically Fix Passwords may time out when filling old/new/confirm new passwords when device is locked

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -71,7 +71,7 @@ constexpr Seconds defaultInteractionPresentationUpdateTimeout = 100_ms;
 
 #if PLATFORM(IOS_FAMILY)
 namespace ForcedDisplayRefreshProperties {
-constexpr Seconds refreshInterval = 250_ms;
+constexpr Seconds refreshInterval = 100_ms;
 constexpr Seconds maximumDuration = 2_min;
 constexpr Seconds interactionPresentationUpdateTimeout = 1_s;
 static_assert(interactionPresentationUpdateTimeout > refreshInterval);


### PR DESCRIPTION
#### 81c701e40c59564d8041f722cccfcddc75d3215b
<pre>
[Text Extraction] iOS: Automatically Fix Passwords may time out when filling old/new/confirm new passwords when device is locked
<a href="https://bugs.webkit.org/show_bug.cgi?id=322408">https://bugs.webkit.org/show_bug.cgi?id=322408</a>
<a href="https://rdar.apple.com/185697376">rdar://185697376</a>

Reviewed by Abrar Rahman Protyasha.

Slightly increase the throttled &quot;framerate&quot; when driving display refreshes manually, when
`backgroundTextExtractionEnabled` is set.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:

Canonical link: <a href="https://commits.webkit.org/319708@main">https://commits.webkit.org/319708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38de62a23e4cabd2daa3e5c100e0a613bf9c41d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5aea3251-a9e1-4899-9412-aab28835af55) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5e6d143-2796-4560-a379-d2e68cbe2203) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46175 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122896 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7336deb-589d-4525-b246-6a05e973ab60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44859 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42755 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49095 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56135 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40682 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56826 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151597 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46178 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125125 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55337 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17754 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54719 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->