### PR TITLE
Use CheckedPtr for Node::m_previousSibling

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -826,7 +826,7 @@ private:
     CheckedPtr<ContainerNode> m_parentNode;
     TreeScope* m_treeScope { nullptr };
     Node* m_shadowIncludingRoot { nullptr };
-    Node* m_previousSibling { nullptr };
+    CheckedPtr<Node> m_previousSibling;
     CheckedPtr<Node> m_next;
     RenderObject* m_renderer { nullptr };
     CompactUniquePtrTuple<NodeRareData, uint16_t> m_rareDataWithBitfields;


### PR DESCRIPTION
#### b98b1c50745f921ffbe586a7945a66ce4b59a3b8
<pre>
Use CheckedPtr for Node::m_previousSibling
<a href="https://bugs.webkit.org/show_bug.cgi?id=322416">https://bugs.webkit.org/show_bug.cgi?id=322416</a>

Reviewed by Anne van Kesteren.

Replaced a raw pointer with CheckedPtr.

No new tests since there should be no behavioral changes.

* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/319774@main">https://commits.webkit.org/319774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d1fd64c454c0a33cf85999bccbe961be78a5325

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56478 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50284 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192765 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146860 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d44168c-ea18-4072-8a31-02be94b82135) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32fbcf40-3f7f-4bd0-bc32-3f0e4780e5a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46193 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163245 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122912 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9032f69d-a7c6-476d-9ef8-be6830ca7ed9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44877 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43140 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests (cancelled)") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155278 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42770 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3925 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49109 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47396 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56149 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151915 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56840 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151613 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46192 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129124 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55351 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17769 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->