### PR TITLE
REGRESSION(319551@main): Broke iOS 26.6

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -152,8 +152,8 @@ struct WebPageTests {
             // the same identity as the page itself.
             let qualifiedServerTrustKey = try #require(SecTrustCopyKey(qualifiedServerTrust))
             let serverKey = try #require(SecTrustCopyKey(serverTrust))
-            let qualifiedServerTrustKeyData = unsafe try #require(SecKeyCopyExternalRepresentation(qualifiedServerTrustKey, nil))
-            let serverKeyData = unsafe try #require(SecKeyCopyExternalRepresentation(serverKey, nil))
+            let qualifiedServerTrustKeyData = try #require(unsafe SecKeyCopyExternalRepresentation(qualifiedServerTrustKey, nil))
+            let serverKeyData = try #require(unsafe SecKeyCopyExternalRepresentation(serverKey, nil))
             #expect(CFEqual(qualifiedServerTrustKeyData, serverKeyData))
 
             // Committing a response without a tls-certificate-binding link clears the 2-QWAC.


### PR DESCRIPTION
#### 4f728bd6f38ac96a0ddc62d334aba9623faa74a2
<pre>
REGRESSION(319551@main): Broke iOS 26.6
<a href="https://bugs.webkit.org/show_bug.cgi?id=322417">https://bugs.webkit.org/show_bug.cgi?id=322417</a>
<a href="https://rdar.apple.com/185662712">rdar://185662712</a>

Unreviewed build fix.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.qualifiedServerTrust):

Canonical link: <a href="https://commits.webkit.org/319715@main">https://commits.webkit.org/319715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee01b5ef601f0896e06aeba2be60434729eb8484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182541 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56488 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50294 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb4726e8-298d-4093-a17e-4063ade45157) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6fdab6c-d055-4720-8b9e-5e0305374b12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a54767b-f48f-459b-a451-3540f8b799dc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3935 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194698 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40690 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56850 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/46201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55361 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->