### PR TITLE
Cherry-pick 305413.1005@safari-7624.5.1.10-branch (a26cf8dc190a). https://bugs.webkit.org/show_bug.cgi?id=317320

### DIFF
--- a/JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js
+++ b/JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js
@@ -1,0 +1,33 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.1")
+var proto = {};
+
+function g1() { return 1; }
+function g2() { return 2; }
+function g3() { return 3; }
+
+proto.__defineGetter__("p", g1);
+
+var o = Object.create(proto);
+
+function getP(obj) {
+    return obj.p;
+}
+noInline(getP);
+
+for (var i = 0; i < 80; ++i)
+    getP(o);
+
+proto.__defineGetter__("p", g2);
+getP(o);
+proto.__defineGetter__("p", g3);
+getP(o);
+
+var evil = new Proxy(function() {}, {
+    apply: function(target, thisArg, args) {
+        delete proto.p;
+        return 0x42;
+    }
+});
+proto.__defineGetter__("p", evil);
+
+getP(o);

--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The victim's JS wrapper is created in the parent realm so it never roots the iframe's window.
+let victim = document.createElement('div');
+window.__victim = victim;
+
+let f = document.createElement('iframe');
+f.srcdoc =
+    '<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for \'script\'">' +
+    '<body>' +
+    '<' + 'script>document.body.appendChild(parent.__victim); parent.__factory = trustedTypes;</' + 'script>';
+f.onload = () => setTimeout(() => setTimeout(go, 0), 0);
+document.body.appendChild(f);
+
+function callback() {
+    document.adoptNode(victim);
+    f.remove();
+    f = null;
+    if (window.GCController)
+        GCController.collect();
+    return null;
+}
+
+function go() {
+    // Register the iframe's default policy via the parent-realm createPolicy binding so the
+    // callback's stored JSDOMGlobalObject is the parent's window.
+    TrustedTypePolicyFactory.prototype.createPolicy.call(window.__factory, 'default', { createScript: callback });
+    window.__factory = null;
+    window.__victim = null;
+    if (window.GCController)
+        GCController.collect();
+    // Triggers the TrustedScript default-policy callback while the only protection for the
+    // iframe's Document is the raw ScriptExecutionContext& held by trustedTypeCompliantString.
+    try { victim.setAttribute('onclick', 'x'); } catch (e) { }
+    document.body.textContent = 'PASS if no crash';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>

--- a/Source/JavaScriptCore/b3/B3PureCSE.cpp
+++ b/Source/JavaScriptCore/b3/B3PureCSE.cpp
@@ -44,6 +44,19 @@ void PureCSE::clear()
     m_map.clear();
 }
 
+void PureCSE::remove(const ValueKey& key, Value* value)
+{
+    if (!key)
+        return;
+
+    auto iter = m_map.find(key);
+    if (iter == m_map.end())
+        return;
+
+    Matches& matches = iter->value;
+    matches.removeAll(value);
+}
+
 Value* PureCSE::findMatch(const ValueKey& key, BasicBlock* block, Dominators& dominators)
 {
     if (!key)

--- a/Source/JavaScriptCore/b3/B3PureCSE.h
+++ b/Source/JavaScriptCore/b3/B3PureCSE.h
@@ -48,6 +48,8 @@ public:
 
     void clear();
 
+    void remove(const ValueKey&, Value*);
+
     Value* findMatch(const ValueKey&, BasicBlock*, Dominators&);
 
     bool process(Value*, Dominators&);

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3568,14 +3568,17 @@ private:
         // Now handle all values between the source and the check.
         for (unsigned i = startIndex + 1; i < predecessor->size(); ++i) {
             Value* value = predecessor->at(i);
+            ValueKey key = value->key(); // Compute before cloneValue mutates the Value
             value->owner = nullptr;
 
             cloneValue(value);
 
             if (value->type() != Void)
                 m_insertionSet.insertValue(m_index, value);
-            else
+            else {
+                m_pureCSE.remove(key, value);
                 m_proc.deleteValue(value);
+            }
         }
 
         // Finally, deal with the check.

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -665,6 +665,7 @@ void testSelectInvert();
 void testCheckSelect();
 void testCheckSelectCheckSelect();
 void testCheckSelectAndCSE();
+void testCheckSelectAndDeadCheckCSE();
 void testPowDoubleByIntegerLoop(double xOperand, int32_t yOperand);
 double b3Pow(double x, int y);
 void testTruncOrHigh();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -712,6 +712,7 @@ void run(const TestConfig* config)
     RUN(testCheckSelect());
     RUN(testCheckSelectCheckSelect());
     RUN(testCheckSelectAndCSE());
+    RUN(testCheckSelectAndDeadCheckCSE());
     RUN_BINARY(testPowDoubleByIntegerLoop, floatingPointOperands<double>(), int64Operands());
 
     RUN(testTruncOrHigh());

--- a/Source/JavaScriptCore/b3/testb3_6.cpp
+++ b/Source/JavaScriptCore/b3/testb3_6.cpp
@@ -861,6 +861,81 @@ void testCheckSelectAndCSE()
     CHECK_EQ(invoke<int>(*code, false), 666);
 }
 
+void testCheckSelectAndDeadCheckCSE()
+{
+    // Exercises B3 strength reduction's "select specialization" (specializeSelect) together with pure CSE.
+    //
+    // When a Check is reached (within selectSpecializationBound) from a Select that has a constant arm,
+    // reduceStrength specializes the Select: it splits the block at the Check, clones the values between
+    // the Select and the Check into a then/else pair of blocks -- substituting the Select's then/else
+    // value in each -- and replaces the originals with Phis at the merge. Void values in that range (such
+    // as an intermediate Check) are removed from the original block and re-emitted in both arms.
+    //
+    // The IR (single block):
+    //
+    //   @cond = arg1
+    //   @sel  = Select(arg0, -42, 35)   ; Select with a constant arm
+    //           Check(@cond)            ; intermediate Check
+    //   @add  = Add(@sel, 42)
+    //           Check(@add)             ; triggering Check (reaches @sel within the bound)
+    //           Check(@cond)            ; later Check on the same condition (CSE)
+    //           Return(@add)
+    //
+    Procedure proc;
+    if (proc.optLevel() < 1)
+        return;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t>(proc, root);
+
+    // Condition shared by the intermediate and later Checks, so the later Check is a CSE candidate. A
+    // plain argument: each Check is kept (the condition isn't a known constant) and doesn't lead back to
+    // the Select.
+    Value* condition = arguments[1];
+
+    auto appendCheck = [&] (Value* predicate, int32_t exitValue) {
+        CheckValue* check = root->appendNew<CheckValue>(proc, Check, Origin(), predicate);
+        check->setGenerator(
+            [exitValue] (CCallHelpers& jit, const StackmapGenerationParams&) {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+                jit.move(CCallHelpers::TrustedImm32(exitValue), GPRInfo::returnValueGPR);
+                jit.emitFunctionEpilogue();
+                jit.ret();
+            });
+    };
+
+    // Defined before the Select so the Select -> triggering-Check run stays within
+    // selectSpecializationBound (== 3): Select, intermediate Check, Add, triggering Check.
+    auto* constant = root->appendNew<ConstPtrValue>(proc, Origin(), 42);
+
+    // (1) The Select to specialize: at least one data arm is constant.
+    auto* selectValue = root->appendNew<Value>(
+        proc, Select, Origin(),
+        arguments[0],
+        root->appendNew<ConstPtrValue>(proc, Origin(), -42),
+        root->appendNew<ConstPtrValue>(proc, Origin(), 35));
+
+    // (2) An intermediate Check between the Select and the triggering Check. Specialization moves it out
+    //     of this block and clones it into both arms.
+    appendCheck(condition, 1);
+
+    // (3) Add consuming the Select, feeding (4); keeps the Select within bound 3 of the triggering Check.
+    auto* addValue = root->appendNew<Value>(proc, Add, Origin(), selectValue, constant);
+
+    // (4) The Check that triggers specialization: it reaches the Select within selectSpecializationBound.
+    appendCheck(addValue, 2);
+
+    // (5) A later Check on the SAME condition as (2), so pure CSE relates the two across the specialized
+    //     region.
+    appendCheck(condition, 3);
+
+    root->appendNewControlValue(proc, Return, Origin(), addValue);
+
+    // After specialization the merged value is unchanged: select(true, -42, 35) + 42 == 0, with no Check
+    // firing for these inputs.
+    auto code = compileProc(proc);
+    CHECK_EQ(invoke<intptr_t>(*code, 1, 0), 0);
+}
+
 double b3Pow(double x, int y)
 {
     if (y < 0 || y > 1000)

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -233,7 +233,8 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) [[unlikely]] {
-        if (jsDynamicCast<InternalFunction*>(calleeAsValue)) {
+        if (auto* internalFunction = jsDynamicCast<InternalFunction*>(calleeAsValue)) {
+            calleeAsFunctionCell = internalFunction;
             CodePtr<JSEntryPtrTag> codePtr = vm.getCTIInternalFunctionTrampolineFor(kind);
             ASSERT(!!codePtr);
             return codePtr.taggedPtr();

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2486,7 +2486,9 @@ JSC_DEFINE_JIT_OPERATION(operationPolymorphicCall, UCPURegister, (CallFrame* cal
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCell);
     if (scope.exception()) [[unlikely]]
         OPERATION_RETURN(scope, std::bit_cast<UCPURegister>(vm.getCTIStub(CommonJITThunkID::ThrowExceptionFromCall).template retagged<JSEntryPtrTag>().code().taggedPtr()));
-    linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
+    // A null cell means virtualForWithFunction did a host call that ran JS and may have freed *callLinkInfo; don't link.
+    if (calleeAsFunctionCell) [[likely]]
+        linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
     // Keep owner alive explicitly. Now this function can be called from tail-call. This means that CallFrame for that owner already goes away, so we should keep it alive if we would like to use it.
     ensureStillAliveHere(owner);
     if (scope.exception()) [[unlikely]]

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -654,7 +654,9 @@ extern "C" UGPRPair SYSV_ABI llint_polymorphic_call(CallFrame* calleeFrame, Call
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCell);
     if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
-    linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
+    // A null cell means virtualForWithFunction did a host call that ran JS and may have freed *callLinkInfo; don't link.
+    if (calleeAsFunctionCell) [[likely]]
+        linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
     ensureStillAliveHere(owner);
     if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -114,7 +114,7 @@ ExceptionOr<void> Attr::setValue(const AtomString& value)
             auto type = trustedTypeForAttribute(element->nodeName(), qualifiedName().localName(),
                 element->namespaceURI(), qualifiedName().namespaceURI());
             if (!type.attributeType.isNull()) {
-                auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value,
+                auto compliantValue = trustedTypesCompliantAttributeValue(protect(document().contextDocument()), type.attributeType, value,
                     type.sink);
                 if (compliantValue.hasException())
                     return compliantValue.releaseException();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2160,7 +2160,7 @@ ExceptionOr<void> Element::setAttribute(const AtomString& qualifiedName, const T
         AttributeTypeAndSink type;
         if (document().contextDocument().requiresTrustedTypes())
             type = trustedTypeForAttribute(nodeName(), name.localName().convertToASCIILowercase(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(protect(document().contextDocument()), type.attributeType, value, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3798,7 +3798,7 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
     if (document().contextDocument().requiresTrustedTypes()) {
         auto& name = attrNode.qualifiedName();
         auto type = trustedTypeForAttribute(nodeName(), name.localName().convertToASCIILowercase(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, attrNodeValue, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(protect(document().contextDocument()), type.attributeType, attrNodeValue, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3855,7 +3855,7 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNodeNS(Attr& attrNode)
     if (document().contextDocument().requiresTrustedTypes()) {
         auto& name = attrNode.qualifiedName();
         auto type = trustedTypeForAttribute(nodeName(), name.localName(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, attrNodeValue, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(protect(document().contextDocument()), type.attributeType, attrNodeValue, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3949,7 +3949,7 @@ ExceptionOr<void> Element::setAttributeNS(const AtomString& namespaceURI, const 
         AttributeTypeAndSink type;
         if (document().contextDocument().requiresTrustedTypes())
             type = trustedTypeForAttribute(nodeName(), parsedAttributeName.localName(), this->namespaceURI(), parsedAttributeName.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(protect(document().contextDocument()), type.attributeType, value, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();


### PR DESCRIPTION
#### d532453033db6ecd94418d3c5309fb31cd0dbb69
<pre>
Cherry-pick 305413.1005@safari-7624.5.1.10-branch (a26cf8dc190a). <a href="https://bugs.webkit.org/show_bug.cgi?id=317320">https://bugs.webkit.org/show_bug.cgi?id=317320</a>

    Use-after-free of ScriptExecutionContext in trustedTypeCompliantString
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317320">https://bugs.webkit.org/show_bug.cgi?id=317320</a>
    <a href="https://rdar.apple.com/177766868">rdar://177766868</a>

    Reviewed by Chris Dumez.

    The method processValueWithDefaultPolicy can end up deleting the ScriptExecutionContext passed as parameter.
    This patch fixes this by adding protection of ScriptExecutionContext.

    Test: fast/html/trusted-types-set-attribute-iframe-removal-crash.html

    * LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html: Added.
    * LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt: Added.
    * Source/WebCore/dom/Attr.cpp:
    (WebCore::Attr::setValue):
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::setAttribute):
    (WebCore::Element::setAttributeNode):
    (WebCore::Element::setAttributeNodeNS):
    (WebCore::Element::setAttributeNS):
    * Source/WebCore/dom/TrustedType.cpp:
    (WebCore::trustedTypeCompliantString):
    (WebCore::requireTrustedTypesForPreNavigationCheckPasses):

    Identifier: 305413.1005@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1116@webkitglib/2.52">https://commits.webkit.org/305877.1116@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e66f7ba8818f1c211a2f86cbfe4cf6d232842e56
<pre>
Cherry-pick 305413.992@safari-7624.5.1.10-branch (09ca909b6a83). <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>

    [JSC] Do not attempt to link a CallLinkInfo after handleHostCall
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>
    <a href="https://rdar.apple.com/178282225">rdar://178282225</a>

    Reviewed by Yusuke Suzuki.

    handleHostCall performs the host call which may execute JS that
    fires a watchpoint invalidating the passed CallLinkInfo. So,
    it&apos;s not safe to modify *CallLinkInfo after the host call.

    So, make the callers of virtualForWithFunction skip the
    linkPolymorphicCall call in this case. This aligns the behavior
    of operationPolymorphicCall / llint_polymorphic_call with linkFor.

    However, to avoid the InternalFunction case potentially getting
    stuck in the polymorphic mode slow path, return the JSCell in this case.
    This is a slight change in behavior: before this change,
    InternalFunction would have caused the CallLinkInfo to downgrade
    to virtual mode. With this change, it can remain in polymorphic
    mode. This also aligns with linkFor behavior.

    Test: JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js

    * JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js: Added.
    (g2):
    (g3):
    (getP):
    (evil.new.Proxy):
    (evil.new.Proxy.apply):
    * Source/JavaScriptCore/bytecode/RepatchInlines.h:
    (JSC::virtualForWithFunction):
    * Source/JavaScriptCore/jit/JITOperations.cpp:
    (JSC::JSC_DEFINE_JIT_OPERATION):
    * Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
    (JSC::LLInt::llint_polymorphic_call):

    Identifier: 305413.992@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1115@webkitglib/2.52">https://commits.webkit.org/305877.1115@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 808c74036a12ebbebfe06f899d2858b400d0f789
<pre>
Cherry-pick 305413.977@safari-7624.5.1.10-branch (353f0e1145bf). <a href="https://bugs.webkit.org/show_bug.cgi?id=316347">https://bugs.webkit.org/show_bug.cgi?id=316347</a>

    [JSC] Fix B3 ReduceStrength Select specialization when a Check appears between the Select and triggering Check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316347">https://bugs.webkit.org/show_bug.cgi?id=316347</a>
    <a href="https://rdar.apple.com/177687354">rdar://177687354</a>

    Reviewed by Marcus Plutowski.

    In B3ReduceStrength, specializeSelect() specializes a Select that has a constant
    arm and is reached, within selectSpecializationBound, from a Check: it splits the
    block at the Check, clones the values between the Select and the Check into the
    then/else arms, and deleteValue()s the Void ones in that range.

    PureCSE records pure Values in a per-iteration map (m_pureCSE) and assumes they
    stay present. Checks, though Void, are also recorded (to enable removing redundant
    Branches), so an intermediate Check in that range is recorded too; specializeSelect
    then deleteValue()s it without updating the map.

    Keep the map consistent: remove the value from m_pureCSE before specializeSelect
    deletes it.

    Tests: Source/JavaScriptCore/b3/testb3_1.cpp
           Source/JavaScriptCore/b3/testb3_6.cpp

    * Source/JavaScriptCore/b3/B3PureCSE.cpp:
    (JSC::B3::PureCSE::clear):
    (JSC::B3::PureCSE::remove):
    * Source/JavaScriptCore/b3/B3PureCSE.h:
    * Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
    * Source/JavaScriptCore/b3/testb3.h:
    * Source/JavaScriptCore/b3/testb3_1.cpp:
    (run):
    * Source/JavaScriptCore/b3/testb3_6.cpp:
    (testCheckSelectAndDeadCheckCSE):

    Identifier: 305413.977@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1114@webkitglib/2.52">https://commits.webkit.org/305877.1114@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff316b14e7b9eaf08250811fe66a943a0a8b582

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182555 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56502 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146872 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184417 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57818 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56225 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146872 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185510 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57818 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122964 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57818 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56225 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4931 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57818 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3949 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/43839 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49133 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56225 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194712 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56173 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151984 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56864 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151684 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27738 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56864 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129148 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125163 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55375 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50308 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54757 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54995 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54823 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->