### PR TITLE
[WebCore] Unsynchronized access to process-global serializedPrimitiveValues() HashMap in CSSPrimitiveValue::customCSSText from Worker thread

### DIFF
--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
@@ -1,0 +1,10 @@
+A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash during concurrent serialization.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue).");
+
+jsTestIsAsync = true;
+
+// Each worker hammers customCSSText() off the main thread for ~800ms. It mixes two paths:
+//   - fractional percentages, which allocate a fresh heap CSSPrimitiveValue per value and, when
+//     overwritten, destroy it (map.add followed by map.remove) to churn the shared HashTable and
+//     provoke rehash() of the backing buffer.
+//   - integer percentages 0..255, which resolve to the shared StaticCSSValuePool objects that are
+//     also serialized on the main thread (the bit-field hazard).
+var workerSource = `
+    function pump() {
+        var deadline = performance.now() + 800;
+        while (performance.now() < deadline) {
+            var faces = [];
+            for (var i = 0; i < 256; ++i) {
+                var fractional = (i + 0.123456).toFixed(6) + "%";
+                var face = new FontFace("worker-" + i, "url(x)", { sizeAdjust: fractional });
+                face.sizeAdjust; // map.add(heap value)
+                faces.push(face);
+            }
+            for (var j = 0; j < faces.length; ++j) {
+                faces[j].sizeAdjust = (j + 0.654321).toFixed(6) + "%"; // destroys previous => map.remove
+                faces[j].sizeAdjust; // map.add(new heap value)
+            }
+            for (var k = 0; k < 256; ++k) {
+                // Shared static-pool objects, also touched on the main thread.
+                var shared = new FontFace("shared-" + k, "url(x)", { sizeAdjust: k + "%" });
+                shared.sizeAdjust;
+                shared.style;
+                shared.weight;
+                shared.width;
+            }
+        }
+        postMessage("done");
+    }
+    pump();
+`;
+
+var NUM_WORKERS = 4;
+var workersDone = 0;
+var blobURL = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+
+function onWorkerDone() {
+    if (++workersDone < NUM_WORKERS)
+        return;
+    testPassed("Did not crash during concurrent serialization.");
+    finishJSTest();
+}
+
+for (var w = 0; w < NUM_WORKERS; ++w) {
+    var worker = new Worker(blobURL);
+    worker.onmessage = onWorkerDone;
+}
+
+// Concurrently churn the shared map on the main thread: fractional percentages create and destroy
+// heap CSSPrimitiveValues, and integer percentages hit the same shared static-pool objects.
+var element = document.documentElement;
+var deadline = performance.now() + 800;
+while (performance.now() < deadline) {
+    for (var i = 0; i < 256; ++i) {
+        element.style.width = (i + 0.7777).toFixed(6) + "%"; // create heap value
+        element.style.getPropertyValue("width");             // map.add; next overwrite => map.remove
+    }
+    element.style.height = "100%";
+    for (var i = 0; i < 64; ++i)
+        element.style.getPropertyValue("height");            // shared static-pool object
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -44,7 +44,9 @@
 #include "StyleComputedStyle.h"
 #include "StyleLengthResolution.h"
 #include "StylePrimitiveNumericTypes+Rounding.h"
+#include <type_traits>
 #include <wtf/Hasher.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -166,6 +168,7 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
         break;
     }
     if (m_hasCachedCSSText) {
+        ASSERT(isMainThread());
         ASSERT(serializedPrimitiveValues().contains(this));
         serializedPrimitiveValues().remove(this);
     }
@@ -350,11 +353,20 @@ String CSSPrimitiveValue::customCSSText(const CSS::SerializationContext& context
     case CSSUnitType::Unknown:
         return String();
     default:
+        // The memoization map and m_hasCachedCSSText are not thread-safe, and worker threads can
+        // serialize FontFace descriptors concurrently with the main thread. Only memoize on the
+        // main thread; other threads serialize without touching the shared state.
+        if (!isMainThread())
+            return serializeInternal(context);
         auto& map = serializedPrimitiveValues();
         ASSERT(map.contains(this) == m_hasCachedCSSText);
         if (m_hasCachedCSSText)
             return map.get(this);
         String serializedValue = serializeInternal(context);
+        // m_hasCachedCSSText is written here without synchronization, so it must live in its own
+        // memory location (not a bit-field packed with concurrently-read members).
+        static_assert(std::is_member_object_pointer_v<decltype(&CSSPrimitiveValue::m_hasCachedCSSText)>,
+            "m_hasCachedCSSText must not be a bit-field");
         m_hasCachedCSSText = true;
         map.add(this, serializedValue);
         return serializedValue;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -310,11 +310,12 @@ protected:
 
     // CSSPrimitiveValue:
     uint8_t m_primitiveUnitType : 7 { 0 }; // CSSUnitType
-    mutable uint8_t m_hasCachedCSSText : 1 { false };
     uint8_t m_isImplicitInitialValue : 1 { false };
 
     // CSSValueList and CSSValuePair:
     ValueSeparator m_valueSeparator : ValueSeparatorBits { ValueSeparator::Space };
+
+    mutable uint8_t m_hasCachedCSSText { false };
 
 private:
     ClassType m_classType : ClassTypeBits;


### PR DESCRIPTION
#### b2c29f67e8c72fe3c0150e69b2e430f64b115481
<pre>
[WebCore] Unsynchronized access to process-global serializedPrimitiveValues() HashMap in CSSPrimitiveValue::customCSSText from Worker thread
<a href="https://rdar.apple.com/177596584">rdar://177596584</a>

Reviewed by Alan Baradlay.

FontFace is Exposed=(Window,Worker), so its descriptor getters serialize
CSSPrimitiveValues off the main thread via customCSSText(), racing the main
thread on the unsynchronized process-global serialization map and the
m_hasCachedCSSText flag. A concurrent HashTable rehash can free the backing
buffer while another thread still holds a bucket pointer into it.

Only memoize on the main thread; other threads serialize directly without
touching the shared state. Move m_hasCachedCSSText out of the bit-field group so
the main thread can set it without racing reads of the adjacent bits of a shared
static value.

Test: fast/css/font-face-worker-serialization-thread-safety.html
* LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt: Added.
* LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html: Added.
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::customCSSText const):
* Source/WebCore/css/CSSValue.h:

Originally-landed-as: 305413.1032@safari-7624.5-branch (bc1c6b94e762). <a href="https://rdar.apple.com/185366777">rdar://185366777</a>
Canonical link: <a href="https://commits.webkit.org/319794@main">https://commits.webkit.org/319794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55edd9a6aea23ea72e32d228fdf7929e1c206305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45075 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4183 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40755 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57091 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151817 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129360 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125416 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55599 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->