### PR TITLE
Prepare safer C++ tooling for 2026-08-21 Swift toolchain

### DIFF
--- a/Tools/Scripts/webkitpy/safer_cpp/checkers.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/checkers.py
@@ -34,9 +34,10 @@ PROJECTS = ['JavaScriptCore', 'PAL', 'WebCore', 'WebDriver', 'WebGPU', 'WebInspe
 
 
 class Checker(object):
-    def __init__(self, name, description):
+    def __init__(self, name, description, new_description=None):
         self._name = name
         self._description = description
+        self._new_description = new_description
 
     def name(self):
         return self._name
@@ -71,6 +72,8 @@ class Checker(object):
         for checker in cls.enumerate():
             if checker.description() == description:
                 return checker
+            if checker._new_description == description:
+                return checker
         return None
 
     @classmethod
@@ -94,7 +97,8 @@ CHECKERS = [
     Checker('UncheckedCallArgsChecker', 'Unchecked call argument for a raw pointer/reference parameter'),
     Checker('UncheckedLocalVarsChecker', 'Unchecked raw pointer or reference not provably backed by checked variable'),
     Checker('UncountedCallArgsChecker', 'Uncounted call argument for a raw pointer/reference parameter'),
-    Checker('UncountedLambdaCapturesChecker', 'Lambda capture of uncounted or unchecked variable'),
+    Checker('UncountedLambdaCapturesChecker', 'Lambda capture of uncounted or unchecked variable', 'Lambda capture of uncounted variable'),
+    Checker('UncheckedLambdaCapturesChecker', 'Lambda capture of unchecked variable'),
     Checker('UncountedLocalVarsChecker', 'Uncounted raw pointer or reference not provably backed by ref-counted variable'),
     Checker('UnretainedCallArgsChecker', 'Unretained call argument for a raw pointer/reference parameter'),
     Checker('UnretainedLambdaCapturesChecker', 'Lambda capture of unretained variables'),


### PR DESCRIPTION
#### 27920d32adee955a420bd46d822e2cddfc595d09
<pre>
Prepare safer C++ tooling for 2026-08-21 Swift toolchain
<a href="https://bugs.webkit.org/show_bug.cgi?id=322428">https://bugs.webkit.org/show_bug.cgi?id=322428</a>

Reviewed by Richard Robinson.

Update the checker entries per UncountedLambdaCapturesChecker / UncheckedLambdaCapturesChecker split
to be consistent with other checkers.

* Tools/Scripts/webkitpy/safer_cpp/checkers.py:
(Checker.__init__):
(Checker.find_checker_by_description):

Canonical link: <a href="https://commits.webkit.org/319717@main">https://commits.webkit.org/319717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72cf070684bf62561f586c6d9d20634975c837b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182591 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b89a0aff-3d1f-4f28-aeb5-9ee3906d676b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184453 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cff09d1b-463a-4383-92d2-f26fce40b3ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185546 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181917 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/194748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27725 "") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->