### PR TITLE
[Tools] compile_commands.json is missing most sources for macOS builds

### DIFF
--- a/Tools/Scripts/generate-compile-commands
+++ b/Tools/Scripts/generate-compile-commands
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2026 ChangSeok Oh <changseok@webkit.org>. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,12 +29,40 @@
 
 # Script to generate compile_commands.json file
 
-import re
-import os
-import sys
+import argparse
 import glob
 import json
-import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+OUTPUT_FILE = 'compile_commands.json'
+THIRD_PARTY_DIRECTORY = os.path.join('Source', 'ThirdParty')
+
+
+def expand_unified_sources(entries, source_dir, build_dir):
+    """Expands the UnifiedSource entries into the sources they bundle.
+
+    rewrite-compile-commands already does this for the CMake ports, so run it
+    rather than growing a second copy of it here.
+    """
+    script = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                          'rewrite-compile-commands')
+
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        input_file = os.path.join(temporary_dir, OUTPUT_FILE)
+        output_file = os.path.join(temporary_dir, 'expanded', OUTPUT_FILE)
+
+        with open(input_file, 'w') as unexpanded:
+            json.dump(entries, unexpanded)
+
+        subprocess.check_call([sys.executable, script, input_file,
+                               output_file, source_dir, build_dir])
+
+        with open(output_file) as expanded:
+            return json.load(expanded)
+
 
 # Get command line args
 parser = argparse.ArgumentParser(description='Generate compile_commands.json for Xcode builds',
@@ -75,30 +104,22 @@ if not os.path.exists(compile_commands_dir):
 # valid json files. Sometimes if a compile error happens or the user stops the build part way through
 # there will be a very invalid json file sitting in the directory. When we go to bundle it up into the final
 # compile_commands.json file, we now have an invalid compile_commands.json file and clangd will not work.
-# To prevent this from happening we should check that every json file we add is valid, and also ensure there are no 
-# duplicate entries. We will build a map of all the valid files.
+# To prevent this from happening we should check that every json file we add is valid, and also ensure there are no
+# duplicate entries.
 
-# Key   - JSON file contents
-# Value - Timestamp contents
-files = dict()
+entries = []
+seen_entries = set()
 
-# Do not index third party code.
-# Most people probably do not need it.
-third_party_regex = re.compile('Source/ThirdParty')
+for j_file_name in sorted(glob.glob(compile_commands_dir + "/*.json")):
+    with open(j_file_name, "r") as j_file:
+        json_contents = j_file.read()
 
-for j_file_name in glob.glob(compile_commands_dir + "/*.json"):
-    j_file = open(j_file_name, "r")
-    json_contents = j_file.read()
-
-    if not opts.include_third_party and third_party_regex.search(json_contents):
-        continue
-
-    # -2 gets rid of the comma at the end of the file.
-    json_contents = json_contents[:-2]
+    # Each fragment is written to be concatenated with the others, so it ends with a comma.
+    json_contents = json_contents.rstrip().rstrip(',')
 
     # Try to load JSON File
     try:
-        json.loads(json_contents)
+        entry = json.loads(json_contents)
     except Exception:
         if opts.delete_invalid:
             os.remove(j_file_name)
@@ -107,30 +128,40 @@ for j_file_name in glob.glob(compile_commands_dir + "/*.json"):
             print("Invalid JSON File: " + j_file_name)
         continue
 
-    # Validate if the json file already exists in the map.
-    if json_contents in files:
-        pass
-    else:
-        files[json_contents] = os.path.getmtime(j_file_name)
+    # Match the file being compiled, not the flags, so that first party code
+    # including a third party header is kept.
+    if not opts.include_third_party and THIRD_PARTY_DIRECTORY in entry.get('file', ''):
+        continue
 
-# Remove any previous compile_commands.json
-try:
-    os.remove("compile_commands.json")
-except Exception:
-    pass
+    if json_contents in seen_entries:
+        continue
+    seen_entries.add(json_contents)
+    entries.append(entry)
+
+unified_source_count = sum(1 for entry in entries if 'UnifiedSource' in entry['file'])
+direct_entry_count = len(entries) - unified_source_count
+expanded_entry_count = 0
+
+# Xcode only bundles sources when unified builds are enabled, so let the build
+# itself say whether there is anything to expand.
+if unified_source_count:
+    entries = expand_unified_sources(entries, os.path.abspath(base_dir),
+                                     os.path.abspath(opts.built_products_dir))
+    expanded_entry_count = len(entries) - direct_entry_count
 
 # Write the new compile_commands.json file
-new_compile_commands_file = open("compile_commands.json", 'w')
-new_compile_commands_file.write("[")
+with open(OUTPUT_FILE, 'w') as new_compile_commands_file:
+    new_compile_commands_file.write("[")
+    for index, entry in enumerate(entries):
+        if index != 0:
+            new_compile_commands_file.write(",\n")
+        else:
+            new_compile_commands_file.write("\n")
+        new_compile_commands_file.write(json.dumps(entry))
+    new_compile_commands_file.write("\n]\n")
 
-for index, key in enumerate(files.keys()):
-    if index != 0:
-        new_compile_commands_file.write(",\n")
-    else:
-        new_compile_commands_file.write("\n")
-    new_compile_commands_file.write(key)
-
-new_compile_commands_file.write("\n]\n")
-new_compile_commands_file.close()
-
-print("Generated Compile Commands!")
+summary = "Generated Compile Commands! %d entries" % len(entries)
+if expanded_entry_count:
+    summary += "\n  (%d direct, %d expanded from %d unified sources)" \
+               % (direct_entry_count, expanded_entry_count, unified_source_count)
+print(summary)

--- a/Tools/Scripts/rewrite-compile-commands
+++ b/Tools/Scripts/rewrite-compile-commands
@@ -33,7 +33,39 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import sys
+
+
+def include_search_directories(entry):
+    """Returns the include directories the bundle itself was compiled with.
+
+    The parent-directory heuristic below only maps bundles back to frameworks
+    living under Source/, so projects elsewhere in the tree (for instance
+    Tools/TestWebKitAPI) need the compiler's own search path to be resolved.
+    """
+    if 'arguments' in entry:
+        arguments = entry['arguments']
+    else:
+        arguments = shlex.split(entry['command'])
+
+    directories = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        for flag in ('-iquote', '-I'):
+            if argument == flag:
+                if index + 1 < len(arguments):
+                    directories.append(arguments[index + 1])
+                    index += 1
+                break
+            if argument.startswith(flag):
+                directories.append(argument[len(flag):])
+                break
+        index += 1
+
+    return directories
+
 
 parser = argparse.ArgumentParser(
     description='This tool takes the compile_commands.json output by CMake and expands any UnifiedSources in it to regular sources.'
@@ -63,6 +95,7 @@ if last_hash == input_hash and os.path.exists(args.output_file):
     sys.exit(0)
 
 generated_compile_commands = []
+unresolved_includes = 0
 
 compile_commands = json.loads(input_data)
 
@@ -88,9 +121,12 @@ for entry in compile_commands:
     else:
         search_directories.append(os.path.join(source_dir, 'Source', parent_dir_1))
 
+    search_directories += include_search_directories(entry)
+
     with open(entry_file) as f:
         for line in f.readlines():
-            include_path = line[10:-2]  # Extract header from `#include "HEADER"\n`
+            # Extract the bundled source from `#include "SOURCE"\n`
+            include_path = line[10:-2]
             for d in search_directories:
                 include_file = os.path.join(d, include_path)
 
@@ -108,6 +144,12 @@ for entry in compile_commands:
 
                     generated_compile_commands.append(renamed_entry)
                     break
+            else:
+                unresolved_includes += 1
+
+if unresolved_includes:
+    print('%s: warning: dropped %d unified source member(s) that could not be '
+          'resolved to a file on disk.' % (parser.prog, unresolved_includes))
 
 output_directory = os.path.dirname(args.output_file)
 if not os.path.isdir(output_directory):


### PR DESCRIPTION
#### f91936cec2871aca7fa22a03c0326bcedd4029bf
<pre>
[Tools] compile_commands.json is missing most sources for macOS builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=322432">https://bugs.webkit.org/show_bug.cgi?id=322432</a>

Reviewed by NOBODY (OOPS!).

Xcode compiles most code through generated UnifiedSource bundles, so the compile commands name the
bundles rather than the sources they bundle. clangd looks entries up by file, so the files
developers actually edit have no entry at all.

Expand the bundles with rewrite-compile-commands, which already does this for the CMake ports. It
resolved members only under Source/, silently dropping those of projects such as
Tools/TestWebKitAPI, so fall back to the include search path the bundle was compiled with.

Also match the third party filter against the file being compiled rather than the whole fragment,
which dropped first party code that includes a third party header.

* Tools/Scripts/generate-compile-commands:
(expand_unified_sources):
* Tools/Scripts/rewrite-compile-commands:
(include_search_directories):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f91936cec2871aca7fa22a03c0326bcedd4029bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146903 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142509 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100691 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43169 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42797 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4001 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56208 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151954 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56912 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46230 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17797 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->