### PR TITLE
[Wasm] Unreachable end ops don't widen result types

### DIFF
--- a/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
+++ b/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
@@ -1,0 +1,75 @@
+// rdar://180535979
+// The unreachable End handler synthesizes an else for `if`-without-`else` and
+// installs the saved if-param stack as the (reachable) else-arm result. Those
+// values must be widened to the block's declared result types before they
+// propagate to the parent stack: an unreachable then-arm may have `br 0`'d a
+// value that only inhabits the wider result type. Without widening, BBQ's
+// emitRefTestOrCast trusts the stale narrow type and elides the IsCell /
+// IsWasmGCObject runtime checks.
+
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        4,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x01, 0x64, 0x00, 0x01, 0x6E,             // type 1: func (param (ref 0)) (result anyref)
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 2: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 3: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   local.get $s
+    //   local.get $cond
+    //   if (param (ref 0)) (result anyref)
+    //     drop
+    //     local.get $ext
+    //     any.convert_extern
+    //     br 0                  ;; then-arm goes unreachable
+    //   end                     ;; <- parseUnreachableExpression()::End, synthetic else
+    //   ref.cast (ref 0)        ;; must NOT elide IsCell / IsWasmGCObject checks
+    //   struct.get 0 0)
+    const body0 = [
+        0x00,
+        0x20, 0x02,
+        0x20, 0x00,
+        0x04, 0x01,
+        0x1A,
+        0x20, 0x01,
+        0xFB, 0x1A,
+        0x0C, 0x00,
+        0x0B,
+        0xFB, 0x16, 0x00,
+        0xFB, 0x02, 0x00, 0x00,
+        0x0B,
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: synthetic else delivers the (ref 0) param; ref.cast succeeds.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: then-arm br's an anyref-wrapped JS number to the if's
+    // continuation. The post-end value is statically anyref, so ref.cast must
+    // perform the full runtime check and trap.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -247,7 +247,13 @@ private:
     [[nodiscard]] PartialResult parseUnreachableExpression();
     [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
     [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
-    [[nodiscard]] PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
+
+    enum FallThroughStateTag {
+        NewSiblingBlock,
+        MergePoint,
+    };
+
+    [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1900,7 +1906,7 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
 }
 
 template<typename Context>
-auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlData, bool forceSignature) -> PartialResult
+auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlData, FallThroughStateTag fallthrough) -> PartialResult
 {
     const auto& blockSignature = controlData.signature();
     const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
@@ -1909,7 +1915,11 @@ auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlDat
         const auto actualType = m_expressionStack[m_currentStackBegin + i].type();
         const auto expectedType = blockSignature.returnType(i);
         WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
-        if (forceSignature)
+        // The spec requires the output type of a structured control instruction to be
+        // the result type from its signature, even when the fallthrough value is a subtype.
+        // FIXME: We should support some sort of abstract interpretation so this can be the
+        // least upper bound of the merging CFG.
+        if (fallthrough == MergePoint)
             m_expressionStack[m_currentStackBegin + i].setType(expectedType);
     }
 
@@ -3539,7 +3549,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
         auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, ifBranchResults));
         m_expressionStack.shrink(m_currentStackBegin);
@@ -3580,7 +3590,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         ResultList results;
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
@@ -3606,7 +3616,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatchAll(preCatchStack, controlEntry.controlData));
@@ -3714,7 +3724,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         const uint32_t parentBegin = parentEntryBegin();
         auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
@@ -3849,20 +3859,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case End: {
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
-            WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+            WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, NewSiblingBlock));
             auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, ifBranchResults));
             m_expressionStack.shrink(m_currentStackBegin);
             m_expressionStack.append(data.elseBlockStack.span());
         }
-
         // FIXME: endBlock may modify the expressionStack slice for the result of the block.
         // That's a little too effectful but we don't have a better API right now.
         // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-
-        // The spec requires the output type of a structured control instruction to be
-        // the result type from its signature, even when the fallthrough value is a subtype.
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData, true));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
 
         const uint32_t parentBegin = parentEntryBegin();
         auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
@@ -4064,7 +4070,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack.shrink(m_currentStackBegin);
                 m_expressionStack.append(data.elseBlockStack.span());
-                WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
 
                 // Reachable End handling: the combined enclosedStack now lives in
                 // m_expressionStack[parentBegin..end].


### PR DESCRIPTION
#### 36058b8e69ac846ca93e33feb106b09d4b2fd787
<pre>
[Wasm] Unreachable end ops don&apos;t widen result types
<a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>
<a href="https://rdar.apple.com/180535979">rdar://180535979</a>

Reviewed by Yusuke Suzuki.

In 305413.1013@safari-7624.5-branch we fixed how result types were
pushed onto the wasm value stack, widening them to the expected type
rather than the last predecessor&apos;s type at the merge.

This missed the case for unreachable expressions in the block, which
is fixed in this patch.

Originally-landed-as: 305413.1080@safari-7624.5-branch (f65ca49ea4a7). <a href="https://rdar.apple.com/185368954">rdar://185368954</a>
Canonical link: <a href="https://commits.webkit.org/320018@main">https://commits.webkit.org/320018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/298ab7315d9c950555aa4b8b9eba50e4fe1194d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147679 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143147 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99402 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43833 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5540 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12395 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43451 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4783 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44664 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56982 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152652 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57686 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152337 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46889 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129965 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56194 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18461 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->