### PR TITLE
[Text Extraction] Add more text context before or after a targeted element that's missing meaningful text context

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2078,6 +2078,47 @@ static std::optional<SimpleRange> searchForText(Node& node, const String& search
     return searchForText(makeRangeSelectingNodeContents(node), searchText);
 }
 
+static RefPtr<Element> nearestNonInlineAncestor(const Element& element)
+{
+    static constexpr unsigned maximumAncestorsToTraverse = 4;
+
+    unsigned traversedAncestors = 0;
+    for (RefPtr ancestor = element.parentElementInComposedTree(); !!ancestor && traversedAncestors <= maximumAncestorsToTraverse; ancestor = ancestor->parentElementInComposedTree(), ++traversedAncestors) {
+        CheckedPtr renderer = ancestor->renderer();
+        if (!renderer)
+            continue;
+
+        if (!renderer->isInline())
+            return ancestor;
+    }
+
+    return { };
+}
+
+enum class InteractionTextSearchKind : bool { ClickTarget, Text };
+
+static std::optional<SimpleRange> searchForInteractionTargetText(Node& target, const String& searchText, InteractionTextSearchKind kind)
+{
+    auto search = [kind, searchText](Node& container) {
+        if (kind == InteractionTextSearchKind::ClickTarget)
+            return searchForClickTarget(container, searchText);
+        return searchForText(container, searchText);
+    };
+
+    if (auto range = search(target))
+        return range;
+
+    RefPtr element = dynamicDowncast<Element>(target);
+    if (!element)
+        return std::nullopt;
+
+    RefPtr ancestor = nearestNonInlineAncestor(*element);
+    if (!ancestor)
+        return std::nullopt;
+
+    return search(*ancestor);
+}
+
 static String invalidNodeIdentifierDescription(std::optional<NodeIdentifier>&& identifier)
 {
     if (!identifier)
@@ -2245,7 +2286,7 @@ static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode
 
     std::optional<SimpleRange> foundRange;
     if (!searchText.isEmpty()) {
-        foundRange = searchForClickTarget(*element, searchText);
+        foundRange = searchForInteractionTargetText(*element, searchText, InteractionTextSearchKind::ClickTarget);
         if (!foundRange) {
             bool targetIsWholePage = element == document->body() || element.get() == document->documentElement();
             bool matched = targetIsWholePage ? normalizedLabelText(*element).containsIgnoringASCIICase(normalizeText(searchText)) : searchTextMatchesElementLabelOrRenderedText(*element, searchText);
@@ -2484,15 +2525,28 @@ static bool containsLetterOrDigit(StringView text)
     });
 }
 
-static String precedingRenderedTextLabel(const Element& element)
+enum class AdjacentTextSearchDirection : bool { Backward, Forward };
+
+static String adjacentRenderedTextLabel(const Element& element, AdjacentTextSearchDirection direction, const Node* stayWithin)
 {
-    static constexpr unsigned maximumPrecedingTextNodesToSearch = 16;
+    static constexpr unsigned maximumAdjacentTextNodesToSearch = 16;
     static constexpr unsigned maximumAdjacentTextLength = 40;
 
-    RefPtr stayWithin = element.document().documentElement();
+    auto advance = [direction, stayWithin](const Node& current) -> Node* {
+        if (direction == AdjacentTextSearchDirection::Backward)
+            return NodeTraversal::previous(current, stayWithin);
+        return NodeTraversal::next(current, stayWithin);
+    };
+
+    auto firstNodeToExamine = [&element, direction, stayWithin]() -> Node* {
+        if (direction == AdjacentTextSearchDirection::Backward)
+            return NodeTraversal::previous(element, stayWithin);
+        return NodeTraversal::nextSkippingChildren(element, stayWithin);
+    };
+
     unsigned examinedTextNodes = 0;
-    Vector<String> collectedInReverse;
-    for (RefPtr node = NodeTraversal::previous(element, stayWithin.get()); node; node = NodeTraversal::previous(*node, stayWithin.get())) {
+    Vector<String> collected;
+    for (RefPtr node = firstNodeToExamine(); node; node = advance(*node)) {
         RefPtr text = dynamicDowncast<Text>(*node);
         if (!text || !text->renderer())
             continue;
@@ -2500,23 +2554,25 @@ static String precedingRenderedTextLabel(const Element& element)
         if (shouldTreatAsPasswordField(text->shadowHost()))
             continue;
 
-        if (++examinedTextNodes > maximumPrecedingTextNodesToSearch)
+        if (++examinedTextNodes > maximumAdjacentTextNodesToSearch)
             break;
 
         auto normalized = normalizeText(text->data());
         if (normalized.isEmpty())
             continue;
 
-        collectedInReverse.append(normalized);
+        collected.append(normalized);
         if (containsLetterOrDigit(normalized))
             break;
     }
 
-    collectedInReverse.reverse();
-    if (collectedInReverse.isEmpty())
+    if (direction == AdjacentTextSearchDirection::Backward)
+        collected.reverse();
+
+    if (collected.isEmpty())
         return { };
 
-    auto joined = makeStringByJoining(collectedInReverse, " "_s);
+    auto joined = makeStringByJoining(collected, " "_s);
     if (!containsLetterOrDigit(joined))
         return { };
 
@@ -2524,6 +2580,49 @@ static String precedingRenderedTextLabel(const Element& element)
         joined = makeString(StringView { joined }.left(maximumAdjacentTextLength - 3), "..."_s);
 
     return joined;
+}
+
+static String adjacentRenderedTextLabelDescription(const Element& element, Vector<String>& stringsToValidate)
+{
+    auto describe = [&](ASCIILiteral prefix, String&& text) {
+        stringsToValidate.append(text);
+        return makeString(prefix, wrapWithDoubleQuotes(WTF::move(text)));
+    };
+
+    if (RefPtr bound = nearestNonInlineAncestor(element)) {
+        auto textBefore = adjacentRenderedTextLabel(element, AdjacentTextSearchDirection::Backward, bound.get());
+        auto textAfter = adjacentRenderedTextLabel(element, AdjacentTextSearchDirection::Forward, bound.get());
+
+        if (!textBefore.isEmpty() && !textAfter.isEmpty()) {
+            stringsToValidate.append(textBefore);
+            stringsToValidate.append(textAfter);
+            return makeString(" between rendered text "_s, wrapWithDoubleQuotes(WTF::move(textBefore)), " and "_s, wrapWithDoubleQuotes(WTF::move(textAfter)));
+        }
+
+        if (!textBefore.isEmpty())
+            return describe(" after rendered text "_s, WTF::move(textBefore));
+
+        if (!textAfter.isEmpty())
+            return describe(" before rendered text "_s, WTF::move(textAfter));
+    }
+
+    if (auto textBefore = adjacentRenderedTextLabel(element, AdjacentTextSearchDirection::Backward, protect(element.document().documentElement()).get()); !textBefore.isEmpty())
+        return describe(" after rendered text "_s, WTF::move(textBefore));
+
+    return { };
+}
+
+static bool hasNoRenderedTextOrLabeledChild(Element& element)
+{
+    if (containsLetterOrDigit(normalizeText(plainText(makeRangeSelectingNodeContents(element), behaviorsForTextExtraction))))
+        return false;
+
+    for (Ref child : descendantsOfType<Element>(element)) {
+        if (!normalizedLabelText(child).isEmpty())
+            return false;
+    }
+
+    return true;
 }
 
 static String textDescription(Element& element, Vector<String>& stringsToValidate, bool isTargetElement = true)
@@ -2632,32 +2731,33 @@ static String textDescription(Element& element, Vector<String>& stringsToValidat
         }
     }
 
-    if (isTargetElement && !hasAccessibleName && (is<HTMLImageElement>(element) || element.isSVGElement())) {
+    String neighborTextDescription;
+    if (isTargetElement && !hasAccessibleName && (is<HTMLImageElement>(element) || element.isSVGElement() || hasNoRenderedTextOrLabeledChild(element))) {
         bool hasImageAltText = false;
         if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
             hasImageAltText = !normalizeText(image->altText()).isEmpty();
 
-        if (!hasImageAltText) {
-            if (auto neighborText = precedingRenderedTextLabel(element); !neighborText.isEmpty()) {
-                stringsToValidate.append(neighborText);
-                return makeString(WTF::move(elementDescription), " after rendered text "_s, wrapWithDoubleQuotes(WTF::move(neighborText)));
-            }
-        }
+        if (!hasImageAltText)
+            neighborTextDescription = adjacentRenderedTextLabelDescription(element, stringsToValidate);
     }
 
+    auto describedElement = [&] {
+        return makeString(elementDescription, neighborTextDescription);
+    };
+
     if (!needsParentContext)
-        return elementDescription;
+        return describedElement();
 
     RefPtr parent = element.parentElementInComposedTree();
     if (!parent)
-        return elementDescription;
+        return describedElement();
 
     auto parentDescription = textDescription(*parent, stringsToValidate, false);
     if (parentDescription.isEmpty())
-        return elementDescription;
+        return describedElement();
 
     if (isTargetElement)
-        return makeString(WTF::move(elementDescription), " under "_s, WTF::move(parentDescription));
+        return makeString(describedElement(), " under "_s, WTF::move(parentDescription));
 
     return parentDescription;
 }
@@ -2730,7 +2830,7 @@ static String textDescription(LocalFrame& frame, std::optional<NodeIdentifier> i
 
     auto searchTextPrefix = emptyString();
     if (!searchText.isEmpty()) {
-        auto range = action == Action::Click ? searchForClickTarget(*target, searchText) : searchForText(*target, searchText);
+        auto range = searchForInteractionTargetText(*target, searchText, action == Action::Click ? InteractionTextSearchKind::ClickTarget : InteractionTextSearchKind::Text);
         if (range) {
             target = commonInclusiveAncestor<ComposedTree>(*range);
             if (!target)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -431,6 +431,48 @@ TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForUnlabeledIcon
     EXPECT_NULL(error);
 }
 
+TEST(TextExtractionTests, InteractionDescriptionAndSearchTextForLabellessIcons)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<style>i, button { display: inline-block; width: 16px; height: 16px }</style>"
+        "<div class='group-one'><div class='head-one'><i class='chevron-one' onclick=''></i><i class='lock-icon'></i><span>Notifications</span></div>"
+        "<div class='sub-one' style='max-height: 0; overflow: hidden'><div>Email notifications</div></div></div>"
+        "<div class='group-two'><div class='head-two'><i class='chevron-two' onclick=''></i><i class='lock-icon'></i><span>Security</span></div>"
+        "<div class='sub-two' style='max-height: 0; overflow: hidden'><div>Change password</div></div></div>"
+        "<div class='row-sort'><span>Sort</span><i class='sort-caret' onclick=''></i><span>ascending</span></div>"
+        "<div class='row-space'><i class='icon-space' onclick=''> </i><span>Space Case</span></div>"
+        "<div class='row-bravo'><span>Bravo Label</span><button onclick=''></button></div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    auto clickDescription = [&](NSString *className, NSString *searchText) -> NSString * {
+        RetainPtr identifier = extractNodeIdentifier(debugText, className);
+        EXPECT_NOT_NULL(identifier);
+
+        RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+        [interaction setNodeIdentifier:identifier];
+        if (searchText)
+            [interaction setText:searchText];
+
+        NSError *error = nil;
+        NSString *description = [interaction debugDescriptionInWebView:webView error:&error];
+        EXPECT_NULL(error);
+        return description;
+    };
+
+    EXPECT_WK_STREQ("Click on i with class “chevron-one” before rendered text “Notifications”", clickDescription(@"chevron-one", nil));
+    EXPECT_WK_STREQ("Click on i with class “chevron-two” before rendered text “Security”", clickDescription(@"chevron-two", nil));
+    EXPECT_WK_STREQ("Click on i with class “sort-caret” between rendered text “Sort” and “ascending”", clickDescription(@"sort-caret", nil));
+    EXPECT_WK_STREQ("Click on i with class “icon-space” before rendered text “Space Case”", clickDescription(@"icon-space", nil));
+    EXPECT_WK_STREQ("Click on button after rendered text “Bravo Label” under div with class “row-bravo”", clickDescription(@"button", nil));
+
+    EXPECT_WK_STREQ("Click on “Security” in child node of span under div with class “head-two”, with rendered text “Security”", clickDescription(@"chevron-two", @"Security"));
+    EXPECT_WK_STREQ("Click", clickDescription(@"chevron-two", @"Notifications"));
+    EXPECT_WK_STREQ("Click", clickDescription(@"chevron-two", @"Nonexistent"));
+}
+
 TEST(TextExtractionTests, InteractionDescriptionIncludesAssociatedLabelText)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 602545c636e67d2e48f25962a51f872d6fe5d86b
<pre>
[Text Extraction] Add more text context before or after a targeted element that&apos;s missing meaningful text context
<a href="https://bugs.webkit.org/show_bug.cgi?id=322436">https://bugs.webkit.org/show_bug.cgi?id=322436</a>
<a href="https://rdar.apple.com/184783170">rdar://184783170</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Improve both text-search-based targeting and summary strings for targeted elements with little-to-no
accessible attributes or other context:

1.  When targeting based on text, we currently require the search text to be present in the rendered
    DOM of the targeted element. However, in the case where the agent is trying to target a button
    or link that&apos;s a sibling of target text, this can cause confusing failures (from the perspective
    of the agent), since the target element doesn&apos;t (literally) contain the search text.

    Mitigate this by relaxing the constraints around text search, so that if we don&apos;t find search
    text underneath the target container, we fall back to searching the nearest non-inline ancestor
    of the target element for the search text.

2.  Instead of surfacing an interaction description like:

    &gt; Click on span with classes “sprite-fm-mono icon-arrow-right expand”

    ...in the case where a targeted element has no text, we should pull text context from rendered
    text siblings within the same block-level container, such that the interaction description can
    look something more like:

    &gt; Click on span with classes “sprite-fm-mono icon-arrow-right expand” before rendered text “Security”

Test: TextExtractionTests.InteractionDescriptionAndSearchTextForLabellessIcons

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::nearestNonInlineAncestor):
(WebCore::TextExtraction::searchForInteractionTargetText):
(WebCore::TextExtraction::resolveMouseTarget):
(WebCore::TextExtraction::adjacentRenderedTextLabel):
(WebCore::TextExtraction::adjacentRenderedTextLabelDescription):
(WebCore::TextExtraction::hasNoRenderedTextOrLabeledChild):
(WebCore::TextExtraction::textDescription):
(WebCore::TextExtraction::precedingRenderedTextLabel): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDescriptionAndSearchTextForLabellessIcons)):

Canonical link: <a href="https://commits.webkit.org/319761@main">https://commits.webkit.org/319761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f218801ec36e9e7490660724c00970eda53a111

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146976 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ecf0f83-daed-45ae-9f74-bd7ed9c51eff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48ddf80a-867a-487e-b568-d63df4203af4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46294 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123005 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4de35ef5-4915-413f-811e-16a95b30cc52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44978 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42862 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4074 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194847 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56281 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40730 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56985 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151721 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46295 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129253 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125272 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55493 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17863 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->