### PR TITLE
Spatial video renderer has no camera controls (experimental)

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -399,6 +399,12 @@ std::optional<int32_t> MediaControlsHost::spatialVideoHorizontalFieldOfView() co
     return metadata->horizontalFieldOfView;
 }
 
+void MediaControlsHost::spatialCameraDidMove(double yaw, double pitch, double fieldOfView)
+{
+    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(m_mediaElement.get()))
+        videoElement->spatialCameraDidMove(yaw, pitch, fieldOfView);
+}
+
 bool MediaControlsHost::isAVExperienceControllerFullscreenEnabled() const
 {
 #if HAVE(AVEXPERIENCECONTROLLER)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -112,6 +112,7 @@ public:
     bool spatialVideoRenderingEnabled() const;
     String spatialVideoProjectionKind() const;
     std::optional<int32_t> spatialVideoHorizontalFieldOfView() const;
+    void spatialCameraDidMove(double yaw, double pitch, double fieldOfView);
     bool NODELETE isAVExperienceControllerFullscreenEnabled() const;
 
     void captionPreferencesChanged();

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -72,6 +72,7 @@ enum DeviceType {
     readonly attribute boolean spatialVideoRenderingEnabled;
     readonly attribute DOMString spatialVideoProjectionKind;
     readonly attribute long? spatialVideoHorizontalFieldOfView;
+    undefined spatialCameraDidMove(unrestricted double yaw, unrestricted double pitch, unrestricted double fieldOfView);
     readonly attribute boolean isAVExperienceControllerFullscreenEnabled;
 
     readonly attribute DOMString externalDeviceDisplayName;

--- a/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
@@ -36,12 +36,13 @@ class SpatialVideoSupport extends MediaControllerSupport
         this._lastX = 0;
         this._lastY = 0;
         this._projection = "equirect360";
+        this._cameraFieldOfView = SpatialVideoSupport.DefaultCameraFieldOfView;
         this._maybeEnable();
     }
 
     get mediaEvents()
     {
-        return ["loadedmetadata", "resize", "webkitprojectionchanged"];
+        return ["loadedmetadata", "resize", "webkitprojectionchanged", "webkitcameraviewchanged"];
     }
 
     get tracksToMonitor()
@@ -86,6 +87,8 @@ class SpatialVideoSupport extends MediaControllerSupport
             return;
         }
 
+        this._applyDeclaredCameraView(media);
+
         if (this._active) {
             if (resolved.projection === this._projection && resolved.fovDegrees === this._fovDegrees)
                 return;
@@ -110,7 +113,7 @@ class SpatialVideoSupport extends MediaControllerSupport
         if (declared)
             return { projection: declared, fovDegrees: null };
 
-        const fov = typeof host.spatialVideoHorizontalFieldOfView === "number" ? host.spatialVideoHorizontalFieldOfView : null;
+        const fov = typeof host.spatialVideoHorizontalFieldOfView === "number" ? host.spatialVideoHorizontalFieldOfView / SpatialVideoSupport.FieldOfViewScale : null;
         switch (host.spatialVideoProjectionKind) {
         case "Equirectangular":
             return { projection: "equirect360", fovDegrees: null };
@@ -121,6 +124,18 @@ class SpatialVideoSupport extends MediaControllerSupport
             return { projection: "wideFOV", fovDegrees: fov };
         }
         return null;
+    }
+
+    _applyDeclaredCameraView(media)
+    {
+        const fieldOfView = parseFloat(media.getAttribute("x-webkit-fieldofview"));
+        this._cameraFieldOfView = isNaN(fieldOfView) ? SpatialVideoSupport.DefaultCameraFieldOfView : clampFieldOfView(fieldOfView);
+
+        const yaw = parseFloat(media.getAttribute("x-webkit-yaw"));
+        this._yaw = isNaN(yaw) ? 0 : yaw * Math.PI / 180;
+
+        const pitch = parseFloat(media.getAttribute("x-webkit-pitch"));
+        this._pitch = isNaN(pitch) ? 0 : clampPitch(pitch * Math.PI / 180);
     }
 
     _enable()
@@ -350,8 +365,7 @@ class SpatialVideoSupport extends MediaControllerSupport
             event.stopPropagation();
             this._yaw -= dx * SpatialVideoSupport.DragSpeed;
             this._pitch -= dy * SpatialVideoSupport.DragSpeed;
-            const pitchLimit = Math.PI / 2 - 0.01;
-            this._pitch = Math.max(-pitchLimit, Math.min(pitchLimit, this._pitch));
+            this._pitch = clampPitch(this._pitch);
             this._lastX = event.clientX;
             this._lastY = event.clientY;
         };
@@ -369,11 +383,17 @@ class SpatialVideoSupport extends MediaControllerSupport
                 this._moved = false;
             }
         };
+        this._onWheel = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this._cameraFieldOfView = clampFieldOfView(this._cameraFieldOfView + event.deltaY * SpatialVideoSupport.ZoomSpeed);
+        };
         container.addEventListener("pointerdown", this._onPointerDown, true);
         container.addEventListener("pointermove", this._onPointerMove, true);
         container.addEventListener("pointerup", this._onPointerUp, true);
         container.addEventListener("pointercancel", this._onPointerUp, true);
         container.addEventListener("click", this._onClick, true);
+        container.addEventListener("wheel", this._onWheel, true);
     }
 
     _removeInteraction()
@@ -386,6 +406,7 @@ class SpatialVideoSupport extends MediaControllerSupport
         container.removeEventListener("pointerup", this._onPointerUp, true);
         container.removeEventListener("pointercancel", this._onPointerUp, true);
         container.removeEventListener("click", this._onClick, true);
+        container.removeEventListener("wheel", this._onWheel, true);
         if (this._savedContainerTouchAction !== undefined)
             container.style.touchAction = this._savedContainerTouchAction;
     }
@@ -448,7 +469,7 @@ class SpatialVideoSupport extends MediaControllerSupport
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         gl.enable(gl.DEPTH_TEST);
 
-        const projection = perspective(SpatialVideoSupport.CameraFOV, this._canvas.width / this._canvas.height, 0.05, 100);
+        const projection = perspective(this._cameraFieldOfView, this._canvas.width / this._canvas.height, 0.05, 100);
         const view = mul4(rotX(this._pitch), rotY(this._yaw));
         gl.uniformMatrix4fv(this._mvpLocation, false, new Float32Array(mul4(projection, view)));
         gl.uniform1f(this._featherLocation, this._feather);
@@ -468,7 +489,17 @@ class SpatialVideoSupport extends MediaControllerSupport
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.index);
         gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
 
+        this._reportCamera();
+
         this._animationFrame = requestAnimationFrame(() => this._drawLoop());
+    }
+
+    _reportCamera()
+    {
+        const host = this.mediaController.host;
+        if (!host || typeof host.spatialCameraDidMove !== "function")
+            return;
+        host.spatialCameraDidMove(this._yaw * 180 / Math.PI, this._pitch * 180 / Math.PI, this._cameraFieldOfView);
     }
 
     _teardown()
@@ -490,9 +521,13 @@ class SpatialVideoSupport extends MediaControllerSupport
 }
 
 SpatialVideoSupport.FeatherFraction = 0.12;
-SpatialVideoSupport.CameraFOV = 80;
+SpatialVideoSupport.FieldOfViewScale = 1000;
+SpatialVideoSupport.DefaultCameraFieldOfView = 80;
+SpatialVideoSupport.MinimumCameraFieldOfView = 30;
+SpatialVideoSupport.MaximumCameraFieldOfView = 110;
 SpatialVideoSupport.DragTolerance = 3;
 SpatialVideoSupport.DragSpeed = 0.005;
+SpatialVideoSupport.ZoomSpeed = 0.1;
 const ProjectionAttributeValues = {
     "equirectangular": "equirect360",
     "360": "equirect360",
@@ -507,6 +542,17 @@ function canvasSizeChanged(canvas)
 {
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
     return canvas.width !== Math.floor(canvas.clientWidth * dpr) || canvas.height !== Math.floor(canvas.clientHeight * dpr);
+}
+
+function clampFieldOfView(degrees)
+{
+    return Math.max(SpatialVideoSupport.MinimumCameraFieldOfView, Math.min(SpatialVideoSupport.MaximumCameraFieldOfView, degrees));
+}
+
+function clampPitch(radians)
+{
+    const limit = Math.PI / 2 - 0.01;
+    return Math.max(-limit, Math.min(limit, radians));
 }
 
 function perspective(fovDegrees, aspect, near, far)

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -307,6 +307,8 @@
     "webkitbeforeblur": { },
     "webkitbeforefocus": { },
     "webkitbeginfullscreen": { },
+    "webkitcameramoved": { },
+    "webkitcameraviewchanged": { },
     "webkitcurrentplaybacktargetiswirelesschanged": { },
     "webkitendfullscreen": { },
     "webkitfocusedelementdisconnected": { },

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -463,5 +463,8 @@ x-apple-data-detectors-type
 x-apple-pdf-annotation
 x-itunes-inherit-uri-query-component
 x-webkit-airplay
+x-webkit-fieldofview
+x-webkit-pitch
 x-webkit-projection
 x-webkit-wirelessvideoplaybackdisabled
+x-webkit-yaw

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -242,11 +242,26 @@ void HTMLVideoElement::attributeChanged(const QualifiedName& name, const AtomStr
         if (name == webkitprojectionAttr && oldValue != newValue && document().settings().spatialVideoRenderingEnabled())
             scheduleEvent(eventNames().webkitprojectionchangedEvent);
 
+        if ((name == webkitfieldofviewAttr || name == webkityawAttr || name == webkitpitchAttr) && document().settings().spatialVideoRenderingEnabled())
+            scheduleEvent(eventNames().webkitcameraviewchangedEvent);
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(WIRELESS_PLAYBACK_TARGET)
         if (name == webkitairplayAttr)
             protect(mediaSession())->setWirelessVideoPlaybackDisabled(isWirelessPlaybackTargetDisabled());
 #endif
     }
+}
+
+void HTMLVideoElement::spatialCameraDidMove(double yaw, double pitch, double fieldOfView)
+{
+    if (m_cameraYaw == yaw && m_cameraPitch == pitch && m_cameraFieldOfView == fieldOfView)
+        return;
+
+    m_cameraYaw = yaw;
+    m_cameraPitch = pitch;
+    m_cameraFieldOfView = fieldOfView;
+
+    scheduleEvent(eventNames().webkitcameramovedEvent);
 }
 
 bool HTMLVideoElement::supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode) const

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -155,6 +155,11 @@ public:
     bool isIntersectingViewport() const final { return m_isIntersectingViewport; }
     void viewportIntersectionChanged(bool isIntersecting);
 
+    double cameraYaw() const { return m_cameraYaw; }
+    double cameraPitch() const { return m_cameraPitch; }
+    double cameraFieldOfView() const { return m_cameraFieldOfView; }
+    void spatialCameraDidMove(double yaw, double pitch, double fieldOfView);
+
 private:
     friend class HTMLVideoElementPictureInPicture;
     HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
@@ -193,6 +198,10 @@ private:
     AtomString m_defaultPosterURL;
 
     FloatSize m_lastReportedNaturalSize { };
+
+    double m_cameraYaw { 0 };
+    double m_cameraPitch { 0 };
+    double m_cameraFieldOfView { 0 };
 
     bool m_renderingCanBeAccelerated { false };
 

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -40,6 +40,12 @@
 
     // Non-standard
     [CEReactions=NotNeeded, Reflect="webkitprojection", EnabledBySetting=SpatialVideoRenderingEnabled] attribute DOMString projection;
+    [CEReactions=NotNeeded, Reflect="webkitfieldofview", EnabledBySetting=SpatialVideoRenderingEnabled] attribute DOMString fieldOfView;
+    [CEReactions=NotNeeded, Reflect="webkityaw", EnabledBySetting=SpatialVideoRenderingEnabled] attribute DOMString yaw;
+    [CEReactions=NotNeeded, Reflect="webkitpitch", EnabledBySetting=SpatialVideoRenderingEnabled] attribute DOMString pitch;
+    [EnabledBySetting=SpatialVideoRenderingEnabled] readonly attribute double cameraYaw;
+    [EnabledBySetting=SpatialVideoRenderingEnabled] readonly attribute double cameraPitch;
+    [EnabledBySetting=SpatialVideoRenderingEnabled] readonly attribute double cameraFieldOfView;
     readonly attribute boolean webkitSupportsFullscreen;
     readonly attribute boolean webkitDisplayingFullscreen;
 


### PR DESCRIPTION
#### 70da8616e020afdc30ab4b8d3f9c708b78a21a4e
<pre>
Spatial video renderer has no camera controls (experimental)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322444">https://bugs.webkit.org/show_bug.cgi?id=322444</a>
<a href="https://rdar.apple.com/185726719">rdar://185726719</a>

Reviewed by NOBODY (OOPS!).

Field of view was a hardcoded constant with no zoom, the view always started looking forward, and a
page could neither frame the shot nor read back where the camera pointed.

Add x-webkit-fieldofview, x-webkit-yaw and x-webkit-pitch, reflected as fieldOfView, yaw and pitch
behind SpatialVideoRenderingEnabled, scheduling webkitcameraviewchanged on assignment. Assigning
applies the value whether or not it changed, so a page can return the camera to a known view after
the user has dragged it.

Expose the live camera separately as readonly cameraYaw, cameraPitch and cameraFieldOfView,
reported through MediaControlsHost::spatialCameraDidMove and announced with webkitcameramoved —
once per drawn frame, and dropped when unchanged.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::spatialCameraDidMove):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js:
(SpatialVideoSupport):
(SpatialVideoSupport.prototype.get mediaEvents):
(SpatialVideoSupport.prototype._maybeEnable):
(SpatialVideoSupport.prototype._resolveProjection):
(SpatialVideoSupport.prototype._applyDeclaredCameraView):
(SpatialVideoSupport.prototype._installInteraction):
(SpatialVideoSupport.prototype._removeInteraction):
(SpatialVideoSupport.prototype._drawLoop):
(SpatialVideoSupport.prototype._reportCamera):
(clampFieldOfView):
(clampPitch):
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::attributeChanged):
(WebCore::HTMLVideoElement::spatialCameraDidMove):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/HTMLVideoElement.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70da8616e020afdc30ab4b8d3f9c708b78a21a4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146923 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c201b78-1382-457a-b133-5f9007eb29c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142529 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98963 "2 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbac3c98-0e46-48aa-a5fd-e916557f7283) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122963 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ae8d575-0edd-4eb4-8ed6-bff4d2a72cc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43188 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42813 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4021 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194794 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56228 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151973 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56932 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151672 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46252 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129200 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125219 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55440 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17813 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54812 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->