### PR TITLE
Unconditionally block external URLs in subframes

### DIFF
--- a/LayoutTests/fast/loader/onload-policy-ignore-for-frame-async-delegates-expected.txt
+++ b/LayoutTests/fast/loader/onload-policy-ignore-for-frame-async-delegates-expected.txt
@@ -1,4 +1,4 @@
-Policy delegate: attempt to load http://www.example.com/ with navigation type 'other'
+CONSOLE MESSAGE: Blocked access to external URL http://www.example.com/
 Test for window.onload never fires if page contains an <iframe> with a bad scheme or whose load is cancelled by returning null from resource load delegate's willSendRequest. If the test passes, you should see the word "PASSED" below.
 
 PASSED

--- a/LayoutTests/fast/loader/onload-policy-ignore-for-frame-expected.txt
+++ b/LayoutTests/fast/loader/onload-policy-ignore-for-frame-expected.txt
@@ -1,4 +1,4 @@
-Policy delegate: attempt to load http://www.example.com/ with navigation type 'other'
+CONSOLE MESSAGE: Blocked access to external URL http://www.example.com/
 Test for window.onload never fires if page contains an <iframe> with a bad scheme or whose load is cancelled by returning null from resource load delegate's willSendRequest. If the test passes, you should see the word "PASSED" below.
 
 PASSED

--- a/LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt
@@ -1,4 +1,4 @@
-Returning null for this redirect
+CONSOLE MESSAGE: Blocked access to external URL http://www.example.com/
 https://bugs.webkit.org/show_bug.cgi?id=27595
 This test checks to make sure that things behave as expected when the resource load delegate returns null in response to willSendRequest.
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4621,11 +4621,11 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
     auto request = adoptWK(WKNavigationActionCopyRequest(navigationAction));
     auto targetFrame = adoptWK(WKNavigationActionCopyTargetFrameInfo(navigationAction));
 
-    // Block access to external URLs in subframe navigations when site isolation is enabled.
-    // With site isolation, the injected bundle's willSendRequestForFrame callback cannot emit
-    // the console message because WKBundleFrameGetJavaScriptContext returns null for provisional
-    // frames in the new process. Without site isolation, the injected bundle handles this.
-    if (targetFrame && !WKFrameInfoGetIsMainFrame(targetFrame.get()) && protectedCurrentInvocation()->options().siteIsolationEnabled()) {
+    // Block access to external URLs in subframe navigations.
+    // The injected bundle's willSendRequestForFrame callback cannot emit the console message because
+    // WKBundleFrameGetJavaScriptContext returns null for provisional frames in the new process when
+    // site isolation is enabled.
+    if (targetFrame && !WKFrameInfoGetIsMainFrame(targetFrame.get())) {
         if (auto url = adoptWK(WKURLRequestCopyURL(request.get()))) {
             auto host = adoptWK(WKURLCopyHostName(url.get()));
             auto scheme = adoptWK(WKURLCopyScheme(url.get()));


### PR DESCRIPTION
#### 61f9f23b682aa75addebeaf1646cbdb9352e0897
<pre>
Unconditionally block external URLs in subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322445">https://bugs.webkit.org/show_bug.cgi?id=322445</a>

Reviewed by Alexey Proskuryakov.

Always block the external URLs in subframes to make test results consistent with regards to site isolation.

* LayoutTests/fast/loader/onload-policy-ignore-for-frame-async-delegates-expected.txt:
* LayoutTests/fast/loader/onload-policy-ignore-for-frame-expected.txt:
* LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt:
* Tools/WebKitTestRunner/TestController.cpp:

Canonical link: <a href="https://commits.webkit.org/319798@main">https://commits.webkit.org/319798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3242d67b0064b1be4057ff8952eaaccca0762144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147021 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b8569ce-d139-4c33-b5e8-6d4da387b350) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33f39b96-339c-439d-85e4-d47be7626cc7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46336 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163373 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3303bf8-c7d4-4b28-a000-a259799a595d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45019 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43274 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42902 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4122 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194892 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56326 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57030 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151765 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46343 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55538 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17905 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->