### PR TITLE
[macOS] YouTube.com audio continues to play after tab is closed

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -99,7 +99,16 @@ RemoteAudioVideoRendererProxyManager::RemoteAudioVideoRendererProxyManager(GPUCo
 {
 }
 
-RemoteAudioVideoRendererProxyManager::~RemoteAudioVideoRendererProxyManager() = default;
+RemoteAudioVideoRendererProxyManager::~RemoteAudioVideoRendererProxyManager()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    for (auto& keyValuePair : std::exchange(m_renderers, { })) {
+        if (RefPtr renderer = keyValuePair.value.renderer) {
+            renderer->pause();
+            renderer->flush();
+        }
+    }
+}
 
 void RemoteAudioVideoRendererProxyManager::ref() const
 {
@@ -198,9 +207,15 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
 void RemoteAudioVideoRendererProxyManager::shutdown(RemoteAudioVideoRendererIdentifier identifier)
 {
     MESSAGE_CHECK(m_renderers.contains(identifier));
+    ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
 
-    if (auto iterator = m_renderers.find(identifier); iterator != m_renderers.end())
+    if (auto iterator = m_renderers.find(identifier); iterator != m_renderers.end()) {
+        if (RefPtr renderer = iterator->value.renderer) {
+            renderer->pause();
+            renderer->flush();
+        }
         m_renderers.remove(iterator);
+    }
 }
 
 RefPtr<WebCore::AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::rendererFor(RemoteAudioVideoRendererIdentifier identifier) const


### PR DESCRIPTION
#### 5173c0afd8a33bfb469c886cc5839a1c54cd7cb7
<pre>
[macOS] YouTube.com audio continues to play after tab is closed
<a href="https://rdar.apple.com/185505597">rdar://185505597</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322448">https://bugs.webkit.org/show_bug.cgi?id=322448</a>

Reviewed by Jean-Yves Avenard and Abrar Rahman Protyasha.

User reports indicate YouTube.com audio playback is continuing under some circumstances, even after
the tab containing the YouTube.com page is closed. Subsequent analysis of users&apos; logs reveals that
the AudioVideoRenderAVFObjC object continues playback until it runs out of enqueued buffers and
stalls. The teardown path inside RemoteAudioVideoRendererProxyManager::shutdown() is being called,
and in fact the RemoteAudioVideoRendererProxyManager itself is being destroyed. But if
RemoteAudioVideoRendererProxyManager is not the lone holder of the AudioVideoRenderer RefPtr, its
refcount will not drop to zero and audio will continue until either buffers run dry or the last
remaining RefPtr is destroyed.

Rather than rely on the refcount dropping to zero to end playback, explicitly pause() and flush
() the renderer when shutting down a player, and do the same to all outstanding renderers when the
Manager itself is destroyed.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::~RemoteAudioVideoRendererProxyManager):
(WebKit::RemoteAudioVideoRendererProxyManager::shutdown):

Canonical link: <a href="https://commits.webkit.org/319759@main">https://commits.webkit.org/319759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26411a8533a187587cd53644fa339154cfc7f5c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146935 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c58b318-a6bf-456a-8f3a-bf2e27a7bb14) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04583283-a4f0-4626-af6f-6d74ee1f2687) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75946620-fcde-4171-9b04-59fffffa3ef9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44937 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43195 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42828 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4033 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56240 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40728 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151682 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46262 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129212 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55452 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17827 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->