### PR TITLE
[Site Isolation] Shared process outlives every frame using it because API::Navigation keeps a reference

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -27,7 +27,6 @@
 #include "APINavigation.h"
 
 #include "BrowsingWarning.h"
-#include "FrameProcess.h"
 #include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
 #include <WebCore/RegistrableDomain.h>
@@ -207,12 +206,6 @@ size_t Navigation::redirectChainIndex(const WTF::URL& url)
     if (index == WTF::notFound)
         index = m_redirectChain.size();
     return index;
-}
-
-void Navigation::setPendingSharedProcess(FrameProcess& sharedProcess)
-{
-    // Extend the life of a shared process until the end of the current navigation.
-    m_pendingSharedProcess = sharedProcess;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -52,7 +52,6 @@ class ResourceResponse;
 
 namespace WebKit {
 class BrowsingWarning;
-class FrameProcess;
 class WebBackForwardListFrameItem;
 }
 
@@ -201,8 +200,6 @@ public:
     WebCore::ProcessIdentifier processID() const { return m_processID; }
     void setProcessID(WebCore::ProcessIdentifier processID) { m_processID = processID; }
 
-    void setPendingSharedProcess(WebKit::FrameProcess&);
-
     void NODELETE setHasStorageForCurrentSite(bool);
     bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
 
@@ -254,7 +251,6 @@ private:
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
     Vector<Function<void()>> m_safeBrowsingCheckCompletionCallbacks;
-    RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
     RefPtr<WebKit::FrameState> m_backForwardFrameState;
 };
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -238,6 +238,7 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
     if (process.isSharedProcess()) {
         m_sharedProcess = nullptr;
         m_sharedProcessSites.clear();
+        m_pagesInSharedProcess.clear();
     } else {
         auto& site = *process.site();
         // Either we are still the current entry for this site (normal teardown), or a

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6132,13 +6132,14 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
     ](FrameProcess* sharedProcess) mutable {
         if (sharedProcess) {
-            navigation->setPendingSharedProcess(*sharedProcess);
             ASSERT(!sharedProcess->process().isInProcessCache());
+            Ref sharedFrameProcess { *sharedProcess };
             if (frame->isMainFrame()) {
                 Ref process { sharedProcess->process() };
                 auto shutdownPreventingScope = process->shutdownPreventingScope();
                 protect(websiteDataStore->networkProcess())->addAllowedFirstPartyForCookies(sharedProcess->process(), site.domain(), LoadedWebArchive::No, [
                     process = WTF::move(process),
+                    sharedFrameProcess = WTF::move(sharedFrameProcess),
                     shutdownPreventingScope = WTF::move(shutdownPreventingScope),
                     continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
                 ] mutable {

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -282,34 +282,53 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, 
 
 RefPtr<WebProcessProxy> WebProcessCache::takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
-    auto it = m_sharedProcessesPerSite.find(mainFrameSite);
-    if (it == m_sharedProcessesPerSite.end()) {
+    RefPtr<CachedProcess> cachedProcess;
+    std::optional<uint64_t> pendingAddRequestIdentifier;
+    if (auto it = m_sharedProcessesPerSite.find(mainFrameSite); it != m_sharedProcessesPerSite.end())
+        cachedProcess = it->value.ptr();
+    else {
+        for (auto& pair : m_pendingAddRequests) {
+            Ref process = pair.value->process();
+            auto& site = process->sharedProcessMainFrameSite();
+            if (process->isSharedProcess() && site && *site == mainFrameSite) {
+                cachedProcess = pair.value.ptr();
+                pendingAddRequestIdentifier = pair.key;
+                break;
+            }
+        }
+    }
+
+    if (!cachedProcess) {
         WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: did not find %" SENSITIVE_LOG_STRING, 0, mainFrameSite.loggingString().utf8().data());
         return nullptr;
     }
 
-    if (it->value->process().websiteDataStore() != &dataStore) {
-        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, datastore not identical", it->value->process().processID());
+    if (cachedProcess->process().websiteDataStore() != &dataStore) {
+        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, datastore not identical", cachedProcess->process().processID());
         return nullptr;
     }
 
-    if (it->value->process().lockdownMode() != lockdownMode) {
-        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, lockdown mode not identical", it->value->process().processID());
+    if (cachedProcess->process().lockdownMode() != lockdownMode) {
+        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, lockdown mode not identical", cachedProcess->process().processID());
         return nullptr;
     }
 
-    if (it->value->process().enhancedSecurity() != enhancedSecurity) {
-        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, enhanced security not identical", it->value->process().processID());
+    if (cachedProcess->process().enhancedSecurity() != enhancedSecurity) {
+        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, enhanced security not identical", cachedProcess->process().processID());
         return nullptr;
     }
 
-    if (!Ref { it->value->process() }->hasSameGPUAndNetworkProcessPreferencesAs(pageConfiguration)) {
-        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, preferences not identical", it->value->process().processID());
+    if (!Ref { cachedProcess->process() }->hasSameGPUAndNetworkProcessPreferencesAs(pageConfiguration)) {
+        WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: cannot take process, preferences not identical", cachedProcess->process().processID());
         return nullptr;
     }
 
-    Ref process = m_sharedProcessesPerSite.take(it)->takeProcess();
-    WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: Taking process from WebProcess cache (size=%u, capacity=%u, processWasTerminated=%d) %" SENSITIVE_LOG_STRING, process->processID(), size(), capacity(), process->wasTerminated(), mainFrameSite.loggingString().utf8().data());
+    if (pendingAddRequestIdentifier)
+        m_pendingAddRequests.remove(*pendingAddRequestIdentifier);
+    else
+        m_sharedProcessesPerSite.remove(mainFrameSite);
+    Ref process = cachedProcess->takeProcess();
+    WEBPROCESSCACHE_RELEASE_LOG("takeSharedProcess: Taking process from WebProcess cache (size=%u, capacity=%u, processWasTerminated=%d, wasPendingAddRequest=%d) %" SENSITIVE_LOG_STRING, process->processID(), size(), capacity(), process->wasTerminated(), !!pendingAddRequestIdentifier, mainFrameSite.loggingString().utf8().data());
 
     ASSERT(!process->pageCount());
     ASSERT(!process->provisionalPageCount());


### PR DESCRIPTION
#### bcee9e49e4dce52384ea23f7d7ab8afee3482367
<pre>
[Site Isolation] Shared process outlives every frame using it because API::Navigation keeps a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=322446">https://bugs.webkit.org/show_bug.cgi?id=322446</a>
<a href="https://rdar.apple.com/185728345">rdar://185728345</a>

Reviewed by Per Arne Vollan.

With the shared process enabled, removing the last frame hosted in the shared process leaves that process holding a page
with no frames in it, and this could cause API test SiteIsolation.RemoveFrames to fail -- the test still finds a remote
frame tree after both example.com frames are gone. This is because BrowsingContextGroup tracks the shared FrameProcess
weakly and only disconnects the process&apos;s RemotePageProxy from ~FrameProcess, so any strong reference outliving the
frames keeps the page, and the process, alive.

The root cause is API::Navigation takes a strong reference to the shared FrameProcess via setPendingSharedProcess(). The
reference was added to bridge the gap between the point a process is picked for a navigation and the point a
ProvisionalFrameProxy or ProvisionalPageProxy takes ownership of it (see 301070@main), with WebFrameProxy taking over on
commit through takeFrameProcess(). However, API::Navigation never releases the reference, so the FrameProcess ends up
living as long as the API::Navigation, which outlives the frames that use the process.

To fix this, this patch captures the strong reference in the completion handler passed to
BrowsingContextGroup::sharedProcessForSite() instead. The reference is released once continueWithProcessForNavigation()
returns, by which point either a ProvisionalFrameProxy or a ProvisionalPageProxy owns the FrameProcess, or the
navigation has been abandoned and nobody needs it. It has to cover that whole call rather than stop at the handoff,
because prepareForProvisionalLoadInProcess() destroys the previous provisional frame before calling
ensureProcessForSite(), which would otherwise find a null m_sharedProcess for a process that still reports
isSharedProcess().

The fix above exposes another bug, since a shared process can now be torn down and recreated within a page&apos;s lifetime:
removeFrameProcess() cleared m_sharedProcess and m_sharedProcessSites but not m_pagesInSharedProcess, which records the
pages already injected into the shared process. BCG would therefore skip injecting a page into the newly created shared
process even though that process does not have the page, and the page&apos;s LoadRequest would go unhandled.

It also makes SiteIsolation.SharedProcessBasicWebProcessCacheCrash fail on the bots, where the child frames ended up in
a different process after the second navigation. Now that the shared process is really released, it is put in the
WebProcessCache and taken back out within the same navigation, and addProcessIfPossible() only adds a process to
m_sharedProcessesPerSite once a responsiveness ping to that process comes back. takeSharedProcess() only looked at that
map, so whenever the next navigation picked a process before the ping returned, it started a second process for the same
site instead. Let takeSharedProcess() also return a process still sitting in m_pendingAddRequests; removeProcess()
already treats those entries as part of the cache, and taking the process back cancels the pending add, since the ping
handler drops a request that is no longer there. takeProcess() has the same gap, but is left alone here.

SiteIsolation.RemoveFrames covers this once SiteIsolationSharedProcessEnabled is on, and
SiteIsolation.SharedProcessBasicWebProcessCacheCrash covers the rebuild path. The preference is off by default, so no
test change is included.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setPendingSharedProcess): Deleted.
* Source/WebKit/UIProcess/API/APINavigation.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::removeFrameProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeSharedProcess):

Canonical link: <a href="https://commits.webkit.org/319916@main">https://commits.webkit.org/319916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b938363c04fa5d343c10c57f4333acc2352a835a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147414 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ca59515-51cc-49e0-b37a-ade4289eb61a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/521933ac-b23e-4035-a48d-1d81e7ac1e32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123361 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c831488e-9993-4c97-97f2-29bb390131ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43597 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43231 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4516 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195284 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56717 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40851 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57422 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39851 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152105 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46668 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129692 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125843 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55930 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18242 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55301 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->