### PR TITLE
[JSC] Stop broadcasting to every parallel marker when a bonus visitor task ends

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -3434,26 +3434,25 @@ void Heap::removeGCCompletionCallback(const GCCompletionCallback& callback)
     m_gcCompletionCallbacks.removeFirst(callback);
 }
 
-void Heap::setBonusVisitorTask(RefPtr<SharedTask<void(SlotVisitor&)>> task)
-{
-    Locker locker { m_markingMutex };
-    m_bonusVisitorTask = task;
-    m_markingConditionVariable.notifyAll();
-}
-
-
 void Heap::runTaskInParallel(RefPtr<SharedTask<void(SlotVisitor&)>> task)
 {
     unsigned initialRefCount = task->refCount();
-    setBonusVisitorTask(task);
-    task->run(*m_collectorSlotVisitor);
-    setBonusVisitorTask(nullptr);
-    // The constraint solver expects return of this function to imply termination of the task in all
-    // threads. This ensures that property.
     {
         Locker locker { m_markingMutex };
+        m_bonusVisitorTask = task;
+        m_markingConditionVariable.notifyAll();
+    }
+
+    task->run(*m_collectorSlotVisitor);
+
+    {
+        Locker locker { m_markingMutex };
+        m_bonusVisitorTask = nullptr;
+
+        // The constraint solver expects return of this function to imply termination of the task in all
+        // threads. This ensures that property.
         while (task->refCount() > initialRefCount)
-            m_markingConditionVariable.wait(m_markingMutex);
+            m_bonusVisitorTaskConditionVariable.wait(m_markingMutex);
     }
 }
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -832,8 +832,6 @@ private:
     
     void assertMarkStacksEmpty();
 
-    void setBonusVisitorTask(RefPtr<SharedTask<void(SlotVisitor&)>>);
-
     void dumpHeapStatisticsAtVMDestruction();
 
     static bool useGenerationalGC();
@@ -1003,6 +1001,7 @@ private:
     bool m_worldIsStopped { false };
     Lock m_markingMutex;
     Condition m_markingConditionVariable;
+    Condition m_bonusVisitorTaskConditionVariable;
 
     MonotonicTime m_beforeGC;
     MonotonicTime m_afterGC;

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -676,13 +676,12 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                 };
 
                 m_heap.m_markingConditionVariable.waitUntil(m_heap.m_markingMutex, timeout, isReady);
-                
-                if (!hasWork(locker)
-                    && m_heap.m_bonusVisitorTask)
-                    bonusTask = m_heap.m_bonusVisitorTask;
-                
+
                 if (m_heap.m_parallelMarkersShouldExit)
                     return SharedDrainResult::Done;
+
+                if (!hasWork(locker) && m_heap.m_bonusVisitorTask)
+                    bonusTask = m_heap.m_bonusVisitorTask;
             }
             
             if (!bonusTask && isEmpty()) {
@@ -701,7 +700,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
         
         if (bonusTask) {
             bonusTask->run(*this);
-            
+
             // The main thread could still be running, and may run for a while. Unless we clear the task
             // ourselves, we will keep looping around trying to run the task.
             {
@@ -709,7 +708,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                 if (m_heap.m_bonusVisitorTask == bonusTask)
                     m_heap.m_bonusVisitorTask = nullptr;
                 bonusTask = nullptr;
-                m_heap.m_markingConditionVariable.notifyAll();
+                m_heap.m_bonusVisitorTaskConditionVariable.notifyOne();
             }
         } else {
             RELEASE_ASSERT(!isEmpty());


### PR DESCRIPTION
#### 2eedeabcb721282641ccc06a25be24cca67ad8df
<pre>
[JSC] Stop broadcasting to every parallel marker when a bonus visitor task ends
<a href="https://bugs.webkit.org/show_bug.cgi?id=322451">https://bugs.webkit.org/show_bug.cgi?id=322451</a>
<a href="https://rdar.apple.com/185735562">rdar://185735562</a>

Reviewed by Yijia Huang.

Heap::runTaskInParallel() publishes a bonus task, runs it on the collector
visitor (collector thread), then clears it. And both setting and
clearing a bonus task (for parallel visitors) notify
m_markingConditionVariable. While publishing a bonus task requires
broadcasting notification, clearing does not need it since it just
reduces a possible task. Also, we do not need to notify
m_markingConditionVariable when clearing a bonus task in drainFromShared
too. We add m_bonusVisitorTaskConditionVariable to signal it to the
collector thread.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::drainFromShared):

Canonical link: <a href="https://commits.webkit.org/319764@main">https://commits.webkit.org/319764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7e9197801acefeedf7e6528ca1b06c67cf9823

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1359b930-7450-4246-9118-dd1927c558d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142568 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52ac19ef-66ea-4025-99ab-d584e7a46915) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5effaeae-61d3-425f-8734-8593141da5f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43212 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4969 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11793 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42851 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4051 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43936 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194824 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56258 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56962 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151698 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46276 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129230 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55470 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17852 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54842 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->