### PR TITLE
[anon-block-removal] A grid-lanes container gets no anonymous item for its inline content

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -184,15 +184,9 @@ void RenderTreeBuilder::Block::attach(RenderBlock& parent, RenderPtr<RenderObjec
         if (m_buildsSimpleAnonymousBlocks)
             return true;
 
-        constexpr auto parentRequiresAnonymousBlockByDisplayValue = EnumSet {
-            Style::DisplayType::BlockFlex,
-            Style::DisplayType::InlineFlex,
-            Style::DisplayType::BlockDeprecatedFlex,
-            Style::DisplayType::InlineDeprecatedFlex,
-            Style::DisplayType::BlockGrid,
-            Style::DisplayType::InlineGrid
-        };
-        if (parentRequiresAnonymousBlockByDisplayValue.contains(parent.style().display().value))
+        // A flex or grid container's children are its items, and CSS requires a box around a run of inline content
+        // to make one out of it, so this is not the anonymous block generation the feature is about.
+        if (parent.style().display().isFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox())
             return true;
         if (parent.isAnonymousBlock() && (parent.isGridItem() || parent.isFlexItemIncludingDeprecated())) {
             // An anonymous flex or grid item takes its display value from the box it wraps, not from the flex or grid container it is an item of.


### PR DESCRIPTION
#### b5fcdaaa6eb02279ef986373e64c17560e781a40
<pre>
[anon-block-removal] A grid-lanes container gets no anonymous item for its inline content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322452">https://bugs.webkit.org/show_bug.cgi?id=322452</a>
&lt;<a href="https://rdar.apple.com/problem/185736289">rdar://problem/185736289</a>&gt;

Reviewed by Antti Koivisto.

Grid-lanes keep their anon boxes similar to flex and grid.

Covered by imported/w3c/web-platform-tests/css/css-grid/grid-lanes/intrinsic-sizing/grid-lanes-contain-intrinsic-size-006.html and -008.html.

* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::attach):

Canonical link: <a href="https://commits.webkit.org/319802@main">https://commits.webkit.org/319802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7240c929065a8478e8007d2b7608321c96ffb5e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6bdf032-29e0-4277-8e0c-682d345d4b66) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142546 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5ad6c13-8a3e-4288-9bf0-c26025a19f95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122981 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fea9c1bf-9aa1-4845-ac30-4d329893b9a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44957 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43207 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42831 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4047 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194820 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56254 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40763 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151695 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46271 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129226 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55466 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17830 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55076 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->