### PR TITLE
[GFC][Cleanup] Move item placement logic into a dedicated class

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2075,6 +2075,7 @@ layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingQuirks.c
 layout/formattingContexts/flex/FlexFormattingContext.cpp @header:RenderStyleGetters @cost:4
 layout/formattingContexts/flex/FlexFormattingUtils.cpp @header:RenderStyleGetters @cost:4
 layout/formattingContexts/grid/GridFormattingContext.cpp @header:RenderStyleGetters
+layout/formattingContexts/grid/GridItemPlacer.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/GridItemSizingFunctions.cpp
 layout/formattingContexts/grid/GridLayout.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/GridLayoutUtils.cpp @header:RenderStyleGetters

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4438,6 +4438,7 @@
 		A515729D2F7AD717008975E0 /* SubtreeScrollbarChangesState.h in Headers */ = {isa = PBXBuildFile; fileRef = A515729A2F7AD717008975E0 /* SubtreeScrollbarChangesState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52460C12FF48CE4003567A5 /* GridItemSizingFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460BE2FF48CE4003567A5 /* GridItemSizingFunctions.h */; };
 		A52460C22FF48CE4003567A5 /* GridSizeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460C02FF48CE4003567A5 /* GridSizeTypes.h */; };
+		A52460C52FF48CE4003567A5 /* GridItemPlacer.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460C32FF48CE4003567A5 /* GridItemPlacer.h */; };
 		A52B348F1FA3BDA6008B6246 /* ServiceWorkerDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B34961FA3E290008B6246 /* ServiceWorkerInspectorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B349E1FA41703008B6246 /* WorkerDebuggerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B349C1FA416F8008B6246 /* WorkerDebuggerProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -17657,6 +17658,8 @@
 		A52460BE2FF48CE4003567A5 /* GridItemSizingFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridItemSizingFunctions.h; sourceTree = "<group>"; };
 		A52460BF2FF48CE4003567A5 /* GridItemSizingFunctions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridItemSizingFunctions.cpp; sourceTree = "<group>"; };
 		A52460C02FF48CE4003567A5 /* GridSizeTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSizeTypes.h; sourceTree = "<group>"; };
+		A52460C32FF48CE4003567A5 /* GridItemPlacer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridItemPlacer.h; sourceTree = "<group>"; };
+		A52460C42FF48CE4003567A5 /* GridItemPlacer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridItemPlacer.cpp; sourceTree = "<group>"; };
 		A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggable.h; sourceTree = "<group>"; };
 		A52B348E1FA3BD79008B6246 /* ServiceWorkerDebuggable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggable.cpp; sourceTree = "<group>"; };
 		A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerInspectorProxy.h; sourceTree = "<group>"; };
@@ -34607,6 +34610,8 @@
 				A5FA57652E85F40600EF058F /* GridAreaLines.h */,
 				A585CC3E2E566A7800A69390 /* GridFormattingContext.cpp */,
 				A585CC3D2E566A7800A69390 /* GridFormattingContext.h */,
+				A52460C42FF48CE4003567A5 /* GridItemPlacer.cpp */,
+				A52460C32FF48CE4003567A5 /* GridItemPlacer.h */,
 				A5AFABD62E8D931F00485152 /* GridItemRect.h */,
 				A52460BF2FF48CE4003567A5 /* GridItemSizingFunctions.cpp */,
 				A52460BE2FF48CE4003567A5 /* GridItemSizingFunctions.h */,
@@ -45926,6 +45931,7 @@
 				CD3E251C18046B0600E27F56 /* GridArea.h in Headers */,
 				A5FA57662E85F40D00EF058F /* GridAreaLines.h in Headers */,
 				A585CC442E566A7800A69390 /* GridFormattingContext.h in Headers */,
+				A52460C52FF48CE4003567A5 /* GridItemPlacer.h in Headers */,
 				A5AFABD72E8D932300485152 /* GridItemRect.h in Headers */,
 				A52460C12FF48CE4003567A5 /* GridItemSizingFunctions.h in Headers */,
 				A585CC452E566A7800A69390 /* GridLayout.h in Headers */,

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -355,16 +355,13 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
         };
         GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedColumnGap, usedRowGap };
 
-        // Clone items per scenario since the placement and sizing algorithm consumes them.
-        auto unplacedGridItemsForScenario = unplacedGridItems;
-
         // When no grid item's inline contribution depends on its own block size, the column sizes are
         // final after step 1 of the grid sizing algorithm, so ask GridLayout for that step alone.
         auto scope = m_intrinsicWidthSizingPath == IntrinsicWidthSizingPath::ColumnsOnly
             ? GridLayoutScope::ColumnSizingOnly
             : GridLayoutScope::Full;
 
-        return GridLayout { *this }.layout(unplacedGridItemsForScenario, leadingImplicitTracks, layoutState, scope).usedTrackSizes.columnSizes;
+        return GridLayout { *this }.layout(unplacedGridItems, leadingImplicitTracks, layoutState, scope).usedTrackSizes.columnSizes;
     };
 
     TrackSizes minContentColumnSizes = columnSizesForConstraint(AxisConstraint::minContent());

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GridItemPlacer.h"
+
+#include "ImplicitGrid.h"
+#include "StyleComputedStyle+GettersInlines.h"
+
+namespace WebCore {
+namespace Layout {
+
+GridItemPlacer::GridItemPlacer(GridAutoFlowOptions autoFlowOptions)
+    : m_autoFlowOptions(autoFlowOptions)
+{
+}
+
+// 8.5. Grid Item Placement Algorithm.
+// https://drafts.csswg.org/css-grid-1/#auto-placement-algo
+//
+// Step 3 (determining the columns in the implicit grid) is handled while the grid is built, in
+// ImplicitGrid::createInitialGrid().
+GridItemPlacementResult GridItemPlacer::placeItems(const UnplacedGridItems& unplacedGridItems, ImplicitGrid& implicitGrid) const
+{
+    // 1. Position anything that's not auto-positioned.
+    for (auto& nonAutoPositionedItem : unplacedGridItems.nonAutoPositionedItems)
+        implicitGrid.insertUnplacedGridItem(nonAutoPositionedItem);
+
+    // 2. Process the items locked to a given row.
+    for (auto& definiteRowPositionedItem : unplacedGridItems.definiteRowPositionedItems)
+        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, m_autoFlowOptions);
+
+    if (!unplacedGridItems.autoPositionedItems.isEmpty()) {
+        // 4. Process auto-positioned items
+        implicitGrid.insertAutoPositionedItems(unplacedGridItems.autoPositionedItems, m_autoFlowOptions);
+    }
+
+    return { implicitGrid.gridAreas(), implicitGrid.columnsCount(), implicitGrid.rowsCount() };
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GridAreaLines.h"
+#include "GridFormattingContext.h"
+#include "GridTypeAliases.h"
+#include "UnplacedGridItem.h"
+
+namespace WebCore {
+namespace Layout {
+
+class ImplicitGrid;
+
+struct GridItemPlacementResult {
+    GridAreas gridAreas;
+    size_t columnsCount { 0 };
+    size_t rowsCount { 0 };
+};
+
+class GridItemPlacer {
+public:
+    GridItemPlacer(GridAutoFlowOptions);
+
+    // Places every item into the given implicit grid, growing it as needed.
+    GridItemPlacementResult placeItems(const UnplacedGridItems&, ImplicitGrid&) const;
+
+private:
+    const GridAutoFlowOptions m_autoFlowOptions;
+};
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -27,6 +27,7 @@
 #include "GridLayout.h"
 
 #include "GridAreaLines.h"
+#include "GridItemPlacer.h"
 #include "GridItemRect.h"
 #include "GridLayoutState.h"
 #include "GridLayoutUtils.h"
@@ -59,91 +60,6 @@ struct GridAreaSizes {
 GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
     : m_gridFormattingContext(gridFormattingContext)
 {
-}
-
-// FIXME: Try moving this to GridFormattingContext to simplify the layout code. The initial implicit
-// grid dimensions depend only on the resolved definite item placements (from constructUnplacedGridItems),
-// the explicit track counts (from style), and the leading implicit track counts, which are all
-// available before layout, so it may be possible to compute them there instead of on GridLayout.
-GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
-{
-    // The explicit grid is preceded by any leading implicit tracks generated for items placed with
-    // a negative line that resolves before the grid start. Every item's line has already been
-    // shifted forward by this amount, so include the leading tracks in the initial bounds.
-    size_t maximumColumnIndex = explicitColumnsCount + leadingImplicitTracks.columnsCount;
-    size_t maximumRowIndex = explicitRowsCount + leadingImplicitTracks.rowsCount;
-
-    auto updateGridBounds = [&](const UnplacedGridItem& item) {
-        if (item.hasDefiniteRowPosition()) {
-            auto [rowStart, rowEnd] = item.definiteRowStartEnd();
-            maximumRowIndex = std::max({ maximumRowIndex, rowStart, rowEnd });
-        }
-
-        if (item.hasDefiniteColumnPosition()) {
-            auto [columnStart, columnEnd] = item.definiteColumnStartEnd();
-            maximumColumnIndex = std::max({ maximumColumnIndex, columnStart, columnEnd });
-        }
-    };
-
-    for (const auto& item : unplacedGridItems.nonAutoPositionedItems)
-        updateGridBounds(item);
-    for (const auto& item : unplacedGridItems.definiteRowPositionedItems)
-        updateGridBounds(item);
-
-    // The implicit grid always starts with at least one row. Grid coverage guarantees at least one
-    // in-flow grid item, and every item occupies at least one row, so placement would end up
-    // creating this row regardless. Starting with it means the grid matrix is never empty, which
-    // lets the column count always be read from the matrix itself.
-    maximumRowIndex = std::max<size_t>(maximumRowIndex, 1);
-
-    return {
-        maximumColumnIndex,
-        maximumRowIndex
-    };
-}
-
-ImplicitGrid GridLayout::constructInitialImplicitGrid(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
-{
-    auto initialDimensions = calculateInitialImplicitGridDimensions(
-        unplacedGridItems, leadingImplicitTracks, explicitColumnsCount, explicitRowsCount);
-
-    ImplicitGrid implicitGrid(initialDimensions.totalColumns, initialDimensions.totalRows);
-    // 3. Determine the columns in the implicit grid.
-    // Spec: "If the largest column span among all the items without a definite column position
-    // is larger than the width of the implicit grid, add columns to the end of the implicit grid
-    // to accommodate that column span."
-    implicitGrid.determineImplicitGridColumns(unplacedGridItems.autoPositionedItems);
-
-    return implicitGrid;
-}
-
-// 8.5. Grid Item Placement Algorithm.
-// https://drafts.csswg.org/css-grid-1/#auto-placement-algo
-auto GridLayout::placeGridItems(UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
-    const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions autoFlowOptions)
-{
-    struct Result {
-        GridAreas gridAreas;
-        size_t columnsCount;
-        size_t rowsCount;
-    };
-
-    auto implicitGrid = constructInitialImplicitGrid(unplacedGridItems, leadingImplicitTracks, gridTemplateColumnsTrackSizes.size(), gridTemplateRowsTrackSizes.size());
-
-    // 1. Position anything that's not auto-positioned.
-    for (auto& nonAutoPositionedItem : unplacedGridItems.nonAutoPositionedItems)
-        implicitGrid.insertUnplacedGridItem(nonAutoPositionedItem);
-
-    // 2. Process the items locked to a given row.
-    for (auto& definiteRowPositionedItem : unplacedGridItems.definiteRowPositionedItems)
-        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, autoFlowOptions);
-
-    if (!unplacedGridItems.autoPositionedItems.isEmpty()) {
-        // 4. Process auto-positioned items
-        implicitGrid.insertAutoPositionedItems(unplacedGridItems.autoPositionedItems, autoFlowOptions);
-    }
-
-    return Result { implicitGrid.gridAreas(), implicitGrid.columnsCount(), implicitGrid.rowsCount() };
 }
 
 auto computeGridItemRects = [](const PlacedGridItems& placedGridItems, const BorderBoxPositions& inlineAxisPositions,
@@ -190,7 +106,7 @@ static GridAreaSizes computeGridAreaSizes(const PlacedGridItems& gridItems, cons
 }
 
 // https://drafts.csswg.org/css-grid-1/#layout-algorithm
-GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, const GridLayoutState& gridLayoutState, GridLayoutScope scope)
+GridLayoutResult GridLayout::layout(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, const GridLayoutState& gridLayoutState, GridLayoutScope scope)
 {
     auto& gridDefinition = gridLayoutState.gridDefinition;
     auto& gridTemplateColumnsTrackSizes = gridDefinition.gridTemplateColumns.sizes;
@@ -198,7 +114,8 @@ GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, Leadin
 
     auto& formattingContext = this->formattingContext();
     // 1. Run the Grid Item Placement Algorithm to resolve the placement of all grid items in the grid.
-    auto [ gridAreas, columnsCount, rowsCount ] = placeGridItems(unplacedGridItems, leadingImplicitTracks, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes, gridDefinition.autoFlowOptions);
+    auto implicitGrid = ImplicitGrid::createInitialGrid(unplacedGridItems, leadingImplicitTracks, gridTemplateColumnsTrackSizes.size(), gridTemplateRowsTrackSizes.size());
+    auto [ gridAreas, columnsCount, rowsCount ] = GridItemPlacer { gridDefinition.autoFlowOptions }.placeItems(unplacedGridItems, implicitGrid);
     auto placedGridItems = formattingContext.constructPlacedGridItems(gridAreas);
 
     auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, leadingImplicitTracks.columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns, gridDefinition.zoom);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -40,16 +40,9 @@ struct ZoomFactor;
 
 namespace Layout {
 
-class ImplicitGrid;
-
 struct GridAreaSizes;
 struct GridLayoutState;
 struct UsedMargins;
-
-struct GridDimensions {
-    size_t totalColumns { 0 };
-    size_t totalRows { 0 };
-};
 
 enum class GridLayoutScope : bool {
     Full, // Run the whole grid sizing algorithm, lay out the grid items, and align them.
@@ -60,15 +53,9 @@ class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    GridLayoutResult layout(UnplacedGridItems&, LeadingImplicitTracks, const GridLayoutState&, GridLayoutScope = GridLayoutScope::Full);
+    GridLayoutResult layout(const UnplacedGridItems&, LeadingImplicitTracks, const GridLayoutState&, GridLayoutScope = GridLayoutScope::Full);
 
 private:
-
-    auto placeGridItems(UnplacedGridItems&, LeadingImplicitTracks, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
-        const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
-
-    static GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, LeadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount);
-    ImplicitGrid constructInitialImplicitGrid(const UnplacedGridItems&, LeadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount);
 
     static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&, const Style::ZoomFactor&);
     static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t implicitTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -27,7 +27,7 @@
 #include "ImplicitGrid.h"
 
 #include "GridAreaLines.h"
-#include "GridLayout.h"
+#include "GridFormattingContext.h"
 #include "PlacedGridItem.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "UnplacedGridItem.h"
@@ -45,6 +45,60 @@ namespace Layout {
 ImplicitGrid::ImplicitGrid(size_t totalColumnsCount, size_t totalRowsCount)
     : m_gridMatrix(Vector<Vector<GridCell>>(FillWith { }, totalRowsCount, Vector<GridCell>(totalColumnsCount)))
 {
+}
+
+struct GridDimensions {
+    size_t totalColumnsCount { 0 };
+    size_t totalRowsCount { 0 };
+};
+
+static GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
+{
+    // The explicit grid is preceded by any leading implicit tracks generated for items placed with
+    // a negative line that resolves before the grid start. Every item's line has already been
+    // shifted forward by this amount, so include the leading tracks in the initial bounds.
+    size_t maximumColumnIndex = explicitColumnsCount + leadingImplicitTracks.columnsCount;
+    size_t maximumRowIndex = explicitRowsCount + leadingImplicitTracks.rowsCount;
+
+    auto updateGridBounds = [&](const UnplacedGridItem& item) {
+        if (item.hasDefiniteRowPosition()) {
+            auto [rowStart, rowEnd] = item.definiteRowStartEnd();
+            maximumRowIndex = std::max({ maximumRowIndex, rowStart, rowEnd });
+        }
+
+        if (item.hasDefiniteColumnPosition()) {
+            auto [columnStart, columnEnd] = item.definiteColumnStartEnd();
+            maximumColumnIndex = std::max({ maximumColumnIndex, columnStart, columnEnd });
+        }
+    };
+
+    for (const auto& item : unplacedGridItems.nonAutoPositionedItems)
+        updateGridBounds(item);
+    for (const auto& item : unplacedGridItems.definiteRowPositionedItems)
+        updateGridBounds(item);
+
+    // The implicit grid always starts with at least one row. Grid coverage guarantees at least one
+    // in-flow grid item, and every item occupies at least one row, so placement would end up
+    // creating this row regardless. Starting with it means the grid matrix is never empty, which
+    // lets the column count always be read from the matrix itself.
+    maximumRowIndex = std::max<size_t>(maximumRowIndex, 1);
+
+    return {
+        maximumColumnIndex,
+        maximumRowIndex
+    };
+}
+
+ImplicitGrid ImplicitGrid::createInitialGrid(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
+{
+    auto initialDimensions = calculateInitialImplicitGridDimensions(
+        unplacedGridItems, leadingImplicitTracks, explicitColumnsCount, explicitRowsCount);
+
+    ImplicitGrid implicitGrid(initialDimensions.totalColumnsCount, initialDimensions.totalRowsCount);
+    // 3. Determine the columns in the implicit grid.
+    implicitGrid.determineImplicitGridColumns(unplacedGridItems.autoPositionedItems);
+
+    return implicitGrid;
 }
 
 void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridItem)

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -36,10 +36,17 @@ namespace Layout {
 
 enum class GridLayoutAlgorithm : uint8_t;
 struct GridAutoFlowOptions;
+struct LeadingImplicitTracks;
+struct UnplacedGridItems;
 
 // https://drafts.csswg.org/css-grid-1/#implicit-grids
 class ImplicitGrid {
 public:
+    // Builds the implicit grid that the grid item placement algorithm starts from: the explicit grid,
+    // grown to cover every definite item placement that falls outside of it and wide enough for the
+    // largest column span among the items without a definite column position.
+    static ImplicitGrid createInitialGrid(const UnplacedGridItems&, LeadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount);
+
     ImplicitGrid(size_t totalColumnsCount, size_t totalRowsCount);
 
     size_t rowsCount() const { return m_gridMatrix.size(); }


### PR DESCRIPTION
#### 9ec22b7a341738632efa8b6ad6564da7d43ccb17
<pre>
[GFC][Cleanup] Move item placement logic into a dedicated class
<a href="https://bugs.webkit.org/show_bug.cgi?id=322447">https://bugs.webkit.org/show_bug.cgi?id=322447</a>
<a href="https://rdar.apple.com/problem/185731047">rdar://problem/185731047</a>

Reviewed by Alan Baradlay.

GridLayout::layout() ran the grid item placement algorithm inline, alongside
track sizing, grid item layout, and alignment. Give placement its own class so
that step 1 of the layout algorithm reads as a single call and GridLayout is
left with only the steps that size and position items.

GridItemPlacer takes the implicit grid rather than building it, so constructing
the initial grid stays the responsibility of ImplicitGrid itself via a new
createInitialGrid() factory. calculateInitialImplicitGridDimensions() moved
there as a file-static helper since it needs no member access, which keeps
GridDimensions out of every header.

Placement only reads the unplaced items -- it writes into the ImplicitGrid --
so placeItems() and GridLayout::layout() now take a const UnplacedGridItems&amp;.
That lets computeIntrinsicWidths() drop the per-scenario clone of the unplaced
items, which was a deep copy of three Vectors per intrinsic width scenario. Its
comment claimed the placement and sizing algorithm consumed them, but nothing
ever mutated them: every ImplicitGrid entry point already took them by const
reference, and the grid cells, grid areas and PlacedGridItems built downstream
all store copies. The clone was not isolating anything, so dropping it leaves
the min-content and max-content scenarios as independent as they already were.

No change in behavior.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::computeIntrinsicWidths):
* Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.cpp: Added.
(WebCore::Layout::GridItemPlacer::GridItemPlacer):
(WebCore::Layout::GridItemPlacer::placeItems const):
* Source/WebCore/layout/formattingContexts/grid/GridItemPlacer.h: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::calculateInitialImplicitGridDimensions): Deleted.
(WebCore::Layout::GridLayout::constructInitialImplicitGrid): Deleted.
(WebCore::Layout::GridLayout::placeGridItems): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::calculateInitialImplicitGridDimensions):
(WebCore::Layout::ImplicitGrid::createInitialGrid):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:

Canonical link: <a href="https://commits.webkit.org/319763@main">https://commits.webkit.org/319763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8db9934637c308f33f088478d26446d00d38247

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146972 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71669e37-c7f8-475c-a144-44632643caa5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08ad5e26-bb36-45fc-83f8-1a723d4441db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46291 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac7c916e-b3a5-4413-bd2b-0c64f99ab957) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44975 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42856 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4070 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49247 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194843 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56277 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40731 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56981 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151717 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46293 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129249 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55489 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17856 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55099 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->