### PR TITLE
reduce the number of daemons running on simulators

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -36,6 +36,7 @@ from webkitpy.common.system.systemhost import SystemHost
 from webkitpy.port.config import apple_additions
 from webkitpy.port.device import Device
 from webkitpy.xcode.device_type import DeviceType
+from webkitpy.xcode.simulator_daemons import disabled_launchd_jobs
 
 try:
     from plistlib import load as readPlist
@@ -632,7 +633,7 @@ class SimulatedDevice(object):
         self.platform = host.platform
 
         self.launchd_configuration = {
-            'disabled.plist': {'com.apple.chronod': True},  # FIXME: rdar://129075664
+            'disabled.plist': disabled_launchd_jobs(),
         }
 
         self.environment_extras = []

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -32,6 +32,7 @@ from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.xcode.device_type import DeviceType
 from webkitpy.xcode import simulated_device
 from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager, SimulatedDevice
+from webkitpy.xcode.simulator_daemons import disabled_launchd_jobs
 
 simctl_json_output = """{
  "devicetypes" : [
@@ -740,12 +741,15 @@ class LaunchdStateCleanupTest(unittest.TestCase):
 class LaunchdConfigurationDefaultTest(unittest.TestCase):
     """webkitpy defines the configuration a simulator boots with; apple_additions only adds to it."""
 
-    def test_chronod_is_disabled_by_default(self):
+    def test_unneeded_daemons_are_disabled_by_default(self):
         host = SimulatedDeviceTest.mock_host_for_simctl()
         SimulatedDeviceTest.reset_simulated_device_manager()
         devices = SimulatedDeviceManager.available_devices(host)
         self.assertTrue(devices)
-        # FIXME: rdar://129075664
         self.assertEqual(
             devices[0].platform_device.launchd_configuration.get('disabled.plist'),
-            {'com.apple.chronod': True})
+            disabled_launchd_jobs())
+
+    def test_daemons_testing_needs_are_not_disabled(self):
+        for label in ('com.apple.sharingd', 'com.apple.eligibilityd', 'com.apple.sleepd'):
+            self.assertNotIn(label, disabled_launchd_jobs())

--- a/Tools/Scripts/webkitpy/xcode/simulator_daemons.py
+++ b/Tools/Scripts/webkitpy/xcode/simulator_daemons.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Background daemons a simulator running layout and API tests does not need. Naming one here keeps it from ever
+# launching, which takes roughly 4x less memory per simulator so more of them fit on a host.
+#
+# Deliberately absent: com.apple.sharingd, which testing needs; com.apple.eligibilityd, which the harness boosts
+# before installing WebKitTestRunnerApp; com.apple.sleepd, which SpringBoard retries thousands of times a second
+# when it is missing, burning 265% CPU per simulator; com.apple.dmd; com.apple.assistantd, which the keyboard
+# asks for dictation availability; and the daemons backing web platform
+# features the tests cover.
+#
+# apple_additions adds the daemons that only exist in Apple's internal builds.
+UNNEEDED_DAEMONS = [
+    # Widgets & Wallpaper
+    'com.apple.chronod',
+    'com.apple.liveactivitiesd',
+    # Siri & Intelligence
+    'com.apple.assistant_cdmd',
+    'com.apple.assistant_service',
+    'com.apple.siriactionsd',
+    'com.apple.siriinferenced',
+    'com.apple.siriknowledged',
+    'com.apple.voicebankingd',
+    'com.apple.speechmodeltrainingd',
+    'com.apple.intelligenceplatformd',
+    'com.apple.intelligencecontextd',
+    'com.apple.intelligenceflowd',
+    'com.apple.intelligencetasksd',
+    'com.apple.generativeexperiencesd',
+    'com.apple.knowledgeconstructiond',
+    'com.apple.modelcatalogd',
+    'com.apple.modelmanagerd',
+    'com.apple.mlhostd',
+    'com.apple.mlruntimed',
+    'com.apple.suggestd',
+    'com.apple.parsecd',
+    'com.apple.parsec-fbf',
+    'com.apple.proactiveeventtrackerd',
+    # Spotlight & Search
+    'com.apple.searchd',
+    'com.apple.searchtoold',
+    'com.apple.spotlightknowledged',
+    'com.apple.spotlightknowledged.updater',
+    'com.apple.corespotlightservice',
+    # iCloud & Apple Account
+    'com.apple.appleaccountd',
+    'com.apple.appleaccounttransparencyd',
+    'com.apple.amsaccountsd',
+    'com.apple.amsondevicestoraged',
+    'com.apple.cloudd',
+    'com.apple.cloudphotod',
+    'com.apple.ckdiscretionaryd',
+    'com.apple.cloudsettingssyncagent',
+    'com.apple.bird',
+    'com.apple.syncdefaultsd',
+    'com.apple.cdpd',
+    'com.apple.sosd',
+    'com.apple.SecureBackupDaemon',
+    'com.apple.protectedcloudstorage.protectedcloudkeysyncing',
+    'com.apple.icloudmailagent',
+    'com.apple.icloudsubscriptionoptimizerd',
+    'com.apple.communicationtrustd',
+    # App Store, Push & Media
+    'com.apple.appstorecomponentsd',
+    'com.apple.itunescloudd',
+    'com.apple.itunesstored',
+    'com.apple.storekitd',
+    'com.apple.videosubscriptionsd',
+    'com.apple.assetsubscriptiond',
+    'com.apple.musicd',
+    # Mail, Calendar & Contacts
+    'com.apple.email.maild',
+    'com.apple.exchangesyncd',
+    'com.apple.dataaccess.dataaccessd',
+    'com.apple.calaccessd',
+    'com.apple.remindd',
+    'com.apple.contacts.postersyncd',
+    'com.apple.peopled',
+    # Safari Sync & Web Services
+    'com.apple.SafariBookmarksSyncAgent',
+    'com.apple.Safari.History',
+    'com.apple.Safari.passwordbreachd',
+    'com.apple.WebBookmarks.webbookmarksd',
+    # Family & Screen Time
+    'com.apple.familycircled',
+    'com.apple.FamilyControlsAgent',
+    'com.apple.familynotificationd',
+    'com.apple.askpermissiond',
+    'com.apple.asktod',
+    'com.apple.ScreenTimeSettingsAgent',
+    # Health, Home & Fitness
+    'com.apple.healthd',
+    'com.apple.healthappd',
+    'com.apple.healthcontentd',
+    'com.apple.healtheventsd',
+    'com.apple.healthrecordsd',
+    'com.apple.finhealthd',
+    'com.apple.homed',
+    'com.apple.homeeventsd',
+    'com.apple.fitcore',
+    'com.apple.fitcore.session',
+    'com.apple.fitnesscoachingd',
+    'com.apple.fitnessintelligenced',
+    'com.apple.activityawardsd',
+    'com.apple.activitysharingd',
+    # Photos & Media Analysis
+    'com.apple.photoanalysisd',
+    'com.apple.photosface',
+    'com.apple.mediaanalysisd',
+    'com.apple.mediaanalysisd.service',
+    'com.apple.mediastream.mstreamd',
+    'com.apple.medialibraryd',
+    'com.apple.assetsd',
+    'com.apple.assetsd.nebulad',
+    # News, Weather, Maps & Games
+    'com.apple.newsd',
+    'com.apple.weatherd',
+    'com.apple.Maps.mapssyncd',
+    'com.apple.Maps.geocorrectiond',
+    'com.apple.maps.destinationd',
+    'com.apple.jetpackassetd',
+    'com.apple.tipsd',
+    'com.apple.gamed',
+    'com.apple.gamesaved',
+    # Messaging & FaceTime
+    'com.apple.identityservicesd',
+    'com.apple.ids_simd',
+    'com.apple.imautomatichistorydeletionagent',
+    'com.apple.imtransferagent',
+    'com.apple.facetimemessagestored',
+    'com.apple.telephonyutilities.callservicesd',
+    # Sharing & Device Connectivity (NB: com.apple.sharingd stays enabled)
+    'com.apple.rapportd',
+    'com.apple.companiond',
+    'com.apple.carkitd',
+    'com.apple.wcd',
+    'com.apple.tvremoted',
+    'com.apple.avatarsd',
+    'com.apple.stickersd',
+    'com.apple.sociallayerd',
+    'com.apple.announced',
+    'com.apple.navd',
+    'com.apple.findmy.findmylocated',
+    # Ads, Diagnostics & Telemetry
+    'com.apple.ap.adprivacyd',
+    'com.apple.ap.promotedcontentd',
+    'com.apple.diagnosticextensionsd',
+    'com.apple.feedbackd',
+    'com.apple.rtcreportingd',
+    'com.apple.securityuploadd',
+    'com.apple.geoanalyticsd',
+    'com.apple.triald',
+    'com.apple.followupd',
+    'com.apple.purplebuddy.budd',
+    'com.apple.devicecheckd',
+    # Other Background Services
+    'com.apple.businessservicesd',
+    'com.apple.deviceaccessd',
+    'com.apple.replicatord',
+    'com.apple.linkd',
+    'com.apple.ind',
+    'com.apple.storagedatad',
+    'com.apple.StatusKitAgent',
+    'com.apple.countryd',
+    'com.apple.mobileassetd',
+    'com.apple.managedconfiguration.passcodenagd',
+    # Watch companion, on-device learning, device management and store leftovers
+    'com.apple.nanotimekitcompaniond',
+    'com.apple.nanosystemsettingsd',
+    'com.apple.nanomapscd',
+    'com.apple.NPKCompanionAgent',
+    'com.apple.nanoregistrylaunchd',
+    'com.apple.nanoprefsyncd.2',
+    'com.apple.nanoappregistryd',
+    'com.apple.nanobackupd',
+    'com.apple.nanonewscd',
+    'com.apple.companionappd',
+    'com.apple.appconduitd',
+    'com.apple.pairedsyncd',
+    'com.apple.pairedunlockd',
+    'com.apple.companionfindlocallyd',
+    'com.apple.companionmessagesd',
+    'com.apple.biomed',
+    'com.apple.biomesyncd',
+    'com.apple.routined',
+    'com.apple.brook.brookcompaniond',
+    'com.apple.imagent',
+    'com.apple.addressbooksyncd',
+    'com.apple.eventkitsyncd',
+    'com.apple.cmfsyncagent',
+    'com.apple.mobiletimerd',
+    'com.apple.donotdisturbd',
+    'com.apple.ManagedSettingsAgent',
+    'com.apple.appprotectiond',
+    'com.apple.fileindexerd',
+    'com.apple.amstoold',
+    'com.apple.featureaccessd',
+    'com.apple.ClipServices.clipserviced',
+    'com.apple.managedassetsd',
+    'com.apple.GSSCred',
+    'com.apple.accessibility.axassetsd',
+    'com.apple.geod',
+]
+
+
+def disabled_launchd_jobs():
+    """The daemons above in the form launchd's disabled list takes.
+
+    launchd_sim reads that list as it starts, so a daemon named here never launches at all, rather than launching
+    during boot and being stopped again afterwards."""
+    return {label: True for label in UNNEEDED_DAEMONS}


### PR DESCRIPTION
#### e67102d7ea99731a5093d5fad817d1811073f54b
<pre>
reduce the number of daemons running on simulators
<a href="https://bugs.webkit.org/show_bug.cgi?id=322455">https://bugs.webkit.org/show_bug.cgi?id=322455</a>
<a href="https://rdar.apple.com/185739531">rdar://185739531</a>

Reviewed by Jonathan Bedard.

Reducing the number of daemons that are running on
simulators greatly reduces their overhead.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDevice.__init__):
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py:
(LaunchdConfigurationDefaultTest.test_unneeded_daemons_are_disabled_by_default):
(LaunchdConfigurationDefaultTest):
(LaunchdConfigurationDefaultTest.test_daemons_testing_needs_are_not_disabled):
(LaunchdConfigurationDefaultTest.test_chronod_is_disabled_by_default): Deleted.
* Tools/Scripts/webkitpy/xcode/simulator_daemons.py: Added.
(disabled_launchd_jobs):

Canonical link: <a href="https://commits.webkit.org/319751@main">https://commits.webkit.org/319751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20774b5294537262c5e7183270ea46776d4e75bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab87e0bf-dff4-48c5-9cfb-5dc5e9a5ec8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f640093-f597-4bc7-bae6-1128582de3b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46296 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123007 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182019 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44980 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42863 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4077 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194850 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56284 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56988 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151723 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46298 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->