### PR TITLE
Refresh the imported css-inline alignment-baseline parsing tests from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed-expected.txt
@@ -6,8 +6,6 @@ PASS Property alignment-baseline value 'ideographic'
 PASS Property alignment-baseline value 'middle'
 PASS Property alignment-baseline value 'central'
 PASS Property alignment-baseline value 'mathematical'
+PASS Property alignment-baseline value 'hanging'
 FAIL Property alignment-baseline value 'text-top' assert_true: 'text-top' is a supported value for alignment-baseline. expected true got false
-FAIL Property alignment-baseline value 'bottom' assert_true: 'bottom' is a supported value for alignment-baseline. expected true got false
-FAIL Property alignment-baseline value 'center' assert_true: 'center' is a supported value for alignment-baseline. expected true got false
-FAIL Property alignment-baseline value 'top' assert_true: 'top' is a supported value for alignment-baseline. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed.html
@@ -20,10 +20,8 @@ test_computed_value("alignment-baseline", "ideographic");
 test_computed_value("alignment-baseline", "middle");
 test_computed_value("alignment-baseline", "central");
 test_computed_value("alignment-baseline", "mathematical");
+test_computed_value("alignment-baseline", "hanging");
 test_computed_value("alignment-baseline", "text-top");
-test_computed_value("alignment-baseline", "bottom");
-test_computed_value("alignment-baseline", "center");
-test_computed_value("alignment-baseline", "top");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt
@@ -2,4 +2,7 @@
 PASS e.style['alignment-baseline'] = "auto" should not set the property value
 PASS e.style['alignment-baseline'] = "none" should not set the property value
 PASS e.style['alignment-baseline'] = "baseline text-bottom" should not set the property value
+PASS e.style['alignment-baseline'] = "top" should not set the property value
+PASS e.style['alignment-baseline'] = "center" should not set the property value
+PASS e.style['alignment-baseline'] = "bottom" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Inline Layout: parsing alignment-baseline with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#alignment-baseline-property">
-<meta name="assert" content="alignment-baseline supports only the grammar 'baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top | bottom | center | top'.">
+<meta name="assert" content="alignment-baseline supports only the grammar 'baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -17,6 +17,12 @@ test_invalid_value("alignment-baseline", "auto");
 
 test_invalid_value("alignment-baseline", "none");
 test_invalid_value("alignment-baseline", "baseline text-bottom");
+
+// These values were moved to `baseline-shift`
+// https://github.com/w3c/csswg-drafts/issues/5180
+test_invalid_value("alignment-baseline", "top");
+test_invalid_value("alignment-baseline", "center");
+test_invalid_value("alignment-baseline", "bottom");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid-expected.txt
@@ -6,8 +6,6 @@ PASS e.style['alignment-baseline'] = "ideographic" should set the property value
 PASS e.style['alignment-baseline'] = "middle" should set the property value
 PASS e.style['alignment-baseline'] = "central" should set the property value
 PASS e.style['alignment-baseline'] = "mathematical" should set the property value
+PASS e.style['alignment-baseline'] = "hanging" should set the property value
 FAIL e.style['alignment-baseline'] = "text-top" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['alignment-baseline'] = "bottom" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['alignment-baseline'] = "center" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['alignment-baseline'] = "top" should set the property value assert_not_equals: property should be set got disallowed value ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Inline Layout: parsing alignment-baseline with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#alignment-baseline-property">
-<meta name="assert" content="alignment-baseline supports the full grammar 'baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top | bottom | center | top'.">
+<meta name="assert" content="alignment-baseline supports the full grammar 'baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -18,10 +18,8 @@ test_valid_value("alignment-baseline", "ideographic");
 test_valid_value("alignment-baseline", "middle");
 test_valid_value("alignment-baseline", "central");
 test_valid_value("alignment-baseline", "mathematical");
+test_valid_value("alignment-baseline", "hanging");
 test_valid_value("alignment-baseline", "text-top");
-test_valid_value("alignment-baseline", "bottom");
-test_valid_value("alignment-baseline", "center");
-test_valid_value("alignment-baseline", "top");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
@@ -12,9 +12,6 @@ PASS Can set 'alignment-baseline' to the 'middle' keyword: middle
 PASS Can set 'alignment-baseline' to the 'central' keyword: central
 PASS Can set 'alignment-baseline' to the 'mathematical' keyword: mathematical
 FAIL Can set 'alignment-baseline' to the 'text-top' keyword: text-top Invalid values
-FAIL Can set 'alignment-baseline' to the 'bottom' keyword: bottom Invalid values
-FAIL Can set 'alignment-baseline' to the 'center' keyword: center Invalid values
-FAIL Can set 'alignment-baseline' to the 'top' keyword: top Invalid values
 PASS Setting 'alignment-baseline' to a length: 0px throws TypeError
 PASS Setting 'alignment-baseline' to a length: -3.14em throws TypeError
 PASS Setting 'alignment-baseline' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline.html
@@ -22,9 +22,6 @@ runPropertyTests('alignment-baseline', [
   { syntax: 'central' },
   { syntax: 'mathematical' },
   { syntax: 'text-top' },
-  { syntax: 'bottom' },
-  { syntax: 'center' },
-  { syntax: 'top' },
 ]);
 
 </script>


### PR DESCRIPTION
#### bfb94d150b4243ef0586cdcc575bbad1e874263c
<pre>
Refresh the imported css-inline alignment-baseline parsing tests from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=322454">https://bugs.webkit.org/show_bug.cgi?id=322454</a>

Reviewed by Tim Nguyen.

The imported copies of these tests predate w3c/csswg-drafts#5180, which moved the
line-relative values top, center and bottom off alignment-baseline onto
baseline-shift. They still assert those three are valid, so WebKit -- which
already rejects them, correctly -- reports three FAILs per file that describe the
grammar as it no longer is. Upstream has since flipped those three over to
alignment-baseline-invalid.html, and added hanging, which WebKit accepts, to the
valid and computed tests.

Refresh alignment-baseline-{valid,computed,invalid}.html and the css-typed-om
alignment-baseline.html from upstream, and rebaseline. This changes which
assertions run, not what WebKit does: nine stale FAILs go away and five new
PASSes appear, and no subtest goes from PASS to FAIL.

The rest of css/css-inline is deliberately left alone. Upstream&apos;s vertical-align
tests there now assert css-inline-3&apos;s shorthand grammar, which WebKit does not
implement, so importing them belongs in its own change.

text-top and text-bottom still FAIL. Those are genuinely unimplemented, and are
fixed in bug 321612.

* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline.html:

Canonical link: <a href="https://commits.webkit.org/319770@main">https://commits.webkit.org/319770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6008cad2c441e9d4d4a22e1b3422c732b81c246c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43216 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42841 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4056 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194829 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152003 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40737 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56967 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151703 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46278 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125254 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55475 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17851 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->