### PR TITLE
Harden `SpinButtonElement` by making `SpinButtonOwner` ref-countable

### DIFF
--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -110,8 +110,8 @@ void SpinButtonElement::defaultEventHandler(Event& event)
             // code which detaches this shadow node. We need to take a reference
             // and check renderer() after such function calls.
             Ref<SpinButtonElement> protectedThis(*this);
-            if (m_spinButtonOwner)
-                m_spinButtonOwner->focusAndSelectSpinButtonOwner();
+            if (RefPtr spinButtonOwner = m_spinButtonOwner)
+                spinButtonOwner->focusAndSelectSpinButtonOwner();
             if (renderer()) {
                 if (m_upDownState != Indeterminate) {
                     // A JavaScript event handler called in doStepAction() below
@@ -186,13 +186,14 @@ bool SpinButtonElement::willRespondToMouseClickEventsWithEditability(Editability
 
 void SpinButtonElement::doStepAction(int amount)
 {
-    if (!m_spinButtonOwner)
+    RefPtr spinButtonOwner = m_spinButtonOwner;
+    if (!spinButtonOwner)
         return;
 
     if (amount > 0)
-        m_spinButtonOwner->spinButtonStepUp();
+        spinButtonOwner->spinButtonStepUp();
     else if (amount < 0)
-        m_spinButtonOwner->spinButtonStepDown();
+        spinButtonOwner->spinButtonStepDown();
 }
 
 void SpinButtonElement::releaseCapture()
@@ -254,7 +255,8 @@ void SpinButtonElement::setHovered(bool flag, Style::InvalidationScope invalidat
 
 bool SpinButtonElement::shouldRespondToMouseEvents() const
 {
-    return !m_spinButtonOwner || m_spinButtonOwner->shouldSpinButtonRespondToMouseEvents();
+    RefPtr spinButtonOwner = m_spinButtonOwner;
+    return !spinButtonOwner || spinButtonOwner->shouldSpinButtonRespondToMouseEvents();
 }
 
 }

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -29,20 +29,12 @@
 #include "HTMLDivElement.h"
 #include "PopupOpeningObserver.h"
 #include "Timer.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class SpinButtonOwner;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpinButtonOwner> : std::true_type { };
-}
-
-namespace WebCore {
-
-class SpinButtonOwner : public CanMakeWeakPtr<SpinButtonOwner> {
+class SpinButtonOwner : public AbstractRefCountedAndCanMakeWeakPtr<SpinButtonOwner> {
 public:
     virtual ~SpinButtonOwner() = default;
     virtual void focusAndSelectSpinButtonOwner() = 0;


### PR DESCRIPTION
#### 9972b95bf01bb57cb62406e1cbaa769721d560da
<pre>
Harden `SpinButtonElement` by making `SpinButtonOwner` ref-countable
<a href="https://bugs.webkit.org/show_bug.cgi?id=322456">https://bugs.webkit.org/show_bug.cgi?id=322456</a>
<a href="https://rdar.apple.com/185740189">rdar://185740189</a>

Reviewed by Chris Dumez.

This makes SpinButtonOwner ref-countable since nothing enforces that
the owner stays alive across its virtual functions.

No new tests since there should be no behavioral changes.

* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::defaultEventHandler):
(WebCore::SpinButtonElement::doStepAction):
(WebCore::SpinButtonElement::shouldRespondToMouseEvents const):
* Source/WebCore/html/shadow/SpinButtonElement.h:

Canonical link: <a href="https://commits.webkit.org/319792@main">https://commits.webkit.org/319792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8ba1582c8735c0b03acc783983c4faf763cea6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43222 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42846 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4063 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56270 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46283 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129242 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125261 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55482 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17846 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->