### PR TITLE
[webkitcorepy] Fix latent bugs uncovered by adding type annotations

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
@@ -32,9 +32,9 @@ class NoAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, not any((
-            option_string.startswith('--no-'),
-            option_string.startswith('--un'),
-            option_string.startswith('--skip-'),
+            option_string.startswith('--no-') if option_string else False,
+            option_string.startswith('--un') if option_string else False,
+            option_string.startswith('--skip-') if option_string else False,
         )))
 
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
@@ -23,7 +23,8 @@
 import argparse
 import logging
 
-from webkitcorepy import log
+
+log = logging.getLogger('webkitcorepy')
 
 
 class NoAction(argparse.Action):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -635,7 +635,7 @@ class AutoInstall(importlib.abc.MetaPathFinder):
         try:
             response = AutoInstall._request('https://{}/simple/pip/'.format(cls.index), ca_cert_path=cls.ca_cert_path)
             if response.code != 200:
-                error('Failed to set AutoInstall index to {}, received {} response when searching for simple/pip'.format(index, response.code))
+                error('Failed to set AutoInstall index to {}, received {} response when searching for simple/pip'.format(cls.index, response.code))
 
         except URLError:
             error('Failed to set AutoInstall index to {}, no response from the server'.format(cls.index))
@@ -661,7 +661,7 @@ class AutoInstall(importlib.abc.MetaPathFinder):
             cls._verify_index()
 
         if cls.ca_cert_path:
-            os.environ[cls.CA_CERT_PATH_ENV_VAR] = ca_cert_path
+            os.environ[cls.CA_CERT_PATH_ENV_VAR] = cls.ca_cert_path
 
         return cls.index
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -40,7 +40,7 @@ import zipfile
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import NullHandler
-from webkitcorepy import log
+
 from webkitcorepy.version import Version
 from webkitcorepy.file_lock import FileLock
 
@@ -48,6 +48,8 @@ from html.parser import HTMLParser
 from urllib.request import urlopen
 from urllib.error import URLError
 from urllib.parse import urlparse
+
+log = logging.getLogger('webkitcorepy')
 
 
 class SimplyPypiIndexPageParser(HTMLParser):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -35,7 +35,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import time
 import zipfile
 
 from collections import defaultdict
@@ -721,12 +720,12 @@ class AutoInstall(importlib.abc.MetaPathFinder):
             sys.stderr.write("Autoinstaller disabled, but 'install' called\n")
             return None
         if isinstance(package, str):
-            # we want this to throw if it hasn't been previously registered; in the case
-            # that this is being called from cls.find_module it should always exist
             packages = cls.packages[package]
         else:
             packages = cls.register(package)
-        return all([to_install.install() for to_install in packages])
+        for to_install in packages:
+            to_install.install()
+        return None
 
     @classmethod
     def install_everything(cls):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py
@@ -98,7 +98,7 @@ class Config(dict[str, 'Config.Values']):
 
         result = jsone.render(value, context=context)
         if isinstance(result, Mapping):
-            return Config(**result)
+            return Config(result)
         return result
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
@@ -134,15 +134,15 @@ class Editor(object):
     def __init__(self, name, path, command=None, wait=None):
         self.name = name
         self.path = path
-        self.command = command or [self.path]
-        self.wait = self.command + (wait or [])
+        self.command = list(command) if command else ([path] if path else [])
+        self.wait = self.command + list(wait or [])
 
     @hybridmethod
     def open(context, file, block=False):
         if isinstance(context, type):
             context = context.preferred()
 
-        if not os.path.isfile(context.path):
+        if not context.path or not os.path.isfile(context.path):
             return False
         return not run((context.wait if block else context.command) + [file], capture_output=True).returncode
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
@@ -89,7 +89,7 @@ class Editor(object):
         return cls(
             name='vi',
             path=path,
-            command=[path],
+            command=[path] if path else None,
         )
 
     @classmethod
@@ -98,7 +98,7 @@ class Editor(object):
         return cls(
             name='open',
             path=path,
-            command=[path, '-t'],
+            command=[path, '-t'] if path else None,
             wait=['--wait-apps'],
         )
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/environment.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/environment.py
@@ -61,7 +61,7 @@ class Environment(object):
     def secure(self, *extra_paths):
         '''Delete unused environment files in self.path along with the provided extra paths'''
 
-        for file in os.listdir(self.path):
+        for file in os.listdir(self.path) if self.path else []:
             path = os.path.join(self.path, file)
             if path not in self._paths:
                 os.remove(path)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/measure_time.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/measure_time.py
@@ -20,9 +20,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import time
 
-from webkitcorepy import log
+
+log = logging.getLogger('webkitcorepy')
 
 
 class MeasureTime(object):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import io
 import subprocess
@@ -27,8 +28,11 @@ import signal
 import sys
 import time
 
-from webkitcorepy import log, string_utils, TimeoutExpired
+from webkitcorepy import string_utils, TimeoutExpired
+
 from webkitcorepy.mocks import Subprocess
+
+log = logging.getLogger('webkitcorepy')
 
 # This file is mocked version of the subprocess.Popen object. This object differs slightly between Python 2 and 3.
 # This object is not a complete mock of subprocess.Popen, but it does enable thorough testing of code which uses Popen,

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
@@ -23,6 +23,8 @@
 import json
 from unittest import mock
 
+from requests.structures import CaseInsensitiveDict
+
 from webkitcorepy import string_utils
 from webkitcorepy.mocks import ContextStack
 
@@ -63,12 +65,12 @@ class Response(object):
             self.content = content or b''
 
         self.url = url
-        self.headers = headers or {}
+        self.headers = CaseInsensitiveDict(headers or {})
 
         if 'Content-Type' not in self.headers:
             self.headers['Content-Type'] = 'text'
         if 'Content-Length' not in self.headers:
-            self.headers['Content-Length'] = len(self.content) if self.content else 0
+            self.headers['Content-Length'] = str(len(self.content)) if self.content else '0'
 
     @property
     def text(self):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
@@ -39,7 +39,7 @@ class Response(object):
     def fromJson(data, url=None, headers=None, status_code=None):
         assert isinstance(data, list) or isinstance(data, dict)
 
-        headers = headers or {}
+        headers = dict(headers or {})
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'text/json'
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
@@ -72,7 +72,7 @@ class Subprocess(ContextStack):
             env = kwargs.pop('env', None)
             generator = kwargs.pop('generator', None)
             if kwargs.keys():
-                raise TypeError('__init__() got an unexpected keyword argument {}'.format(kwargs.keys()[0]))
+                raise TypeError('__init__() got an unexpected keyword argument {}'.format(next(iter(kwargs))))
 
             if isinstance(args, str) or isinstance(args, unicode):
                 self.args = [args]
@@ -91,7 +91,7 @@ class Subprocess(ContextStack):
             input = kwargs.pop('input', None)
             env = kwargs.pop('env', None)
             if kwargs.keys():
-                raise TypeError('matches() got an unexpected keyword argument {}'.format(kwargs.keys()[0]))
+                raise TypeError('matches() got an unexpected keyword argument {}'.format(next(iter(kwargs))))
 
             if len(self.args) > len(args):
                 return False
@@ -123,7 +123,7 @@ class Subprocess(ContextStack):
             input = kwargs.pop('input', None)
             env = kwargs.pop('env', dict())
             if kwargs.keys():
-                raise TypeError('__call__() got an unexpected keyword argument {}'.format(kwargs.keys()[0]))
+                raise TypeError('__call__() got an unexpected keyword argument {}'.format(next(iter(kwargs))))
             return self.generator(*args, cwd=cwd, input=input, env=env)
 
         @classmethod
@@ -177,7 +177,7 @@ class Subprocess(ContextStack):
         if all([isinstance(arg, self.CommandRoute) for arg in args]):
             self.ordered = kwargs.pop('ordered', False)
             if kwargs.keys():
-                raise TypeError('__init__() got an unexpected keyword argument {}'.format(kwargs.keys()[0]))
+                raise TypeError('__init__() got an unexpected keyword argument {}'.format(next(iter(kwargs))))
             self.completions = list(args) if self.ordered else sorted(args, key=cmp_to_key(self.CommandRoute.compare))
         elif any([isinstance(arg, self.CommandRoute) for arg in args]):
             raise TypeError('mocks.Subprocess arguments must be of a consistent type')

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py
@@ -172,7 +172,7 @@ class OutputDuplicate(mocks.ContextStack):
         super(OutputDuplicate, self).__init__(cls=OutputDuplicate)
 
         self.output = StringIO()
-        self.loggers = [logging.getLogger()] or loggers
+        self.loggers = loggers or [logging.getLogger()]
 
         self._handler_stack = []
         self._streams_stack = []

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py
@@ -25,8 +25,11 @@ import io
 import logging
 import sys
 
-from webkitcorepy import log, mocks
+from webkitcorepy import mocks
+
 from webkitcorepy.string_utils import StringIO
+
+log = logging.getLogger('webkitcorepy')
 
 
 class LoggerCapture(object):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
@@ -44,7 +44,7 @@ class PartialProxy(mocks.ContextStack):
         import requests
 
         class Session(requests.Session):
-            def request(self, method, url, **kwargs):
+            def request(self, method, url, *args, **kwargs):
                 split = url.split('/')
                 protocol = split[0]
                 host = split[2] if len(split) >= 3 else None
@@ -60,7 +60,7 @@ class PartialProxy(mocks.ContextStack):
                             break
                         current = current.previous
 
-                return super(Session, self).request(method, url, **kwargs)
+                return super(Session, self).request(method, url, *args, **kwargs)
 
         self._temp_patches = [
             mock.patch('requests.Session', new=Session),

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
@@ -74,7 +74,7 @@ def join(list, conjunction='and'):
 
 
 def split(string, conjunctions=None):
-    conjunctions = ['and', 'or']
+    conjunctions = conjunctions or ['and', 'or']
     if not string:
         return []
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -28,7 +28,9 @@ import queue as Queue
 import signal
 import sys
 
-from webkitcorepy import OutputCapture, Timeout, log
+from webkitcorepy import OutputCapture, Timeout
+
+log = logging.getLogger('webkitcorepy')
 
 
 class _Message(object):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -230,10 +230,6 @@ class _Process(object):
     working = False
     queue = None
     stop_repeat = False
-    name = None
-    working = False
-    queue = None
-    stop_repeat = False
     repeat_task_queue = None
 
     class LogHandler(logging.Handler):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
@@ -28,7 +28,9 @@ import sys
 import time
 import unittest
 
-from webkitcorepy import arguments, log, string_utils, Terminal
+from webkitcorepy import arguments, string_utils, Terminal
+
+log = logging.getLogger('webkitcorepy')
 
 
 class TestRunner(object):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from collections import defaultdict
 from unittest.mock import patch
 from urllib.error import URLError
 
@@ -143,3 +144,18 @@ class MergeMoveTest(unittest.TestCase):
         self._unpack('provides-file', ['sample/thing'])
         self._unpack('provides-package', ['sample/thing/__init__.py'])
         self.assertEqual(self._contents(), ['sample/thing/__init__.py'])
+
+
+class InstallTest(unittest.TestCase):
+    def test_install_nothing_registered(self) -> None:
+        with patch.object(AutoInstall, 'enabled', return_value=True), \
+                patch.object(AutoInstall, 'packages', new=defaultdict(list)):
+            self.assertIsNone(AutoInstall.install('never-registered'))
+
+    def test_install_registered_package(self) -> None:
+        with patch.object(AutoInstall, 'enabled', return_value=True), \
+                patch.object(AutoInstall, 'packages', new=defaultdict(list)), \
+                patch.object(Package, 'install', autospec=True, return_value=None) as install:
+            AutoInstall.register(Package('example', Version(1, 0)))
+            self.assertIsNone(AutoInstall.install('example'))
+            self.assertEqual(install.call_count, 1)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py
@@ -98,6 +98,15 @@ class ConfigRenderTestCase(unittest.TestCase):
         }, context={'x': 5})
         self.assertDictEqual(result, {'value': 10})
 
+    def test_render_key_named_mapping(self) -> None:
+        result = Config.render({'mapping': {'key': 'value'}})
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'mapping': {'key': 'value'}})
+
+    def test_render_key_named_mapping_alongside_others(self) -> None:
+        result = Config.render({'mapping': {'key': 'value'}, 'other': 1})
+        self.assertDictEqual(result, {'mapping': {'key': 'value'}, 'other': 1})
+
 
 class ConfigLoadsTestCase(unittest.TestCase):
     def test_loads_yaml(self):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/editor_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/editor_unittest.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from unittest import mock
+
+from webkitcorepy import Editor
+
+
+class EditorTest(unittest.TestCase):
+    def test_command_without_path(self) -> None:
+        editor = Editor(name='editor', path=None)
+        self.assertEqual(editor.command, [])
+        self.assertEqual(editor.wait, [])
+
+    def test_command_is_copied_from_argument(self) -> None:
+        command = ['/usr/bin/editor', '-n']
+        editor = Editor(name='editor', path='/usr/bin/editor', command=command, wait=['-w'])
+        self.assertEqual(editor.command, ['/usr/bin/editor', '-n'])
+        self.assertEqual(editor.wait, ['/usr/bin/editor', '-n', '-w'])
+
+        editor.command.append('-extra')
+        self.assertEqual(command, ['/usr/bin/editor', '-n'])
+
+    def test_open_without_path(self) -> None:
+        self.assertFalse(Editor(name='editor', path=None).open('file.txt'))
+
+    def test_open_without_path_blocking(self) -> None:
+        self.assertFalse(Editor(name='editor', path=None).open('file.txt', block=True))
+
+    def test_vi_without_vi_installed(self) -> None:
+        with mock.patch('shutil.which', return_value=None):
+            self.assertEqual(Editor.vi().command, [])
+
+    def test_default_without_open_installed(self) -> None:
+        with mock.patch('shutil.which', return_value=None):
+            self.assertEqual(Editor.default().command, [])

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/environment_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/environment_unittest.py
@@ -22,6 +22,8 @@
 
 import os
 
+from unittest import mock
+
 from webkitcorepy import testing, Environment
 
 
@@ -93,3 +95,13 @@ class TestEnvironment(testing.PathTestCase):
             self.assertFalse(os.path.isfile(os.path.join(self.path, 'KEY_C')))
         finally:
             Environment._instance = None
+
+    def test_secure_without_path(self) -> None:
+        extra_path = os.path.join(self.path, 'KEY')
+        with open(extra_path, 'w') as file:
+            file.write('value')
+
+        with mock.patch('os.listdir') as listdir:
+            Environment().secure(extra_path)
+            listdir.assert_not_called()
+            self.assertFalse(os.path.isfile(extra_path))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py
@@ -50,11 +50,11 @@ class MockRequests(unittest.TestCase):
             response = requests.get('https://webkit.org/text')
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.text, 'text content')
-            self.assertDictEqual(response.headers, {'Content-Length': 12, 'Content-Type': 'text'})
+            self.assertEqual(response.headers, {'Content-Length': '12', 'Content-Type': 'text'})
 
     def test_json(self):
         with self.Example('webkit.org'):
             response = requests.get('https://webkit.org/json')
             self.assertEqual(response.status_code, 200)
             self.assertDictEqual(response.json(), dict(content='json'))
-            self.assertDictEqual(response.headers, {'Content-Length': 19, 'Content-Type': 'text/json'})
+            self.assertEqual(response.headers, {'Content-Length': '19', 'Content-Type': 'text/json'})

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py
@@ -58,3 +58,11 @@ class MockRequests(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertDictEqual(response.json(), dict(content='json'))
             self.assertEqual(response.headers, {'Content-Length': '19', 'Content-Type': 'text/json'})
+
+
+class MockResponse(unittest.TestCase):
+    def test_from_json_does_not_mutate_headers(self) -> None:
+        headers = {'Accept': 'application/json'}
+        response = mocks.Response.fromJson(data=dict(content='json'), headers=headers)
+        self.assertEqual(headers, {'Accept': 'application/json'})
+        self.assertEqual(response.headers['Content-Type'], 'text/json')

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/subprocess_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/subprocess_unittest.py
@@ -133,6 +133,24 @@ class MockSubprocess(unittest.TestCase):
             self.assertEqual(run(['command'], stdin=BytesIO(b'stdin')).returncode, 0)
 
 
+class MockSubprocessUnexpectedKeywordArgument(unittest.TestCase):
+    def test_subprocess_constructor(self) -> None:
+        with self.assertRaisesRegex(TypeError, 'unexpected keyword argument bogus'):
+            mocks.Subprocess(mocks.Subprocess.Route('ls'), bogus=True)
+
+    def test_route_constructor(self) -> None:
+        with self.assertRaisesRegex(TypeError, 'unexpected keyword argument bogus'):
+            mocks.Subprocess.Route('ls', bogus=True)
+
+    def test_route_matches(self) -> None:
+        with self.assertRaisesRegex(TypeError, 'unexpected keyword argument bogus'):
+            mocks.Subprocess.Route('ls').matches('ls', bogus=True)
+
+    def test_route_call(self) -> None:
+        with self.assertRaisesRegex(TypeError, 'unexpected keyword argument bogus'):
+            mocks.Subprocess.Route('ls')('ls', bogus=True)
+
+
 class MockCheckOutput(unittest.TestCase):
     def test_popen(self):
         with mocks.Subprocess(MockSubprocess.LS):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/output_capture_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/output_capture_unittest.py
@@ -104,3 +104,15 @@ class OutputDuplicateTest(unittest.TestCase):
 
         self.assertEqual(captuered.webkitcorepy.log.getvalue(), 'Log 1\nLog 2\n')
         self.assertEqual(captuered.stdout.getvalue(), 'Level 1\nLevel 2\n')
+
+    def test_provided_loggers(self) -> None:
+        logger = logging.getLogger('output-duplicate-test')
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        try:
+            with OutputDuplicate(loggers=[logger]) as duplicator:
+                logger.info('Printed')
+                self.assertEqual(duplicator.output.getvalue(), 'Printed\n')
+        finally:
+            logger.setLevel(logging.NOTSET)
+            logger.propagate = True

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
@@ -76,6 +76,10 @@ class StringUtils(unittest.TestCase):
         self.assertEqual(string_utils.split(''), [])
         self.assertEqual(string_utils.split('integer or string'), ['integer', 'string'])
 
+    def test_split_with_conjunctions(self) -> None:
+        self.assertEqual(string_utils.split('integer nor string', conjunctions=['nor']), ['integer', 'string'])
+        self.assertEqual(string_utils.split('integer and string', conjunctions=['nor']), ['integer and string'])
+
     def test_outof(self):
         self.assertEqual(string_utils.out_of(1, 3), '[1/3]')
         self.assertEqual(string_utils.out_of(1, 10), '[ 1/10]')

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/timeout_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/timeout_unittest.py
@@ -24,6 +24,8 @@ import time
 import threading
 import unittest
 
+from unittest.mock import patch
+
 from webkitcorepy import OutputCapture, Timeout, mocks
 
 
@@ -51,6 +53,16 @@ class TimeoutTests(unittest.TestCase):
             self.assertEqual(threading.current_thread().ident, tmp.data.thread_id)
             self.assertTrue(time.time() + 1 >= tmp.data.alarm_time)
         self.assertEqual(None, tmp.data)
+
+    def test_timeout_data_compared_to_foreign_type(self) -> None:
+        data = Timeout.Data(alarm_time=time.time(), handler=None)
+        with self.assertRaises(ValueError) as context:
+            data.__lt__('not-timeout-data')
+        self.assertIn("<class 'str'>", str(context.exception))
+
+    def test_check_without_current_timeout(self) -> None:
+        with patch.object(Timeout, 'difference', return_value=0):
+            self.assertIsNone(Timeout.check())
 
     def test_difference(self):
         with mocks.Time:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import operator
 import sys
 import unittest
 
@@ -222,6 +223,20 @@ class VersionTestCase(unittest.TestCase):
         self.assertGreaterEqual(Version(1, 2, 3), None)
         self.assertLess(None, Version(1, 2, 3))
         self.assertLessEqual(None, Version(1, 2, 3))
+
+    def test_compare_versions_to_padded_tuple(self) -> None:
+        self.assertEqual(Version(1, 2), (1, 2, 0, 0, 0))
+        self.assertTrue(Version(1, 2) < (1, 3, 0, 0, 0))
+        self.assertTrue(Version(1, 2) >= (1, 2, 0, 0, 0))
+
+    def test_equality_with_non_iterable(self) -> None:
+        self.assertFalse(Version(1, 2, 3) == 5)
+        self.assertTrue(Version(1, 2, 3) != 5)
+
+    def test_ordering_against_non_iterable(self) -> None:
+        for operation in [operator.lt, operator.le, operator.gt, operator.ge]:
+            with self.assertRaisesRegex(TypeError, 'not supported between instances'):
+                operation(Version(1, 2, 3), 5)
 
     def test_matches(self):
         version = Version(1, 2, 3)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -52,7 +52,7 @@ class Timeout(object):
             if not other:
                 return False
             if not isinstance(other, Timeout.Data):
-                raise ValueError('Expected {} in comparison, received {}').format(Timeout.Data, type(other))
+                raise ValueError('Expected {} in comparison, received {}'.format(Timeout.Data, type(other)))
             return self.alarm_time < other.alarm_time
 
     class Exception(Exception):
@@ -114,6 +114,8 @@ class Timeout(object):
         if cls.difference(current_time=current_time) != 0:
             return
         current = cls.current()
+        if not current:
+            return
         current.triggered = True
         cls.bind()
         current.handler(Timeout.SIGALRM, None)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import bisect
 import collections
 import importlib
@@ -29,8 +30,11 @@ import signal
 import threading
 import time
 
-from webkitcorepy import log, string_utils
+from webkitcorepy import string_utils
+
 from webkitcorepy.call_by_need import CallByNeed
+
+log = logging.getLogger('webkitcorepy')
 
 mock = CallByNeed(lambda: importlib.import_module('unittest.mock'))
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
@@ -185,19 +185,31 @@ class Version(object):
     def __lt__(self, other):
         if other is None:
             return False
-        return tuple(self) < tuple(other)
+        try:
+            return tuple(self) < tuple(other)
+        except TypeError:
+            return NotImplemented
 
     def __le__(self, other):
         if other is None:
             return False
-        return tuple(self) <= tuple(other)
+        try:
+            return tuple(self) <= tuple(other)
+        except TypeError:
+            return NotImplemented
 
     def __gt__(self, other):
         if other is None:
             return True
-        return tuple(self) > tuple(other)
+        try:
+            return tuple(self) > tuple(other)
+        except TypeError:
+            return NotImplemented
 
     def __ge__(self, other):
         if other is None:
             return True
-        return tuple(self) >= tuple(other)
+        try:
+            return tuple(self) >= tuple(other)
+        except TypeError:
+            return NotImplemented

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
@@ -180,7 +180,10 @@ class Version(object):
     def __eq__(self, other):
         if other is None:
             return False
-        return tuple(self) == tuple(other)
+        try:
+            return tuple(self) == tuple(other)
+        except TypeError:
+            return NotImplemented
 
     def __lt__(self, other):
         if other is None:


### PR DESCRIPTION
#### bd224e6fda4058357e1213f4d07075b46413dc94
<pre>
[webkitcorepy] Add tests for the latent bugs fixed in this change
<a href="https://bugs.webkit.org/show_bug.cgi?id=322457">https://bugs.webkit.org/show_bug.cgi?id=322457</a>
<a href="https://rdar.apple.com/185740455">rdar://185740455</a>

Reviewed by NOBODY (OOPS!).

Each of these fixes sat on an error path or argument combination no test
exercised, which is why the suite stayed green through all of them. Every test
here was checked against a reverted fix and observed to fail.

`editor_unittest.py` is new; the module had no tests.

Two tests are deliberately not crash-based. `test_secure_without_path` patches
`os.listdir` and asserts it is never reached, because unguarded
`os.listdir(None)` lists the working directory rather than raising, so a
crash-based test would depend on the cwd. `test_check_without_current_timeout`
patches `Timeout.difference`, since the guard it covers is only reachable when
a timeout expires between two calls.

`test_compare_versions_to_padded_tuple` guards behaviour this change preserves
rather than alters: `Version(1, 2) == (1, 2, 0, 0, 0)` must stay true. It is
there to catch the tempting alternative fix of an `isinstance` check on the
comparison operators, which would break it.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/editor_unittest.py: Added.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/environment_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/subprocess_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/output_capture_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/timeout_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py:
</pre>
----------------------------------------------------------------------
#### 216003f62eedfed6d5bc9aa68116d0d96db78543
<pre>
Have webkitcorepy submodules get their logger directly

Reviewed by NOBODY (OOPS!).

Eight submodules did `from webkitcorepy import log`, importing the package that
was in the middle of importing them. That works only because `__init__.py`
assigns `log` before it imports any submodule; moving that assignment below the
imports, or reaching a submodule by another path first, raises ImportError on a
partially initialized module.

`logging.getLogger` is a registry keyed by name, so asking for
`&apos;webkitcorepy&apos;` directly yields the same Logger object and removes the cycle.
`__init__.py` still attaches the NullHandler before any submodule is imported,
so handler setup is unchanged. No behaviour change.

This only decouples `log`. `string_utils`, `mocks` and a few classes are still
imported through the package facade, so the cycle is shorter rather than gone.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/measure_time.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py:
</pre>
----------------------------------------------------------------------
#### 4f14d42f95e4120a1038e9f2fc2ec7d6ab612844
<pre>
Extract behaviour fixes from the webkitcorepy typing work

Reviewed by NOBODY (OOPS!).

These are behaviour changes that Sam Sneddon&apos;s in-progress annotation branch
carries alongside its type annotations. Landing them separately keeps that
diff to annotations, where a reviewer can see it.

Two are real. `Config.render` splatted the rendered document into the
constructor as keyword arguments, so a top-level key named `mapping` bound to
`Config.__init__`&apos;s parameter of the same name and its contents were merged one
level up, silently losing the key. And `Editor` still built `command=[None]`
when `shutil.which()` found nothing, because `__init__` fell back to
`[self.path]`; `open()` then called `os.path.isfile(None)` and raised
`TypeError` rather than returning `False`, on a machine where none of the
candidate editors exist. `__bool__` already guarded correctly.

The rest are latent. `AutoInstall.install` returned `all()` over a list of
`None`, so it reported `False` on success and `True` when it installed nothing;
no caller reads it. Its comment claimed the lookup throws for an unregistered
name, which a `defaultdict` does not. `Response.fromJson` wrote `Content-Type`
into the caller&apos;s `headers` dict. `OutputDuplicate`&apos;s `loggers` argument has
never had any effect, since `[logging.getLogger()] or loggers` always takes the
non-empty list; the sibling `OutputCapture` and `LoggerCapture` both let the
caller&apos;s value win, so this makes a published argument live for the first time.
`Environment.secure()` lacked the `path` guard `load()` has.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(AutoInstall.install):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py:
(Config.render):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py:
(Editor.__init__):
(Editor.open):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/environment.py:
(Environment.secure):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py:
(Response.fromJson):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/output_capture.py:
(OutputDuplicate.__init__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
</pre>
----------------------------------------------------------------------
#### ef53587a1ca92d07b5edc3b106fd66598fb4f83f
<pre>
Version.__eq__ should return NotImplemented rather than raising

Reviewed by NOBODY (OOPS!).

`Version.__eq__` called `tuple(other)` unguarded, so comparing a `Version`
against a non-iterable raised `TypeError` out of a method that must never
raise. Returning `NotImplemented` lets Python fall back to identity
comparison.

Equality against a sequence is preserved, so `Version(1, 2) == (1, 2, 0, 0, 0)`
still holds; only the crash is removed.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py:
(Version.__eq__):
</pre>
----------------------------------------------------------------------
#### f7eeff8e4412ac978c49331cd9022f8287986a8d
<pre>
[webkitcorepy] Fix latent bugs uncovered by adding type annotations
<a href="https://bugs.webkit.org/show_bug.cgi?id=322457">https://bugs.webkit.org/show_bug.cgi?id=322457</a>
<a href="https://rdar.apple.com/185740455">rdar://185740455</a>

Reviewed by NOBODY (OOPS!).

Annotating `webkitcorepy` surfaced defects that share a shape: each sits on an
error path or an argument combination no test exercises, so the suite stays
green while the code raises the wrong exception or ignores what it was passed.

`AutoInstall._verify_index` reports a bad index by raising `NameError` from an
unbound local, and `set_index` writes its rejected argument into `os.environ`
rather than `cls.ca_cert_path`. `kwargs.keys()[0]` has not been subscriptable
since Python 3, so every unexpected-keyword-argument path in the mock
`Subprocess` raised `TypeError` and hid the caller&apos;s typo. `split()` overwrote
its own `conjunctions` argument, leaving the parameter dead. `Editor.vi()` and
`Editor.default()` built `command=[None]` when `shutil.which()` found nothing,
failing inside `subprocess` rather than reporting the editor as unavailable.

The remainder narrow gaps between a mock and what it stands in for.
`Session.request` rejected positional arguments that `requests` accepts, and a
mock response stored `Content-Length` as an `int` in a plain dict where
`requests` returns a `str` in a `CaseInsensitiveDict` — `webkitbugspy` already
relies on the latter, comparing a lowercased header key against a string.

The `NoAction.__call__` and `Timeout.check()` guards have no reachable trigger
today; both are cheap, and each removes a state the annotations would otherwise
have to describe.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py:
(NoAction.__call__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(AutoInstall._verify_index):
(AutoInstall.set_index):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py:
(Editor.vi):
(Editor.default):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py:
(split):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/requests_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py:
(Timeout.Data.__lt__):
(Timeout.check):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd224e6fda4058357e1213f4d07075b46413dc94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142735 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99109 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123163 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182197 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43389 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43024 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4261 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195029 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182274 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56463 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57168 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39638 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/media/now-playing-info-default-artwork-favicon.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/webshare/webshare-allow-attribute-share.https.html, http/tests/websocket/tests/hybi/bufferedAmount-after-close-in-busy.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151886 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46450 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55676 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->