### PR TITLE
List marker is painted on top of the list item's content instead of behind it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists Reference: an outside list marker paints behind the list item's content</title>
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  /* No marker at all, which is what a marker covered by the content looks like. */
+  li { list-style-type: none; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists Reference: an outside list marker paints behind the list item's content</title>
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  /* No marker at all, which is what a marker covered by the content looks like. */
+  li { list-style-type: none; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: an outside list marker paints behind the list item's content</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#marker-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css2/zindex.html#painting-order">
+<link rel="match" href="list-marker-paint-order-ref.html">
+<meta name="assert" content="The marker box paints before the list item's content, so content pulled over the marker by a negative margin covers the marker instead of the marker covering the content.">
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  li { list-style-position: outside; list-style-type: disc; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -533,8 +533,10 @@ bool InlineFormattingContext::createDisplayContentForLineFromCachedContent(const
         return false;
     }
 
-    lineContent.lineGeometry.logicalTopLeft = { constraints.horizontal().logicalLeft, constraints.logicalTop() };
+    auto logicalTopLeft = InlineLayoutPoint { constraints.horizontal().logicalLeft, constraints.logicalTop() };
+    lineContent.lineGeometry.logicalTopLeft = logicalTopLeft;
     lineContent.lineGeometry.logicalWidth = constraints.horizontal().logicalWidth;
+    lineContent.lineGeometry.initialLogicalTopLeft = logicalTopLeft;
     lineContent.contentGeometry.logicalLeft = InlineFormattingUtils::horizontalAlignmentOffset(root().style(), lineContent.contentGeometry.logicalWidth, lineContent.lineGeometry.logicalWidth, lineContent.hangingContent.logicalWidth, true);
 
     auto canUseSimplifiedDisplayContentBuild = mayUseSimplifiedDisplayContentBuild && lineContent.hasContentfulInFlowContent();

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -455,10 +455,12 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
 void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    RenderBlockFlow::paintObject(paintInfo, paintOffset);
-
+    // The marker box paints before our content, so content overlapping it (a negative margin pulling the first line
+    // over the marker) covers it rather than the other way around.
     if (CheckedPtr excludedMarker = this->excludedMarker(); excludedMarker && !excludedMarker->hasSelfPaintingLayer())
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
+
+    RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
 String RenderListItem::markerText(RenderListMarker::IncludeSuffix includeSuffix) const


### PR DESCRIPTION
#### 635301493cc498ceb550449f9090700dbc81622d
<pre>
List marker is painted on top of the list item&apos;s content instead of behind it
<a href="https://bugs.webkit.org/show_bug.cgi?id=322458">https://bugs.webkit.org/show_bug.cgi?id=322458</a>
<a href="https://rdar.apple.com/185741211">rdar://185741211</a>

Reviewed by NOBODY (OOPS!).

RenderListItem::paintObject paints the marker after calling the base class, so the marker ends up over the list
item&apos;s content instead of behind it. Content that reaches back across the marker, a first line pulled out by a
negative margin, is drawn under the marker rather than covering it.

Tests: imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
       imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html: Added. The same
  content with no marker at all, which is what a marker covered by the content looks like.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html: Added.
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::paintObject):
</pre>
----------------------------------------------------------------------
#### 76b397b4e414c8dc0e2bed68d9245f4303b3da90
<pre>
[inline] LineGeometry::initialLogicalTopLeft is left unset for a line built from cached maximum intrinsic width content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322356">https://bugs.webkit.org/show_bug.cgi?id=322356</a>
<a href="https://rdar.apple.com/185638011">rdar://185638011</a>

Reviewed by NOBODY (OOPS!).

Add missing initialLogicalTopLeft initialization (couldn&apos;t find a repro test case).

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::createDisplayContentForLineFromCachedContent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/635301493cc498ceb550449f9090700dbc81622d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146971 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e4fdd84-ad0c-4ba1-9dac-35029f0e1028) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142566 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69c4c70a-fb4a-4b04-b50e-904cbfeb4017) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46290 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163328 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123000 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44d142d4-1b74-4967-9210-43e754c4d0bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43228 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42857 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4069 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194842 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152017 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56980 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39470 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151718 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46292 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129248 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125267 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55488 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17857 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54860 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->