### PR TITLE
ANGLE: Metal: EnsureLoopForwardProgress infinite loops with unsigned tautology compare classified as finite

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp
@@ -9,6 +9,8 @@
 
 #include "compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.h"
 
+#include <limits>
+
 #include "compiler/translator/Compiler.h"
 #include "compiler/translator/StaticType.h"
 #include "compiler/translator/tree_util/IntermNodePatternMatcher.h"
@@ -92,9 +94,41 @@ const TVariable *computeFiniteLoopVariable(TIntermLoop *loop)
         case EOpNotEqual:
         case EOpLessThan:
         case EOpGreaterThan:
+            break;
         case EOpLessThanEqual:
         case EOpGreaterThanEqual:
+        {
+            // `variable <= numeric_limits<..>::max()` and `variable >= numeric_limits<...>::min()`
+            // are never satisfied. These loops are infinite.
+            const TConstantUnion *bound = binCond->getRight()->getConstantValue();
+            if (bound == nullptr)
+            {
+                // We cannot prove a non-const variable is min/max. However, the MSL compiler
+                // might be able to prove it, and thus analyze the loop as infinite.
+                return nullptr;
+            }
+            const bool checkMax = binCond->getOp() == EOpLessThanEqual;
+            switch (bound->getType())
+            {
+                case EbtInt:
+                    if (bound->getIConst() == (checkMax ? std::numeric_limits<int>::max()
+                                                        : std::numeric_limits<int>::min()))
+                    {
+                        return nullptr;
+                    }
+                    break;
+                case EbtUInt:
+                    if (bound->getUConst() ==
+                        (checkMax ? std::numeric_limits<unsigned int>::max() : 0u))
+                    {
+                        return nullptr;
+                    }
+                    break;
+                default:
+                    return nullptr;
+            }
             break;
+        }
         default:
             return nullptr;
     }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp
@@ -578,7 +578,11 @@ void main() {
                          "for (uint i = 0u; i < 4294967295u; ++i) { }",
                          "for (uint i = 10u; i > 1u+3u ; --i) { }",
                          "const int z = 7; for (int i = 0; i < z; i++) { }",
-                         "for (int i = 0; i < 10; i++) { for (int j = 0; j < 1000; ++j) { }}"};
+                         "for (int i = 0; i < 10; i++) { for (int j = 0; j < 1000; ++j) { }}",
+                         "for (uint i = 10u; i >= 1u; --i) { }",
+                         "for (uint i = 0u; i <= 10u; ++i) { }",
+                         "for (int i = 0; i <= 2147483646; ++i) { }",
+                         "for (int i = 0; i >= -2147483647; --i) { }"};
 
     for (const char *test : kTests)
     {
@@ -621,6 +625,14 @@ void main() {
         "for (int i = 0; i < 10; i++) { for (int j = 0; j < 10; i--, j++) { } }",
         "for (int i = 0; i < 10; f()) { }",
         "for (int i = 0; i < 10; a == 0 ? i++ : i = 0) { }",
+        "for (uint i = 0u; i >= 0u; i--) { }",
+        "for (uint i = 0u; i >= 0u; i++) { }",
+        "for (uint i = 0u; i <= 4294967295u; i++) { }",
+        "for (int i = 0; i <= 2147483647; i++) { }",
+        "for (int i = 0; i >= -2147483647 - 1; i--) { }",
+        "const uint z = 0u; for (uint i = 0u; i >= z; i--) { }",
+        "for (int i = 0; i <= a; i++) { }",
+        "for (uint i = 0u; i >= b; i--) { }"
     };
 
     for (const char *test : kTests)


### PR DESCRIPTION
#### fd1caf2e06751dcc918767f82a7ba876ec4dfb80
<pre>
ANGLE: Metal: EnsureLoopForwardProgress infinite loops with unsigned tautology compare classified as finite
<a href="https://bugs.webkit.org/show_bug.cgi?id=317286">https://bugs.webkit.org/show_bug.cgi?id=317286</a>
<a href="https://rdar.apple.com/178005812">rdar://178005812</a>

Reviewed by Dan Glastonbury.

Finite loop classification relies on the property that ++i or --i eventually lands
to a value that makes the condition evaluate to false. This is not true for cases
   uint i: i &gt;= 0u, i &lt;= 4294967295u
   int i: i &lt; -2147483646, i &gt;= 2147483647

Classify these as infinite by checking the constant for &lt;=, &gt;=.

* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp:

Originally-landed-as: 305413.1008@safari-7624.5-branch (af3089d4dc75). <a href="https://rdar.apple.com/185367969">rdar://185367969</a>
Canonical link: <a href="https://commits.webkit.org/319891@main">https://commits.webkit.org/319891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a788c57700813a9f7f9036aa0d089b16d2f1bc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43543 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43174 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4448 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195215 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56649 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152351 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40829 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57354 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152047 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46608 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55862 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18185 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->