### PR TITLE
Image observer save/restore should be scope-bound

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1758,13 +1758,12 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
     if (!image)
         return { };
 
-    auto observer = image->imageObserver();
+    bool drawsSVGImage = image->drawsSVGImage();
+    ImageObserverDisableScope imageObserverDisabler(*image, drawsSVGImage);
     auto shouldPostProcess { true };
 
-    if (image->drawsSVGImage()) {
-        image->setImageObserver(nullptr);
+    if (drawsSVGImage)
         image->setContainerSize(imageRect.size());
-    }
 
     if (RefPtr bitmapImage = dynamicDowncast<BitmapImage>(*image)) {
         // Drawing an animated image to a canvas should draw the first frame (except for a few layout tests)
@@ -1801,9 +1800,6 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
         c->drawImage(*image, normalizedDstRect, normalizedSrcRect, options);
 
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, shouldPostProcess ? defaultDidDrawOptions() : defaultDidDrawOptionsWithoutPostProcessing());
-
-    if (image->drawsSVGImage())
-        image->setImageObserver(WTF::move(observer));
 
     return { };
 }

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -175,15 +175,13 @@ void BitmapImage::drawLuminanceMaskPattern(GraphicsContext& context, const Float
     if (!buffer)
         return;
 
-    auto observer = imageObserver();
-
-    // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
-    setImageObserver(nullptr);
-
     auto bufferRect = FloatRect { { }, buffer->logicalSize() };
-    draw(buffer->context(), bufferRect, tileRect, { options, DecodingMode::Synchronous, ImageOrientation::Orientation::FromImage });
+    {
+        // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
+        ImageObserverDisableScope imageObserverDisabler(*this);
+        draw(buffer->context(), bufferRect, tileRect, { options, DecodingMode::Synchronous, ImageOrientation::Orientation::FromImage });
+    }
 
-    setImageObserver(WTF::move(observer));
     buffer->convertToLuminanceMask();
 
     context.setDrawLuminanceMask(false);

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -495,4 +495,19 @@ std::optional<Color> Image::singlePixelSolidColor() const
     return std::nullopt;
 }
 
+ImageObserverDisableScope::ImageObserverDisableScope(Image& image, bool disable)
+    : m_image(image)
+    , m_observer(disable ? image.imageObserver() : nullptr)
+    , m_disable(disable)
+{
+    if (m_disable)
+        m_image->setImageObserver(nullptr);
+}
+
+ImageObserverDisableScope::~ImageObserverDisableScope()
+{
+    if (m_disable)
+        m_image->setImageObserver(WTF::move(m_observer));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -33,6 +33,7 @@
 #include <WebCore/ImageOrientation.h>
 #include <WebCore/ImagePaintingOptions.h>
 #include <WebCore/ImageTypes.h>
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
@@ -213,6 +214,19 @@ private:
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Image&);
+
+class ImageObserverDisableScope {
+    WTF_FORBID_HEAP_ALLOCATION;
+    WTF_MAKE_NONCOPYABLE(ImageObserverDisableScope);
+public:
+    WEBCORE_EXPORT explicit ImageObserverDisableScope(Image&, bool disable = true);
+    WEBCORE_EXPORT ~ImageObserverDisableScope();
+
+private:
+    const Ref<Image> m_image;
+    RefPtr<ImageObserver> m_observer;
+    bool m_disable;
+};
 
 } // namespace WebCore
 

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -224,10 +224,8 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     if (!m_page)
         return ImageDrawResult::DidNothing;
 
-    RefPtr observer = imageObserver();
-
     // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
-    setImageObserver(nullptr);
+    ImageObserverDisableScope imageObserverDisabler(*this);
 
     IntSize roundedContainerSize = roundedIntSize(containerSize);
     setContainerSize(roundedContainerSize);
@@ -242,10 +240,7 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
 
     protect(frameView())->scrollToFragment(initialFragmentURL);
 
-    ImageDrawResult result = draw(context, dstRect, scaledSrc, options);
-
-    setImageObserver(WTF::move(observer));
-    return result;
+    return draw(context, dstRect, scaledSrc, options);
 }
 
 bool SVGImage::hasHDRContent() const
@@ -280,13 +275,11 @@ RefPtr<NativeImage> SVGImage::nativeImage(const FloatSize& size, const Destinati
     if (!imageBuffer)
         return nullptr;
 
-    RefPtr observer = imageObserver();
-    setImageObserver(nullptr);
+    ImageObserverDisableScope imageObserverDisabler(*this);
     setContainerSize(size);
 
     imageBuffer->context().drawImage(*this, FloatPoint(0, 0));
 
-    setImageObserver(WTF::move(observer));
     return ImageBuffer::sinkIntoNativeImage(WTF::move(imageBuffer));
 }
 


### PR DESCRIPTION
#### a3d2b19de1762775a0db3494b2171356a53aa304
<pre>
Image observer save/restore should be scope-bound
<a href="https://bugs.webkit.org/show_bug.cgi?id=322460">https://bugs.webkit.org/show_bug.cgi?id=322460</a>
<a href="https://rdar.apple.com/185746232">rdar://185746232</a>

Reviewed by Simon Fraser.

Call sites temporarily clear an image&apos;s observer and restore it manually.
Because restoration re-reads a mutable image variable, reassignment or
an early exit can leave the CachedImage without its observer permanently.

Introduce a small RAII guard that binds the image so restoration is tied to the
originally bound image and guaranteed on every exit path.

No behavior change.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::drawLuminanceMaskPattern):
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::ImageObserverDisableScope::ImageObserverDisableScope):
(WebCore::ImageObserverDisableScope::~ImageObserverDisableScope):
* Source/WebCore/platform/graphics/Image.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::drawForContainer):
(WebCore::SVGImage::nativeImage):

Canonical link: <a href="https://commits.webkit.org/319766@main">https://commits.webkit.org/319766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a229fc686f56ef271a49f277263c31b886364e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146983 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31a88f97-9303-47f4-923f-e7fbfc062072) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142579 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/392022e0-46b7-44af-a71d-aeb64666b05d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46301 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123014 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39f03697-2b5f-4f88-87ce-bb2951ed864a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44985 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42871 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4081 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49258 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56288 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40734 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56992 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151730 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46306 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129260 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125282 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17873 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54872 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->