### PR TITLE
Remove dead autoPictureInPicture/disablePictureInPicture accessors in HTMLVideoElementPictureInPicture

### DIFF
--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -146,26 +146,6 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
         promise->reject(ExceptionCode::NotSupportedError, "The video element does not support the Picture-in-Picture mode."_s);
 }
 
-bool HTMLVideoElementPictureInPicture::autoPictureInPicture(HTMLVideoElement& videoElement)
-{
-    return HTMLVideoElementPictureInPicture::from(videoElement).m_autoPictureInPicture;
-}
-
-void HTMLVideoElementPictureInPicture::setAutoPictureInPicture(HTMLVideoElement& videoElement, bool autoPictureInPicture)
-{
-    HTMLVideoElementPictureInPicture::from(videoElement).m_autoPictureInPicture = autoPictureInPicture;
-}
-
-bool HTMLVideoElementPictureInPicture::disablePictureInPicture(HTMLVideoElement& videoElement)
-{
-    return HTMLVideoElementPictureInPicture::from(videoElement).m_disablePictureInPicture;
-}
-
-void HTMLVideoElementPictureInPicture::setDisablePictureInPicture(HTMLVideoElement& videoElement, bool disablePictureInPicture)
-{
-    HTMLVideoElementPictureInPicture::from(videoElement).m_disablePictureInPicture = disablePictureInPicture;
-}
-
 void HTMLVideoElementPictureInPicture::exitPictureInPicture(Ref<DeferredPromise>&& promise)
 {
     INFO_LOG(LOGIDENTIFIER);

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -30,7 +30,6 @@
 
 #include "PictureInPictureObserver.h"
 #include "Supplementable.h"
-#include <wtf/CancellableTask.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
@@ -56,10 +55,6 @@ public:
     virtual ~HTMLVideoElementPictureInPicture();
 
     static void requestPictureInPicture(HTMLVideoElement&, Ref<DeferredPromise>&&);
-    static bool autoPictureInPicture(HTMLVideoElement&);
-    static void setAutoPictureInPicture(HTMLVideoElement&, bool);
-    static bool disablePictureInPicture(HTMLVideoElement&);
-    static void setDisablePictureInPicture(HTMLVideoElement&, bool);
 
     void exitPictureInPicture(Ref<DeferredPromise>&&);
 
@@ -82,15 +77,10 @@ private:
     static ASCIILiteral supplementName() { return "HTMLVideoElementPictureInPicture"_s; }
     bool isHTMLVideoElementPictureInPicture() const final { return true; }
 
-    bool m_autoPictureInPicture { false };
-    bool m_disablePictureInPicture { false };
-
     WeakRef<HTMLVideoElement> m_videoElement;
     const Ref<PictureInPictureWindow> m_pictureInPictureWindow;
     RefPtr<DeferredPromise> m_enterPictureInPicturePromise;
     RefPtr<DeferredPromise> m_exitPictureInPicturePromise;
-
-    TaskCancellationGroup m_eventTaskGroup;
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### 396f000caabcc215d7cce0ffc5f5663352812a38
<pre>
Remove dead autoPictureInPicture/disablePictureInPicture accessors in HTMLVideoElementPictureInPicture
<a href="https://bugs.webkit.org/show_bug.cgi?id=322463">https://bugs.webkit.org/show_bug.cgi?id=322463</a>
<a href="https://rdar.apple.com/185751998">rdar://185751998</a>

Reviewed by Jean-Yves Avenard.

HTMLVideoElement+PictureInPicture.idl declares both autoPictureInPicture and
disablePictureInPicture as [Reflect], so the generated bindings read and write
the content attribute directly on HTMLVideoElement:

    impl.hasAttributeWithoutSynchronization(HTMLNames::autopictureinpictureAttr)
    impl.setBooleanAttribute(HTMLNames::autopictureinpictureAttr, ...)

Nothing has called the four static accessors on the supplement since
216923@main added [Reflect] without removing them, and m_autoPictureInPicture
/ m_disablePictureInPicture have been state that nobody reads. Remove all six.

Also remove m_eventTaskGroup, which is never referenced anywhere - the class
queues its enterpictureinpicture and leavepictureinpicture tasks through
ActiveDOMObject::queueTaskKeepingObjectAlive() - along with the now-unneeded
CancellableTask.h include.

No behavior change, so no new tests.

* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::autoPictureInPicture): Deleted.
(WebCore::HTMLVideoElementPictureInPicture::setAutoPictureInPicture): Deleted.
(WebCore::HTMLVideoElementPictureInPicture::disablePictureInPicture): Deleted.
(WebCore::HTMLVideoElementPictureInPicture::setDisablePictureInPicture): Deleted.
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:

Canonical link: <a href="https://commits.webkit.org/319797@main">https://commits.webkit.org/319797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5726bfe39819455843de8699c288c77cd5e93b37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146988 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d962f408-17bb-4fd3-8666-93b2a92af06b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142580 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8e7e98c-7244-4850-9ffb-1bc4db661bd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123015 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f010ec4-4137-4bcd-8a1f-2dfcb58a706d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43244 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42873 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4086 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194859 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56293 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40759 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56997 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151736 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46308 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129265 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125287 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55505 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17875 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->