### PR TITLE
Field ordering in Geolocation wastes 8 bytes of padding per instance

### DIFF
--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -165,17 +165,16 @@ private:
     Watchers m_watchers;
     GeoNotifierSet m_pendingForPermissionNotifiers;
     RefPtr<GeolocationPosition> m_lastPosition;
-
-    bool m_hasBeenRequested { false };
-
-    AllowGeolocation m_allowGeolocation { AllowGeolocation::Unknown };
     String m_authorizationToken;
-    bool m_isSuspended { false };
-    bool m_resetOnResume { false };
-    bool m_hasChangedPosition { false };
     RefPtr<GeolocationPositionError> m_errorWaitingForResume;
     Timer m_resumeTimer;
     GeoNotifierSet m_requestsAwaitingCachedPosition;
+
+    AllowGeolocation m_allowGeolocation { AllowGeolocation::Unknown };
+    bool m_hasBeenRequested { false };
+    bool m_isSuspended { false };
+    bool m_resetOnResume { false };
+    bool m_hasChangedPosition { false };
 };
     
 } // namespace WebCore


### PR DESCRIPTION
#### 6ceceeb3ecb092dec058629ef0ce923e521b5869
<pre>
Field ordering in Geolocation wastes 8 bytes of padding per instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=322467">https://bugs.webkit.org/show_bug.cgi?id=322467</a>
<a href="https://rdar.apple.com/185752888">rdar://185752888</a>

Reviewed by Chris Dumez.

Geolocation interleaves its one-byte members with pointer-sized ones, leaving
11 bytes of interior padding: 6 after m_hasBeenRequested/m_allowGeolocation,
and 5 after the three bools that follow m_authorizationToken.

Group AllowGeolocation and the four bools at the end of the class, and move
the pointer-sized members up with the rest. sizeof(Geolocation) goes from 328
to 320. Verified with -fdump-record-layouts; the saving holds on every 64-bit
ABI including MSVC, and 32-bit targets are unaffected.

No behaviour change.

* Source/WebCore/Modules/geolocation/Geolocation.h:

Canonical link: <a href="https://commits.webkit.org/319771@main">https://commits.webkit.org/319771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c5655f85ac020b08fb4ca2901b1e0faa196cf7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f52e8bfd-79ea-4a2b-8ae5-ac86d6f144aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142582 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6078be4f-398d-4863-a9ee-f71ca481935b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123017 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f11ffde9-6de6-42cd-9ad2-e02f5d3f3510) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44993 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42875 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4090 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49267 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56297 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40739 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57001 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151733 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46310 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129269 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125293 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55509 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17877 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54881 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->