### PR TITLE
HighlightRegistry::addAnnotationHighlightWithRange() does redundant atom table and hash lookups

### DIFF
--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -162,17 +162,20 @@ void HighlightRegistry::setHighlightVisibility(HighlightVisibility highlightVisi
 }
 #endif
 
-static ASCIILiteral annotationHighlightKey()
+static const AtomString& annotationHighlightKey()
 {
-    return "annotationHighlightKey"_s;
+    static MainThreadNeverDestroyed<const AtomString> key { "annotationHighlightKey"_s };
+    return key.get();
 }
 
 void HighlightRegistry::addAnnotationHighlightWithRange(Ref<StaticRange>&& value)
 {
-    if (m_map.contains(annotationHighlightKey()))
-        protect(*m_map.get(annotationHighlightKey()))->addToSetLike(value);
-    else
-        setFromMapLike(annotationHighlightKey(), Highlight::create({ std::ref<AbstractRange>(value.get()) }));
+    auto& key = annotationHighlightKey();
+    if (RefPtr highlight = m_map.get(key)) {
+        highlight->addToSetLike(value);
+        return;
+    }
+    setFromMapLike(AtomString { key }, Highlight::create({ std::ref<AbstractRange>(value.get()) }));
 }
 
 }


### PR DESCRIPTION
#### 4d2212f4f8ca37f93afa738fe4c52e2765a444b9
<pre>
HighlightRegistry::addAnnotationHighlightWithRange() does redundant atom table and hash lookups
<a href="https://bugs.webkit.org/show_bug.cgi?id=322469">https://bugs.webkit.org/show_bug.cgi?id=322469</a>
<a href="https://rdar.apple.com/185755876">rdar://185755876</a>

Reviewed by Chris Dumez.

annotationHighlightKey() returned an ASCIILiteral, so each use implicitly
constructed an AtomString, and AtomString(ASCIILiteral) calls
AtomStringImpl::add() under AtomStringTableLocker. Two of those ran on every
call: contains() then get() on the hit path, contains() then setFromMapLike() on
the miss path. Return a MainThreadNeverDestroyed&lt;const AtomString&gt; instead so the
atom is created once, and fold the contains()/get() pair into a single m_map.get()
so the key is hashed once rather than twice.

Using the RefPtr that get() already returns also drops a protect() call on the
raw map value.

No change in behavior.

* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::annotationHighlightKey):
(WebCore::HighlightRegistry::addAnnotationHighlightWithRange):

Canonical link: <a href="https://commits.webkit.org/319871@main">https://commits.webkit.org/319871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8feb530ce993538e9e38ef7732ceca2b9197e1ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e83ae696-a1e9-4e3f-8191-f125d4703575) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142592 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99012 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 2 flakes 3 failures; Uploaded test results; 1 flakes 5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75069a33-5be0-4a62-9c41-e1d2344b2009) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123027 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6881fa4-946c-445a-a065-01fda80e245b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45003 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43259 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42888 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4103 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194876 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56310 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151750 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129282 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55522 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17891 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->