### PR TITLE
[Cleanup] Permissions::toPermissionName should use SortedArrayMap

### DIFF
--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -56,6 +56,7 @@
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <optional>
 #include <wtf/Expected.h>
+#include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -143,21 +144,19 @@ std::optional<PermissionQuerySource> Permissions::sourceFromContext(const Script
     return std::nullopt;
 }
 
-
 std::optional<PermissionName> Permissions::toPermissionName(const String& name)
 {
-    if (name == "camera"_s)
-        return PermissionName::Camera;
-    if (name == "geolocation"_s)
-        return PermissionName::Geolocation;
-    if (name == "microphone"_s)
-        return PermissionName::Microphone;
-    if (name == "notifications"_s)
-        return PermissionName::Notifications;
-    if (name == "push"_s)
-        return PermissionName::Push;
-    if (name == "storage-access"_s)
-        return PermissionName::StorageAccess;
+    static constexpr SortedArrayMap permissionNames { WTF::toArray<std::pair<ComparableASCIILiteral, PermissionName>>({
+        { "camera"_s, PermissionName::Camera },
+        { "geolocation"_s, PermissionName::Geolocation },
+        { "microphone"_s, PermissionName::Microphone },
+        { "notifications"_s, PermissionName::Notifications },
+        { "push"_s, PermissionName::Push },
+        { "storage-access"_s, PermissionName::StorageAccess },
+    }) };
+
+    if (auto* permissionName = permissionNames.tryGet(name))
+        return *permissionName;
     return std::nullopt;
 }
 


### PR DESCRIPTION
#### 81bd1218f44463fc0a5ce58bebb1a9c01e2c63f8
<pre>
[Cleanup] Permissions::toPermissionName should use SortedArrayMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=322470">https://bugs.webkit.org/show_bug.cgi?id=322470</a>
<a href="https://rdar.apple.com/185758902">rdar://185758902</a>

Reviewed by NOBODY (OOPS!).

toPermissionName() mapped a permission name to PermissionName with a chain of
six sequential String comparisons, so each new name meant another branch.
Replace it with a static constexpr SortedArrayMap, the idiom the codebase
already uses for string-to-enum conversion -- see
ApplicationManifestParser::parseDir() and GPUAdapter&apos;s
convertFeatureNameToEnum(). A new name becomes a table entry rather than a
branch, entry order is checked against std::is_sorted at compile time, and if
the remaining ten PermissionName enumerators are ever mapped the lookup crosses
SortedArrayMap&apos;s binarySearchThreshold and becomes a binary search with no
further change here.

Not a lookup speedup: at six entries tryGet() compiles to a linear
std::find_if, doing the same StringView-versus-literal comparisons operator==
already did.

ComparableASCIILiteral rather than ComparableLettersLiteral, because permission
names are case-sensitive and operator== was too -- the letters variant compares
ASCII-case-insensitively and would start accepting &quot;Camera&quot;.

The set of accepted names is unchanged.

No change in behavior.

* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::toPermissionName):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81bd1218f44463fc0a5ce58bebb1a9c01e2c63f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147008 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df5886b7-1b99-4d6b-922f-b578865db997) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142600 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99011 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77ff272d-d910-4003-a981-02eefaf33b5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123035 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/424da3f3-2554-4ccd-adf5-348c5cbe0cd7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43262 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42891 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194879 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56313 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152053 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57017 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39514 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/popup-same-site-via-same-site-redirect.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/post-basic.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/enable-debug-mode.html, http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-insecure-page.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151753 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46326 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129285 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55525 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17894 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54897 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->