### PR TITLE
[AppKit Gestures] Some scrolls should not produce momentum

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1492,6 +1492,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (gesture.state != NSGestureRecognizerStateEnded)
         return;
 
+    if (![self supportsMomentumScroll:gesture])
+        return;
+
     auto unfilteredVelocity = velocityInView(gesture, webView.get());
 
     // Continue the scroll along the same axis the drag was locked to rather than reintroducing


### PR DESCRIPTION
#### 6937c075deee8f8ab8748f0f7f3bb8ef9c97dd4b
<pre>
[AppKit Gestures] Some scrolls should not produce momentum
<a href="https://bugs.webkit.org/show_bug.cgi?id=322471">https://bugs.webkit.org/show_bug.cgi?id=322471</a>
<a href="https://rdar.apple.com/185759621">rdar://185759621</a>

Reviewed by Richard Robinson.

Certain scroll gestures are configured to not require a trailing
momentum stage. In this patch, we begin respecting that.

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController sendWheelEventForGesture:]):

Canonical link: <a href="https://commits.webkit.org/319785@main">https://commits.webkit.org/319785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc1718c63de6a44fbafd59ac1dd4008ee016e319

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147014 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2fd83960-8b1c-4b92-87e5-6c77a3eacd7c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142604 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e624776-367f-42ab-8c89-3f48020f9c7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123039 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3d53c00-6a07-480d-a662-9ba0ab99e4e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45009 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43268 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42896 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4114 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194885 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56319 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152055 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57023 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151755 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46328 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129291 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55531 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17899 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54969 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->