### PR TITLE
DOMParser-parsed XML script elements execute after being cloned

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt
@@ -4,5 +4,6 @@ PASS parseFromString as HTML, append importNode result
 PASS parseFromString as HTML, svg script, appendChild
 PASS parseFromString as HTML, svg script, append importNode result
 PASS parseFromString as XML, svg script, appendChild
-FAIL parseFromString as XML, svg script, append importNode result assert_equals: expected 0 but got 1
+PASS parseFromString as XML, svg script, append importNode result
+PASS parseFromString as XML, svg script, append importNode result, but with namespace prefix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html
@@ -62,6 +62,14 @@ test(_ => {
   document.body.appendChild(document.importNode(d.rootElement, true));
   assert_equals(window.mark, 0);
 }, "parseFromString as XML, svg script, append importNode result");
+
+test(_ => {
+  window.mark = 0;
+  const d = new DOMParser().parseFromString(
+    "<xx:svg xmlns:xx='http://www.w3.org/2000/svg'><xx:script>window.mark = 1;</xx:script></xx:svg>", "text/xml");
+  document.body.appendChild(document.importNode(d.rootElement, true));
+  assert_equals(window.mark, 0);
+}, "parseFromString as XML, svg script, append importNode result, but with namespace prefix");
 </script>
 </body>
 </html>

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -53,6 +53,8 @@ public:
 
     bool prepareScript(const TextPosition& scriptStartPosition = TextPosition());
 
+    void markAlreadyStarted() { m_alreadyStarted = true; }
+
     const AtomString& scriptCharset() const LIFETIME_BOUND { return m_characterEncoding; }
     WEBCORE_EXPORT String scriptContent() const;
     void executeClassicScript(const ScriptSourceCode&);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -983,6 +983,14 @@ void XMLDocumentParser::endElementNs()
     }
 
     if (!element || m_isInFrameView == IsInFrameView::No) {
+        // We never prepare scripts in this case (e.g. when parsing a fragment or a document without
+        // a frame view, like a DOMParser document). Mark them as already started so that they stay
+        // inert when cloned or adopted into a document that does execute scripts, matching what
+        // HTMLConstructionSite does for the HTML fragment parser.
+        if (element && !parserContentPolicy().contains(ParserContentPolicy::DoNotMarkAlreadyStarted)) {
+            if (auto* scriptElement = dynamicDowncastScriptElement(*element))
+                scriptElement->markAlreadyStarted();
+        }
         popCurrentNode();
         return;
     }


### PR DESCRIPTION
#### 542a224086b9fb0e0ec89ffb7ba02ea2dfbb8194
<pre>
DOMParser-parsed XML script elements execute after being cloned
<a href="https://bugs.webkit.org/show_bug.cgi?id=322474">https://bugs.webkit.org/show_bug.cgi?id=322474</a>

Reviewed by Anne van Kesteren.

DOMParser.parseFromString() must parse XML with XML scripting support disabled,
so the resulting script elements have to stay inert. They did, but only by
accident: the XML parser creates them with createdByParser = true, which makes
them parser-inserted, and ScriptElement::postConnectionSteps() skips
parser-inserted scripts. Their &quot;already started&quot; flag was never set, because
XMLDocumentParser::endElementNs() returns early -- before prepareScript() --
when the document has no frame view.

Cloning drops parser-insertedness but copies &quot;already started&quot;, so
document.importNode() of an XML-parsed script produced a script element with
neither flag set. Appending it to a live document ran it.

The HTML side doesn&apos;t have this problem: the HTML parser calls prepareScript(),
which sets &quot;already started&quot; before bailing out at the &quot;no frame&quot; check, so
HTML DOMParser documents already hand out inert clones.

Set &quot;already started&quot; on script elements in the XML parser path that never
prepares them, matching what HTMLConstructionSite does for the HTML fragment
parser. This keys off isScriptElement() rather than a QualifiedName comparison,
so prefixed script elements (&lt;xx:script&gt;) are covered too, and it honours
ParserContentPolicy::DoNotMarkAlreadyStarted so createContextualFragment()
keeps executing its scripts.

This also covers XML fragment parsing (XHTML innerHTML), whose scripts were
likewise only inert by virtue of being parser-inserted, as well as
XMLHttpRequest.responseXML and XSLT result documents -- every XML parse where
WebKit does not run scripts.

Firefox marks these already started via nsXMLContentSink calling
AttemptToExecute(); Chromium recently did the same in its XML parser, scoped to
DOMParser documents. Also resyncs the test from upstream, which grew a subtest
covering the prefixed form.

* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-scripting-support-disabled.html:
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::markAlreadyStarted):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs):

Canonical link: <a href="https://commits.webkit.org/319922@main">https://commits.webkit.org/319922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e6d891258c31b8a1e965c76ee3b8f17ff9380e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147320 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/472b95f7-7165-4c99-a2b7-e3cb068ca044) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58297 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56690 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31d74f63-8c5a-4ec2-a88d-9201cdc5844d) 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185987 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Failed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123285 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49a13534-05cf-4a7f-9764-982c6ef075df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43522 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43154 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4422 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195190 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152330 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40855 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57329 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152026 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129598 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125715 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55837 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18165 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->