### PR TITLE
[JSC] Do not broadcast termination from the thread that is about to stop draining

### DIFF
--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -637,7 +637,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                         return SharedDrainResult::TimedOut;
 
                     if (didReachTermination(locker)) {
-                        m_heap.m_markingConditionVariable.notifyAll();
+                        // No marker needs waking here. There is no work which can be processed in the helpers.
                         return SharedDrainResult::Done;
                     }
                     
@@ -653,6 +653,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                     return SharedDrainResult::TimedOut;
                 
                 if (didReachTermination(locker)) {
+                    // This is necessary to wake up MainDrain side.
                     m_heap.m_markingConditionVariable.notifyAll();
                     
                     // If we're in concurrent mode, then we know that the mutator will eventually do
@@ -697,7 +698,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
             m_heap.m_numberOfActiveParallelMarkers++;
             m_heap.m_numberOfWaitingParallelMarkers--;
         }
-        
+
         if (bonusTask) {
             bonusTask->run(*this);
 
@@ -740,22 +741,19 @@ SlotVisitor::SharedDrainResult SlotVisitor::drainInParallelPassively(MonotonicTi
         return drainInParallel(timeout);
     }
 
-    donateAll(Locker { m_heap.m_markingMutex });
-    return waitForTermination(timeout);
-}
-
-SlotVisitor::SharedDrainResult SlotVisitor::waitForTermination(MonotonicTime timeout)
-{
     Locker locker { m_heap.m_markingMutex };
+    donateAll(locker);
+
+    // Wait for termination.
     for (;;) {
         if (hasElapsed(timeout))
             return SharedDrainResult::TimedOut;
-        
+
         if (didReachTermination(locker)) {
-            m_heap.m_markingConditionVariable.notifyAll();
+            // No marker needs waking here. There is no work which can be processed in the helpers.
             return SharedDrainResult::Done;
         }
-        
+
         m_heap.m_markingConditionVariable.waitUntil(m_heap.m_markingMutex, timeout);
     }
 }

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -140,8 +140,6 @@ public:
 
     SharedDrainResult drainInParallel(MonotonicTime timeout = MonotonicTime::infinity());
     SharedDrainResult drainInParallelPassively(MonotonicTime timeout = MonotonicTime::infinity());
-    
-    SharedDrainResult waitForTermination(MonotonicTime timeout = MonotonicTime::infinity());
 
     // Attempts to perform an increment of draining that involves only walking `bytes` worth of data. This
     // is likely to accidentally walk more or less than that. It will usually mark more than bytes. It may


### PR DESCRIPTION
#### f733e45e7f50ad876bd768dfe35ea536ab7045c3
<pre>
[JSC] Do not broadcast termination from the thread that is about to stop draining
<a href="https://bugs.webkit.org/show_bug.cgi?id=322475">https://bugs.webkit.org/show_bug.cgi?id=322475</a>
<a href="https://rdar.apple.com/185763143">rdar://185763143</a>

Reviewed by Yijia Huang.

When reaching to termination, there is no work. Then waking up helper
threads do not offer anything since it is waiting until (1) there is a
work, (2) bonus visitor task exists, or (3) m_parallelMarkersShouldExit.
This patch removes these unnecessary wakeup.

* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::drainFromShared):
(JSC::SlotVisitor::drainInParallelPassively):
(JSC::SlotVisitor::waitForTermination):
* Source/JavaScriptCore/heap/SlotVisitor.h:

Canonical link: <a href="https://commits.webkit.org/319889@main">https://commits.webkit.org/319889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7212e733bdf3ce056358c2d98cbd6ea7bb9ef1d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183119 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4510 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44389 "Failed to checkout and rebase branch from PR 72377") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195278 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/152101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27788 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50859 "Failed to checkout and rebase branch from PR 72377") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->