### PR TITLE
[AppKit Gestures] Notify the client of unhandled magnification gestures

### DIFF
--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -61,6 +61,8 @@ public:
     static OptionSet<WebKit::WebEventModifier> NODELETE toWebEventModifierFlags(NSEventModifierFlags);
 
     static WebEventPhase phaseForEvent(NSEvent *);
+    static WebEventPhase NODELETE phaseForNativeEventPhase(NSEventPhase);
+    static NSEventPhase NODELETE toNativeEventPhase(WebEventPhase);
 #endif
 #endif // USE(APPKIT)
 };

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -43,23 +43,52 @@ namespace WebKit {
 
 WebEventPhase WebEventFactory::phaseForEvent(NSEvent *event)
 {
+    return phaseForNativeEventPhase([event phase]);
+}
+
+WebEventPhase WebEventFactory::phaseForNativeEventPhase(NSEventPhase nativePhase)
+{
     using enum WebEventPhase;
 
     auto phase = None;
-    if ([event phase] & NSEventPhaseBegan)
+    if (nativePhase & NSEventPhaseBegan)
         phase = Began;
-    if ([event phase] & NSEventPhaseStationary)
+    if (nativePhase & NSEventPhaseStationary)
         phase = Stationary;
-    if ([event phase] & NSEventPhaseChanged)
+    if (nativePhase & NSEventPhaseChanged)
         phase = Changed;
-    if ([event phase] & NSEventPhaseEnded)
+    if (nativePhase & NSEventPhaseEnded)
         phase = Ended;
-    if ([event phase] & NSEventPhaseCancelled)
+    if (nativePhase & NSEventPhaseCancelled)
         phase = Cancelled;
-    if ([event phase] & NSEventPhaseMayBegin)
+    if (nativePhase & NSEventPhaseMayBegin)
         phase = MayBegin;
 
     return phase;
+}
+
+NSEventPhase WebEventFactory::toNativeEventPhase(WebEventPhase phase)
+{
+    switch (phase) {
+    case WebEventPhase::None:
+        return NSEventPhaseNone;
+    case WebEventPhase::Began:
+        return NSEventPhaseBegan;
+    case WebEventPhase::Stationary:
+        return NSEventPhaseStationary;
+    case WebEventPhase::Changed:
+        return NSEventPhaseChanged;
+    case WebEventPhase::Ended:
+        return NSEventPhaseEnded;
+    case WebEventPhase::Cancelled:
+        return NSEventPhaseCancelled;
+    case WebEventPhase::MayBegin:
+    case WebEventPhase::WillBegin:
+        return NSEventPhaseMayBegin;
+    }
+
+    ASSERT_NOT_REACHED();
+    return NSEventPhaseNone;
 }
 
 static WebWheelEvent::Phase momentumPhaseForEvent(NSEvent *event)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -921,6 +921,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 - (void)_gestureEventWasNotHandledByWebCore:(NSEvent *)event WK_API_AVAILABLE(macos(10.13.4));
 
+- (void)_magnificationGestureEventWasNotHandledByWebCoreWithPhase:(NSEventPhase)phase magnification:(CGFloat)magnification locationInWindow:(NSPoint)locationInWindow WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 - (void)_disableFrameSizeUpdates WK_API_AVAILABLE(macos(10.13.4));
 - (void)_enableFrameSizeUpdates WK_API_AVAILABLE(macos(10.13.4));
 

--- a/Source/WebKit/UIProcess/API/mac/WKView.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKView.mm
@@ -927,6 +927,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
 }
 
+- (void)_web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:(NSEventPhase)phase magnification:(CGFloat)magnification locationInWindow:(NSPoint)locationInWindow
+{
+}
+
 - (void)_didHandleAcceptedCandidate
 {
 }

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1566,6 +1566,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _gestureEventWasNotHandledByWebCore:event];
 }
 
+- (void)_web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:(NSEventPhase)phase magnification:(CGFloat)magnification locationInWindow:(NSPoint)locationInWindow
+{
+    [self _magnificationGestureEventWasNotHandledByWebCoreWithPhase:phase magnification:magnification locationInWindow:locationInWindow];
+}
+
 - (void)_takeFindStringFromSelectionInternal:(id)sender
 {
     [self takeFindStringFromSelection:sender];
@@ -2095,6 +2100,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_gestureEventWasNotHandledByWebCore:(NSEvent *)event
 {
     _impl->gestureEventWasNotHandledByWebCoreFromViewOnly(event);
+}
+
+- (void)_magnificationGestureEventWasNotHandledByWebCoreWithPhase:(NSEventPhase)phase magnification:(CGFloat)magnification locationInWindow:(NSPoint)locationInWindow
+{
+    _impl->magnificationGestureEventWasNotHandledByWebCoreFromViewOnly(phase, magnification, locationInWindow);
 }
 
 - (double)minimumMagnification

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -188,6 +188,7 @@ using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 - (void)_web_editorStateDidChange;
 
 - (void)_web_gestureEventWasNotHandledByWebCore:(NSEvent *)event;
+- (void)_web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:(NSEventPhase)phase magnification:(CGFloat)magnification locationInWindow:(NSPoint)locationInWindow;
 
 - (void)_web_didChangeContentSize:(NSSize)newSize;
 
@@ -692,6 +693,7 @@ public:
     void gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent&);
 #endif
     void gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *);
+    void magnificationGestureEventWasNotHandledByWebCoreFromViewOnly(NSEventPhase, CGFloat magnification, NSPoint locationInWindow);
 
     void didRestoreScrollPosition();
     
@@ -1039,7 +1041,7 @@ private:
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
     bool inputMethodUsesCorrectKeyEventOrder();
 
-    void magnificationGestureWasNotHandledByWebCoreFromViewOnly(float magnification, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
+    void applyNativeMagnification(float magnification, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5828,7 +5828,6 @@ void WebViewImpl::rotateWithEvent(NSEvent *event)
 
 void WebViewImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent& event)
 {
-    // FIXME: We need to drive the -_gestureEventWasNotHandledByWebCore: SPI even when there is no backing NSEvent.
     if (RetainPtr nativeEvent = event.nativeEvent()) {
         [m_view.get() _web_gestureEventWasNotHandledByWebCore:nativeEvent];
         return;
@@ -5837,7 +5836,10 @@ void WebViewImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent
     if (event.kind() != NativeWebGestureEvent::Kind::Magnification || !event.allowsNativeZoom())
         return;
 
-    magnificationGestureWasNotHandledByWebCoreFromViewOnly(event.gestureScale(), event.phase(), event.position());
+    auto eventPhase = WebEventFactory::toNativeEventPhase(event.phase());
+    auto locationInWindow = [m_view.get() convertPoint:event.position() toView:nil];
+
+    [m_view.get() _web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:eventPhase magnification:event.gestureScale() locationInWindow:locationInWindow];
 }
 
 #endif
@@ -5847,10 +5849,15 @@ void WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *event)
     if (event.type != NSEventTypeMagnify)
         return;
 
-    magnificationGestureWasNotHandledByWebCoreFromViewOnly(event.magnification, WebEventFactory::phaseForEvent(event), [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
+    applyNativeMagnification(event.magnification, WebEventFactory::phaseForEvent(event), [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
 }
 
-void WebViewImpl::magnificationGestureWasNotHandledByWebCoreFromViewOnly(float magnification, WebEventPhase phase, FloatPoint originInViewCoordinates)
+void WebViewImpl::magnificationGestureEventWasNotHandledByWebCoreFromViewOnly(NSEventPhase phase, CGFloat magnification, NSPoint locationInWindow)
+{
+    applyNativeMagnification(magnification, WebEventFactory::phaseForNativeEventPhase(phase), [m_view.get() convertPoint:locationInWindow fromView:nil]);
+}
+
+void WebViewImpl::applyNativeMagnification(float magnification, WebEventPhase phase, FloatPoint originInViewCoordinates)
 {
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (m_allowsMagnification && m_gestureController)


### PR DESCRIPTION
#### c763056577cb27c4f34bb791c41d291c1fbf9da7
<pre>
[AppKit Gestures] Notify the client of unhandled magnification gestures
<a href="https://bugs.webkit.org/show_bug.cgi?id=322478">https://bugs.webkit.org/show_bug.cgi?id=322478</a>
<a href="https://rdar.apple.com/184773360">rdar://184773360</a>

Reviewed by Richard Robinson.

gestureEventWasNotHandledByWebCore can only tell the client about
unhandled gestures in the presence of a backing NSEvent. Gesture events
constructed under UseAppKitGestureForGestureEvents do not have one, and
so we never end up informing the client of this signal.

We add an adjacent SPI -_magnificationGestureEventWasNotHandled...,
shaped similarly to the existing -_gestureEventWasNotHandledByWebCore:
method. In this SPI, we simply launder the necessary state clients would
want to know (magnification, window location, and phase) off from the
gesture recognition path.

To aid our changes, we also refactor a few things; namely, add two phase
conversion helpers to WebEventFactory, with phaseForEvent now delegating
to one of them, and rename magnificationGestureWasNotHandledByWebCore...
to applyNativeMagnification. This method now has two callers, and
&quot;FromViewOnly&quot; described its caller rather than itself, so it was a
misnomer with the new SPI.

* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::phaseForEvent):
(WebKit::WebEventFactory::phaseForNativeEventPhase):
(WebKit::WebEventFactory::toNativeEventPhase):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKView.mm:
(-[WKView _web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:magnification:locationInWindow:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_magnificationGestureEventWasNotHandledByWebCoreWithPhase:magnification:locationInWindow:]):
(-[WKWebView _magnificationGestureEventWasNotHandledByWebCoreWithPhase:magnification:locationInWindow:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::magnifyWithEvent):
(WebKit::WebViewImpl::smartMagnifyWithEvent):
(WebKit::WebViewImpl::setLastMouseDownEvent):
(WebKit::WebViewImpl::magnificationGestureWasNotHandledByWebCoreFromViewOnly): Deleted.

Canonical link: <a href="https://commits.webkit.org/319829@main">https://commits.webkit.org/319829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd44b2c65bfe77e177521f67e315f6a02d46f1c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147047 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec5a2c28-83b4-4959-b059-31c7576337b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142629 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12ecaf3c-a8a8-40c9-a710-2dd0009feac9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123064 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/180bb3dc-f907-44f1-ae02-93f208186fb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43302 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42924 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4149 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56352 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152086 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57056 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39543 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151785 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46361 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129324 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125357 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55564 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17927 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->