### PR TITLE
Cherry-pick 305413.1016@safari-7624.5.1.10-branch (33120ad29238). https://bugs.webkit.org/show_bug.cgi?id=316439

### DIFF
--- a/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt
+++ b/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the GPU process does not crash.

--- a/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html
+++ b/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if the GPU process does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+let CoreIPC;
+let currentIdentifier = 0x1000 + Math.floor(Math.random() * 0x1000000);
+function generateIdentifier() { return currentIdentifier++; }
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function createRemoteRenderingBackend() {
+    const streamConnection = CoreIPC.newStreamConnection();
+    const renderingBackendIdentifier = generateIdentifier();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+    const didInitializeReply = streamConnection.connection.waitForMessage(
+        renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+    return { streamConnection, remoteRenderingBackend };
+}
+
+const COLORSPACE_SRGB = { serializableColorSpace: { alias: { optionalValue: { m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 19 } } } } } };
+
+function createRemoteImageBuffer(backend, w, h) {
+    const imageBufferIdentifier = generateIdentifier();
+    const graphicsContextIdentifier = generateIdentifier();
+    backend.remoteRenderingBackend.CreateImageBuffer({
+        logicalSize: { width: w, height: h },
+        renderingMode: 1,
+        renderingPurpose: 0,
+        resolutionScale: 1.0,
+        colorSpace: COLORSPACE_SRGB,
+        bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+        identifier: imageBufferIdentifier,
+        contextIdentifier: graphicsContextIdentifier
+    });
+    return {
+        remoteGraphicsContext: backend.streamConnection.newInterface("RemoteGraphicsContext", graphicsContextIdentifier),
+        imageBufferIdentifier, graphicsContextIdentifier
+    };
+}
+
+const RECT256 = { location: { x: 0, y: 0 }, size: { width: 256, height: 256 } };
+const RECT64 = { location: { x: 0, y: 0 }, size: { width: 64, height: 64 } };
+const IDENTITY = { span: [1.0, 0.0, 0.0, 1.0, 0.0, 0.0] };
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+    try {
+        CoreIPC = (await import('./coreipc.js')).CoreIPC;
+        CoreIPC.typeInfo['WebCore::PlatformColorSpace'] = [{ type: 'std::optional<WebKit::CoreIPCCGColorSpace>', name: 'alias' }];
+
+        // Two RemoteRenderingBackend instances => two GPU process work-queue threads.
+        const A = createRemoteRenderingBackend();
+        const B = createRemoteRenderingBackend();
+
+        // Tile T owned by backend A.
+        const T = createRemoteImageBuffer(A, 256, 256);
+        T.remoteGraphicsContext.SetFillPackedColor({ color: { value: 0xff00ff00 } });
+        T.remoteGraphicsContext.FillRect({ rect: RECT256, requiresClipToRect: 0 });
+
+        // Create destination buffers on A whose base-state fill brush references T,
+        // serialize each into the per-connection shared resource cache, and adopt on B.
+        const N = 128;
+        const Dp = [];
+        for (let i = 0; i < N; i++) {
+            const D = createRemoteImageBuffer(A, 64, 64);
+            D.remoteGraphicsContext.SetFillPatternImageBuffer({
+                imageBufferIdentifier: T.imageBufferIdentifier,
+                pattern: { repeatX: true, repeatY: true, patternSpaceTransform: IDENTITY }
+            });
+            const sId = generateIdentifier();
+            A.remoteRenderingBackend.MoveToSerializedBuffer({
+                identifier: D.imageBufferIdentifier, serializedIdentifier: sId
+            });
+            const ibId = generateIdentifier();
+            const ctxId = generateIdentifier();
+            B.remoteRenderingBackend.MoveToImageBuffer({
+                identifier: sId, imageBufferIdentifier: ibId, contextIdentifier: ctxId
+            });
+            Dp.push(B.streamConnection.newInterface("RemoteGraphicsContext", ctxId));
+        }
+
+        // Race B's pattern fills (which would dereference T) against A's draws into T.
+        for (let iter = 0; iter < 8; iter++) {
+            for (let i = 0; i < N; i++) {
+                Dp[i].FillRect({ rect: RECT64, requiresClipToRect: 0 });
+                for (let k = 0; k < 8; k++) {
+                    T.remoteGraphicsContext.FillRect({ rect: RECT256, requiresClipToRect: 0 });
+                    T.remoteGraphicsContext.ClearRect({ rect: RECT256 });
+                }
+            }
+            await sleep(0);
+        }
+
+        A.streamConnection.connection.invalidate();
+        B.streamConnection.connection.invalidate();
+    } catch (e) { }
+    window.testRunner?.notifyDone();
+}, 10);
+</script>

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		3A7AA54E28E1319D009E09C2 /* PixelLocalStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A7AA54C28E1319D009E09C2 /* PixelLocalStorage.cpp */; };
 		3AD0D2242988C96D0080D728 /* renderermtl_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AD0D2222988C96D0080D728 /* renderermtl_utils.cpp */; };
 		3AD0D2252988C96D0080D728 /* renderermtl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AD0D2232988C96D0080D728 /* renderermtl_utils.h */; };
+		4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */; };
 		6E27925927EA43F500B1BA86 /* BaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E27925827EA43F500B1BA86 /* BaseTypes.cpp */; };
 		7B1538852BBC2C7A00B50C74 /* IntermRebuild.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B1538812BBC2C7A00B50C74 /* IntermRebuild.cpp */; };
 		7B1538862BBC2C7A00B50C74 /* NodeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1538822BBC2C7A00B50C74 /* NodeType.h */; };
@@ -1734,6 +1735,7 @@
 		3AD0D2232988C96D0080D728 /* renderermtl_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = renderermtl_utils.h; sourceTree = "<group>"; };
 		4458D1152B634F4200B64F47 /* BaseTarget.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BaseTarget.xcconfig; sourceTree = "<group>"; };
 		4458D1172B63500B00B64F47 /* translator_fuzzer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = translator_fuzzer.cpp; sourceTree = "<group>"; };
+		4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntegerOverflowClampTest.cpp; sourceTree = "<group>"; };
 		5C1BAA961DFB60FF002906BB /* gl3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gl3.h; path = include/GLES3/gl3.h; sourceTree = "<group>"; };
 		5C1BAA971DFB60FF002906BB /* gl3platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gl3platform.h; path = include/GLES3/gl3platform.h; sourceTree = "<group>"; };
 		5C1BAA981DFB60FF002906BB /* gl31.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gl31.h; path = include/GLES3/gl31.h; sourceTree = "<group>"; };
@@ -3963,6 +3965,7 @@
 				7BFAF5682DE59E0900327F7F /* IndexBufferOffsetTest.cpp */,
 				7BFAF5692DE59E0900327F7F /* IndexedPointsTest.cpp */,
 				7BFAF56A2DE59E0900327F7F /* InstancingTest.cpp */,
+				4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */,
 				7BFAF56B2DE59E0900327F7F /* KTXCompressedTextureTest.cpp */,
 				7BFAF56C2DE59E0900327F7F /* LineLoopTest.cpp */,
 				7BFAF56D2DE59E0900327F7F /* LinkAndRelinkTest.cpp */,
@@ -5955,6 +5958,7 @@
 				7BFAF5EE2DE59E0900327F7F /* IndexBufferOffsetTest.cpp in Sources */,
 				7BFAF5F42DE59E0900327F7F /* IndexedPointsTest.cpp in Sources */,
 				7BFAF5CE2DE59E0900327F7F /* InstancingTest.cpp in Sources */,
+				4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */,
 				7BFAF5D82DE59E0900327F7F /* KTXCompressedTextureTest.cpp in Sources */,
 				7BB9723D2DE4827800455D13 /* libEGL_autogen.cpp in Sources */,
 				7BB972362DE480F000455D13 /* libGLESv2_autogen.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
@@ -372,7 +372,7 @@ static const char *GetOperatorString(TOperator op,
         case TOperator::EOpLogicalAnd:
             return "&&";
         case TOperator::EOpNegative:
-            return "-";
+            return resultType.isSignedInt() ? "ANGLE_negateInt" : "-";
         case TOperator::EOpPositive:
             if (argType0->isMatrix())
             {
@@ -430,11 +430,13 @@ static const char *GetOperatorString(TOperator op,
 
         case TOperator::EOpDiv:
         case TOperator::EOpDivAssign:
-            return resultType.isSignedInt() ? "ANGLE_div" : "/";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_div"
+                                                                                      : "/";
 
         case TOperator::EOpIMod:
         case TOperator::EOpIModAssign:
-            return resultType.isSignedInt() ? "ANGLE_imod" : "%";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_imod"
+                                                                                      : "%";
 
         case TOperator::EOpEqual:
             if ((argType0->getStruct() && argType1->getStruct()) &&
@@ -629,7 +631,7 @@ static const char *GetOperatorString(TOperator op,
         case TOperator::EOpIntBitsToFloat:
         case TOperator::EOpUintBitsToFloat:
         {
-#define RETURN_AS_TYPE_SCALAR()             \
+    #define RETURN_AS_TYPE_SCALAR()             \
     do                                      \
         switch (resultType.getBasicType())  \
         {                                   \
@@ -645,7 +647,7 @@ static const char *GetOperatorString(TOperator op,
         }                                   \
     while (false)
 
-#define RETURN_AS_TYPE(post)                     \
+    #define RETURN_AS_TYPE(post)                     \
     do                                           \
         switch (resultType.getBasicType())       \
         {                                        \
@@ -686,8 +688,8 @@ static const char *GetOperatorString(TOperator op,
                 return "TOperator_TODO";
             }
 
-#undef RETURN_AS_TYPE
-#undef RETURN_AS_TYPE_SCALAR
+    #undef RETURN_AS_TYPE
+    #undef RETURN_AS_TYPE_SCALAR
         }
 
         case TOperator::EOpPackUnorm2x16:

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
@@ -296,6 +296,7 @@ class ProgramPrelude : public TIntermTraverser
     void addAssignInt();
     void subInt();
     void subAssignInt();
+    void negateInt();
     void loopForwardProgress();
 
   private:
@@ -455,8 +456,6 @@ ANGLE_ALWAYS_INLINE X ANGLE_mod(X x, Y y)
 // - the divisor is 0
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // When the behavior would be undefined the result is `x`.
-// FIXME: This function should also handle INT_MIN / -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(div,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -464,8 +463,16 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 {
     Z zx = Z(x);
     Z zy = Z(y);
-    auto predicate = zy == Z(0);
-    return zx / metal::select(zy, Z(1), predicate);
+    if constexpr (metal::is_signed_v<Z>) {
+        using U = metal::make_unsigned_t<Z>;
+        Z safeY = metal::select(zy, Z(1), zy == Z(0));
+        auto isNegOne = safeY == Z(-1);
+        safeY = metal::select(safeY, Z(1), isNegOne);
+        Z q = zx / safeY;
+        return metal::select(q, as_type<Z>(U(0) - U(zx)), isNegOne);
+    } else {
+        return zx / metal::select(zy, Z(1), zy == Z(0));
+    }
 }
 )")
 
@@ -474,8 +481,6 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // - either of the operands is negative (undefined behavior in Metal)
 // When the behavior would be undefined the result is 0.
-// FIXME: This function should also handle INT_MIN % -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(imod,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -483,6 +488,7 @@ ANGLE_ALWAYS_INLINE Z ANGLE_imod(X x, Y y)
 {
     if constexpr (metal::is_signed_v<Z>) {
         Z y_or_one = metal::select(Z(y), Z(1), Z(y) == Z(0));
+        y_or_one = metal::select(y_or_one, Z(1), y_or_one == Z(-1));
         if (metal::any(((Z(x) | y_or_one) & Z(2147483648u)) != Z(0u)))
         {
             return as_type<Z>(
@@ -3056,6 +3062,16 @@ ANGLE_ALWAYS_INLINE thread X &ANGLE_subAssignInt(thread X &x, Y y)
 }
 )")
 
+// Avoid undefined behavior due to integer overflow.
+PROGRAM_PRELUDE_DECLARE(negateInt,
+                        R"(
+template <typename T>
+ANGLE_ALWAYS_INLINE T ANGLE_negateInt(T x)
+{
+    return as_type<T>(metal::make_unsigned_t<T>(0) - metal::make_unsigned_t<T>(x));
+}
+)")
+
 PROGRAM_PRELUDE_DECLARE(loopForwardProgress,
                         R"(
 ANGLE_ALWAYS_INLINE void ANGLE_loopForwardProgress()
@@ -3886,6 +3902,10 @@ void ProgramPrelude::visitOperator(TOperator op,
             if (argType0->isMatrix())
             {
                 negateMatrix();
+            }
+            if (argType0->isSignedInt())
+            {
+                negateInt();
             }
             break;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/VertexArray.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/VertexArray.cpp
@@ -539,11 +539,6 @@ ANGLE_INLINE VertexArray::DirtyBindingBits VertexArray::bindVertexBufferImpl(con
     binding->setOffset(offset);
     binding->setStride(stride);
 
-    if (mRobustBufferAccessEnabled)
-    {
-        updateCachedElementLimit(*binding, mCachedBufferSize[bindingIndex]);
-    }
-
     return dirtyBindingBits;
 }
 
@@ -569,6 +564,10 @@ void VertexArray::bindVertexBuffer(const Context *context,
     {
         mDirtyBits.set(DIRTY_BIT_BINDING_0 + bindingIndex);
         mDirtyBindingBits[bindingIndex] |= dirtyBindingBits;
+        if (mRobustBufferAccessEnabled)
+        {
+            updateCachedElementLimit(mState.mVertexBindings[bindingIndex], mCachedBufferSize[bindingIndex]);
+        }
     }
 }
 
@@ -637,6 +636,10 @@ ANGLE_INLINE void VertexArray::setVertexAttribPointerImpl(const Context *context
     {
         setDirtyAttribBit(attribIndex, DIRTY_ATTRIB_POINTER_BUFFER);
         *isVertexAttribDirtyOut = true;
+    }
+    if (mRobustBufferAccessEnabled && (attribDirty || dirtyBindingBits.any()))
+    {
+        updateCachedElementLimit(mState.mVertexBindings[attribIndex], mCachedBufferSize[attribIndex]);
     }
 
     mState.mNullPointerClientMemoryAttribsMask.set(attribIndex,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json
@@ -161,7 +161,7 @@
     ],
     "From GL_ANGLE_depth_texture and OES_depth_texture":
     [
-        [ "GL_DEPTH_COMPONENT32_OES",  "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT_24_8" ],
+        [ "GL_DEPTH_COMPONENT32_OES",  "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT" ],
         [ "GL_DEPTH_COMPONENT",        "GL_DEPTH_COMPONENT", "GL_UNSIGNED_SHORT" ],
         [ "GL_DEPTH_COMPONENT",        "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT" ]
     ],

--- a/Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp
@@ -762,18 +762,8 @@ bool ValidES3FormatCombination(GLenum format, GLenum type, GLenum internalFormat
                     {
                         case GL_DEPTH_COMPONENT24:
                         case GL_DEPTH_COMPONENT16:
-                        case GL_DEPTH_COMPONENT:
-                            return true;
-                        default:
-                            break;
-                    }
-                    break;
-                }
-                case GL_UNSIGNED_INT_24_8:
-                {
-                    switch (internalFormat)
-                    {
                         case GL_DEPTH_COMPONENT32_OES:
+                        case GL_DEPTH_COMPONENT:
                             return true;
                         default:
                             break;

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
@@ -100,6 +100,7 @@ angle_end2end_tests_sources = [
   "gl_tests/IndexBufferOffsetTest.cpp",
   "gl_tests/IndexedPointsTest.cpp",
   "gl_tests/InstancingTest.cpp",
+  "gl_tests/IntegerOverflowClampTest.cpp",
   "gl_tests/KTXCompressedTextureTest.cpp",
   "gl_tests/LineLoopTest.cpp",
   "gl_tests/LinkAndRelinkTest.cpp",

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp
@@ -1050,6 +1050,66 @@ TEST_P(DepthStencilFormatsTest, VerifyDepthStencilUploadData)
     EXPECT_PIXEL_RECT_EQ(0, 0, getWindowWidth(), getWindowHeight(), GLColor::black);
 }
 
+// TexImage2D with (D32_OES, DEPTH_COMPONENT, UNSIGNED_INT) should succeed.
+TEST_P(DepthStencilFormatsTest, DepthComponent32OES_UnsignedInt_Accepted)
+{
+    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_OES_depth_texture") &&
+                       !IsGLExtensionEnabled("GL_ANGLE_depth_texture"));
+
+    GLTexture depthTex;
+    glBindTexture(GL_TEXTURE_2D, depthTex);
+
+    std::vector<GLuint> pixels(1, 0xffffffff);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32_OES, 1, 1, 0, GL_DEPTH_COMPONENT,
+                 GL_UNSIGNED_INT, pixels.data());
+    ASSERT_GL_NO_ERROR();
+
+    GLTexture colorTex;
+    glBindTexture(GL_TEXTURE_2D, colorTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTex, 0);
+    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_GEQUAL);
+    glClearColor(0, 1, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ANGLE_GL_PROGRAM(programRed, essl1_shaders::vs::Simple(), essl1_shaders::fs::Red());
+
+    // Fail Depth Test: 0.99 >= 1.0 is false, color stays green
+    float depthValue = 0.99f;
+    drawQuad(programRed, essl1_shaders::PositionAttrib(), depthValue * 2 - 1);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+
+    // Pass Depth Test: 1.0 >= 1.0 is true, color becomes red
+    depthValue = 1.0f;
+    drawQuad(programRed, essl1_shaders::PositionAttrib(), depthValue * 2 - 1);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
+
+    glDisable(GL_DEPTH_TEST);
+    ASSERT_GL_NO_ERROR();
+}
+
+// TexImage2D with (D32_OES, DEPTH_COMPONENT, UNSIGNED_INT_24_8) should fail.
+TEST_P(DepthStencilFormatsTest, DepthComponent32OES_UnsignedInt248_Rejected)
+{
+    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_OES_depth_texture") &&
+                       !IsGLExtensionEnabled("GL_ANGLE_depth_texture"));
+
+    GLTexture tex;
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    std::vector<GLuint> pixels(64 * 4, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32_OES, 64, 4, 0, GL_DEPTH_COMPONENT,
+                 GL_UNSIGNED_INT_24_8, pixels.data());
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+}
+
 // Verify that depth texture's data can be uploaded correctly
 TEST_P(DepthStencilFormatsTest, VerifyDepth32UploadData)
 {

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
@@ -1,0 +1,175 @@
+//
+// Copyright 2026 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+// IntegerOverflowClampTest: Verifies that ANGLE_int_clamp array-bounds guards
+// survive integer UB operations in the Metal shader compiler's optimizer.
+
+#include "test_utils/ANGLETest.h"
+#include "test_utils/gl_raii.h"
+
+using namespace angle;
+
+namespace
+{
+
+class IntegerOverflowClampTest : public ANGLETest<>
+{
+  protected:
+    static constexpr uint32_t kIntMin = static_cast<uint32_t>(std::numeric_limits<int32_t>::min());
+
+    IntegerOverflowClampTest()
+    {
+        setWindowWidth(4);
+        setWindowHeight(1);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+    }
+
+    void runShader(const char *vs, const uint32_t *data, size_t dataSize, uint32_t expected)
+    {
+        constexpr char kFS[] = R"(#version 300 es
+precision highp float;
+void main() { }
+)";
+
+        std::vector<std::string> varyings = {"result"};
+        GLuint program =
+            CompileProgramWithTransformFeedback(vs, kFS, varyings, GL_SEPARATE_ATTRIBS);
+        ASSERT_NE(0u, program);
+
+        glUseProgram(program);
+
+        GLBuffer ubo;
+        glUniformBlockBinding(program, glGetUniformBlockIndex(program, "Data"), 0);
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo);
+        glBufferData(GL_UNIFORM_BUFFER, dataSize, data, GL_STATIC_DRAW);
+        glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo);
+
+        GLBuffer transformFeedbackBuffer;
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, sizeof(uint32_t), nullptr, GL_STATIC_DRAW);
+
+        GLTransformFeedback transformFeedback;
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, transformFeedback);
+        glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, transformFeedbackBuffer);
+
+        glEnable(GL_RASTERIZER_DISCARD);
+        glBeginTransformFeedback(GL_POINTS);
+        glDrawArrays(GL_POINTS, 0, 1);
+        glEndTransformFeedback();
+        glDisable(GL_RASTERIZER_DISCARD);
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, 0);
+        ASSERT_GL_NO_ERROR();
+
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        const void *mapped =
+            glMapBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0, sizeof(uint32_t), GL_MAP_READ_BIT);
+        ASSERT_NE(nullptr, mapped);
+        uint32_t actual = *static_cast<const uint32_t *>(mapped);
+        glUnmapBuffer(GL_TRANSFORM_FEEDBACK_BUFFER);
+
+        EXPECT_EQ(expected, actual)
+            << "Got 0x" << std::hex << actual << ", expected 0x" << expected;
+
+        glDeleteProgram(program);
+    }
+};
+
+// Test that negating INT_MIN does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, NegateIntMin)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = -value;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that dividing INT_MIN by -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, DivByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = value / -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that INT_MIN mod -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, ModByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value % -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+// Test that unsigned divide-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedDivByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 1u / (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin | 1u);
+}
+
+// Test that unsigned mod-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedModByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 7u % (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(IntegerOverflowClampTest);
+ANGLE_INSTANTIATE_TEST(IntegerOverflowClampTest, ES3_METAL());
+
+}  // namespace

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
@@ -1405,6 +1405,72 @@ TEST_P(VertexAttributeOORTest, ANGLEDrawArraysOutOfBoundsCases)
     EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 }
 
+// Test that glVertexAttribPointer call that changes only the format works.
+TEST_P(VertexAttributeOORTest, FormatOnlyChangeRefreshesElementLimit)
+{
+    // The front-end per-attribute cache is bypassed when the backend exposes robust buffer access.
+    ANGLE_SKIP_TEST_IF(IsGLExtensionEnabled("GL_KHR_robust_buffer_access_behavior"));
+
+    constexpr char kVS[] = R"(attribute vec4 a;
+void main()
+{
+    gl_Position = a;
+    gl_PointSize = 8.0;
+})";
+    constexpr char kFS[] = R"(precision mediump float;
+void main()
+{
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+    glUseProgram(program);
+
+    const GLint attribLoc = glGetAttribLocation(program, "a");
+    ASSERT_NE(-1, attribLoc);
+
+    // Pre-fill the 32-byte buffer so every in-bounds vertex maps to gl_Position = (0, 0, 0, 1):
+    //   - 4xFLOAT vertex 0 reads bytes [0, 16) -> (0.0, 0.0, 0.0, 1.0).
+    //   - 1xBYTE  vertex 0 reads byte 0 (X = 0); default Y/Z/W give (0, 0, 0, 1).
+    //   - 1xBYTE  vertex 1 reads byte 28 (X = 0); default Y/Z/W give (0, 0, 0, 1).
+    GLfloat data[8] = {0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    GLBuffer buffer;
+    glBindBuffer(GL_ARRAY_BUFFER, buffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(data), data, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(attribLoc);
+
+    const GLint centerX = getWindowWidth() / 2;
+    const GLint centerY = getWindowHeight() / 2;
+    glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    // 1xBYTE (attrib size = 1).
+    // Element limit = (32 - 0 - 1) / 28 + 1 = 2.
+    glVertexAttribPointer(attribLoc, 1, GL_BYTE, GL_FALSE, 28, nullptr);
+    glDrawArrays(GL_POINTS, 0, 2);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(centerX, centerY, GLColor::green);
+
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    // 4xFLOAT (attrib size = 16).
+    // Element limit = (32 - 0 - 16) / 28 + 1 = 1.
+    glVertexAttribPointer(attribLoc, 4, GL_FLOAT, GL_FALSE, 28, nullptr);
+    glDrawArrays(GL_POINTS, 0, 1);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(centerX, centerY, GLColor::green);
+
+    // Two vertices is out-of-bounds for the new (4xFLOAT) format.
+    glDrawArrays(GL_POINTS, 0, 2);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    glClear(GL_COLOR_BUFFER_BIT);
+    glVertexAttribPointer(attribLoc, 1, GL_BYTE, GL_FALSE, 28, nullptr);
+    glDrawArrays(GL_POINTS, 0, 2);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(centerX, centerY, GLColor::green);
+}
+
 // Test that enabling a buffer in an unused attribute doesn't crash.  There should be an active
 // attribute after that.
 TEST_P(RobustVertexAttributeTest, BoundButUnusedBuffer)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -188,6 +188,8 @@ void RemoteRenderingBackend::moveToSerializedBuffer(RenderingResourceIdentifier 
     MESSAGE_CHECK(remoteImageBuffer, "Missing ImageBuffer");
     Ref imageBuffer = RemoteImageBuffer::sinkIntoImageBuffer(remoteImageBuffer.releaseNonNull());
     MESSAGE_CHECK(imageBuffer->hasOneRef(), "ImageBuffer in use");
+    // Avoid leaking cross-RemoteRenderingBackend state through context by releasing the context.
+    imageBuffer->releaseGraphicsContext();
     bool success = m_sharedResourceCache->addSerializedImageBuffer(serializedIdentifier, WTF::move(imageBuffer));
     MESSAGE_CHECK(success, "Duplicate SerializedImageBuffer");
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -91,6 +91,7 @@
 #endif
 
 #define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_streamConnection, message);
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, m_streamConnection, returnValue)
 
 namespace WebKit {
 using namespace WebCore;
@@ -287,6 +288,12 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
     if (purpose == RenderingPurpose::Canvas && m_sharedResourceCache->reachedImageBufferForCanvasLimit())
         return nullptr;
 
+    // Verify DisplayList rendering mode is only used when RemoteSnapshotting is enabled
+    if (renderingMode == RenderingMode::DisplayList) {
+        auto prefs = sharedPreferencesForWebProcess();
+        MESSAGE_CHECK_WITH_RETURN_VALUE(prefs && prefs->remoteSnapshottingEnabled, nullptr);
+    }
+
     adjustImageBufferCreationContext(m_sharedResourceCache, creationContext);
     adjustImageBufferRenderingMode(m_sharedResourceCache, purpose, renderingMode);
 
@@ -307,12 +314,6 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
 void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferFormat pixelFormat, RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier)
 {
     assertIsCurrent(workQueue());
-
-    // Verify DisplayList rendering mode is only used when RemoteSnapshotting is enabled
-    if (renderingMode == RenderingMode::DisplayList) {
-        auto prefs = sharedPreferencesForWebProcess();
-        MESSAGE_CHECK(prefs && prefs->remoteSnapshottingEnabled, "RemoteSnapshotting is not enabled");
-    }
 
     RefPtr<ImageBuffer> imageBuffer = allocateImageBuffer(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, { });
     if (!imageBuffer) {
@@ -711,5 +712,6 @@ void RemoteRenderingBackend::getImageBufferResourceLimitsForTesting(CompletionHa
 } // namespace WebKit
 
 #undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_WITH_RETURN_VALUE
 
 #endif // ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### 418b3e661af8865550df72bf272be4913a08f6ee
<pre>
Cherry-pick 305413.1016@safari-7624.5.1.10-branch (33120ad29238). <a href="https://bugs.webkit.org/show_bug.cgi?id=316439">https://bugs.webkit.org/show_bug.cgi?id=316439</a>

    RemoteRenderingBackend can still allocateImageBuffer() with RenderingMode::DisplayList
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316439">https://bugs.webkit.org/show_bug.cgi?id=316439</a>
    <a href="https://rdar.apple.com/176382472">rdar://176382472</a>

    Reviewed by Simon Fraser.

    RemoteRenderingBackend::allocateImageBuffer() is called from
    1. RemoteRenderingBackend::createImageBuffer()
    2. RemoteImageBufferSet::ensureBufferForDisplay().

    In 311931@main, which fixes bug 307843, a MESSAGE_CHECK() was added in
    RemoteRenderingBackend::allocateImageBuffer() to prevent creating a remote
    ImageBufferDisplayListBackend. But this change left the call from
    RemoteImageBufferSet::ensureBufferForDisplay().

    The fix is to move the MESSAGE_CHECK from RemoteRenderingBackend::createImageBuffer()
    to RemoteRenderingBackend::allocateImageBuffer().

    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::allocateImageBuffer):
    (WebKit::RemoteRenderingBackend::createImageBuffer):

    Identifier: 305413.1016@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1121@webkitglib/2.52">https://commits.webkit.org/305877.1121@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4de8bc28e5cfff734ac8c65ac943af91e75c4712
<pre>
Cherry-pick 305413.1007@safari-7624.5.1.10-branch (d5c5da3f748b). <a href="https://bugs.webkit.org/show_bug.cgi?id=317295">https://bugs.webkit.org/show_bug.cgi?id=317295</a>

    SerializedImageBuffer leaks cross-RemoteRenderingBackend data through GraphicsContext
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317295">https://bugs.webkit.org/show_bug.cgi?id=317295</a>
    <a href="https://rdar.apple.com/175520296">rdar://175520296</a>

    Reviewed by Dan Glastonbury.

    ImageBuffer context state might leak non-thread-safe
    cross-RemoteRenderingBackend instances through GraphicsContext state.

    Release the GraphicsContext when transfering the ImageBuffer to
    different RRB.

    * LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt: Added.
    * LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html: Added.
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::moveToSerializedBuffer):

    Identifier: 305413.1007@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1120@webkitglib/2.52">https://commits.webkit.org/305877.1120@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c8ab82498cbe84c9990f847a1b053597bc639c97
<pre>
Cherry-pick 305413.1006@safari-7624.5.1.10-branch (3320c0a36383). <a href="https://bugs.webkit.org/show_bug.cgi?id=317294">https://bugs.webkit.org/show_bug.cgi?id=317294</a>

    ANGLE: Element limit not updated after format only VertexAttribPointer change
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317294">https://bugs.webkit.org/show_bug.cgi?id=317294</a>
    <a href="https://rdar.apple.com/176813568">rdar://176813568</a>

    Reviewed by Dan Glastonbury.

    Before, changing the type of a vertex attrib would not cause recomputation
    of how many elements can be drawn. The type size affects this, as
    last attrib of the buffer accesses only the type size amount of data, not
    the stride amount of data.

    Example buffer size == 32:
    - type size == 1, stride == 28  --&gt; buffer fits 2 elements.
    - type size == 16, stride == 28 --&gt; buffer fits 1 element.

    Fix by recomputing the element count also in case the type changes.

    * Source/ThirdParty/ANGLE/src/libANGLE/VertexArray.cpp:
    (gl::VertexArray::bindVertexBufferImpl):
    (gl::VertexArray::bindVertexBuffer):
    (gl::VertexArray::setVertexAttribPointerImpl):
    * Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp:

    Identifier: 305413.1006@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1119@webkitglib/2.52">https://commits.webkit.org/305877.1119@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b2139ded406227ebf18951dd3e4ffdf8c7ae05f3
<pre>
Cherry-pick 305413.991@safari-7624.5-branch (43afeddf1aab). <a href="https://bugs.webkit.org/show_bug.cgi?id=315543">https://bugs.webkit.org/show_bug.cgi?id=315543</a>

    [ANGLE] MSL translator missing integer UB wrappers allow array bounds clamp elimination
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315543">https://bugs.webkit.org/show_bug.cgi?id=315543</a>
    <a href="https://rdar.apple.com/176813852">rdar://176813852</a>

    Reviewed by Kimmo Kinnunen.

    The MSL translator uses UB-safe wrapper functions to perform integer arithmetic via unsigned
    operations, preventing Metal&apos;s LLVM backend from exploiting undefined behavior to fold away
    the ANGLE_int_clamp array-bounds guard. Three operations are not routed through these wrappers:
    signed unary negate, signed division by -1, and unsigned div/mod. The resulting UB lets LLVM&apos;s
    optimizer eliminate the bounds clamp, allowing a WebGL2 page to index arbitrarily into GPU
    device memory.

    The fix routes all three operations through UB-safe wrappers: a new ANGLE_negateInt that negates
    via unsigned subtraction, an extended ANGLE_div that guards divisor -1 in addition to 0, and
    routing unsigned div/mod through the existing ANGLE_div/ANGLE_imod whose unsigned branches already
    mask zero divisors.

    The new wrappers are tested in IntegerOverflowClampTest.cpp.

    * Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
    * Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp:
    (GetOperatorString):
    * Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp:
    (PROGRAM_PRELUDE_DECLARE):
    * Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni:
    * Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp: Added.
    (angle::IntegerOverflowClampTest::IntegerOverflowClampTest):
    (angle::IntegerOverflowClampTest::runShader):

    Identifier: 305413.991@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1118@webkitglib/2.52">https://commits.webkit.org/305877.1118@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d945f9ea601f4a2fc3e89e1233f5002115b46fac
<pre>
Cherry-pick 305413.982@safari-7624.5.1.10-branch (8b1c27595893). <a href="https://bugs.webkit.org/show_bug.cgi?id=315712">https://bugs.webkit.org/show_bug.cgi?id=315712</a>

    [ANGLE] Fix GL_DEPTH_COMPONENT32_OES format validation to reject GL_UNSIGNED_INT_24_8
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315712">https://bugs.webkit.org/show_bug.cgi?id=315712</a>
    <a href="https://rdar.apple.com/176813583">rdar://176813583</a>

    Reviewed by Kimmo Kinnunen.

    es3_format_type_combinations.json incorrectly pairs GL_DEPTH_COMPONENT32_OES with GL_UNSIGNED_INT_24_8,
    allowing TexImage2D with internalformat=GL_DEPTH_COMPONENT32_OES, format=GL_DEPTH_COMPONENT, and
    type=GL_UNSIGNED_INT_24_8 to pass ES3 format validation. GL_UNSIGNED_INT_24_8 is only valid with
    GL_DEPTH_STENCIL (per OpenGL ES 3.0.6, Table 3.6). Metal backend&apos;s load-function table has no converter
    for this combination and falls through to UnreachableLoadFunction which in release-mode is a no-op,
    causing an uninitialized malloc&apos;d buffer to be uploaded into the GPU process depth texture.

    Change the JSON entry from GL_UNSIGNED_INT_24_8 to GL_UNSIGNED_INT and regenerate format_map_autogen.cpp.
    The invalid combination is now rejected with GL_INVALID_OPERATION before any buffer allocation occurs.

    * Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json:
    * Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp:
    (gl::ValidES3FormatCombination):
    * Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp:

    Identifier: 305413.982@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1117@webkitglib/2.52">https://commits.webkit.org/305877.1117@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f5ad87ad1f28dbcdb46e2fa047c76d7360d2571

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182809 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56732 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193026 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147097 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58074 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56467 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147097 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185764 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58074 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123103 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58074 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56467 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58074 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4198 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49379 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56467 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194967 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56401 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152132 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57106 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151836 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27753 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57106 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129375 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125447 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55614 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50542 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54985 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55222 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55052 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->