### PR TITLE
[JSC] Optimize MarkedBlock::Handle::stopAllocating

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -160,12 +160,7 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList, StopAllocatin
     
     blockHeader().m_newlyAllocated.clearAll();
     blockHeader().m_newlyAllocatedVersion = heap()->objectSpace().newlyAllocatedVersion();
-
-    forEachCell(
-        [&] (size_t, HeapCell* cell, HeapCell::Kind) -> IterationStatus {
-            block().setNewlyAllocated(cell);
-            return IterationStatus::Continue;
-        });
+    blockHeader().m_newlyAllocated.setEachNthBit(m_atomsPerCell, m_startAtom, endAtom);
 
     freeList.forEach(
         [&] (HeapCell* cell) {

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -453,18 +453,26 @@ inline void BitSet<bitSetSize, WordType>::setEachNthBit(size_t n, size_t start, 
     size_t endWordIndex = end / wordSize;
     size_t index = start - wordIndex * wordSize;
     while (wordIndex < endWordIndex) {
-        while (index < wordSize) {
-            bits[wordIndex] |= (one << index);
-            index += n;
+        if (index < wordSize) {
+            WordType word = bits[wordIndex];
+            do {
+                word |= (one << index);
+                index += n;
+            } while (index < wordSize);
+            bits[wordIndex] = word;
         }
         index -= wordSize;
         wordIndex++;
     }
 
     size_t endIndex = end - endWordIndex * wordSize;
-    while (index < endIndex) {
-        bits[wordIndex] |= (one << index);
-        index += n;
+    if (index < endIndex) {
+        WordType word = bits[wordIndex];
+        do {
+            word |= (one << index);
+            index += n;
+        } while (index < endIndex);
+        bits[wordIndex] = word;
     }
 
     cleanseLastWord();


### PR DESCRIPTION
#### f198e8af3b2af94d6582b4c64ff061f4c433dcb7
<pre>
[JSC] Optimize MarkedBlock::Handle::stopAllocating
<a href="https://bugs.webkit.org/show_bug.cgi?id=322480">https://bugs.webkit.org/show_bug.cgi?id=322480</a>
<a href="https://rdar.apple.com/185772918">rdar://185772918</a>

Reviewed by Dan Hecht.

In MarkedBlock::Handle::stopAllocating, we need to set a bit for
NewlyAllocated status in BitSet. This can be accelerated by using
setEachNthBit as cell size is fixed for each MarkedBlock. This patch
uses it. Also optimizing setEachNthBit code not to do read-modify-write
multiple times for the same word.

* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::stopAllocating):
* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::setEachNthBit):

Canonical link: <a href="https://commits.webkit.org/319824@main">https://commits.webkit.org/319824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c79e6a8af44e9b87345ad99c62cc904753d83454

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147164 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6110cf2-f469-40b5-9495-a876444c4b67) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56534 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54b34223-6bb3-4cb4-b2e7-97eae0c47410) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185831 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/877026d5-0a54-4583-9d37-685b53e684d1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/11975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43035 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4266 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44146 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195034 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56468 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57173 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151894 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46461 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55681 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55289 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->