### PR TITLE
[ANGLE] MSL translator missing integer UB wrappers allow array bounds clamp elimination

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		44EF4D53A634EA5A0968572B /* es3pStateChangeTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D739486DA5E0126F0D0EF4BB /* es3pStateChangeTests.cpp */; };
 		4557460D814F5DF1D5787863 /* es3sLongRunningShaderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7134402C9425888101366367 /* es3sLongRunningShaderTests.cpp */; };
 		457CC0343015771C001DE9FC /* angle_end2end_tests_expectations.txt in State Test Expectations */ = {isa = PBXBuildFile; fileRef = 7BD3D2E82FCDBB4E00C386DC /* angle_end2end_tests_expectations.txt */; };
+		4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */; };
 		45F4464AB2B8513CB3E3762B /* es3fNegativeStateApiTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F264D619701179ECB7F6033 /* es3fNegativeStateApiTests.cpp */; };
 		46574F8EBAA668D2A75348A0 /* es3pShaderOperatorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7F384DF192F867DA1896E9B2 /* es3pShaderOperatorTests.cpp */; };
 		46724657AF064907DE2EA506 /* deThreadTest.c in Sources */ = {isa = PBXBuildFile; fileRef = ADE748218E43074A54016343 /* deThreadTest.c */; };
@@ -3203,6 +3204,7 @@
 		44A549579F74A7BBCF80C243 /* es2fMultisampleTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = es2fMultisampleTests.cpp; sourceTree = "<group>"; };
 		44E247508F92F73A06DB9605 /* sglrReferenceContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sglrReferenceContext.cpp; sourceTree = "<group>"; };
 		451D41F7AE0365931A4AA60B /* tes3InfoTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tes3InfoTests.cpp; sourceTree = "<group>"; };
+		4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntegerOverflowClampTest.cpp; sourceTree = "<group>"; };
 		45A743169381B27478632DE1 /* glsUniformBlockCase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = glsUniformBlockCase.cpp; sourceTree = "<group>"; };
 		45DE4E258609976D2067B1DE /* es3sSpecialFloatTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = es3sSpecialFloatTests.cpp; sourceTree = "<group>"; };
 		463D416587F5C55E8292E1C8 /* es3fShaderDerivateTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = es3fShaderDerivateTests.cpp; sourceTree = "<group>"; };
@@ -6506,6 +6508,7 @@
 				7BFAF5682DE59E0900327F7F /* IndexBufferOffsetTest.cpp */,
 				7BFAF5692DE59E0900327F7F /* IndexedPointsTest.cpp */,
 				7BFAF56A2DE59E0900327F7F /* InstancingTest.cpp */,
+				4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */,
 				7BFAF56B2DE59E0900327F7F /* KTXCompressedTextureTest.cpp */,
 				7BFAF56C2DE59E0900327F7F /* LineLoopTest.cpp */,
 				7BFAF56D2DE59E0900327F7F /* LinkAndRelinkTest.cpp */,
@@ -10556,6 +10559,7 @@
 				7BFAF5EE2DE59E0900327F7F /* IndexBufferOffsetTest.cpp in Sources */,
 				7BFAF5F42DE59E0900327F7F /* IndexedPointsTest.cpp in Sources */,
 				7BFAF5CE2DE59E0900327F7F /* InstancingTest.cpp in Sources */,
+				4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */,
 				7BFAF5D82DE59E0900327F7F /* KTXCompressedTextureTest.cpp in Sources */,
 				7BB9723D2DE4827800455D13 /* libEGL_autogen.cpp in Sources */,
 				7BB972362DE480F000455D13 /* libGLESv2_autogen.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
@@ -370,7 +370,7 @@ static const char *GetOperatorString(TOperator op,
         case TOperator::EOpLogicalAnd:
             return "&&";
         case TOperator::EOpNegative:
-            return "-";
+            return resultType.isSignedInt() ? "ANGLE_negateInt" : "-";
         case TOperator::EOpPositive:
             if (argType0->isMatrix())
             {
@@ -428,11 +428,13 @@ static const char *GetOperatorString(TOperator op,
 
         case TOperator::EOpDiv:
         case TOperator::EOpDivAssign:
-            return resultType.isSignedInt() ? "ANGLE_div" : "/";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_div"
+                                                                                      : "/";
 
         case TOperator::EOpIMod:
         case TOperator::EOpIModAssign:
-            return resultType.isSignedInt() ? "ANGLE_imod" : "%";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_imod"
+                                                                                      : "%";
 
         case TOperator::EOpEqual:
             if ((argType0->getStruct() && argType1->getStruct()) &&

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
@@ -295,6 +295,7 @@ class ProgramPrelude : public TIntermTraverser
     void addAssignInt();
     void subInt();
     void subAssignInt();
+    void negateInt();
     void loopForwardProgress();
 
   private:
@@ -454,8 +455,6 @@ ANGLE_ALWAYS_INLINE X ANGLE_mod(X x, Y y)
 // - the divisor is 0
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // When the behavior would be undefined the result is `x`.
-// FIXME: This function should also handle INT_MIN / -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(div,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -463,8 +462,16 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 {
     Z zx = Z(x);
     Z zy = Z(y);
-    auto predicate = zy == Z(0);
-    return zx / metal::select(zy, Z(1), predicate);
+    if constexpr (metal::is_signed_v<Z>) {
+        using U = metal::make_unsigned_t<Z>;
+        Z safeY = metal::select(zy, Z(1), zy == Z(0));
+        auto isNegOne = safeY == Z(-1);
+        safeY = metal::select(safeY, Z(1), isNegOne);
+        Z q = zx / safeY;
+        return metal::select(q, as_type<Z>(U(0) - U(zx)), isNegOne);
+    } else {
+        return zx / metal::select(zy, Z(1), zy == Z(0));
+    }
 }
 )")
 
@@ -473,8 +480,6 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // - either of the operands is negative (undefined behavior in Metal)
 // When the behavior would be undefined the result is 0.
-// FIXME: This function should also handle INT_MIN % -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(imod,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -482,6 +487,7 @@ ANGLE_ALWAYS_INLINE Z ANGLE_imod(X x, Y y)
 {
     if constexpr (metal::is_signed_v<Z>) {
         Z y_or_one = metal::select(Z(y), Z(1), Z(y) == Z(0));
+        y_or_one = metal::select(y_or_one, Z(1), y_or_one == Z(-1));
         if (metal::any(((Z(x) | y_or_one) & Z(2147483648u)) != Z(0u)))
         {
             return as_type<Z>(
@@ -3046,6 +3052,16 @@ ANGLE_ALWAYS_INLINE thread X &ANGLE_subAssignInt(thread X &x, Y y)
 }
 )")
 
+// Avoid undefined behavior due to integer overflow.
+PROGRAM_PRELUDE_DECLARE(negateInt,
+                        R"(
+template <typename T>
+ANGLE_ALWAYS_INLINE T ANGLE_negateInt(T x)
+{
+    return as_type<T>(metal::make_unsigned_t<T>(0) - metal::make_unsigned_t<T>(x));
+}
+)")
+
 PROGRAM_PRELUDE_DECLARE(loopForwardProgress,
                         R"(
 ANGLE_ALWAYS_INLINE void ANGLE_loopForwardProgress()
@@ -3869,6 +3885,10 @@ void ProgramPrelude::visitOperator(TOperator op,
             if (argType0->isMatrix())
             {
                 negateMatrix();
+            }
+            if (argType0->isSignedInt())
+            {
+                negateInt();
             }
             break;
 

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
@@ -107,6 +107,7 @@ angle_end2end_tests_sources = [
   "gl_tests/IndexBufferOffsetTest.cpp",
   "gl_tests/IndexedPointsTest.cpp",
   "gl_tests/InstancingTest.cpp",
+  "gl_tests/IntegerOverflowClampTest.cpp",
   "gl_tests/KTXCompressedTextureTest.cpp",
   "gl_tests/LineLoopTest.cpp",
   "gl_tests/LinkAndRelinkTest.cpp",

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
@@ -1,0 +1,175 @@
+//
+// Copyright 2026 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+// IntegerOverflowClampTest: Verifies that ANGLE_int_clamp array-bounds guards
+// survive integer UB operations in the Metal shader compiler's optimizer.
+
+#include "test_utils/ANGLETest.h"
+#include "test_utils/gl_raii.h"
+
+using namespace angle;
+
+namespace
+{
+
+class IntegerOverflowClampTest : public ANGLETest<>
+{
+  protected:
+    static constexpr uint32_t kIntMin = static_cast<uint32_t>(std::numeric_limits<int32_t>::min());
+
+    IntegerOverflowClampTest()
+    {
+        setWindowWidth(4);
+        setWindowHeight(1);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+    }
+
+    void runShader(const char *vs, const uint32_t *data, size_t dataSize, uint32_t expected)
+    {
+        constexpr char kFS[] = R"(#version 300 es
+precision highp float;
+void main() { }
+)";
+
+        std::vector<std::string> varyings = {"result"};
+        GLuint program =
+            CompileProgramWithTransformFeedback(vs, kFS, varyings, GL_SEPARATE_ATTRIBS);
+        ASSERT_NE(0u, program);
+
+        glUseProgram(program);
+
+        GLBuffer ubo;
+        glUniformBlockBinding(program, glGetUniformBlockIndex(program, "Data"), 0);
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo);
+        glBufferData(GL_UNIFORM_BUFFER, dataSize, data, GL_STATIC_DRAW);
+        glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo);
+
+        GLBuffer transformFeedbackBuffer;
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, sizeof(uint32_t), nullptr, GL_STATIC_DRAW);
+
+        GLTransformFeedback transformFeedback;
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, transformFeedback);
+        glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, transformFeedbackBuffer);
+
+        glEnable(GL_RASTERIZER_DISCARD);
+        glBeginTransformFeedback(GL_POINTS);
+        glDrawArrays(GL_POINTS, 0, 1);
+        glEndTransformFeedback();
+        glDisable(GL_RASTERIZER_DISCARD);
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, 0);
+        ASSERT_GL_NO_ERROR();
+
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        const void *mapped =
+            glMapBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0, sizeof(uint32_t), GL_MAP_READ_BIT);
+        ASSERT_NE(nullptr, mapped);
+        uint32_t actual = *static_cast<const uint32_t *>(mapped);
+        glUnmapBuffer(GL_TRANSFORM_FEEDBACK_BUFFER);
+
+        EXPECT_EQ(expected, actual)
+            << "Got 0x" << std::hex << actual << ", expected 0x" << expected;
+
+        glDeleteProgram(program);
+    }
+};
+
+// Test that negating INT_MIN does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, NegateIntMin)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = -value;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that dividing INT_MIN by -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, DivByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = value / -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that INT_MIN mod -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, ModByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value % -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+// Test that unsigned divide-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedDivByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 1u / (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin | 1u);
+}
+
+// Test that unsigned mod-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedModByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 7u % (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(IntegerOverflowClampTest);
+ANGLE_INSTANTIATE_TEST(IntegerOverflowClampTest, ES3_METAL());
+
+}  // namespace


### PR DESCRIPTION
#### f05fd6d8b3bee9719437f45a7cb1d1d7ee9c3151
<pre>
[ANGLE] MSL translator missing integer UB wrappers allow array bounds clamp elimination
<a href="https://bugs.webkit.org/show_bug.cgi?id=315543">https://bugs.webkit.org/show_bug.cgi?id=315543</a>
<a href="https://rdar.apple.com/176813852">rdar://176813852</a>

Reviewed by Kimmo Kinnunen.

The MSL translator uses UB-safe wrapper functions to perform integer arithmetic via unsigned
operations, preventing Metal&apos;s LLVM backend from exploiting undefined behavior to fold away
the ANGLE_int_clamp array-bounds guard. Three operations are not routed through these wrappers:
signed unary negate, signed division by -1, and unsigned div/mod. The resulting UB lets LLVM&apos;s
optimizer eliminate the bounds clamp, allowing a WebGL2 page to index arbitrarily into GPU
device memory.

The fix routes all three operations through UB-safe wrappers: a new ANGLE_negateInt that negates
via unsigned subtraction, an extended ANGLE_div that guards divisor -1 in addition to 0, and
routing unsigned div/mod through the existing ANGLE_div/ANGLE_imod whose unsigned branches already
mask zero divisors.

The new wrappers are tested in IntegerOverflowClampTest.cpp.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp:
(GetOperatorString):
* Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp:
(PROGRAM_PRELUDE_DECLARE):
* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp: Added.
(angle::IntegerOverflowClampTest::IntegerOverflowClampTest):
(angle::IntegerOverflowClampTest::runShader):

Originally-landed-as: 305413.991@safari-7624.5-branch (43afeddf1aab). <a href="https://rdar.apple.com/185368065">rdar://185368065</a>
Canonical link: <a href="https://commits.webkit.org/319823@main">https://commits.webkit.org/319823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64fc0152ae2f1c3f483f813cf0c733bf1ba96ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142704 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43361 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42990 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4227 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56430 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40776 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57135 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151855 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46419 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125486 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55643 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18000 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55014 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->