### PR TITLE
[MSE] Seeking to the end of a HTMLMediaElement backed by a MediaSource will unnecessarily fire an ended event

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end-expected.txt
@@ -1,0 +1,23 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+EVENT(startstreaming)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(source.duration = sourceBuffer.buffered.end(0))
+EVENT(durationchange)
+RUN(source.endOfStream())
+EVENT(endstreaming)
+EXPECTED (source.streaming == 'false') OK
+RUN(video.currentTime = video.duration)
+EVENT(seeked)
+EVENT(ended)
+EXPECTED (video.currentTime == video.duration == 'true') OK
+EXPECTED (source.streaming == 'false') OK
+EXPECTED (streamingEvents == '0') OK
+EXPECTED (endedEvents == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end.html
+++ b/LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource-no-streaming-toggle-at-end</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var streamingEvents = 0;
+    var endedEvents = 0;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48khz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (ManagedMediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            waitFor(video, 'error').then(failTest);
+
+            video.disableRemotePlayback = true;
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+
+            await waitFor(source, 'sourceopen');
+            await waitFor(source, 'startstreaming');
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(sourceBuffer, 'update');
+
+            run('source.duration = sourceBuffer.buffered.end(0)');
+            await waitFor(video, 'durationchange');
+
+            const endStreaming = waitFor(source, 'endstreaming');
+            run('source.endOfStream()');
+            await endStreaming;
+            testExpected('source.streaming', false);
+
+            // Seeking to the end of an ended source puts the element in ended playback.
+            source.addEventListener('startstreaming', () => { streamingEvents++; });
+            source.addEventListener('endstreaming', () => { streamingEvents++; });
+            video.addEventListener('ended', () => { endedEvents++; });
+
+            const ended = waitFor(video, 'ended');
+            run('video.currentTime = video.duration');
+            await waitFor(video, 'seeked');
+            await ended;
+
+            // Further seeks to that position change nothing: neither the streaming state nor 'ended'
+            // may fire again.
+            for (let i = 0; i < 10; i++) {
+                video.currentTime = video.duration;
+                await once(video, 'seeked');
+            }
+
+            testExpected('video.currentTime == video.duration', true);
+            testExpected('source.streaming', false);
+            testExpected('streamingEvents', 0);
+            testExpected('endedEvents', 1);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -128,6 +128,12 @@ void ManagedMediaSource::monitorSourceBuffers()
     auto currentTime = this->currentTime();
     ASSERT(currentTime.isValid());
 
+    // Once the source is ended and the playback position has reached the end of the media, no further data can ever be needed.
+    if (isEnded() && currentTime >= duration()) {
+        setStreaming(false);
+        return;
+    }
+
     auto limitAhead = [&] (double upper) {
         MediaTime aheadTime = currentTime + MediaTime::createWithDouble(upper);
         return isEnded() ? std::min(duration(), aheadTime) : aheadTime;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4134,8 +4134,10 @@ void HTMLMediaElement::seekTask()
     }
     time = seekableRanges->ranges().nearest(time);
 
-    m_sentEndEvent = false;
     m_lastSeekTime = time;
+    // A seek landing on the end of the media leaves the element in ended playback, so 'ended' must not fire a second time.
+    if (!endedPlayback())
+        m_sentEndEvent = false;
     m_pendingSeekType = thisSeekType;
     setSeeking(true);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1679,6 +1679,28 @@ void NetworkProcess::notifyMediaStreamingActivity(bool activity)
 {
 #if PLATFORM(COCOA)
     static constexpr auto notifyMediaStreamingName = "com.apple.WebKit.mediaStreamingActivity"_s;
+    // Every observer of that notification is woken up by it, so the published state is rate-limited:
+    // content toggling streaming rapidly gets coalesced into the state it settles on.
+    static constexpr Seconds notificationInterval = 10_s;
+
+    if (m_notifiedMediaStreamingActivity == activity) {
+        m_pendingMediaStreamingActivity.reset();
+        return;
+    }
+
+    auto elapsed = MonotonicTime::now() - m_lastMediaStreamingActivityNotificationTime;
+    if (m_notifiedMediaStreamingActivity && elapsed < notificationInterval) {
+        m_pendingMediaStreamingActivity = activity;
+        if (std::exchange(m_mediaStreamingActivityFlushScheduled, true))
+            return;
+        RunLoop::mainSingleton().dispatchAfter(notificationInterval - elapsed, [protectedThis = Ref { *this }] {
+            protectedThis->m_mediaStreamingActivityFlushScheduled = false;
+            if (auto activity = std::exchange(protectedThis->m_pendingMediaStreamingActivity, { }))
+                protectedThis->notifyMediaStreamingActivity(*activity);
+        });
+        return;
+    }
+    m_pendingMediaStreamingActivity.reset();
 
     if (m_mediaStreamingActivitityToken == NOTIFY_TOKEN_INVALID) {
         auto status = notify_register_check(notifyMediaStreamingName, &m_mediaStreamingActivitityToken);
@@ -1693,6 +1715,8 @@ void NetworkProcess::notifyMediaStreamingActivity(bool activity)
         RELEASE_LOG_ERROR(IPC, "notify_set_state() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
         return;
     }
+    m_notifiedMediaStreamingActivity = activity;
+    m_lastMediaStreamingActivityNotificationTime = MonotonicTime::now();
     status = notify_post(notifyMediaStreamingName);
     RELEASE_LOG_ERROR_IF(status != NOTIFY_STATUS_OK, IPC, "notify_post() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
 #else

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -61,6 +61,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -702,6 +703,10 @@ private:
     bool m_didSyncCookiesForClose { false };
 #if PLATFORM(COCOA)
     int m_mediaStreamingActivitityToken { NOTIFY_TOKEN_INVALID };
+    MonotonicTime m_lastMediaStreamingActivityNotificationTime;
+    std::optional<bool> m_notifiedMediaStreamingActivity;
+    std::optional<bool> m_pendingMediaStreamingActivity;
+    bool m_mediaStreamingActivityFlushScheduled { false };
     bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### cab391584f801d18cde18093204d9b980964ca80
<pre>
[MSE] Seeking to the end of a HTMLMediaElement backed by a MediaSource will unnecessarily fire an ended event
<a href="https://bugs.webkit.org/show_bug.cgi?id=322488">https://bugs.webkit.org/show_bug.cgi?id=322488</a>
<a href="https://rdar.apple.com/185145277">rdar://185145277</a>

Reviewed by Jer Noble.

When a player seeked to a MediaSource video&apos;s duration in repetition, the `ended` event would have been fired
again even if it had been fired before and currentTime didn&apos;t change.
That&apos;s because while HTMLMediaElement::seekTask has a shortcut to detect a seek to the same currentTime
and just fire the `seeked` event, when a MediaSource is in use this shortcut is bypassed
and so we start a fullseek.
When timechanged is called again by the MediaPlayer, we compare the currentTime with the duration
and if equal we fired the `ended` event.

Additionally, with ManagedMediaSource, following 312694@main , we call MediaSource::monitorSourceBuffers()
again, which at the start of a seek cause the ManagedMedaSource.streaming attribute to become true
and at the end to be false, and so startstreaming/endstreaming would have too been fired.
Any calls to monitorSourceBuffers() at end-of-stream would have produced that pair of events to be fired
(312694@main only made it obvious)

We now add an early exit in ManagedMedaSource::monitorSourceBuffers() if the MediaSource is ended and
currentTime &gt;= duration, we call setStreaming(false) and return. Nothing will call setStreaming(true)
again.

To prevent the redundant, and incorrect ended event, we only clear m_sentEndEvent if the MediaSource
isn&apos;t ended and we aren&apos;t seeking to duration()

Fly-by: we limit the system notifications about streaming activity to once per 10s only.
  - First call ever (m_notifiedMediaStreamingActivity unset) posts immediately — no startup delay.
  - A call matching the currently published state clears any pending change and returns; nothing is posted.
  - A change within 10s of the last post is stored in m_pendingMediaStreamingActivity and a single dispatchAfter is armed for the remainder of the window.
    Further toggles overwrite the pending value without arming more work.
  - When the window closes, the flush re-enters notifyMediaStreamingActivity with the pending value, which then either posts it or drops it if it equals what&apos;s already published.

Test added: media/media-source/media-managedmse-no-streaming-toggle-at-end.html

* LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-no-streaming-toggle-at-end.html: Added.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekTask):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::notifyMediaStreamingActivity):
* Source/WebKit/NetworkProcess/NetworkProcess.h:

Canonical link: <a href="https://commits.webkit.org/319847@main">https://commits.webkit.org/319847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ccd1f297fd305e3c4c7af25a3eb0c6c4f3a9f7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147241 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac21284c-4b21-4e83-8674-80aca78f249d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c5c6a8a-371c-45d3-8727-8822031de71b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf250c16-9a8d-4773-80e9-f81fa3ab5c33) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43458 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43088 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4343 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195111 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40796 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57250 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151959 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129519 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55758 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18099 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55129 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55366 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->