### PR TITLE
[JSC][Wasm] BBQ should honor unlikely br_if branch hints

### DIFF
--- a/JSTests/wasm/branch-hints/branchHintsBBQ.js
+++ b/JSTests/wasm/branch-hints/branchHintsBBQ.js
@@ -1,0 +1,181 @@
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+//@ requireOptions("--useOMGJIT=0", "--useWasmIPInt=0")
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+const existing = new WebAssembly.Instance(new WebAssembly.Module(
+    typeof readbuffer !== "undefined" ? readbuffer('branchHintsModule.wasm') : read('branchHintsModule.wasm', 'binary')
+));
+assert.eq(existing.exports._fun(-1), 10);
+assert.eq(existing.exports._fun(0), 10);
+assert.eq(existing.exports._fun(1), 10);
+assert.eq(existing.exports._fun(2), 20);
+
+const Op = { Block: 0x02, End: 0x0b, BrIf: 0x0d, Return: 0x0f, Drop: 0x1a, LocalGet: 0x20, I32Const: 0x41 };
+
+function readLeb(bytes, i)
+{
+    let value = 0;
+    let shift = 0;
+    while (true) {
+        const byte = bytes[i++];
+        value |= (byte & 0x7f) << shift;
+        if (!(byte & 0x80))
+            return [value >>> 0, i];
+        shift += 7;
+    }
+}
+
+function skipOp(bytes, i)
+{
+    const op = bytes[i++];
+    switch (op) {
+    case Op.End:
+    case Op.Drop:
+    case Op.Return:
+        return i;
+    case Op.Block:
+        return i + 1;
+    case Op.BrIf:
+    case Op.LocalGet:
+        [, i] = readLeb(bytes, i);
+        return i;
+    case Op.I32Const:
+        [, i] = readLeb(bytes, i);
+        return i;
+    default:
+        throw new Error(`unhandled opcode 0x${op.toString(16)}`);
+    }
+}
+
+function firstFunctionOpcodeOffset(wasmBytes, opcode)
+{
+    const bytes = new Uint8Array(wasmBytes);
+    let i = 8;
+    while (i < bytes.length) {
+        const id = bytes[i++];
+        let size;
+        [size, i] = readLeb(bytes, i);
+        const end = i + size;
+        if (id === 10) {
+            [, i] = readLeb(bytes, i);
+            let bodySize;
+            [bodySize, i] = readLeb(bytes, i);
+            const bodyStart = i;
+            const bodyEnd = i + bodySize;
+            let localDeclCount;
+            [localDeclCount, i] = readLeb(bytes, i);
+            for (let n = 0; n < localDeclCount; ++n) {
+                [, i] = readLeb(bytes, i);
+                i++;
+            }
+            while (i < bodyEnd) {
+                if (bytes[i] === opcode)
+                    return i - bodyStart;
+                i = skipOp(bytes, i);
+            }
+            throw new Error("opcode not found in function body");
+        }
+        i = end;
+    }
+    throw new Error("missing code section");
+}
+
+function instantiateWithHint(buildCode, opcode, likely, functionIndex, imports)
+{
+    const unsigned = buildCode(new Builder()).WebAssembly().get();
+    const offset = firstFunctionOpcodeOffset(unsigned, opcode);
+    const builder = new Builder();
+    builder.Unknown("metadata.code.branch_hint")
+        .Byte(1)
+        .Byte(functionIndex)
+        .Byte(1)
+        .Byte(offset)
+        .Byte(1)
+        .Byte(likely ? 1 : 0)
+        .End();
+    const module = new WebAssembly.Module(buildCode(builder).WebAssembly().get());
+    assert.eq(WebAssembly.Module.customSections(module, "metadata.code.branch_hint").length, 1);
+    return new WebAssembly.Instance(module, imports);
+}
+
+function voidBrIfCode(builder)
+{
+    return builder
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("select")
+        .End()
+        .Code()
+            .Function("select", { params: ["i32"], ret: "i32" })
+                .Block("void", b =>
+                    b.GetLocal(0)
+                    .BrIf(0)
+                    .I32Const(7)
+                    .Return()
+                )
+                .I32Const(3)
+            .End()
+        .End();
+}
+
+function valuedBrIfCode(builder)
+{
+    return builder
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("select")
+        .End()
+        .Code()
+            .Function("select", { params: ["i32"], ret: "i32" })
+                .Block("i32", b =>
+                    b.I32Const(7)
+                    .GetLocal(0)
+                    .BrIf(0)
+                    .Drop()
+                    .I32Const(3)
+                )
+            .End()
+        .End();
+}
+
+function importedVoidBrIf(builder)
+{
+    return builder
+        .Type().End()
+        .Import()
+            .Function("env", "imp", { params: [], ret: "void" })
+        .End()
+        .Function().End()
+        .Export()
+            .Function("select")
+        .End()
+        .Code()
+            .Function("select", { params: ["i32"], ret: "i32" })
+                .Block("void", b =>
+                    b.GetLocal(0)
+                    .BrIf(0)
+                    .I32Const(7)
+                    .Return()
+                )
+                .I32Const(3)
+            .End()
+        .End();
+}
+
+for (const likely of [false, true]) {
+    const voidBrIf = instantiateWithHint(voidBrIfCode, Op.BrIf, likely, 0);
+    assert.eq(voidBrIf.exports.select(0), 7);
+    assert.eq(voidBrIf.exports.select(1), 3);
+
+    const valued = instantiateWithHint(valuedBrIfCode, Op.BrIf, likely, 0);
+    assert.eq(valued.exports.select(0), 3);
+    assert.eq(valued.exports.select(1), 7);
+
+    const imported = instantiateWithHint(importedVoidBrIf, Op.BrIf, likely, 1, { env: { imp() { } } });
+    assert.eq(imported.exports.select(0), 7);
+    assert.eq(imported.exports.select(1), 3);
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3984,6 +3984,28 @@ void BBQJIT::prepareForExceptions()
     return { };
 }
 
+BranchHint BBQJIT::currentBranchHint() const
+{
+    ASSERT(m_parser);
+    return m_info.getBranchHint(m_functionIndex, m_parser->currentOpcodeStartingOffset());
+}
+
+void BBQJIT::emitHintedBrIf(ControlData& target, GPRReg condition, std::span<TypedExpression> results)
+{
+    currentControlData().flushAtBlockBoundary(*this, 0, results, false);
+    if (branchHintMarksTakenRare(currentBranchHint()) && target.targetLocations().isEmpty()) {
+        target.addBranch(m_jit.branchTest32(ResultCondition::NonZero, condition));
+        currentControlData().finalizeBlock(*this, 0, results, true);
+        return;
+    }
+
+    Jump ifNotTaken = m_jit.branchTest32(ResultCondition::Zero, condition);
+    currentControlData().addExit(*this, target.targetLocations(), results);
+    target.addBranch(m_jit.jump());
+    ifNotTaken.link(&m_jit);
+    currentControlData().finalizeBlock(*this, target.targetLocations().size(), results, true);
+}
+
 [[nodiscard]] PartialResult BBQJIT::addBranch(ControlData& target, Value condition, std::span<TypedExpression> results)
 {
     if (condition.isConst() && !condition.asI32()) // If condition is known to be false, this is a no-op.
@@ -4009,14 +4031,8 @@ void BBQJIT::prepareForExceptions()
     if (condition.isConst() || condition.isNone()) {
         currentControlData().flushAndSingleExit(*this, target, results, false, condition.isNone());
         target.addBranch(m_jit.jump()); // We know condition is true, since if it was false we would have returned early.
-    } else {
-        currentControlData().flushAtBlockBoundary(*this, 0, results, condition.isNone());
-        Jump ifNotTaken = m_jit.branchTest32(ResultCondition::Zero, conditionLocation.asGPR());
-        currentControlData().addExit(*this, target.targetLocations(), results);
-        target.addBranch(m_jit.jump());
-        ifNotTaken.link(&m_jit);
-        currentControlData().finalizeBlock(*this, target.targetLocations().size(), results, true);
-    }
+    } else
+        emitHintedBrIf(target, conditionLocation.asGPR(), results);
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -30,6 +30,7 @@
 #include "MathCommon.h"
 #include "PCToCodeOriginMap.h"
 #include "SimpleRegisterAllocator.h"
+#include "WasmBranchHints.h"
 #include "WasmCallingConvention.h"
 #include "WasmCompilationContext.h"
 #include "WasmFunctionParser.h"
@@ -1998,6 +1999,9 @@ public:
     [[nodiscard]] PartialResult addReturn(const ControlData& data, std::span<const TypedExpression> returnValues);
 
     [[nodiscard]] PartialResult addBranch(ControlData& target, Value condition, std::span<TypedExpression> results);
+
+    BranchHint currentBranchHint() const;
+    void emitHintedBrIf(ControlData& target, GPRReg condition, std::span<TypedExpression> results);
 
     [[nodiscard]] PartialResult addBranchNull(ControlData& data, ExpressionType reference, std::span<TypedExpression> returnValues, bool shouldNegate, ExpressionType& result);
 

--- a/Source/JavaScriptCore/wasm/WasmBranchHints.h
+++ b/Source/JavaScriptCore/wasm/WasmBranchHints.h
@@ -76,5 +76,10 @@ inline constexpr bool isValidBranchHint(BranchHint hint)
     return false;
 }
 
+inline constexpr bool branchHintMarksTakenRare(BranchHint hint)
+{
+    return hint == BranchHint::Unlikely;
+}
+
 }
 } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -179,9 +179,9 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
         return false;
     }
 
-    BranchHint getBranchHint(uint32_t functionOffset, uint32_t branchOffset) const
+    BranchHint getBranchHint(FunctionCodeIndex index, uint32_t branchOffset) const
     {
-        auto it = branchHints.find(functionOffset);
+        auto it = branchHints.find(static_cast<uint32_t>(toSpaceIndex(index)));
         return it == branchHints.end()
             ? BranchHint::Invalid
             : it->value.getBranchHint(branchOffset);


### PR DESCRIPTION
#### 6a311eb5deb095527097c784aacd9053c08c836e
<pre>
[JSC][Wasm] BBQ should honor unlikely br_if branch hints
<a href="https://bugs.webkit.org/show_bug.cgi?id=322489">https://bugs.webkit.org/show_bug.cgi?id=322489</a>

Reviewed by NOBODY (OOPS!).

OMG already maps metadata.code.branch_hint to B3 frequency. BBQ ignored
the section. For an Unlikely br_if with no exit shuffle, emit a direct
taken jump so the common path is fall-through.

getBranchHint looked up FunctionCodeIndex in a map keyed by funcidx, so
hints on a module with imported functions never applied. Use toSpaceIndex.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBranchHints.h:
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* JSTests/wasm/branch-hints/branchHintsBBQ.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a311eb5deb095527097c784aacd9053c08c836e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142669 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99059 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43331 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5068 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11901 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42961 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4187 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44068 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56390 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152123 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57095 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151820 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46389 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129364 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125424 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55603 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17972 "Found 1 new test failure: imported/w3c/web-platform-tests/webmessaging/postMessage_MessagePorts_xsite.sub.window.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->