### PR TITLE
[JavaScriptCore] Absence PropertyCondition does not consult non-reified static property tables

### DIFF
--- a/JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js
+++ b/JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js
@@ -1,0 +1,52 @@
+// Absence PropertyCondition should consult non-reified static property tables;
+// otherwise, the Abstract Interpreter folds GetById past Symbol.prototype's
+// static `description`.
+
+function assert(cond) {
+    if (!cond)
+        throw new Error("Assertion failed");
+}
+
+function assertThrows(fn) {
+    try {
+        fn();
+    } catch (e) {
+        return;
+    }
+
+    throw "Expected an exception";
+}
+
+let K = {};
+K.y = 13.37;
+Object.prototype.description = K;
+
+function setup(a) { return a.description; }
+noInline(setup);
+let setupObj = {};
+for (let i = 0; i < 50_000; i++) setup(setupObj);
+
+let o_warm  = Object(Symbol("warm")); o_warm.x  = 1;
+let o_leak  = Object(Symbol("leak")); o_leak.x  = 1;
+let o_crash = Object(Symbol());       o_crash.x = 1;
+
+function f(a, n) {
+    let b = a;
+    if (n > 0) {
+        let r = a.description;
+        let v = r.y;
+        return v;
+    }
+    b.x; b.x; b.x;
+    return undefined;
+}
+noInline(f);
+
+assert(f(o_warm, 1) === undefined);
+for (let i = 0; i < 500_000; i++) f(o_warm, 0);
+
+var hole = f(o_leak, 1);
+assert(hole === undefined);
+assert(typeof hole === "undefined");
+
+assertThrows(() => f(o_crash, 1));

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -74,15 +74,12 @@ void PropertyCondition::dump(PrintStream& out) const
 bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     Concurrency concurrency, Structure* structure, JSObject* base) const
 {
-    if (PropertyConditionInternal::verbose) {
-        dataLog(
-            "Determining validity of ", *this, " with structure ", pointerDump(structure), " and base ",
-            JSValue(base), " assuming impure property watchpoints are set.\n");
-    }
-    
+    dataLogLnIf(PropertyConditionInternal::verbose,
+        "Determining validity of ", *this, " with structure ", pointerDump(structure), " and base ",
+        JSValue(base), " assuming impure property watchpoints are set.");
+
     if (!*this) {
-        if (PropertyConditionInternal::verbose)
-            dataLog("Invalid because unset.\n");
+        dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because unset.");
         return false;
     }
 
@@ -95,16 +92,14 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     case Equivalence:
     case HasStaticProperty:
         if (!structure->propertyAccessesAreCacheable()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because property accesses are not cacheable.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because property accesses are not cacheable.");
             return false;
         }
         break;
         
     case HasPrototype:
         if (!structure->prototypeQueriesAreCacheable()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because prototype queries are not cacheable.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because prototype queries are not cacheable.");
             return false;
         }
         break;
@@ -116,11 +111,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         unsigned currentAttributes;
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid(), currentAttributes);
         if (currentOffset != offset() || currentAttributes != attributes()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLogLn(
-                    "Invalid because we need offset, attributes to be ", offset(), ", ", attributes(),
-                    " but they are ", currentOffset, ", ", currentAttributes);
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because we need offset, attributes to be ", offset(), ", ", attributes(),
+                " but they are ", currentOffset, ", ", currentAttributes);
             return false;
         }
 
@@ -136,8 +129,7 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         
     case Absence: {
         if (structure->isDictionary()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because it's a dictionary.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because it's a dictionary.");
             return false;
         }
 
@@ -151,17 +143,21 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
 
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid());
         if (currentOffset != invalidOffset) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because the property exists at offset: ", currentOffset, "\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the property exists at offset: ", currentOffset);
             return false;
         }
 
-        if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
+        if (structure->hasNonReifiedStaticProperties()) {
+            if (structure->findPropertyHashEntry(uid())) {
+                dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the property exists in the non-reified static property table: ", uid(), ".");
+                return false;
             }
+        }
+
+        if (structure->storedPrototypeObject() != prototype()) {
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -170,14 +166,12 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     
     case AbsenceOfSetEffect: {
         if (structure->isDictionary()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because it's a dictionary.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because it's a dictionary.");
             return false;
         }
         
         if (structure->typeInfo().overridesPut() && JSObject::mightBeSpecialProperty(structure->vm(), structure->typeInfo().type(), uid())) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because its put() override may treat ", uid(), " property as special non-structure one.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because its put() override may treat ", uid(), " property as special non-structure one.");
             return false;
         }
 
@@ -185,18 +179,15 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid(), currentAttributes);
         if (currentOffset != invalidOffset) {
             if (currentAttributes & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue)) {
-                if (PropertyConditionInternal::verbose) {
-                    dataLog(
-                        "Invalid because we expected not to have a setter, but we have one at offset ",
-                        currentOffset, " with attributes ", currentAttributes, "\n");
-                }
+                dataLogLnIf(PropertyConditionInternal::verbose,
+                    "Invalid because we expected not to have a setter, but we have one at offset ",
+                    currentOffset, " with attributes ", currentAttributes);
                 return false;
             }
         } else if (structure->hasNonReifiedStaticProperties()) {
             if (auto entry = structure->findPropertyHashEntry(uid())) {
                 if (entry->value->attributes() & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue) {
-                    if (PropertyConditionInternal::verbose)
-                        dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
+                    dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".");
                     return false;
                 }
             }
@@ -211,11 +202,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
         
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -232,23 +221,19 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
 
         if (hasIndexedProperties(structure->indexingType())) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because the indexed properties exist: ", structure->indexingType(), "\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the indexed properties exist: ", structure->indexingType());
             return false;
         }
 
         if (structure->mayInterceptIndexedAccesses() || structure->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because structure intercepts index access.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because structure intercepts index access.");
             return false;
         }
 
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
 
@@ -265,11 +250,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
 
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -283,11 +266,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         if (!base || base->structure() != structure) {
             // Conservatively return false, since we cannot verify this one without having the
             // object.
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because we don't have a base or the base has the wrong structure: ",
-                    RawPointer(base), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because we don't have a base or the base has the wrong structure: ",
+                RawPointer(base));
             return false;
         }
         
@@ -296,21 +277,16 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid());
         if (currentOffset == invalidOffset) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the base no long appears to have ", uid(), " on its structure: ",
-                        RawPointer(base), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the base no long appears to have ", uid(), " on its structure: ",
+                RawPointer(base));
             return false;
         }
 
         JSValue currentValue = base->getDirect(cellLocker, concurrency, structure, currentOffset);
         if (currentValue != requiredValue() || !currentValue) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the value is ", currentValue, " but we require ", requiredValue(),
-                    "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the value is ", currentValue, " but we require ", requiredValue());
             return false;
         }
         


### PR DESCRIPTION
#### 33876268a1c683eff9a7b1a74e2a1fe6177ed664
<pre>
[JavaScriptCore] Absence PropertyCondition does not consult non-reified static property tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=314836">https://bugs.webkit.org/show_bug.cgi?id=314836</a>
<a href="https://rdar.apple.com/176792596">rdar://176792596</a>

Reviewed by Yusuke Suzuki.

This patch modifies the Absence case for PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint
to consult the non-reified static property table if the property isn&apos;t present in the property table.
This prevents the Abstract Interpreter from misfolding GetById.

Test: JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js

* JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js: Added.
(assert):
(assertThrows):
(setup):
(f):
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):

Originally-landed-as: 305413.1014@safari-7624.5-branch (d0cd53048a11). <a href="https://rdar.apple.com/185368891">rdar://185368891</a>
Canonical link: <a href="https://commits.webkit.org/319807@main">https://commits.webkit.org/319807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd441eeee005267d881025e8ce872aa96893f20b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147087 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45082 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43332 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5069 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11900 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42960 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4188 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44069 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56391 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57096 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151821 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46390 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129365 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55604 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->