### PR TITLE
[Swift] Remove need for unsafe 'getUrlCopy': C++ macros version

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		82722C867A8346EB9034D804 /* ThreadSafeLazyUniquePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 96C342C5B2894529B448A3CD /* ThreadSafeLazyUniquePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
+		86A48D5393DCC98740A125D4 /* SwiftAccessors.h in Headers */ = {isa = PBXBuildFile; fileRef = B9FCFF520962F6C9E6F4477B /* SwiftAccessors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8AB05DFB2C99482E00738BDD /* PreciseSum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8AB05DF92C99482E00738BDD /* PreciseSum.cpp */; };
 		8AB05DFC2C99482E00738BDD /* PreciseSum.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB05DFA2C99482E00738BDD /* PreciseSum.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		92874A1B2D6AF35200BBF326 /* LLVMProfilingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 92874A1A2D6AF34200BBF326 /* LLVMProfilingUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1751,6 +1752,7 @@
 		ADF2CE641E39F106006889DB /* MemoryFootprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryFootprint.h; sourceTree = "<group>"; };
 		ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryFootprintCocoa.cpp; sourceTree = "<group>"; };
 		B6397A84DB2844D9A8644961 /* OrderedHashSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashSet.h; sourceTree = "<group>"; };
+		B9FCFF520962F6C9E6F4477B /* SwiftAccessors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftAccessors.h; sourceTree = "<group>"; };
 		BBEA08032CCFDB33000AC148 /* MallocCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocCommon.h; sourceTree = "<group>"; };
 		BBFA08032CCFDB33000AC148 /* MallocCommon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MallocCommon.cpp; sourceTree = "<group>"; };
 		BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantListOperations.h; sourceTree = "<group>"; };
@@ -2833,6 +2835,7 @@
 				E3260E972DA0E508003FC93F /* StructDump.h */,
 				93B07ED726B8715B00A09B34 /* SuspendableWorkQueue.cpp */,
 				93B07ED626B86BB500A09B34 /* SuspendableWorkQueue.h */,
+				B9FCFF520962F6C9E6F4477B /* SwiftAccessors.h */,
 				9758E8EF2DDCA639004434FD /* SwiftBridging.h */,
 				5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */,
 				5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */,
@@ -4023,6 +4026,7 @@
 				FF8CB4012A88C0D3004AF498 /* SuperFastHash.h in Headers */,
 				DD3DC89A27A4BF8E007E5B61 /* SuspendableWorkQueue.h in Headers */,
 				E396C11E2BE885D9000CBAE1 /* sve.h in Headers */,
+				86A48D5393DCC98740A125D4 /* SwiftAccessors.h in Headers */,
 				9758E8F02DDCA639004434FD /* SwiftBridging.h in Headers */,
 				5C12460E2DC25A130077D423 /* SwiftCXXThunk.h in Headers */,
 				DDF307DA27C086DF006A526F /* SymbolImpl.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -355,6 +355,7 @@ set(WTF_PUBLIC_HEADERS
     StringPrintStream.h
     StructDump.h
     SuspendableWorkQueue.h
+    SwiftAccessors.h
     SwiftBridging.h
     SwiftCXXThunk.h
     SynchronizedFixedQueue.h

--- a/Source/WTF/wtf/SwiftAccessors.h
+++ b/Source/WTF/wtf/SwiftAccessors.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/SwiftBridging.h>
+
+/// Declares a Swift-only companion for a getter that returns `const _type&`.
+///
+/// Place it in the class body next to the getter it shadows:
+/// @code
+/// const String& NODELETE url() const LIFETIME_BOUND;
+/// SWIFT_COPYING_ACCESSOR(url, String)
+/// @endcode
+///
+/// Only for fields that are cheap to copy. Do not use it for large
+/// non-refcounted fields such as a Vector, HashMap or EditorState; those need a
+/// genuine borrow, which this macro does not provide. If the field's type is a
+/// SWIFT_SHARED_REFERENCE, neither applies: hand Swift a pointer instead.
+#ifdef __swift__
+#define SWIFT_COPYING_ACCESSOR(_name, _type) \
+    _type _name##CopyForSwift() const SWIFT_NAME(_name()) { return _name(); }
+#else
+#define SWIFT_COPYING_ACCESSOR(_name, _type)
+#endif

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -21,6 +21,11 @@ module wtf [system] {
         export *
     }
 
+    explicit module SwiftAccessors {
+        header "SwiftAccessors.h"
+        export *
+    }
+
     explicit module WebCoreThread {
         header "ios/WebCoreThread.h"
         export *

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -30,6 +30,7 @@
 #include <WebCore/WritingMode.h>
 #include <array>
 #include <concepts>
+#include <wtf/SwiftAccessors.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -99,6 +100,11 @@ public:
     const T& right() const LIFETIME_BOUND { return at(BoxSide::Right); }
     const T& bottom() const LIFETIME_BOUND { return at(BoxSide::Bottom); }
     const T& left() const LIFETIME_BOUND { return at(BoxSide::Left); }
+
+    SWIFT_COPYING_ACCESSOR(top, T)
+    SWIFT_COPYING_ACCESSOR(right, T)
+    SWIFT_COPYING_ACCESSOR(bottom, T)
+    SWIFT_COPYING_ACCESSOR(left, T)
 
     void setAt(BoxSide side, const T& v) { at(side) = v; }
     void setTop(const T& top) { setAt(BoxSide::Top, top); }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -33,6 +33,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/SwiftAccessors.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -67,6 +68,7 @@ public:
 
     const String& NODELETE originalURL() const LIFETIME_BOUND;
     const String& NODELETE url() const LIFETIME_BOUND;
+    SWIFT_COPYING_ACCESSOR(url, String)
     const String& NODELETE title() const LIFETIME_BOUND;
     bool NODELETE wasCreatedByJSWithoutUserInteraction() const;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -56,19 +56,6 @@ extension WebKit.VectorBackForwardListItemState: CxxVector {
     typealias Element = WebKit.BackForwardListItemState
 }
 
-extension WebKit.WebBackForwardListItem {
-    private borrowing func getUrlCopy() -> WTF.String {
-        // Safety: we immediately make a copy of the string before
-        // it could be freed or mutated. FIXME(rdar://145054011): remove
-        // this.
-        unsafe __urlUnsafe().pointee
-    }
-
-    var url: WTF.String {
-        getUrlCopy()
-    }
-}
-
 // Some of these utility functions would be better in WebBackForwardListSwiftUtilities.h
 // but can't be put there as we are unable to use swift::Array and swift::String
 // rdar://161270632
@@ -304,7 +291,7 @@ final class WebBackForwardList {
         // If the target item wasn't even in the list, there's nothing else to do.
         guard var targetIndex else {
             backForwardLog(
-                "(Back/Forward) WebBackForwardList \(ObjectIdentifier(self)) could not go to item \(item.identifier().toString()) \(item.url) because it was not found"
+                "(Back/Forward) WebBackForwardList \(ObjectIdentifier(self)) could not go to item \(item.identifier().toString()) \(item.url()) because it was not found"
             )
             return
         }

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.swift
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.swift
@@ -59,22 +59,18 @@ final class WKPanGestureRecognizer: NSPanGestureRecognizer {
         let locationInView = location(in: webView)
         let pinnedState = page.pinnedStateIncludingAncestorsAtPoint(.init(locationInView))
 
-        // Safety: Accessing these functions on `pinnedState` is safe because a copy is immediately made,
-        // and the functions's return value's lifetime is bound to `pinnedState` anyways.
-        // FIXME: (rdar://145054011) Remove `unsafe` when possible.
-
         if abs(delta.x) > abs(delta.y) {
-            if unsafe delta.x < 0 && pinnedState.__rightUnsafe().pointee {
+            if delta.x < 0 && pinnedState.right() {
                 return .fail
             }
-            if unsafe delta.x > 0 && pinnedState.__leftUnsafe().pointee {
+            if delta.x > 0 && pinnedState.left() {
                 return .fail
             }
         } else {
-            if unsafe delta.y < 0 && pinnedState.__topUnsafe().pointee {
+            if delta.y < 0 && pinnedState.top() {
                 return .fail
             }
-            if unsafe delta.y > 0 && pinnedState.__bottomUnsafe().pointee {
+            if delta.y > 0 && pinnedState.bottom() {
                 return .fail
             }
         }


### PR DESCRIPTION
This is another experimental approach at removing the need for `unsafe` in getUrlCopy by providing a safe way to return a copy of the field which is returned by reference. This version involves a C++ side change to generate an accessor method which Swift can safely call.

See also #72396 which solves the same problem a very different way.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7067694a7a3227158422cd96432f03079f4f2897

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182802 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147090 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bf180d1-15fe-4c5d-b291-6001cf35a70e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99064 "2 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d595f93-a965-4cf5-968e-f77633fcc7e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123102 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2fa42d3-dd5f-4919-af68-9126774df2d5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43335 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5072 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11904 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42964 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4191 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44072 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56394 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152127 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151824 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129368 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55607 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17970 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54978 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->