### PR TITLE
A block level box on a line is left behind when a column break moves the line

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001-expected.txt
@@ -1,0 +1,6 @@
+line one
+line two
+after break
+
+PASS A block level box starts where the line before it ends, in the column that line was moved to
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Multi-column Layout: a block level box on a line moved by a column break</title>
+<link rel="help" href="https://www.w3.org/TR/css-multicol-1/#column-breaks">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#block-in-inline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#columns {
+    columns: 2;
+    column-gap: 0;
+    column-fill: auto;
+    width: 400px;
+    height: 45px;
+    font: 16px/18px monospace;
+    orphans: 1;
+    widows: 1;
+}
+#target {
+    height: 10px;
+    background: green;
+}
+</style>
+<div id="columns">
+    <div>line one<br>line two<br><span><span id="text">after break</span><div id="target"></div></span></div>
+</div>
+<script>
+test(() => {
+    var line = document.getElementById("text").getBoundingClientRect();
+    var target = document.getElementById("target").getBoundingClientRect();
+    assert_equals(target.left, line.left, "left edge");
+    assert_equals(target.top, line.bottom, "top edge");
+}, "A block level box starts where the line before it ends, in the column that line was moved to");
+</script>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -634,6 +634,13 @@ FloatRect LineLayout::constructContent(const Layout::InlineLayoutState& inlineLa
     return damagedRect;
 }
 
+static void relayoutAfterPaginationOffset(RenderBox& renderer)
+{
+    // The box's own content may break differently at the position it moved to.
+    renderer.markForPaginationRelayoutIfNeeded();
+    renderer.layoutIfNeeded();
+}
+
 void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdjustments, const Layout::InlineLayoutState& inlineLayoutState, bool didDiscardContent)
 {
     if (!m_inlineContent && !didDiscardContent)
@@ -654,6 +661,18 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
         for (auto& box : m_inlineContent->displayContent().boxes) {
             if (box.isInlineBox() || box.isTextOrSoftLineBreak())
                 continue;
+
+            if (box.isBlockLevelBox()) {
+                // Block layout laid this box out against the position its line had before pagination moved the line
+                // (see layoutWithFormattingContextForBlockInInline). The line moved, this renderer did not.
+                auto adjustmentOffset = visualAdjustmentOffset(box.lineIndex());
+                if (!adjustmentOffset.isZero()) {
+                    CheckedRef blockRenderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
+                    blockRenderer->move(adjustmentOffset.width(), adjustmentOffset.height());
+                    relayoutAfterPaginationOffset(blockRenderer);
+                }
+                continue;
+            }
 
             auto& layoutBox = box.layoutBox();
             if (!layoutBox.isAtomicInlineBox())
@@ -721,11 +740,8 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
                     renderer->repaint();
             }
 
-            if (paginationOffset) {
-                // Float content may be affected by the new position.
-                renderer->markForPaginationRelayoutIfNeeded();
-                renderer->layoutIfNeeded();
-            }
+            if (paginationOffset)
+                relayoutAfterPaginationOffset(renderer);
 
             continue;
         }


### PR DESCRIPTION
#### c9d5b3f137ca209ef6ec4cd79dc1856377e5f4dd
<pre>
A block level box on a line is left behind when a column break moves the line
<a href="https://bugs.webkit.org/show_bug.cgi?id=322487">https://bugs.webkit.org/show_bug.cgi?id=322487</a>
&lt;<a href="https://rdar.apple.com/problem/185787568">rdar://problem/185787568</a>&gt;

Reviewed by Antti Koivisto.

Line positions are adjusted for column and page breaks after inline layout has finished, while a block level
box on a line is laid out by block layout during inline layout, at the position the line had before that
adjustment. Moving the lines afterwards moved the display boxes but left the block box&apos;s renderer where it
was, so it overlapped the line it is supposed to follow. A widow that made line layout restart hid this,
which is why it took a case with no restart to see it.

Give the renderer the offset its line took, and let it lay out again in case its own content breaks
differently at the new position.

* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/block-in-inline-after-column-break-001.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
(WebCore::LayoutIntegration::relayoutAfterPaginationOffset):

Canonical link: <a href="https://commits.webkit.org/319821@main">https://commits.webkit.org/319821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5558c90c92f6763fb7095ab31d481a965ac16d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147091 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12641121-08e6-43e1-b201-f5f66c6ade9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/013b4615-a180-412a-b2cc-d6140a0d13ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46389 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163436 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 2 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8ab28c4-0f00-4515-8767-4f5b96c1589c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43334 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42965 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4192 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49373 "Found 2 new failures in layout/integration/inline/LayoutIntegrationLineLayout.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40772 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57100 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151823 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46392 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129369 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55608 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17971 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->