### PR TITLE
[GTK][WPE] Using g_loadable_icon_load[_async] on a WebKitImage provides wrong translucent pixel values

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
@@ -330,7 +330,7 @@ static GInputStream* webkitImageLoad(GLoadableIcon* icon, int size, char** type,
         image->priv->width,
         image->priv->height,
         WebKitImageColorType,
-        kUnpremul_SkAlphaType
+        kPremul_SkAlphaType
     );
 
     static_assert(WebKitImageColorType == kBGRA_8888_SkColorType, "WebKitImage assumes PixelFormat::BGRA8 from WebImage");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitImage.cpp
@@ -21,7 +21,10 @@
 
 #include "TestMain.h"
 #include <WebKitImagePrivate.h>
+#include <png.h>
 #include <span>
+#include <wtf/Forward.h>
+#include <wtf/Vector.h>
 #include <wtf/glib/GUniquePtr.h>
 
 class WebKitImageTest : public Test {
@@ -144,8 +147,9 @@ static void testWebKitImageIconInterface(WebKitImageTest*, gconstpointer)
 
 static void testWebKitImageLoadableIconLoadSync(WebKitImageTest*, gconstpointer)
 {
-    auto makeSingleRedPixel = []() -> GRefPtr<GBytes> {
-        uint8_t pixel[] = { 255, 0, 0, 255 };
+    // WebKitImage uses premultiplied alpha, a completely red component matches the alpha value when premultiplied.
+    static constexpr auto makeSingleRedPixel = [](uint8_t alpha = 255) -> GRefPtr<GBytes> {
+        uint8_t pixel[] = { alpha, 0, 0, alpha };
         return adoptGRef(g_bytes_new(pixel, sizeof(pixel)));
     };
     GRefPtr<WebKitImage> image = webkitImageNew(1, 1, 4, makeSingleRedPixel());
@@ -176,6 +180,76 @@ static void testWebKitImageLoadableIconLoadSync(WebKitImageTest*, gconstpointer)
     g_assert_cmpint(buffer[5], ==, 0x0A);
     g_assert_cmpint(buffer[6], ==, 0x1A);
     g_assert_cmpint(buffer[7], ==, 0x0A);
+
+    image = webkitImageNew(1, 1, 4, makeSingleRedPixel(0x80)); // 50% opaque red.
+    stream = adoptGRef(g_loadable_icon_load(G_LOADABLE_ICON(image.get()), 0, &type.outPtr(), nullptr, &error.outPtr()));
+
+    g_assert_no_error(error.get());
+    g_assert_nonnull(stream.get());
+    g_assert_cmpstr(type.get(), ==, "image/png");
+
+    bool pngErrored = false;
+    static constexpr auto pngErroredCallback = [](png_struct* png, const char*) {
+        bool* errored = reinterpret_cast<bool*>(png_get_error_ptr(png));
+        *errored = true;
+    };
+
+    png_struct* png = png_create_read_struct(PNG_LIBPNG_VER_STRING, &pngErrored, pngErroredCallback, pngErroredCallback);
+    g_assert_nonnull(png);
+
+    static constexpr auto pngReadCallback = [](png_struct* png, uint8_t* buffer, size_t numBytes) {
+        GRefPtr<GError> error;
+        auto* stream = G_INPUT_STREAM(png_get_io_ptr(png));
+        auto readBytes = g_input_stream_read(stream, buffer, numBytes, nullptr, &error.outPtr());
+        g_assert_cmpint(readBytes, ==, numBytes);
+        g_assert_no_error(error.get());
+    };
+    png_set_read_fn(png, stream.get(), pngReadCallback);
+
+    png_info* pngInfo = png_create_info_struct(png);
+    g_assert_nonnull(pngInfo);
+
+    png_read_info(png, pngInfo);
+    g_assert_false(pngErrored);
+
+    uint32_t pngWidth = 0, pngHeight = 0;
+    int pngDepth = 0, pngColorType = 0;
+    png_get_IHDR(png, pngInfo, &pngWidth, &pngHeight, &pngDepth, &pngColorType, nullptr, nullptr, nullptr);
+    g_assert_false(pngErrored);
+
+    g_assert_cmpuint(pngWidth, ==, 1);
+    g_assert_cmpuint(pngHeight, ==, 1);
+    g_assert_cmpuint(pngColorType, ==, PNG_COLOR_TYPE_RGBA);
+
+    if (pngColorType == PNG_COLOR_TYPE_PALETTE || (pngColorType == PNG_COLOR_TYPE_GRAY && pngDepth < 8) || png_get_valid(png, pngInfo, PNG_INFO_tRNS))
+        png_set_expand(png); // Resolve palette colors and apply transparency.
+
+    if (pngDepth == 16)
+        png_set_strip_16(png); // Lower higher bit depth images to 8bpp, it is enough for testing.
+
+    if (pngColorType == PNG_COLOR_TYPE_GRAY || pngColorType == PNG_COLOR_TYPE_GRAY_ALPHA)
+        png_set_gray_to_rgb(png); // Always produce RGB for grayscale images.
+
+    png_read_update_info(png, pngInfo);
+    g_assert_false(pngErrored);
+
+    uint32_t pngRowBytes = png_get_rowbytes(png, pngInfo);
+    Vector<uint8_t> pngRow { FillWith { }, pngRowBytes, 0x00 };
+    uint8_t* pngRowPointers[1] = { pngRow.mutableSpan().data() };
+    png_read_image(png, pngRowPointers);
+    g_assert_false(pngErrored);
+
+    png_read_end(png, nullptr);
+    g_assert_false(pngErrored);
+
+    // PNG pixel data is decoded in BGRA order and always stored un-premultiplied, so that is what libpng returns.
+    g_assert_cmpuint(pngRow[0], ==, 0x00);
+    g_assert_cmpuint(pngRow[1], ==, 0x00);
+    g_assert_cmpuint(pngRow[2], ==, 0xFF);
+    g_assert_cmpuint(pngRow[3], ==, 0x80);
+
+    png_destroy_info_struct(png, &pngInfo);
+    png_destroy_read_struct(&png, nullptr, nullptr);
 }
 
 static void testWebKitImageLoadableIconLoadAsync(WebKitImageTest* test, gconstpointer)


### PR DESCRIPTION
#### 05b0362e7afb422264eec6fa23675d71d700855d
<pre>
[GTK][WPE] Using g_loadable_icon_load[_async] on a WebKitImage provides wrong translucent pixel values
<a href="https://bugs.webkit.org/show_bug.cgi?id=322484">https://bugs.webkit.org/show_bug.cgi?id=322484</a>

Reviewed by Patrick Griffis.

WebKitImage is documented to use premultiplied alpha, but when wrapping the
pixel data with a SkImage the flag kUnpremul_SkAlphaType was used. The fix
is to use the correct kPremul_SkAlphaType flag instead

The &quot;/webkit/WebKitImage/loadable-icon-interface-sync-load&quot; test case is
modified to add encoding of a WebKitImage with a translucent pixel as PNG
and then reading it back using plain libpng calls to verify that the pixel
was stored un-premultiplied correctly in the PNG (as per the spec).

* Source/WebKit/UIProcess/API/glib/WebKitImage.cpp:
(webkitImageLoad):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitImage.cpp:
(testWebKitImageLoadableIconLoadSync):

Canonical link: <a href="https://commits.webkit.org/319805@main">https://commits.webkit.org/319805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f950e8e8b90390b931754f05af96b8257257ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142677 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45088 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42967 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4196 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49377 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194965 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56399 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152130 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57104 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151827 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46396 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129373 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125445 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55612 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17984 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->