### PR TITLE
Make ScopedLambda non-moveable

### DIFF
--- a/Source/WTF/wtf/ScopedLambda.h
+++ b/Source/WTF/wtf/ScopedLambda.h
@@ -29,6 +29,7 @@
 #include <type_traits>
 #include <wtf/Compiler.h>
 #include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -54,6 +55,7 @@ template<typename FunctionType> class ScopedLambda;
 template<typename ResultType, typename... ArgumentTypes>
 class ScopedLambda<ResultType(ArgumentTypes...)> final {
     WTF_FORBID_HEAP_ALLOCATION;
+    WTF_MAKE_NONMOVABLE(ScopedLambda);
 public:
     ScopedLambda(ResultType (*impl)(void* arg, ArgumentTypes...) = nullptr, void* arg = nullptr)
         : m_impl(impl)

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -455,7 +455,7 @@ static bool encode(CGImageRef image, const String& mimeType, std::optional<doubl
 
     CGDataConsumerCallbacks callbacks {
         [](void* context, const void* buffer, size_t count) -> size_t {
-            auto functor = *static_cast<const ScopedLambda<PutBytesCallback>*>(context);
+            auto& functor = *static_cast<const ScopedLambda<PutBytesCallback>*>(context);
             return functor(unsafeMakeSpan(static_cast<const uint8_t*>(buffer), count));
         },
         nullptr


### PR DESCRIPTION
#### 54b9fc03d8cb650626fcab77a275117cf99cc11f
<pre>
Make ScopedLambda non-moveable
<a href="https://bugs.webkit.org/show_bug.cgi?id=322495">https://bugs.webkit.org/show_bug.cgi?id=322495</a>
<a href="https://rdar.apple.com/185800489">rdar://185800489</a>

Reviewed by Yijia Huang.

Moving/Copying doesn&apos;t seem useful and introduces a footgun to escape
the ScopedLambda past the lifetime of the passed lambda, e.g. via a move
to the heap.

No new tests, no behavior change.

* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::encode):
    Use a reference of the ScopedLambda rather than a copy.

Canonical link: <a href="https://commits.webkit.org/319843@main">https://commits.webkit.org/319843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7e43729b5495d84c61b163b2c4b27ddcc10867e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147112 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a61ad0d1-437c-48a1-8d4b-8891f40f259a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4378f4d7-9ac0-401d-871b-0dda87050f82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123120 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/221f53ef-0109-47cf-b02e-1375d899cea5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43353 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5090 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11931 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42991 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4213 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44094 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56416 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152146 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57121 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151843 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46418 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129390 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125468 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55629 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18001 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55237 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->