### PR TITLE
[Site-Isolation] Add coverage for the audio session category surviving a pause and resume

### DIFF
--- a/LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume-expected.txt
+++ b/LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume-expected.txt
@@ -1,0 +1,31 @@
+
+** A cross-site frame starts WebAudio, so its process chooses AmbientSound.
+EXPECTED (frameResult.state == 'running') OK
+EXPECTED (frameResult.category == 'AmbientSound') OK
+
+** Start a video-only stream, as a live stream does before its audio arrives.
+EXPECTED (video.audioTracks.length == '0') OK
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+
+** The audio track arrives while already playing.
+EXPECTED (video.audioTracks.length == '1') OK
+
+** Unmuting makes it audible, so the category becomes MediaPlayback.
+RUN(video.muted = false)
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.systemAudioSessionCategory() == 'MediaPlayback') OK
+
+** Pause.
+RUN(video.pause())
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+
+** Resume. The category must come back to MediaPlayback, on this
+** process and on the session the other processes share.
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.muted == 'false') OK
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.systemAudioSessionCategory() == 'MediaPlayback') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume.html
+++ b/LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<html>
+<head>
+    <title>audio-session-category-cross-site-pause-resume</title>
+    <script src="/media-resources/video-test.js"></script>
+    <script src="/media-resources/media-source/mock-media-source.js"></script>
+    <script>
+
+    // rdar://180062104: on iOS with Site Isolation, pausing and resuming a live stream left
+    // it silent. The audio session never took the MediaPlayback category, so playback
+    // produced no audio and the site fell back to muted playback.
+    //
+    // The test stream is modelled on a live stream that starts video-only and gains its audio
+    // track after playback begins, which takes the session from silent to audible.
+
+    let source;
+    let videoSourceBuffer;
+    let audioSourceBuffer;
+    let bufferedTo = 0;
+    let frameResult;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function append(sourceBuffer, buffer)
+    {
+        return new Promise(resolve => {
+            sourceBuffer.addEventListener('updateend', resolve, { once: true });
+            sourceBuffer.appendBuffer(buffer);
+        });
+    }
+
+    function appendSamples(sourceBuffer, trackID, start, end)
+    {
+        return append(sourceBuffer, makeASample(start, start, end - start, 1, trackID, SAMPLE_FLAG.SYNC, 1));
+    }
+
+    async function waitForCategory(category)
+    {
+        // The category is applied asynchronously, so poll rather than checking once.
+        let counter = 0;
+        while (++counter < 500 && internals.audioSessionCategory() != category)
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+        testExpected('internals.audioSessionCategory()', category);
+    }
+
+    async function testSystemCategory(category)
+    {
+        const systemCategory = await internals.systemAudioSessionCategory();
+        reportExpected(systemCategory == category, 'internals.systemAudioSessionCategory()', '==', category, systemCategory);
+    }
+
+    function nextMessage()
+    {
+        return new Promise(resolve => window.addEventListener('message', event => resolve(event.data), { once: true }));
+    }
+
+    async function addAmbientCrossSiteFrame()
+    {
+        consoleWrite('** A cross-site frame starts WebAudio, so its process chooses AmbientSound.');
+        const message = nextMessage();
+        const frame = document.createElement('iframe');
+        frame.src = 'http://localhost:8080/media/resources/ambient-web-audio-frame.html';
+        document.body.appendChild(frame);
+        frameResult = await message;
+        testExpected('frameResult.state', 'running');
+        testExpected('frameResult.category', 'AmbientSound');
+    }
+
+    async function startVideoOnlyPlayback()
+    {
+        consoleWrite('<br>** Start a video-only stream, as a live stream does before its audio arrives.');
+        source = new MediaSource();
+        const sourceOpen = new Promise(resolve => source.addEventListener('sourceopen', resolve, { once: true }));
+        video.src = URL.createObjectURL(source);
+        await sourceOpen;
+
+        videoSourceBuffer = source.addSourceBuffer('video/mock; codecs=mock');
+        await append(videoSourceBuffer, makeAInit(3600, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]));
+        await appendSamples(videoSourceBuffer, 1, 0, 30);
+        bufferedTo = 30;
+        testExpected('video.audioTracks.length', 0);
+
+        // Matches iPhone behaviour, where the page cannot change the volume.
+        internals.setMediaElementVolumeLocked(video, true);
+
+        const playing = waitFor(video, 'playing', true);
+        runWithKeyDown(() => { run('video.play()') });
+        await playing;
+        testExpected('video.paused', false);
+    }
+
+    async function addAudioTrackMidPlayback()
+    {
+        consoleWrite('<br>** The audio track arrives while already playing.');
+        audioSourceBuffer = source.addSourceBuffer('audio/mock; codecs=mock');
+        await append(audioSourceBuffer, makeAInit(3600, [makeATrack(2, 'mock', TRACK_KIND.AUDIO)]));
+
+        await appendSamples(audioSourceBuffer, 2, 0, bufferedTo);
+        testExpected('video.audioTracks.length', 1);
+
+        consoleWrite('<br>** Unmuting makes it audible, so the category becomes MediaPlayback.');
+        runWithKeyDown(() => { run('video.muted = false') });
+        await waitFor(video, 'volumechange', true);
+        await waitForCategory('MediaPlayback');
+        await testSystemCategory('MediaPlayback');
+    }
+
+    async function pauseAndResume()
+    {
+        consoleWrite('<br>** Pause.');
+        run('video.pause()');
+        await waitFor(video, 'pause', true);
+        await waitForCategory('MediaPlayback');
+
+        consoleWrite('<br>** Resume. The category must come back to MediaPlayback, on this');
+        consoleWrite('** process and on the session the other processes share.');
+
+        await appendSamples(videoSourceBuffer, 1, bufferedTo, bufferedTo + 30);
+        await appendSamples(audioSourceBuffer, 2, bufferedTo, bufferedTo + 30);
+        bufferedTo += 30;
+
+        const playing = waitFor(video, 'playing', true);
+        runWithKeyDown(() => { run('video.play()') });
+        await playing;
+
+        testExpected('video.paused', false);
+        testExpected('video.muted', false);
+        await waitForCategory('MediaPlayback');
+        await testSystemCategory('MediaPlayback');
+    }
+
+    window.addEventListener('load', async () => {
+        if (!window.internals) {
+            failTest('This test requires internals!');
+            return;
+        }
+
+        findMediaElement();
+
+        internals.settings.setShouldManageAudioSessionCategory(true);
+        // Matches iPhone behaviour, where an audible rate change needs a user gesture.
+        internals.setMediaElementRestrictions(video, 'requireusergestureforaudioratechange');
+
+        failTestIn(20000);
+
+        await addAmbientCrossSiteFrame();
+        await startVideoOnlyPlayback();
+        await addAudioTrackMidPlayback();
+        await pauseAndResume();
+
+        endTest();
+    });
+
+    </script>
+</head>
+<body>
+    <video muted></video>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/resources/ambient-web-audio-frame.html
+++ b/LayoutTests/http/tests/media/resources/ambient-web-audio-frame.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Cross-site helper frame for audio-session-category-cross-site-pause-resume.html.
+//
+// This frame starts a WebAudio graph, which makes this process choose the
+// AmbientSound audio session category.
+//
+// Under Site Isolation this frame is cross-site relative to its opener, so it runs in
+// its own process. When the two processes' categories are reconciled, this frame's
+// AmbientSound has to lose to the main frame's MediaPlayback. rdar://180062104 was the
+// case where nothing asserted MediaPlayback and this AmbientSound won, leaving the
+// shared session in a category that produces no audible playback.
+window.addEventListener('load', async () => {
+    let category = 'no-internals';
+    if (window.internals) {
+        internals.settings.setShouldManageAudioSessionCategory(true);
+        category = internals.audioSessionCategory();
+    }
+
+    let state = 'no-audiocontext';
+    try {
+        const context = new AudioContext();
+        const gain = context.createGain();
+        gain.gain.value = 0;
+        gain.connect(context.destination);
+        const oscillator = context.createOscillator();
+        oscillator.connect(gain);
+        oscillator.start();
+        await context.resume();
+        state = context.state;
+        if (window.internals)
+            category = internals.audioSessionCategory();
+    } catch (error) {
+        state = `error: ${error.name}`;
+    }
+
+    parent.postMessage({ state, category }, '*');
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3490,6 +3490,7 @@ http/wpt/site-isolation [ Skip ]
 media/audio-session-category.html [ Skip ]
 media/audio-session-category-at-most-recent-playback.html [ Skip ]
 media/audio-session-category-play-unmute-pause.html [ Skip ]
+http/tests/media/audio-session-category-cross-site-pause-resume.html [ Skip ]
 
 # This test assumes we cannot play RTSP, but we can.
 media/unsupported-rtsp.html [ WontFix Skip ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5032,7 +5032,8 @@ void HTMLMediaElement::setVolumeLocked(bool volumeLocked)
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::VolumeLocked, volumeLocked);
     m_volumeLocked = volumeLocked;
-    protect(player())->setVolumeLocked(volumeLocked);
+    if (RefPtr player = m_player)
+        player->setVolumeLocked(volumeLocked);
 }
 
 void HTMLMediaElement::updateBufferingState()


### PR DESCRIPTION
#### 142648917833d9aeddbd4c8ec997f0d65ce0c06c
<pre>
[site-isolation] Add coverage for the audio session category surviving a pause and resume
<a href="https://bugs.webkit.org/show_bug.cgi?id=322497">https://bugs.webkit.org/show_bug.cgi?id=322497</a>
<a href="https://rdar.apple.com/180062104">rdar://180062104</a>

Reviewed by NOBODY (OOPS!).

Verify that pausing and resuming a live stream doesn&apos;t mute audio.

Fix a test-only HTMLMediaElement null dereference when internals.setVolumeLocked() is called
found while writing the test.

Test: http/tests/media/audio-session-category-cross-site-pause-resume.html

* LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume-expected.txt: Added.
* LayoutTests/http/tests/media/audio-session-category-cross-site-pause-resume.html: Added.
* LayoutTests/http/tests/media/resources/ambient-web-audio-frame.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setVolumeLocked):
* LayoutTests/platform/glib/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/142648917833d9aeddbd4c8ec997f0d65ce0c06c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147217 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2900ca50-b722-41fd-a8b4-b3ed7e8a32c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142779 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99142 "3 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e8c854b-f1ae-4c22-8eea-b3c567889f39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/572847f0-9aed-4ad2-b967-9fa40e25dc26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43439 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43071 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4319 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195087 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152239 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151936 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46497 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129495 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125583 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55734 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18081 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->