### PR TITLE
[GStreamer] Use fixed watermarks for WebKitWebSource's internal queue

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -49,16 +49,13 @@
 
 using namespace WebCore;
 
-// Never pause download of media resources smaller than 2MiB.
-#define SMALL_MEDIA_RESOURCE_MAX_SIZE 2 * 1024 * 1024
+// Keep at most 20MiB buffered. When this threshold is reached,
+// the download task is paused.
+#define HIGH_QUEUE_THRESHOLD 20 * 1024 * 1024
 
-// Keep at most 2% of the full, non-small, media resource buffered. When this
-// threshold is reached, the download task is paused.
-#define HIGH_QUEUE_FACTOR_THRESHOLD 0.02
-
-// Keep at least 20% of maximum queue size buffered. When this threshold is
-// reached, the download task resumes.
-#define LOW_QUEUE_FACTOR_THRESHOLD 0.2
+// Keep at least 2MiB buffered. When this threshold is reached,
+// the download task resumes.
+#define LOW_QUEUE_THRESHOLD 2 * 1024 * 1024
 
 struct WebKitWebSrcPrivate {
 
@@ -395,9 +392,9 @@ static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSr
     }
 
     GST_TRACE_OBJECT(src, "is download suspended %s, does have EOS %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT
-        " (min %u)", boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->doesHaveEOS), boolForPrinting(members->size.has_value())
-        , boolForPrinting(members->isSeekable), members->size.value_or(-1), SMALL_MEDIA_RESOURCE_MAX_SIZE);
-    if (members->doesHaveEOS || !members->size || !members->isSeekable || *members->size <= SMALL_MEDIA_RESOURCE_MAX_SIZE) {
+        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->doesHaveEOS), boolForPrinting(members->size.has_value())
+        , boolForPrinting(members->isSeekable), members->size.value_or(-1));
+    if (members->doesHaveEOS || !members->isSeekable) {
         GST_TRACE_OBJECT(src, "download cannot be stopped/restarted");
         return;
     }
@@ -408,9 +405,9 @@ static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSr
     }
 
     size_t queueSize = gst_adapter_available(members->adapter.get());
-    GST_TRACE_OBJECT(src, "queue size %zu (min %1.0f)", queueSize, *members->size * HIGH_QUEUE_FACTOR_THRESHOLD * LOW_QUEUE_FACTOR_THRESHOLD);
+    GST_TRACE_OBJECT(src, "queue size %zu (min %d)", queueSize, LOW_QUEUE_THRESHOLD);
 
-    if (queueSize >= *members->size * HIGH_QUEUE_FACTOR_THRESHOLD * LOW_QUEUE_FACTOR_THRESHOLD) {
+    if (queueSize >= LOW_QUEUE_THRESHOLD) {
         GST_TRACE_OBJECT(src, "queue size above low watermark, not restarting download");
         return;
     }
@@ -432,20 +429,17 @@ static void stopLoaderIfNeeded([[maybe_unused]] WebKitWebSrc* src, DataMutexLock
         return;
     }
 
-    GST_TRACE_OBJECT(src, "is download suspended %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT " (min %u)"
-        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->size.has_value()), boolForPrinting(members->isSeekable), members->size.value_or(-1)
-        , SMALL_MEDIA_RESOURCE_MAX_SIZE);
-    if (!members->size)
-        return;
+    GST_TRACE_OBJECT(src, "is download suspended %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT
+        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->size.has_value()), boolForPrinting(members->isSeekable), members->size.value_or(-1));
 
-    if (!members->isSeekable || members->size <= SMALL_MEDIA_RESOURCE_MAX_SIZE) {
+    if (!members->isSeekable) {
         GST_TRACE_OBJECT(src, "download cannot be stopped/restarted");
         return;
     }
 
     size_t queueSize = gst_adapter_available(members->adapter.get());
-    GST_TRACE_OBJECT(src, "queue size %zu (max %1.0f)", queueSize, *members->size * HIGH_QUEUE_FACTOR_THRESHOLD);
-    if (queueSize <= *members->size * HIGH_QUEUE_FACTOR_THRESHOLD) {
+    GST_TRACE_OBJECT(src, "queue size %zu (max %d)", queueSize, HIGH_QUEUE_THRESHOLD);
+    if (queueSize <= HIGH_QUEUE_THRESHOLD) {
         GST_TRACE_OBJECT(src, "queue size under high watermark, not stopping download");
         return;
     }


### PR DESCRIPTION
#### 71c8aeac877f4b2890b694003de958a508a0fa18
<pre>
[GStreamer] Use fixed watermarks for WebKitWebSource&apos;s internal queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=322499">https://bugs.webkit.org/show_bug.cgi?id=322499</a>

Reviewed by Philippe Normand.

Currently we use watermarks proportional to the total size of the resource,
which can result in excessively large or small watermarks, and requires a
special case for small files (arguably one would be needed for large files too).

Setting fixed values for watermarks will be simpler and more consistent.

* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(restartLoaderIfNeeded):
(stopLoaderIfNeeded):

Canonical link: <a href="https://commits.webkit.org/319853@main">https://commits.webkit.org/319853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e6c63ccfeaf1abfe5cc86b1373f0c1acfd71033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43344 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42973 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4206 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56409 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40801 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57114 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151835 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46402 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129383 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125459 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55622 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->