### PR TITLE
[JSC][Wasm] Inline table.get for externref and anyref

### DIFF
--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -202,6 +202,7 @@ namespace JSC::B3 {
     macro(WasmRTT_displaySizeExcludingThis, Wasm::RTT::offsetOfDisplaySizeExcludingThis(), Mutability::Immutable) \
     macro(WasmRTT_kind, Wasm::RTT::offsetOfKind(), Mutability::Immutable) \
     macro(WasmTable_length, Wasm::Table::offsetOfLength(), Mutability::Mutable) \
+    macro(WasmExternOrAnyRefTable_jsValues, Wasm::ExternOrAnyRefTable::offsetOfJSValues(), Mutability::Mutable) \
     macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity(), Mutability::Mutable) \
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer(), Mutability::Mutable) \
     macro(WeakMapImpl_keyCount, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfKeyCount(), Mutability::Mutable) \
@@ -240,6 +241,7 @@ namespace JSC::B3 {
     macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
     macro(IntCache, 0, sizeof(NumericStrings::CacheEntryWithJSString<int>)) \
     macro(WasmRTT_data, Wasm::RTT::offsetOfData(), sizeof(RefPtr<const Wasm::RTT>)) \
+    macro(WasmExternOrAnyRefTable_jsValuesBuffer, 0, sizeof(WriteBarrier<Unknown>)) \
     macro(WebAssemblyGCStructure_inlinedDisplay, WebAssemblyGCStructure::offsetOfInlinedDisplay(), sizeof(WriteBarrierStructureID)) \
 
 #define FOR_EACH_NUMBERED_ABSTRACT_HEAP(macro) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -61,6 +61,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmOMGIRGenerator.h"
 #include "WasmOperations.h"
 #include "WasmOps.h"
+#include "WasmTable.h"
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
 #include "WebAssemblyFunctionBase.h"
@@ -155,26 +156,61 @@ Value BBQJIT::instanceValue()
 // Tables
 [[nodiscard]] PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    auto table = m_info.table(tableIndex);
+    auto& table = m_info.table(tableIndex);
     ASSERT(index.type() == table.addressType().asWasmTypeKind());
     TypeKind returnType = table.wasmType().kind();
     ASSERT(typeKindSizeInBytes(returnType) == 8);
 
+    if (table.type() == TableElementType::Funcref) {
+        emitZeroExtendAddressOperand(table.addressType().is64Bit(), index);
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(tableIndex),
+            index
+        };
+        result = topValue(returnType);
+        emitCCall(&operationGetWasmTableElement, arguments, result);
+        Location resultLocation = loadIfNecessary(result);
+
+        LOG_INSTRUCTION("TableGet", tableIndex, index, RESULT(result));
+
+        recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branchTest64(ResultCondition::Zero, resultLocation.asGPR()));
+        return { };
+    }
+
     emitZeroExtendAddressOperand(table.addressType().is64Bit(), index);
 
-    Vector<Value, 8> arguments = {
-        instanceValue(),
-        Value::fromI32(tableIndex),
-        index
-    };
-    result = topValue(returnType);
-    emitCCall(&operationGetWasmTableElement, arguments, result);
-    Location resultLocation = loadIfNecessary(result);
+    {
+        ScratchScope<3, 0> scratches(*this);
+        GPRReg tableGPR = scratches.gpr(0);
+        GPRReg scratchGPR = scratches.gpr(1);
+        GPRReg valueGPR = scratches.gpr(2);
+
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)), tableGPR);
+        m_jit.load32(Address(tableGPR, Table::offsetOfLength()), scratchGPR);
+
+        GPRReg indexGPR;
+        if (index.isConst()) {
+            uint64_t indexValue = table.addressType().is64Bit() ? static_cast<uint64_t>(index.asI64()) : static_cast<uint32_t>(index.asI32());
+            recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branch64(RelationalCondition::BelowOrEqual, scratchGPR, TrustedImm64(indexValue)));
+            m_jit.move(TrustedImm64(indexValue), scratchGPR);
+            indexGPR = scratchGPR;
+        } else {
+            indexGPR = loadIfNecessary(index).asGPR();
+            recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, indexGPR, scratchGPR));
+        }
+
+        m_jit.loadPtr(Address(tableGPR, ExternOrAnyRefTable::offsetOfJSValues()), tableGPR);
+        static_assert(sizeof(WriteBarrier<Unknown>) == 8);
+        m_jit.load64(MacroAssembler::BaseIndex(tableGPR, indexGPR, MacroAssembler::TimesEight), valueGPR);
+
+        consume(index);
+        result = topValue(returnType);
+        m_jit.move(valueGPR, allocate(result).asGPR());
+    }
 
     LOG_INSTRUCTION("TableGet", tableIndex, index, RESULT(result));
-
-    recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branchTest64(ResultCondition::Zero, resultLocation.asGPR()));
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1720,19 +1720,50 @@ auto OMGIRGenerator::addRefIsNull(ExpressionType value, ExpressionType& result) 
 
 auto OMGIRGenerator::addTableGet(unsigned tableIndex, ExpressionType index, ExpressionType& result) -> PartialResult
 {
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Externref), operationGetWasmTableElement,
-        instanceValue(), constant(Int32, tableIndex), addressOperand(m_info.table(tableIndex).addressType().is64Bit(), index));
-    {
+    auto& tableInformation = m_info.table(tableIndex);
+    if (tableInformation.type() == TableElementType::Funcref) {
+        Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Externref), operationGetWasmTableElement,
+            instanceValue(), constant(Int32, tableIndex), addressOperand(tableInformation.addressType().is64Bit(), index));
         result = push(resultValue);
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), 0)));
-
         check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsTableAccess);
         });
+        return { };
     }
 
+    auto* table = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)));
+    m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_tables[tableIndex], table);
+    table->setReadsMutability(B3::Mutability::Immutable);
+    table->setControlDependent(false);
+
+    Value* indexValue = addressOperand(tableInformation.addressType().is64Bit(), index);
+    auto* length32 = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), table, safeCast<int32_t>(Table::offsetOfLength()));
+    m_heaps.decorateMemory(&m_heaps.WasmTable_length, length32);
+    Value* length = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), length32);
+
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), indexValue, length));
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsTableAccess);
+    });
+
+    auto* jsValues = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), table, safeCast<int32_t>(ExternOrAnyRefTable::offsetOfJSValues()));
+    m_heaps.decorateMemory(&m_heaps.WasmExternOrAnyRefTable_jsValues, jsValues);
+
+    static_assert(sizeof(WriteBarrier<Unknown>) == 8);
+    Value* offset = m_currentBlock->appendNew<Value>(m_proc, Shl, origin(), indexValue, constant(Int32, 3));
+    Value* slot = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), jsValues, offset);
+    auto* resultValue = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int64, origin(), slot);
+    Value* rawIndex = get(index);
+    const B3::AbstractHeap* slotHeap = &m_heaps.WasmExternOrAnyRefTable_jsValuesBuffer.atAnyIndex();
+    if (rawIndex->hasInt32())
+        slotHeap = &m_heaps.WasmExternOrAnyRefTable_jsValuesBuffer[static_cast<ptrdiff_t>(static_cast<uint32_t>(rawIndex->asInt32()))];
+    else if (rawIndex->hasInt64())
+        slotHeap = &m_heaps.WasmExternOrAnyRefTable_jsValuesBuffer[static_cast<ptrdiff_t>(static_cast<uint64_t>(rawIndex->asInt64()))];
+    m_heaps.decorateMemory(slotHeap, resultValue);
+    result = push(resultValue);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -127,6 +127,8 @@ public:
     void fill(VM&, JSValue);
     JSValue get(uint32_t index) const { return m_jsValues.get()[index].get(); }
 
+    static constexpr ptrdiff_t offsetOfJSValues() { return OBJECT_OFFSETOF(ExternOrAnyRefTable, m_jsValues); }
+
 private:
     ExternOrAnyRefTable(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType);
 


### PR DESCRIPTION
#### 798b6ba2bd68b9c0b55d6086a0c180ece54b5c0f
<pre>
[JSC][Wasm] Inline table.get for externref and anyref
<a href="https://bugs.webkit.org/show_bug.cgi?id=198506">https://bugs.webkit.org/show_bug.cgi?id=198506</a>

Reviewed by Yusuke Suzuki.

BBQ and OMG now emit a bounds check against Table length and a load from
ExternOrAnyRefTable::m_jsValues.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmTable.h:

Canonical link: <a href="https://commits.webkit.org/320002@main">https://commits.webkit.org/320002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bd88476676a44e5d8cfc9c0236fd3b7cae1bf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147598 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143077 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43761 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5477 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12321 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43375 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4700 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44577 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56900 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57604 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152265 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46819 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129884 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56112 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18387 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->