### PR TITLE
List marker is painted on top of the list item's content instead of behind it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists Reference: an outside list marker paints behind the list item's content</title>
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  /* No marker at all, which is what a marker covered by the content looks like. */
+  li { list-style-type: none; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists Reference: an outside list marker paints behind the list item's content</title>
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  /* No marker at all, which is what a marker covered by the content looks like. */
+  li { list-style-type: none; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: an outside list marker paints behind the list item's content</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#marker-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css2/zindex.html#painting-order">
+<link rel="match" href="list-marker-paint-order-ref.html">
+<meta name="assert" content="The marker box paints before the list item's content, so content pulled over the marker by a negative margin covers the marker instead of the marker covering the content.">
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-inline-start: 100px }
+  li { list-style-position: outside; list-style-type: disc; color: black; font: 20px/1 monospace }
+  span { display: inline-block; margin-left: -150px; width: 300px; height: 60px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><span></span></div></li></ul>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -455,10 +455,12 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
 void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    RenderBlockFlow::paintObject(paintInfo, paintOffset);
-
+    // The marker box paints before our content, so content overlapping it (a negative margin pulling the first line
+    // over the marker) covers it rather than the other way around.
     if (CheckedPtr excludedMarker = this->excludedMarker(); excludedMarker && !excludedMarker->hasSelfPaintingLayer())
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
+
+    RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
 String RenderListItem::markerText(RenderListMarker::IncludeSuffix includeSuffix) const


### PR DESCRIPTION
#### 791e1e02c6c1ee6f753599f9194d3cd66b911356
<pre>
List marker is painted on top of the list item&apos;s content instead of behind it
<a href="https://bugs.webkit.org/show_bug.cgi?id=322458">https://bugs.webkit.org/show_bug.cgi?id=322458</a>
<a href="https://rdar.apple.com/185741211">rdar://185741211</a>

Reviewed by Antti Koivisto.

RenderListItem::paintObject paints the marker after calling the base class, so the marker ends up over the list
item&apos;s content instead of behind it. Content that reaches back across the marker, a first line pulled out by a
negative margin, is drawn under the marker rather than covering it.

Tests: imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html
       imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-paint-order.html: Added.
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::paintObject):

Canonical link: <a href="https://commits.webkit.org/319818@main">https://commits.webkit.org/319818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28f111cf9ac0f6aa95921220fb296bf7fa06f6aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147114 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9f19bb7-ac2a-41ce-9e4f-79bfa1529434) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f86995d9-2124-45c3-b4e1-15c5ef3bc03f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123121 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4b2fc89-4a76-4560-80a4-83f3ff030b3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45100 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43351 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42981 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4215 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194984 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57123 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151844 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46410 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129392 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125470 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55631 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17991 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->