### PR TITLE
[webkitbot] webkitbot fails to parse identifiers when they are linkified in Slack

### DIFF
--- a/Tools/WebKitBot/src/CommandParser.mjs
+++ b/Tools/WebKitBot/src/CommandParser.mjs
@@ -59,6 +59,9 @@ function extractRevision(text)
         if (!candidate)
             continue;
 
+        // Accept identifiers pasted as commits.webkit.org links, which is what webkitbot itself posts.
+        candidate = candidate.replace(/^https?:\/\/commits\.webkit\.org\//, "");
+
         let match = candidate.match(/^r?(\d{5,6}|\d+@[^:\s]+|[0-9a-f]{6,40}):?$/);
         if (!match)
             return null;
@@ -143,6 +146,11 @@ export function extractTextIfMentioned(text, id)
 
     // 3. Strip Slack's auto-linked URLs: <https://url> → https://url, <https://url|label> → https://url
     text = text.replace(/<(https?:\/\/[^|>]+)(?:\|[^>]*)?>/g, "$1");
+
+    // 4. Strip Slack's auto-linked email addresses: <mailto:target|label> → target.
+    //    Slack mistakes commit identifiers for email addresses, so "319186@main" arrives as
+    //    <mailto:319186@main|319186@main>.
+    text = text.replace(/<mailto:([^|>\s]+)(?:\|[^>]*)?>/g, "$1");
 
     return text;
 }

--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -285,9 +285,10 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
             return;
         }
 
+        dataLogLn("Failed to parse revision and reason from: ", args);
         await this.postMessage({
             channel: event.channel,
-            text: `<@${event.user}> Failed to parse revision and reason`,
+            text: `<@${event.user}> Failed to parse revision and reason: \`${escapeForSlackText(args.join(" "))}\``,
         });
     }
 

--- a/Tools/WebKitBot/tests/WebKitBot.test.mjs
+++ b/Tools/WebKitBot/tests/WebKitBot.test.mjs
@@ -148,6 +148,72 @@ test("multiple revisions with spaces", () => {
     expect(revisions).toEqual(["263483", "263484", "263485", "263486"]);
 });
 
+test("identifier linkified by Slack as an email address", () => {
+    let message = `<@${WebKitBotID}> revert <mailto:319186@main|319186@main> Causes MotionMark regression`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    expect(text).toBe(" revert 319186@main Causes MotionMark regression");
+
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+    expect(args).toEqual(["319186@main", "Causes", "MotionMark", "regression"]);
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(reason).toBe("Causes MotionMark regression");
+    expect(revisions).toEqual(["319186@main"]);
+});
+
+test("multiple identifiers linkified by Slack as email addresses", () => {
+    let message = `<@${WebKitBotID}> revert <mailto:319186@main|319186@main>, <mailto:319187@main|319187@main>: testing revert`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    expect(text).toBe(" revert 319186@main, 319187@main: testing revert");
+
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+    expect(args).toEqual(["319186@main,", "319187@main:", "testing", "revert"]);
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(reason).toBe("testing revert");
+    expect(revisions).toEqual(["319186@main", "319187@main"]);
+});
+
+test("identifier pasted as a commits.webkit.org link", () => {
+    let message = `<@${WebKitBotID}> revert <https://commits.webkit.org/319186@main> testing revert`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    expect(text).toBe(" revert https://commits.webkit.org/319186@main testing revert");
+
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(reason).toBe("testing revert");
+    expect(revisions).toEqual(["319186@main"]);
+});
+
+test("revision pasted as a labelled commits.webkit.org link", () => {
+    let message = `<@${WebKitBotID}> revert <https://commits.webkit.org/r263483|r263483> testing revert`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    expect(text).toBe(" revert https://commits.webkit.org/r263483 testing revert");
+
+    let {revisions, reason} = extractRevisionsAndReason(extractCommandAndArgs(text).args);
+    expect(reason).toBe("testing revert");
+    expect(revisions).toEqual(["263483"]);
+});
+
+test("user mentions in the reason are left intact", () => {
+    let message = `<@${WebKitBotID}> revert 263483 breaks the build, see <@U12345678>`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    expect(text).toBe(" revert 263483 breaks the build, see <@U12345678>");
+
+    let {revisions, reason} = extractRevisionsAndReason(extractCommandAndArgs(text).args);
+    expect(reason).toBe("breaks the build, see <@U12345678>");
+    expect(revisions).toEqual(["263483"]);
+});
+
 test("mention in different place", () => {
     let message = `revert 263483, 263484, r263485, r263486: testing revert <@${WebKitBotID}>`;
 


### PR DESCRIPTION
#### 24562bd10d496a41b56a1d593737f1adcb2188f0
<pre>
[webkitbot] webkitbot fails to parse identifiers when they are linkified in Slack
<a href="https://bugs.webkit.org/show_bug.cgi?id=253031">https://bugs.webkit.org/show_bug.cgi?id=253031</a>
<a href="https://rdar.apple.com/105998389">rdar://105998389</a>

Reviewed by Aakash Jain.

A commit identifier such as 319186@main matches local@domain, so Slack treats it as an
email address and linkifies it, delivering the message text to @webkitbot as:

    &lt;@UBOT&gt; revert &lt;mailto:319186@main|319186@main&gt; Causes MotionMark regression

The text extraction only unwrapped &lt;<a href="https://url|label">https://url|label</a>&gt; links, so the mailto wrapper
survived preprocessing. This caused the whole argument list to fall through to the &quot;reason&quot;,
resulting in the &quot;Failed to parse revision and reason&quot; response.

In addition to unwrapping mailto links, accept identifiers pasted as commits.webkit.org links,
since that is the form webkitbot itself posts and people copy them back into the channel.

* Tools/WebKitBot/src/CommandParser.mjs:
(extractRevision): Strip a leading commits.webkit.org URL from each candidate.
(extractTextIfMentioned): Strip Slack&apos;s auto-linked email addresses.
* Tools/WebKitBot/src/WebKitBot.mjs:
(WebKitBot.prototype.revertCommand): Log and echo the arguments that failed to parse, so
issues like this show up in the pod logs in the future.
* Tools/WebKitBot/tests/WebKitBot.test.mjs: Add coverage for linkified identifiers,
commits.webkit.org links, and for leaving user mentions in the reason intact.

Canonical link: <a href="https://commits.webkit.org/319815@main">https://commits.webkit.org/319815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b4a0e93ff307be1ae4e744cd7faa2124b30f9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147121 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45a6b53a-42a9-4355-91db-1234d5a543f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56491 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142699 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147121 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa2001c6-a0af-40a1-bfbf-39750d22b9e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185788 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fa821f7-b7c9-43a5-a333-e147055f83c6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43358 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155502 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42984 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4222 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47621 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56425 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152156 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57130 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46415 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125479 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55638 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55246 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->