### PR TITLE
[JSC] add/sub of a zero immediate should be a mov

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -191,6 +191,10 @@ public:
     void add32(TrustedImm32 imm, RegisterID src, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            zeroExtend32ToWord(src, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)
@@ -322,6 +326,10 @@ public:
     void add64(TrustedImm32 imm, RegisterID src, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            move(src, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)
@@ -352,6 +360,10 @@ public:
     void add64(TrustedImm64 imm, RegisterID src, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            move(src, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)
@@ -1503,6 +1515,10 @@ public:
     void sub32(RegisterID left, TrustedImm32 imm, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            zeroExtend32ToWord(left, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)
@@ -1575,6 +1591,10 @@ public:
     void sub64(RegisterID left, TrustedImm32 imm, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            move(left, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)
@@ -1595,6 +1615,10 @@ public:
     void sub64(RegisterID left, TrustedImm64 imm, RegisterID dest)
     {
         auto immediate = imm.m_value;
+        if (!immediate) {
+            move(left, dest);
+            return;
+        }
         if (auto tuple = tryExtractShiftedImm(immediate)) {
             auto [u12, shift, inverted] = tuple.value();
             if (!inverted)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -5122,6 +5122,9 @@ public:
 
     void add64(TrustedImm32 imm, RegisterID srcDest)
     {
+        if (!imm.m_value)
+            return;
+
         if (imm.m_value == 1)
             m_assembler.incq_r(srcDest);
         else
@@ -5130,6 +5133,9 @@ public:
 
     void add64(TrustedImm64 imm, RegisterID dest)
     {
+        if (!imm.m_value)
+            return;
+
         if (imm.m_value == 1)
             m_assembler.incq_r(dest);
         else {
@@ -5140,11 +5146,21 @@ public:
 
     void add64(TrustedImm32 imm, RegisterID src, RegisterID dest)
     {
+        if (!imm.m_value) {
+            move(src, dest);
+            return;
+        }
+
         m_assembler.leaq_mr(imm.m_value, src, dest);
     }
 
     void add64(TrustedImm64 imm, RegisterID src, RegisterID dest)
     {
+        if (!imm.m_value) {
+            move(src, dest);
+            return;
+        }
+
         if (WTF::isRepresentableAs<int32_t>(imm.m_value))
             m_assembler.leaq_mr(imm.m_value, src, dest);
         else {
@@ -5785,6 +5801,9 @@ public:
 
     void sub64(TrustedImm32 imm, RegisterID dest)
     {
+        if (!imm.m_value)
+            return;
+
         if (imm.m_value == 1)
             m_assembler.decq_r(dest);
         else
@@ -5793,6 +5812,11 @@ public:
 
     void sub64(RegisterID a, TrustedImm32 imm, RegisterID dest)
     {
+        if (!imm.m_value) {
+            move(a, dest);
+            return;
+        }
+
         if (a == dest) {
             sub64(imm, dest);
             return;
@@ -5807,6 +5831,9 @@ public:
 
     void sub64(TrustedImm64 imm, RegisterID dest)
     {
+        if (!imm.m_value)
+            return;
+
         if (imm.m_value == 1)
             m_assembler.decq_r(dest);
         else {
@@ -5817,6 +5844,11 @@ public:
 
     void sub64(RegisterID src, TrustedImm64 imm, RegisterID dest)
     {
+        if (!imm.m_value) {
+            move(src, dest);
+            return;
+        }
+
         if (src == dest) {
             sub64(imm, dest);
             return;

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -975,6 +975,216 @@ void testStore64Imm64AddressPointer()
     doTest(0xAAAA432198765555);
 }
 
+void testAdd32Imm()
+{
+    for (auto immediate : int32Operands()) {
+        for (auto immediate2 : int32Operands()) {
+            auto add = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm32(immediate), GPRInfo::returnValueGPR);
+                jit.add32(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint32_t>(add), static_cast<uint32_t>(immediate) + static_cast<uint32_t>(immediate2));
+        }
+    }
+}
+
+void testAdd32ArgImm()
+{
+    for (auto immediate : int32Operands()) {
+        auto add = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.add32(CCallHelpers::TrustedImm32(immediate), GPRInfo::argumentGPR0, GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value : int32Operands())
+            CHECK_EQ(invoke<uint32_t>(add, value), static_cast<uint32_t>(value) + static_cast<uint32_t>(immediate));
+    }
+}
+
+void testAdd64Imm32()
+{
+    for (auto immediate : int64Operands()) {
+        for (auto immediate2 : int32Operands()) {
+            auto add = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
+                jit.add64(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint64_t>(add), static_cast<uint64_t>(immediate) + static_cast<uint64_t>(immediate2));
+        }
+    }
+}
+
+void testAdd64ArgImm32()
+{
+    for (auto immediate : int32Operands()) {
+        auto add = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.add64(CCallHelpers::TrustedImm32(immediate), GPRInfo::argumentGPR0, GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value : int64Operands())
+            CHECK_EQ(invoke<uint64_t>(add, value), static_cast<uint64_t>(value) + static_cast<uint64_t>(immediate));
+    }
+}
+
+void testAdd64Imm64()
+{
+    for (auto immediate : int64Operands()) {
+        for (auto immediate2 : int64Operands()) {
+            auto add = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
+                jit.add64(CCallHelpers::TrustedImm64(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint64_t>(add), static_cast<uint64_t>(immediate) + static_cast<uint64_t>(immediate2));
+        }
+    }
+}
+
+void testAdd64ArgImm64()
+{
+    for (auto immediate : int64Operands()) {
+        auto add = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.add64(CCallHelpers::TrustedImm64(immediate), GPRInfo::argumentGPR0, GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value : int64Operands())
+            CHECK_EQ(invoke<uint64_t>(add, value), static_cast<uint64_t>(value) + static_cast<uint64_t>(immediate));
+    }
+}
+
+void testSub32Args()
+{
+    for (auto value : int32Operands()) {
+        auto sub = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.sub32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value2 : int32Operands())
+            CHECK_EQ(invoke<uint32_t>(sub, value, value2), static_cast<uint32_t>(value - value2));
+    }
+}
+
+void testSub32Imm()
+{
+    for (auto immediate : int32Operands()) {
+        for (auto immediate2 : int32Operands()) {
+            auto sub = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm32(immediate), GPRInfo::returnValueGPR);
+                jit.sub32(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint32_t>(sub), static_cast<uint32_t>(immediate - immediate2));
+        }
+    }
+}
+
+void testSub64Imm32()
+{
+    for (auto immediate : int64Operands()) {
+        for (auto immediate2 : int32Operands()) {
+            auto sub = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
+                jit.sub64(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint64_t>(sub), static_cast<uint64_t>(immediate - immediate2));
+        }
+    }
+}
+
+void testSub64ArgImm32()
+{
+    for (auto immediate : int32Operands()) {
+        auto sub = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.sub64(GPRInfo::argumentGPR0, CCallHelpers::TrustedImm32(immediate), GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value : int64Operands())
+            CHECK_EQ(invoke<int64_t>(sub, value), static_cast<int64_t>(value - immediate));
+    }
+}
+
+void testSub64Imm64()
+{
+    for (auto immediate : int64Operands()) {
+        for (auto immediate2 : int64Operands()) {
+            auto sub = compile([=] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+
+                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
+                jit.sub64(CCallHelpers::TrustedImm64(immediate2), GPRInfo::returnValueGPR);
+
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(invoke<uint64_t>(sub), static_cast<uint64_t>(immediate - immediate2));
+        }
+    }
+}
+
+void testSub64ArgImm64()
+{
+    for (auto immediate : int64Operands()) {
+        auto sub = compile([=] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+
+            jit.sub64(GPRInfo::argumentGPR0, CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
+
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+
+        for (auto value : int64Operands())
+            CHECK_EQ(invoke<int64_t>(sub, value), static_cast<int64_t>(value - immediate));
+    }
+}
+
 #endif // CPU(X86_64) || CPU(ARM64)
 
 void testCompareDouble(MacroAssembler::DoubleCondition condition)
@@ -1222,111 +1432,6 @@ void testMultiplyAddZeroExtend32()
                 CHECK_EQ(invoke<int64_t>(add, n, m, a), static_cast<int64_t>(un) * static_cast<int64_t>(um) + a);
             }
         }
-    }
-}
-
-void testSub32Args()
-{
-    for (auto value : int32Operands()) {
-        auto sub = compile([=] (CCallHelpers& jit) {
-            emitFunctionPrologue(jit);
-
-            jit.sub32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
-
-            emitFunctionEpilogue(jit);
-            jit.ret();
-        });
-
-        for (auto value2 : int32Operands())
-            CHECK_EQ(invoke<uint32_t>(sub, value, value2), static_cast<uint32_t>(value - value2));
-    }
-}
-
-void testSub32Imm()
-{
-    for (auto immediate : int32Operands()) {
-        for (auto immediate2 : int32Operands()) {
-            auto sub = compile([=] (CCallHelpers& jit) {
-                emitFunctionPrologue(jit);
-
-                jit.move(CCallHelpers::TrustedImm32(immediate), GPRInfo::returnValueGPR);
-                jit.sub32(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
-
-                emitFunctionEpilogue(jit);
-                jit.ret();
-            });
-            CHECK_EQ(invoke<uint32_t>(sub), static_cast<uint32_t>(immediate - immediate2));
-        }
-    }
-}
-
-void testSub64Imm32()
-{
-    for (auto immediate : int64Operands()) {
-        for (auto immediate2 : int32Operands()) {
-            auto sub = compile([=] (CCallHelpers& jit) {
-                emitFunctionPrologue(jit);
-
-                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
-                jit.sub64(CCallHelpers::TrustedImm32(immediate2), GPRInfo::returnValueGPR);
-
-                emitFunctionEpilogue(jit);
-                jit.ret();
-            });
-            CHECK_EQ(invoke<uint64_t>(sub), static_cast<uint64_t>(immediate - immediate2));
-        }
-    }
-}
-
-void testSub64ArgImm32()
-{
-    for (auto immediate : int32Operands()) {
-        auto sub = compile([=] (CCallHelpers& jit) {
-            emitFunctionPrologue(jit);
-
-            jit.sub64(GPRInfo::argumentGPR0, CCallHelpers::TrustedImm32(immediate), GPRInfo::returnValueGPR);
-
-            emitFunctionEpilogue(jit);
-            jit.ret();
-        });
-
-        for (auto value : int64Operands())
-            CHECK_EQ(invoke<int64_t>(sub, value), static_cast<int64_t>(value - immediate));
-    }
-}
-
-void testSub64Imm64()
-{
-    for (auto immediate : int64Operands()) {
-        for (auto immediate2 : int64Operands()) {
-            auto sub = compile([=] (CCallHelpers& jit) {
-                emitFunctionPrologue(jit);
-
-                jit.move(CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
-                jit.sub64(CCallHelpers::TrustedImm64(immediate2), GPRInfo::returnValueGPR);
-
-                emitFunctionEpilogue(jit);
-                jit.ret();
-            });
-            CHECK_EQ(invoke<uint64_t>(sub), static_cast<uint64_t>(immediate - immediate2));
-        }
-    }
-}
-
-void testSub64ArgImm64()
-{
-    for (auto immediate : int64Operands()) {
-        auto sub = compile([=] (CCallHelpers& jit) {
-            emitFunctionPrologue(jit);
-
-            jit.sub64(GPRInfo::argumentGPR0, CCallHelpers::TrustedImm64(immediate), GPRInfo::returnValueGPR);
-
-            emitFunctionEpilogue(jit);
-            jit.ret();
-        });
-
-        for (auto value : int64Operands())
-            CHECK_EQ(invoke<int64_t>(sub, value), static_cast<int64_t>(value - immediate));
     }
 }
 
@@ -8425,6 +8530,21 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testCountTrailingZeros64WithoutNullCheck());
     RUN(testShiftAndAdd());
     RUN(testStore64Imm64AddressPointer());
+
+    RUN(testAdd32Imm());
+    RUN(testAdd32ArgImm());
+    RUN(testAdd64Imm32());
+    RUN(testAdd64ArgImm32());
+    RUN(testAdd64Imm64());
+    RUN(testAdd64ArgImm64());
+
+    RUN(testSub32Args());
+    RUN(testSub32Imm());
+    RUN(testSub64Imm32());
+    RUN(testSub64ArgImm32());
+    RUN(testSub64Imm64());
+    RUN(testSub64ArgImm64());
+
 #endif
 
     RUN(testLoadAcq8SignedExtendTo32_Address_RegisterID());
@@ -8459,13 +8579,6 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testLoadStorePair64Double());
     RUN(testMultiplySignExtend32());
     RUN(testMultiplyZeroExtend32());
-
-    RUN(testSub32Args());
-    RUN(testSub32Imm());
-    RUN(testSub64Imm32());
-    RUN(testSub64ArgImm32());
-    RUN(testSub64Imm64());
-    RUN(testSub64ArgImm64());
 
     RUN(testMultiplyAddSignExtend32());
     RUN(testMultiplyAddZeroExtend32());


### PR DESCRIPTION
#### 80fc868e7373b04d6c0456a974af2c8ea89ace5f
<pre>
[JSC] add/sub of a zero immediate should be a mov
<a href="https://bugs.webkit.org/show_bug.cgi?id=322504">https://bugs.webkit.org/show_bug.cgi?id=322504</a>

Reviewed by Keith Miller.

The immediate forms of add32/add64/sub32/sub64 wrote a register-to-register
copy the expensive way when the immediate was zero: add xD, xS, #0 or
sub wD, wS, #0 on arm64, and leaq 0(%src), %dest or a dead addq $0, %reg on
x86_64, where the TrustedImm64 pair also burned a movabsq and the scratch
register. A mov is eliminated at rename where add-with-zero and lea are not,
and the 64-bit forms drop the instruction entirely when source and destination
coincide. The 32-bit forms go through zeroExtend32ToWord() instead, since they
must still zero the destination&apos;s upper half.

None of these entry points promise flags -- arm64 already uses the
non-flag-setting add and sub, and flag-consuming callers use
branchAdd64/branchSub64 -- so dropping x86_64&apos;s flag write is invisible.

x86_64 needed more entry points than arm64: only the add32/sub32 three-operand
forms had the check, and its two-operand forms emit their own instruction
rather than forwarding to the three-operand ones. Its 32-bit two-operand forms
are left alone, where the substitution would be movl %eax, %eax: a byte shorter
than addl $0, %eax but the same single uop.

The dominant source is JIT::emit_op_new_array(), which passes the address of
the literal&apos;s first element with

    addPtr(TrustedImm32(valuesStart.offset() * sizeof(Register)),
        callFrameRegister, argumentGPR2);

and that offset is zero for an empty [] literal.

Scanning everything the JITs emit while running JetStream 3, armlint reports
4563 sites on arm64, 3081 of them exactly add x2, x29, #0 (3335 Baseline, 1068
DFG) and the remaining 699 sub wD, wS, #0. The same scan on x86_64 -- 111654
code blobs and 240 MB captured through LinkBuffer&apos;s perf JITDump -- has x86lint
reporting 3989 sites:

    3091  lea rD, [rS]      zero displacement, 3090 Baseline and 1 DFG
     680  add/sub rD, 0     64-bit, 676 DFG, 3 Baseline, 1 WasmBBQ
     216  add/sub eD, 0     32-bit, deliberately unchanged
       2  lea rD, [rS+rI]   two-register, unrelated to this change

All 3091 zero-displacement LEAs are exactly leaq 0(%rbp), %rdx, which is
callFrameRegister into argumentGPR2. After this change an empty array literal
compiles to mov x2, fp or movq %rbp, %rdx; no zero-immediate add or sub is left
on arm64, and on x86_64 both targeted rows are empty, 3771 sites in total. The
32-bit row&apos;s drift to 219 is JIT nondeterminism between runs.

testmasm covered none of these entry points on x86_64: the six sub tests sat in
the #if CPU(ARM64) block and there were no add tests at all. Move them to
#if CPU(X86_64) || CPU(ARM64) and add testAdd32Imm, testAdd32ArgImm,
testAdd64Imm32, testAdd64ArgImm32, testAdd64Imm64 and testAdd64ArgImm64, one
per immediate form. int32Operands() and int64Operands() both start at 0, so all
of them exercise the zero-immediate path. testmasm goes from 382 to 394 tests
on x86_64, all passing.

Found with armlint and x86lint.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add32):
(JSC::MacroAssemblerARM64::add64):
(JSC::MacroAssemblerARM64::sub32):
(JSC::MacroAssemblerARM64::sub64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::add64):
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testAdd32Imm):
(JSC::testAdd32ArgImm):
(JSC::testAdd64Imm32):
(JSC::testAdd64ArgImm32):
(JSC::testAdd64Imm64):
(JSC::testAdd64ArgImm64):
(JSC::run):

Co-Authored-By: Claude Opus 5 (1M context) &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/319908@main">https://commits.webkit.org/319908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5f4dada61e20d1c48d34a235a182a4dd86c6d83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193342 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45358 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5339 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12167 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43227 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4515 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44394 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195283 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56716 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152417 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40843 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57421 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152112 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46662 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125842 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55929 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18238 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55300 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->