### PR TITLE
[Grid Lanes] Resolve fit-tolerance outside of GridLanesLayout

### DIFF
--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -29,9 +29,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderGrid.h"
 #include "StyleComputedStyle+GettersInlines.h"
-#include "StyleFitTolerance.h"
 #include "StyleGridPositionsResolver.h"
-#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "WritingMode.h"
 
 namespace WebCore {
@@ -47,17 +45,17 @@ GridLanesLayout::GridLanesLayout(RenderGrid& renderGrid, unsigned gridAxisTracks
     m_renderGrid->populateExplicitGridAndOrderIterator();
 }
 
-void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)
+void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns, std::cref(*this));
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows, std::cref(*this));
 
     // 4.4 Grid Lanes Layout and Placement Algorithm
     // https://drafts.csswg.org/css-grid-3/#grid-lanes-layout-algorithm
-    placeGridLanesItems(algorithm, layoutPhase);
+    placeGridLanesItems(algorithm, fitTolerance, layoutPhase);
 }
 
-void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)
+void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
     if (!m_gridAxisTracksCount)
         return;
@@ -67,7 +65,7 @@ void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algori
         if (grid.orderIterator().shouldSkipChild(*gridItem))
             continue;
 
-        auto gridArea = hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()) ? gridAreaForDefiniteGridAxisItem(*gridItem) : gridAreaForIndefiniteGridAxisItem(*gridItem);
+        auto gridArea = hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()) ? gridAreaForDefiniteGridAxisItem(*gridItem) : gridAreaForIndefiniteGridAxisItem(*gridItem, fitTolerance);
         insertIntoGridAndLayoutItem(algorithm, *gridItem, gridArea, layoutPhase);
     }
 }
@@ -199,15 +197,12 @@ LayoutUnit GridLanesLayout::maxRunningPositionForSpan(unsigned startLine, unsign
     return maxPosition;
 }
 
-GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
+GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance fitTolerance)
 {
     auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), m_gridAxisTracksCount);
     auto gridAxisLines = m_gridAxisTracksCount + 1;
 
-    // Get fit-tolerance from the grid lanes container's style
-    const auto& tolerance = m_renderGrid->style().fitTolerance();
-
-    if (tolerance.isInfinite()) {
+    if (WTF::holdsAlternative<CSS::Keyword::Infinite>(fitTolerance)) {
         // Infinite tolerance: place items strictly in order without considering track lengths
         // Use round-robin placement starting from the cursor position
         auto startingLine = m_autoFlowNextCursor;
@@ -221,31 +216,7 @@ GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& ite
     }
 
     // For normal and length-percentage tolerances, find positions within tolerance of the shortest track
-    // Calculate tolerance value
-    auto contentBoxSize = gridAxisDirection() == Style::GridTrackSizingDirection::Columns
-        ? m_renderGrid->contentBoxLogicalHeight()
-        : m_renderGrid->contentBoxLogicalWidth();
-
-    LayoutUnit toleranceValue = tolerance.switchOn(
-        [&](const CSS::Keyword::Normal&) -> LayoutUnit {
-            // Normal resolves to 1em
-            return LayoutUnit { m_renderGrid->style().computedFontSize() };
-        },
-        [&](const typename Style::FitTolerance::Fixed& fixed) -> LayoutUnit {
-            return LayoutUnit { fixed.resolveZoom(m_renderGrid->style().usedZoomForLength()) };
-        },
-        [&](const typename Style::FitTolerance::Percentage& percentage) -> LayoutUnit {
-            return Style::evaluate<LayoutUnit>(percentage, contentBoxSize);
-        },
-        [&](const typename Style::FitTolerance::Calc& calc) -> LayoutUnit {
-            return Style::evaluate<LayoutUnit>(calc, contentBoxSize, m_renderGrid->style().usedZoomForLength());
-        },
-        [](const CSS::Keyword::Infinite&) -> LayoutUnit {
-            // This case shouldn't be reached due to the outer if check
-            ASSERT_NOT_REACHED();
-            return LayoutUnit { };
-        }
-    );
+    auto toleranceValue = std::get<LayoutUnit>(fitTolerance);
 
     // Step 1: Find the absolute shortest position across all tracks
     auto maxStartingLine = gridAxisLines - itemSpanLength;

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -50,15 +50,17 @@ public:
         MaxContent
     };
 
-    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, Phase);
+    using ResolvedFitTolerance = Variant<LayoutUnit, CSS::Keyword::Infinite>;
+
+    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, ResolvedFitTolerance, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 
 private:
-    GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
+    GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
-    void placeGridLanesItems(const GridTrackSizingAlgorithm&, Phase);
+    void placeGridLanesItems(const GridTrackSizingAlgorithm&, ResolvedFitTolerance, Phase);
     void setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, Phase);
     LayoutUnit calculateGridLanesIntrinsicLogicalWidth(RenderBox&, Phase);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -45,6 +45,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
+#include "StyleFitTolerance.h"
 #include "StyleGridPositionsResolver.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <ranges>
@@ -592,6 +593,40 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     return true;
 }
 
+static GridLanesLayout::ResolvedFitTolerance resolveFitTolerance(const RenderGrid& grid, Style::GridTrackSizingDirection stackingAxisDirection)
+{
+    const auto& tolerance = grid.style().fitTolerance();
+    if (tolerance.isInfinite())
+        return CSS::Keyword::Infinite { };
+
+    // Placement tolerance is a distance measured along the stacking axis, so a percentage
+    // resolves against the stacking axis content box size.
+    auto stackingAxisContentBoxSize = stackingAxisDirection == Style::GridTrackSizingDirection::Rows
+        ? grid.contentBoxLogicalHeight()
+        : grid.contentBoxLogicalWidth();
+
+    return tolerance.switchOn(
+        [&](const CSS::Keyword::Normal&) -> LayoutUnit {
+            // Normal resolves to 1em
+            return LayoutUnit { grid.style().computedFontSize() };
+        },
+        [&](const Style::FitTolerance::Fixed& fixed) -> LayoutUnit {
+            return LayoutUnit { fixed.resolveZoom(grid.style().usedZoomForLength()) };
+        },
+        [&](const Style::FitTolerance::Percentage& percentage) -> LayoutUnit {
+            return Style::evaluate<LayoutUnit>(percentage, stackingAxisContentBoxSize);
+        },
+        [&](const Style::FitTolerance::Calc& calc) -> LayoutUnit {
+            return Style::evaluate<LayoutUnit>(calc, stackingAxisContentBoxSize, grid.style().usedZoomForLength());
+        },
+        [](const CSS::Keyword::Infinite&) -> LayoutUnit {
+            // Handled by the isInfinite() early return above.
+            ASSERT_NOT_REACHED();
+            return LayoutUnit { };
+        }
+    );
+}
+
 void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
     ASSERT(isGridLanes());
@@ -657,7 +692,7 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
         auto gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(orthogonalDirection(stackingAxisDirection));
 
         auto gridLanesLayout = GridLanesLayout { *this, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection };
-        gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, GridLanesLayout::Phase::Layout);
+        gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, resolveFitTolerance(*this, stackingAxisDirection), GridLanesLayout::Phase::Layout);
 
         // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
         // placement, but its min-content and max-content results are not what the overlay should
@@ -862,12 +897,14 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
         // Constructing a GridLanesLayout clears the grid, so the track count both runs are given
         // has to be the one taken before either of them placed anything.
+        auto fitTolerance = resolveFitTolerance(*this, Style::GridTrackSizingDirection::Columns);
+
         auto minContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
-        minContentLayout.performGridLanesPlacement(algorithm, GridLanesLayout::Phase::MinContent);
+        minContentLayout.performGridLanesPlacement(algorithm, fitTolerance, GridLanesLayout::Phase::MinContent);
         minLogicalWidth = minContentLayout.gridContentSize();
 
         auto maxContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
-        maxContentLayout.performGridLanesPlacement(algorithm, GridLanesLayout::Phase::MaxContent);
+        maxContentLayout.performGridLanesPlacement(algorithm, fitTolerance, GridLanesLayout::Phase::MaxContent);
         maxLogicalWidth = maxContentLayout.gridContentSize();
     }
 


### PR DESCRIPTION
#### ee671ed1c8f5bc9023ec5681cbb94007e8b278ab
<pre>
[Grid Lanes] Resolve fit-tolerance outside of GridLanesLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=322508">https://bugs.webkit.org/show_bug.cgi?id=322508</a>
<a href="https://rdar.apple.com/problem/185811508">rdar://problem/185811508</a>

Reviewed by Alan Baradlay.

GridLanesLayout should not need to know about the legacy render tree grid
implementation. As a step in that direction, stop having it consult the grid
container&apos;s style to resolve fit-tolerance. RenderGrid now resolves the style
value into a used value up front and passes it in, so the placement code only
ever deals with an already resolved length, or the infinite keyword.

This removes the reads on the grid container that existed solely to compute the
tolerance: style().fitTolerance(), style().computedFontSize(),
style().usedZoomForLength(), contentBoxLogicalWidth() and
contentBoxLogicalHeight().

Resolving once per placement run instead of once per auto placed item is not a
behavior change. Nothing in the placement loop mutates the container&apos;s content
box, and the container&apos;s logical height is not set until after placement has
finished.

* Source/WebCore/rendering/GridLanesLayout.h:
Add ResolvedFitTolerance, which is either the used length or the infinite
keyword. It is only needed while items are being placed, so it is threaded
through placement rather than stored as a member.

* Source/WebCore/rendering/GridLanesLayout.cpp:
Drop the StyleFitTolerance.h and StylePrimitiveNumericTypes+Evaluation.h includes,
which were only needed by the resolution that moved out.
(WebCore::GridLanesLayout::performGridLanesPlacement):
(WebCore::GridLanesLayout::placeGridLanesItems):
(WebCore::GridLanesLayout::gridAreaForIndefiniteGridAxisItem):
Take the resolved tolerance as a parameter and pass it down to
gridAreaForIndefiniteGridAxisItem(), which is the only thing that uses it.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::resolveFitTolerance):
The moved resolution, which is why StyleFitTolerance.h is now included here. A
percentage resolves against the stacking axis content box size, since the
tolerance is a distance measured along the stacking axis. The local is named for
that axis so it is harder to misread which one applies.
(WebCore::RenderGrid::layoutGridLanes):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
Resolve the tolerance and hand it to performGridLanesPlacement(). The intrinsic
width path runs placement twice, so it resolves once and reuses the value.

Canonical link: <a href="https://commits.webkit.org/319851@main">https://commits.webkit.org/319851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e631730fa57b2ee3b882037c201980a6ffbb0df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147247 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b39bf356-5735-470d-abf3-c11b36575b5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142805 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73b6ed78-de05-43aa-81a9-ce99395cdea5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123232 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9af2963f-e21a-49a4-93b2-2fc4898755b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43464 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43095 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4349 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195117 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56551 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40800 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57256 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151963 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46527 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129525 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18106 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55135 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->