### PR TITLE
SOAuthorizationSession should allow the client to present the authorization view controller via its own view controller on macOS

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -127,6 +127,7 @@ private:
 
     RetainPtr<SOAuthorizationViewController> m_viewController;
 #if PLATFORM(MAC)
+    RetainPtr<NSViewController> m_presentingViewController;
     RetainPtr<NSWindow> m_sheetWindow;
     RetainPtr<NSObject> m_sheetWindowWillCloseObserver;
     RetainPtr<NSObject> m_presentingWindowDidDeminiaturizeObserver;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -402,6 +402,15 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
     ASSERT(!m_sheetWindow);
     ASSERT(!m_sheetWindowWillCloseObserver);
 
+    // Let the client (e.g. Safari) present the authorization view controller within its own UI.
+    if (RetainPtr<NSViewController> presentingViewController = page->uiClient().presentingViewController()) {
+        AUTHORIZATIONSESSION_RELEASE_LOG("presentViewController: Presenting via client-provided view controller %p.", presentingViewController.get());
+        m_presentingViewController = presentingViewController;
+        [presentingViewController presentViewControllerAsSheet:m_viewController.get()];
+        uiCallback(YES, nil);
+        return;
+    }
+
     dismissModalSheetIfNecessary();
 
     m_sheetWindow = [NSWindow windowWithContentViewController:m_viewController.get()];
@@ -472,6 +481,14 @@ void SOAuthorizationSession::dismissViewController()
     }
 
 #if PLATFORM(MAC)
+    if (m_presentingViewController) {
+        AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Dismissing client-presented view controller %p.", m_presentingViewController.get());
+        [m_presentingViewController dismissViewController:m_viewController.get()];
+        m_presentingViewController = nullptr;
+        m_viewController = nullptr;
+        return;
+    }
+
     if (!m_sheetWindow) {
         ASSERT(!m_sheetWindowWillCloseObserver);
         AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: No view controller or sheet window, so returning early.");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -202,6 +202,9 @@ private:
 @property bool allowSOAuthorizationLoad;
 @property bool isAsyncExecution;
 @property bool disableExtensibleSSODuringPolicyDecision;
+#if PLATFORM(MAC)
+@property (nonatomic, retain) NSViewController *presentingViewController;
+#endif
 - (instancetype)init;
 @end
 
@@ -281,6 +284,11 @@ private:
 - (UIViewController *)_presentingViewControllerForWebView:(WKWebView *)webView
 {
     return nil;
+}
+#elif PLATFORM(MAC)
+- (NSViewController *)_presentingViewControllerForWebView:(WKWebView *)webView
+{
+    return self.presentingViewController;
 }
 #endif
 
@@ -1830,6 +1838,48 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
     EXPECT_FALSE(uiShowed);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionSucceedWithUIViaPresentingViewController)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    RetainPtr presentingViewController = adoptNS([[NSViewController alloc] init]);
+    RetainPtr presentingView = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    [presentingViewController setView:presentingView.get()];
+    [[webView hostWindow].contentView addSubview:presentingView.get()];
+    [delegate setPresentingViewController:presentingViewController.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&authorizationPerformed);
+    EXPECT_TRUE(policyForAppSSOPerformed);
+
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    [viewController setView:view.get()];
+
+    [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
+        EXPECT_TRUE(success);
+    }];
+    Util::run(&uiShowed);
+
+    // The view controller should be presented on the client-supplied presenting view controller rather than in a WebKit-owned window.
+    EXPECT_TRUE([[presentingViewController presentedViewControllers] containsObject:viewController.get()]);
+
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
+    Util::run(&navigationCompleted);
+    EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
+    EXPECT_FALSE(uiShowed);
+    EXPECT_FALSE([[presentingViewController presentedViewControllers] containsObject:viewController.get()]);
 }
 
 TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)


### PR DESCRIPTION
#### ba29ff41e0a023bd1c7d3e64d4c35cc20046efbf
<pre>
SOAuthorizationSession should allow the client to present the authorization view controller via its own view controller on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=322459">https://bugs.webkit.org/show_bug.cgi?id=322459</a>

Reviewed by Alex Christensen.

Currently, SOAuthorizationSession presents its authorization view controller
by creating and managing its own NSWindow on macOS. This means the client
(e.g. Safari) has no way to present the authorization UI within its own
window/view hierarchy, such as a sheet on an existing browser window.

Allow the client to opt in to presenting the authorization view controller
itself by supplying a view controller via the UI client
(WKUIDelegatePrivate._presentingViewControllerForWebView:). When a
client-provided view controller is available, present the authorization
view controller as a sheet on it instead of creating a new NSWindow, and
dismiss it the same way when the session ends.

Add a unit test verifying that the SOAuthorization view controller is presented
as a child of the client-supplied view controller instead of a WebKit provided
window.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::presentViewController):
(WebKit::SOAuthorizationSession::dismissViewController):

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(-[TestSOAuthorizationDelegate _presentingViewControllerForWebView:]):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithUIViaPresentingViewController)):

Canonical link: <a href="https://commits.webkit.org/319838@main">https://commits.webkit.org/319838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616db28b7ae58bd87593014bb4e0c1a236d7dd31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142721 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43381 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43009 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4249 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56451 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57156 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151875 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46437 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129425 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125507 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55664 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18019 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->