### PR TITLE
[git webkit] prepare-commit-msg fails to amend when the checkout is older than the installed hook

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -342,19 +342,21 @@ def amended_message(full_message, combined_tests, combined_changes, amend_change
     if amend_changes and update_changelog:
         try:
             from webkitscmpy.commit_parser import CommitMessageParser
-        except ImportError as e:
+
+            commit_message_parser = CommitMessageParser()
+            commit_message_parser.parse_message(full_message)
+            updated_changelog_lines = commit_message_parser.reconcile_with_changed_files(combined_changes)
+            reviewed_by_lines = (commit_message_parser.reviewed_by_lines or ['Reviewed by NOBODY (OOPS!).'])
+            description_lines = (commit_message_parser.description_lines or ['Explanation of why this fixes the bug (OOPS!).'])
+            reconcile_tests = getattr(commit_message_parser, 'reconcile_tests', None)
+            updated_tests_lines = reconcile_tests(combined_tests) if reconcile_tests else list(commit_message_parser.tests_lines)
+            tests_lines = updated_tests_lines + [''] if updated_tests_lines else []
+            amended_message = commit_message_parser.title_lines + [''] + reviewed_by_lines + [''] + description_lines + [''] + tests_lines + updated_changelog_lines
+            removed_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(annotate_deleted_lines(amend_changes, combined_changes), return_deleted=True)
+        except (ImportError, AttributeError) as e:
             sys.stderr.write(f'{e}: Could not update changelog automatically. Falling back to the default template.\n')
             return full_message
 
-        commit_message_parser = CommitMessageParser()
-        commit_message_parser.parse_message(full_message)
-        updated_changelog_lines = commit_message_parser.reconcile_with_changed_files(combined_changes)
-        reviewed_by_lines = (commit_message_parser.reviewed_by_lines or ['Reviewed by NOBODY (OOPS!).'])
-        description_lines = (commit_message_parser.description_lines or ['Explanation of why this fixes the bug (OOPS!).'])
-        updated_tests_lines = commit_message_parser.reconcile_tests(combined_tests)
-        tests_lines = updated_tests_lines + [''] if updated_tests_lines else []
-        amended_message = commit_message_parser.title_lines + [''] + reviewed_by_lines + [''] + description_lines + [''] + tests_lines + updated_changelog_lines
-        removed_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(annotate_deleted_lines(amend_changes, combined_changes), return_deleted=True)
         return '''{message_body}
 
 # Your changelog has been updated with the following files/functions:


### PR DESCRIPTION
#### 920f5177de716d41851e4b98f59989d9f9b5fad5
<pre>
[git webkit] prepare-commit-msg fails to amend when the checkout is older than the installed hook
<a href="https://bugs.webkit.org/show_bug.cgi?id=322514">https://bugs.webkit.org/show_bug.cgi?id=322514</a>
<a href="https://rdar.apple.com/185816251">rdar://185816251</a>

Reviewed by Alex Christensen.

The hook is rendered into .git/hooks, but it imports webkitscmpy from the
checkout, so a hook installed from main runs against whatever branch is checked
out. Amending on a branch cut before 319270@main raised the following
error:

AttributeError: &apos;CommitMessageParser&apos; object has no attribute &apos;reconcile_tests&apos;

and aborted the commit.

Call reconcile_tests only when the parser has it and keep the tests section as
written otherwise, so amending still updates the file list. Every other parser
call here carries the same hazard, so move them under the existing ImportError
guard and catch AttributeError as well. An out-of-date checkout now falls back
to the commit message as written instead of failing the commit, the same way
pre-push tolerates a checkout too old for its imports.

* Tools/Scripts/hooks/prepare-commit-msg:

Canonical link: <a href="https://commits.webkit.org/319828@main">https://commits.webkit.org/319828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c09307fb1ed9c0cb2ca302b46c25e949ec1ad20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147149 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7962b46a-9cdc-4629-a32c-592aba179bb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142722 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6547d5f7-18a7-4697-8f2c-2907b1c3b574) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46439 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12fa5efe-4545-433c-994a-de30a3c897e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45131 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43012 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4251 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56453 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40773 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57158 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151878 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46441 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125509 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55666 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18022 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->