### PR TITLE
Cherry-pick 319805@main (05b0362e7afb). https://bugs.webkit.org/show_bug.cgi?id=322484

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
@@ -339,7 +339,7 @@ static GInputStream* webkitImageLoad(GLoadableIcon* icon, int size, char** type,
         image->priv->width,
         image->priv->height,
         WebKitImageColorType,
-        kUnpremul_SkAlphaType
+        kPremul_SkAlphaType
     );
 
     static_assert(WebKitImageColorType == kBGRA_8888_SkColorType, "WebKitImage assumes PixelFormat::BGRA8 from WebImage");

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
@@ -21,7 +21,9 @@
 
 #include "TestMain.h"
 #include <WebKitImagePrivate.h>
+#include <png.h>
 #include <span>
+#include <wtf/Vector.h>
 #include <wtf/glib/GUniquePtr.h>
 
 class WebKitImageTest : public Test {
@@ -144,8 +146,9 @@ static void testWebKitImageIconInterface(WebKitImageTest*, gconstpointer)
 
 static void testWebKitImageLoadableIconLoadSync(WebKitImageTest*, gconstpointer)
 {
-    auto makeSingleRedPixel = []() -> GRefPtr<GBytes> {
-        uint8_t pixel[] = { 255, 0, 0, 255 };
+    // WebKitImage uses premultiplied alpha, a completely red component matches the alpha value when premultiplied.
+    static constexpr auto makeSingleRedPixel = [](uint8_t alpha = 255) -> GRefPtr<GBytes> {
+        uint8_t pixel[] = { alpha, 0, 0, alpha };
         return adoptGRef(g_bytes_new(pixel, sizeof(pixel)));
     };
     GRefPtr<WebKitImage> image = webkitImageNew(1, 1, 4, makeSingleRedPixel());
@@ -176,6 +179,78 @@ static void testWebKitImageLoadableIconLoadSync(WebKitImageTest*, gconstpointer)
     g_assert_cmpint(buffer[5], ==, 0x0A);
     g_assert_cmpint(buffer[6], ==, 0x1A);
     g_assert_cmpint(buffer[7], ==, 0x0A);
+
+    image = webkitImageNew(1, 1, 4, makeSingleRedPixel(0x80)); // 50% opaque red.
+    stream = adoptGRef(g_loadable_icon_load(G_LOADABLE_ICON(image.get()), 0, &type.outPtr(), nullptr, &error.outPtr()));
+
+    g_assert_no_error(error.get());
+    g_assert_nonnull(stream.get());
+    g_assert_cmpstr(type.get(), ==, "image/png");
+
+    bool pngErrored = false;
+    static constexpr auto pngErroredCallback = [](png_struct* png, const char*) {
+        bool* errored = reinterpret_cast<bool*>(png_get_error_ptr(png));
+        *errored = true;
+    };
+
+    png_struct* png = png_create_read_struct(PNG_LIBPNG_VER_STRING, &pngErrored, pngErroredCallback, pngErroredCallback);
+    g_assert_nonnull(png);
+
+    static constexpr auto pngReadCallback = [](png_struct* png, uint8_t* buffer, size_t numBytes) {
+        GRefPtr<GError> error;
+        auto* stream = G_INPUT_STREAM(png_get_io_ptr(png));
+        auto readBytes = g_input_stream_read(stream, buffer, numBytes, nullptr, &error.outPtr());
+        g_assert_cmpint(readBytes, ==, numBytes);
+        g_assert_no_error(error.get());
+    };
+    png_set_read_fn(png, stream.get(), pngReadCallback);
+
+    png_info* pngInfo = png_create_info_struct(png);
+    g_assert_nonnull(pngInfo);
+
+    png_read_info(png, pngInfo);
+    g_assert_false(pngErrored);
+
+    uint32_t pngWidth = 0, pngHeight = 0;
+    int pngDepth = 0, pngColorType = 0;
+    png_get_IHDR(png, pngInfo, &pngWidth, &pngHeight, &pngDepth, &pngColorType, nullptr, nullptr, nullptr);
+    g_assert_false(pngErrored);
+
+    g_assert_cmpuint(pngWidth, ==, 1);
+    g_assert_cmpuint(pngHeight, ==, 1);
+    g_assert_cmpuint(pngColorType, ==, PNG_COLOR_TYPE_RGBA);
+
+    if (pngColorType == PNG_COLOR_TYPE_PALETTE || (pngColorType == PNG_COLOR_TYPE_GRAY && pngDepth < 8) || png_get_valid(png, pngInfo, PNG_INFO_tRNS))
+        png_set_expand(png); // Resolve palette colors and apply transparency.
+
+    if (pngDepth == 16)
+        png_set_strip_16(png); // Lower higher bit depth images to 8bpp, it is enough for testing.
+
+    if (pngColorType == PNG_COLOR_TYPE_GRAY || pngColorType == PNG_COLOR_TYPE_GRAY_ALPHA)
+        png_set_gray_to_rgb(png); // Always produce RGB for grayscale images.
+
+    png_read_update_info(png, pngInfo);
+    g_assert_false(pngErrored);
+
+    uint32_t pngRowBytes = png_get_rowbytes(png, pngInfo);
+    Vector<uint8_t> pngRow(pngRowBytes, [](size_t) -> uint8_t {
+        return 0x00;
+    });
+    uint8_t* pngRowPointers[1] = { pngRow.mutableSpan().data() };
+    png_read_image(png, pngRowPointers);
+    g_assert_false(pngErrored);
+
+    png_read_end(png, nullptr);
+    g_assert_false(pngErrored);
+
+    // PNG pixel data is decoded in BGRA order and always stored un-premultiplied, so that is what libpng returns.
+    g_assert_cmpuint(pngRow[0], ==, 0x00);
+    g_assert_cmpuint(pngRow[1], ==, 0x00);
+    g_assert_cmpuint(pngRow[2], ==, 0xFF);
+    g_assert_cmpuint(pngRow[3], ==, 0x80);
+
+    png_destroy_info_struct(png, &pngInfo);
+    png_destroy_read_struct(&png, nullptr, nullptr);
 }
 
 static void testWebKitImageLoadableIconLoadAsync(WebKitImageTest* test, gconstpointer)


### PR DESCRIPTION
#### 4d7e7cdf887ddb00e84f677641643ddd708ffcc4
<pre>
Cherry-pick 319805@main (05b0362e7afb). <a href="https://bugs.webkit.org/show_bug.cgi?id=322484">https://bugs.webkit.org/show_bug.cgi?id=322484</a>

    [GTK][WPE] Using g_loadable_icon_load[_async] on a WebKitImage provides wrong translucent pixel values
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322484">https://bugs.webkit.org/show_bug.cgi?id=322484</a>

    Reviewed by Patrick Griffis.

    WebKitImage is documented to use premultiplied alpha, but when wrapping the
    pixel data with a SkImage the flag kUnpremul_SkAlphaType was used. The fix
    is to use the correct kPremul_SkAlphaType flag instead

    The &quot;/webkit/WebKitImage/loadable-icon-interface-sync-load&quot; test case is
    modified to add encoding of a WebKitImage with a translucent pixel as PNG
    and then reading it back using plain libpng calls to verify that the pixel
    was stored un-premultiplied correctly in the PNG (as per the spec).

    * Source/WebKit/UIProcess/API/glib/WebKitImage.cpp:
    (webkitImageLoad):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitImage.cpp:
    (testWebKitImageLoadableIconLoadSync):

    Canonical link: <a href="https://commits.webkit.org/319805@main">https://commits.webkit.org/319805@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1122@webkitglib/2.52">https://commits.webkit.org/305877.1122@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d623c89a4746a2c1c48cb8d8d38aa6e4c254b90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182886 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56809 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193103 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147174 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184748 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58151 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56544 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147174 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58151 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123175 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58151 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56544 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58151 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4276 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49456 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56544 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195044 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56478 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152203 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57183 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151900 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27770 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57183 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129452 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125536 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55691 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50622 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55062 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55299 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55129 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->