### PR TITLE
[Cleanup] Streamline the viewport-percentage unit resolution functions

### DIFF
--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -145,12 +145,59 @@ enum class ViewportType : uint8_t {
     Dynamic,
 };
 
-enum class ViewportPhysicalDimension : uint8_t {
+enum class ViewportDimension : uint8_t {
     Height,
     Width,
     Max,
     Min,
+    Inline,
+    Block,
 };
+
+template<LogicalBoxAxis axis>
+static double NODELETE resolveViewportLogicalAxis(const FloatSize& size, const ComputedStyle& style)
+{
+    switch (mapAxisLogicalToPhysical(style.writingMode(), axis)) {
+    case BoxAxis::Horizontal:
+        return size.width();
+    case BoxAxis::Vertical:
+        return size.height();
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+template<LogicalBoxAxis axis>
+static double resolveViewportLogicalAxis(const FloatSize& size, const RenderView& renderView, const auto& adaptor)
+{
+    if (auto* style = adaptor.styleForViewportUnits())
+        return resolveViewportLogicalAxis<axis>(size, *style);
+
+    auto* rootElement = renderView.document().documentElement();
+    if (!rootElement)
+        return 0;
+    auto* rootStyle = rootElement->renderStyle();
+    if (!rootStyle)
+        return 0;
+    return resolveViewportLogicalAxis<axis>(size, *rootStyle);
+}
+
+template<ViewportDimension axis>
+static double resolveViewportAxis(const FloatSize& size, const RenderView& renderView, const auto& adaptor)
+{
+    if constexpr (axis == ViewportDimension::Height)
+        return size.height();
+    else if constexpr (axis == ViewportDimension::Width)
+        return size.width();
+    else if constexpr (axis == ViewportDimension::Max)
+        return size.maxDimension();
+    else if constexpr (axis == ViewportDimension::Min)
+        return size.minDimension();
+    else if constexpr (axis == ViewportDimension::Inline)
+        return resolveViewportLogicalAxis<LogicalBoxAxis::Inline>(size, renderView, adaptor);
+    else if constexpr (axis == ViewportDimension::Block)
+        return resolveViewportLogicalAxis<LogicalBoxAxis::Block>(size, renderView, adaptor);
+}
 
 template<ViewportType type>
 static FloatSize resolveViewportType(const RenderView& renderView)
@@ -165,87 +212,21 @@ static FloatSize resolveViewportType(const RenderView& renderView)
         return renderView.sizeForCSSDynamicViewportUnits();
 }
 
-template<ViewportPhysicalDimension axis>
-static double resolveViewportPercentagePhysicalAxis(const FloatSize& size)
-{
-    if constexpr (axis == ViewportPhysicalDimension::Height)
-        return size.height();
-    else if constexpr (axis == ViewportPhysicalDimension::Width)
-        return size.width();
-    else if constexpr (axis == ViewportPhysicalDimension::Max)
-        return size.maxDimension();
-    else if constexpr (axis == ViewportPhysicalDimension::Min)
-        return size.minDimension();
-}
 
-template<LogicalBoxAxis axis>
-static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const ComputedStyle& style)
+template<ViewportType type, ViewportDimension axis>
+static double resolveViewportUnit(const auto& adaptor)
 {
-    switch (mapAxisLogicalToPhysical(style.writingMode(), axis)) {
-    case BoxAxis::Horizontal:
-        return size.width();
-    case BoxAxis::Vertical:
-        return size.height();
-    }
+    adaptor.setUsesViewportUnits();
 
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-template<LogicalBoxAxis axis>
-static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const ComputedStyle* style)
-{
-    if (!style)
-        return 0;
-    return resolveViewportPercentageLogicalAxis<axis>(size, *style);
-}
-
-template<LogicalBoxAxis axis>
-static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const RenderView& renderView)
-{
-    auto* rootElement = renderView.document().documentElement();
-    if (!rootElement)
-        return 0;
-    return resolveViewportPercentageLogicalAxis<axis>(size, rootElement->renderStyle());
-}
-
-template<LogicalBoxAxis axis>
-static double resolveViewportPercentageLogicalAxis(const FloatSize& size, const RenderView& renderView, const ComputedStyle* style)
-{
-    if (style)
-        return resolveViewportPercentageLogicalAxis<axis>(size, *style) / renderView.pageZoomFactor();
-    return resolveViewportPercentageLogicalAxis<axis>(size, renderView) / renderView.pageZoomFactor();
-}
-
-template<ViewportType type, ViewportPhysicalDimension axis>
-static double resolveViewportPercentageUnit(const RenderView& renderView)
-{
-    return resolveViewportPercentagePhysicalAxis<axis>(resolveViewportType<type>(renderView)) / 100.0;
-}
-
-template<ViewportType type, LogicalBoxAxis axis>
-static double resolveViewportPercentageUnit(const RenderView& renderView, const ComputedStyle* style)
-{
-    return resolveViewportPercentageLogicalAxis<axis>(resolveViewportType<type>(renderView), renderView, style) / 100.0;
-}
-
-template<ViewportType type, ViewportPhysicalDimension axis>
-static double resolveViewportPercentageUnit(const RenderView* renderView)
-{
+    auto* renderView = adaptor.renderViewForViewportUnits();
     if (!renderView) {
-        if constexpr (axis == ViewportPhysicalDimension::Max || axis == ViewportPhysicalDimension::Min)
+        if constexpr (axis == ViewportDimension::Max || axis == ViewportDimension::Min)
             return 1;
         else
             return 0;
     }
-    return resolveViewportPercentageUnit<type, axis>(*renderView) / renderView->pageZoomFactor();
-}
 
-template<ViewportType type, LogicalBoxAxis axis>
-static double resolveViewportPercentageUnit(const RenderView* renderView, const ComputedStyle* style)
-{
-    if (!renderView)
-        return 0;
-    return resolveViewportPercentageUnit<type, axis>(*renderView, style) / renderView->pageZoomFactor();
+    return resolveViewportAxis<axis>(resolveViewportType<type>(*renderView), *renderView, adaptor) / 100.0 / renderView->pageZoomFactor();
 }
 
 // MARK: - "container-percentage" resolution functions
@@ -540,80 +521,56 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
     // MARK: "viewport-percentage" resolution
 
     case Vh:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Height>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Height>(adaptor);
     case Vw:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Width>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Width>(adaptor);
     case Vmax:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Max>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Max>(adaptor);
     case Vmin:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Min>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Min>(adaptor);
     case Vb:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Block>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Block>(adaptor);
     case Vi:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Inline>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Default, ViewportDimension::Inline>(adaptor);
 
     case Svh:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Height>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Height>(adaptor);
     case Svw:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Width>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Width>(adaptor);
     case Svmax:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Max>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Max>(adaptor);
     case Svmin:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Min>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Min>(adaptor);
     case Svb:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Block>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Block>(adaptor);
     case Svi:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Inline>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Small, ViewportDimension::Inline>(adaptor);
 
     case Lvh:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Height>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Height>(adaptor);
     case Lvw:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Width>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Width>(adaptor);
     case Lvmax:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Max>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Max>(adaptor);
     case Lvmin:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Min>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Min>(adaptor);
     case Lvb:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Block>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Block>(adaptor);
     case Lvi:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Inline>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Large, ViewportDimension::Inline>(adaptor);
 
     case Dvh:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Height>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Height>(adaptor);
     case Dvw:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Width>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Width>(adaptor);
     case Dvmax:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Max>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Max>(adaptor);
     case Dvmin:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Min>(adaptor.renderViewForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Min>(adaptor);
     case Dvb:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Block>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Block>(adaptor);
     case Dvi:
-        adaptor.setUsesViewportUnits();
-        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Inline>(adaptor.renderViewForViewportUnits(), adaptor.styleForViewportUnits());
+        return value * resolveViewportUnit<ViewportType::Dynamic, ViewportDimension::Inline>(adaptor);
 
     // MARK: "container-percentage" resolution
 


### PR DESCRIPTION
#### ae6f786db13d0bc15dfe1726dd5c0ada20843e5c
<pre>
[Cleanup] Streamline the viewport-percentage unit resolution functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=322518">https://bugs.webkit.org/show_bug.cgi?id=322518</a>

Reviewed by Darin Adler.

Simplify the logic for viewport-percentage unit resolution, removing a
bit of duplicate logic.

* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::resolveViewportLogicalAxis):
(WebCore::Style::resolveViewportAxis):
(WebCore::Style::resolveViewportType):
(WebCore::Style::resolveViewportUnit):
(WebCore::Style::resolveLengthImpl):
(WebCore::Style::resolveViewportPercentagePhysicalAxis): Deleted.
(WebCore::Style::resolveViewportPercentageLogicalAxis): Deleted.
(WebCore::Style::resolveViewportPercentageUnit): Deleted.

Canonical link: <a href="https://commits.webkit.org/319862@main">https://commits.webkit.org/319862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9d7d007e55c91b0da910f60debbab244b558a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43387 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43018 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4260 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56462 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152187 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40808 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57167 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151884 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46448 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129436 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55675 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->