### PR TITLE
Speculative fix for result loss in Results DB

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context.py
@@ -23,6 +23,7 @@
 import calendar
 import io
 import json
+import sys
 import time
 import zipfile
 
@@ -185,9 +186,13 @@ class UploadContext(object):
                     timestamp=data['timestamp'],
                     test_results=data['test_results'],
                 )
+            else:
+                sys.stderr.write(f'Discarding queued upload {key}, no data is associated with it\n')
             job_complete = True
         finally:
             if job_complete or attempts >= self.MAX_ATTEMPTS:
+                if not job_complete:
+                    sys.stderr.write(f'Discarding queued upload {key} after {attempts} attempts to process it\n')
                 self.redis.delete(key)
                 self.redis.delete(f'data_for_{key}')
             else:
@@ -220,11 +225,7 @@ class UploadContext(object):
 
         for branch in self.commit_context.branch_keys_for_commits(commits):
             hash_key = hash(configuration) ^ hash(branch) ^ hash(self.commit_context.uuid_for_commits(commits)) ^ hash(suite) ^ hash(timestamp)
-            self.redis.set(
-                f'{self.QUEUE_NAME}:{hash_key}',
-                json.dumps(dict(started_processing=0, attempts=0)),
-                ex=self.PROCESS_TIMEOUT,
-            )
+            # The data is written first so that a worker never finds a job it cannot process.
             self.redis.set(
                 f'data_for_{self.QUEUE_NAME}:{hash_key}',
                 json.dumps(dict(
@@ -234,6 +235,11 @@ class UploadContext(object):
                     timestamp=timestamp,
                     test_results=test_results,
                 )),
+                ex=self.PROCESS_TIMEOUT,
+            )
+            self.redis.set(
+                f'{self.QUEUE_NAME}:{hash_key}',
+                json.dumps(dict(started_processing=0, attempts=0)),
                 ex=self.PROCESS_TIMEOUT,
             )
         return {key: dict(status='Queued') for key in list(self._process_upload_callbacks[suite].keys()) + list(self._process_upload_callbacks[None].keys())}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context_unittest.py
@@ -170,3 +170,62 @@ class UploadContextTest(WaitForDockerTestCase):
             self.assertEqual(0, len(self.model.suite_context.find_by_commit(configurations=[Configuration()], suite='layout-tests')))
             self.assertTrue(self.model.upload_context.do_processing_work())
             self.assertEqual(1, len(self.model.suite_context.find_by_commit(configurations=[Configuration()], suite='layout-tests')))
+
+    def _queue_one_upload(self):
+        configuration_to_search = Configuration(platform='iOS', version='12.0.0', is_simulator=True, style='Asan')
+        configuration, uploads = next(iter(self.model.upload_context.find_test_results(configurations=[configuration_to_search], suite='layout-tests', recent=False).items()))
+        self.model.upload_context.process_test_results(
+            configuration=configuration,
+            commits=uploads[0]['commits'],
+            suite='layout-tests',
+            test_results=uploads[0]['test_results'],
+            timestamp=uploads[0]['timestamp'],
+        )
+        keys = [key.decode('utf-8') for key in self.model.redis.scan_iter(match=f'{UploadContext.QUEUE_NAME}*')]
+        self.assertEqual(1, len(keys))
+        return keys[0]
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_async_data_written_before_job(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra, async_processing=True)
+        MockModelFactory.add_mock_results(self.model)
+
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            key = self._queue_one_upload()
+
+            # A worker which finds a queued upload must always be able to process it.
+            self.assertIsNotNone(self.model.redis.get(f'data_for_{key}'))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_async_upload_without_data_is_reported(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra, async_processing=True)
+        MockModelFactory.add_mock_results(self.model)
+
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            key = self._queue_one_upload()
+            self.model.redis.delete(f'data_for_{key}')
+
+            self.model.upload_context.do_processing_work()
+            self.assertEqual(0, len(self.model.suite_context.find_by_commit(configurations=[Configuration()], suite='layout-tests')))
+            self.assertIsNone(self.model.redis.get(key))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_async_upload_dropped_after_max_attempts(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra, async_processing=True)
+        MockModelFactory.add_mock_results(self.model)
+
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            key = self._queue_one_upload()
+
+            def failing_callback(**kwargs):
+                raise RuntimeError('Simulated processing failure')
+
+            self.model.upload_context.register_upload_callback('failing', failing_callback)
+
+            for _ in range(UploadContext.MAX_ATTEMPTS):
+                self.assertIsNotNone(self.model.redis.get(key))
+                with self.assertRaises(RuntimeError):
+                    self.model.upload_context.do_processing_work()
+
+            self.assertIsNone(self.model.redis.get(key))
+            self.assertIsNone(self.model.redis.get(f'data_for_{key}'))


### PR DESCRIPTION
#### fa839d61bf1ac7624bfa8bbedd6d5a13ee6191e1
<pre>
Speculative fix for result loss in Results DB
<a href="https://bugs.webkit.org/show_bug.cgi?id=322523">https://bugs.webkit.org/show_bug.cgi?id=322523</a>
<a href="https://rdar.apple.com/185825119">rdar://185825119</a>

Reviewed by NOBODY (OOPS!).

1. Write the payload before the job that references it; a worker scanning mid-enqueue now
sees either nothing or a complete job.

2. Make both discard paths visible  in logs. Two sys.stderr.write calls in _do_job_for_key — one
when a queued job has no payload, one when a job is dropped after MAX_ATTEMPTS. sys.stderr
matches what model.py and ci_context.py already do here.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context.py:
(UploadContext._do_job_for_key):
(UploadContext.process_test_results):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/upload_context_unittest.py:
(UploadContextTest.test_async_callback):
(UploadContextTest):
(UploadContextTest._queue_one_upload):
(UploadContextTest.test_async_data_written_before_job):
(UploadContextTest.test_async_upload_without_data_is_reported):
(UploadContextTest.test_async_upload_dropped_after_max_attempts):
(UploadContextTest.test_async_upload_dropped_after_max_attempts.failing_callback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa839d61bf1ac7624bfa8bbedd6d5a13ee6191e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147171 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72997c92-4253-4023-81bf-731558f01ab4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142743 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99120 "2 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32645cb7-b2ee-4466-9275-2caaaf75b18f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f33ef885-78a4-44ca-9b00-a70bf2ad8ebd) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182209 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45152 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43398 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43029 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4273 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195041 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182286 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56475 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152199 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151896 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46458 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125532 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55688 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18039 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55059 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->