### PR TITLE
[JSC][Wasm] Inline table.set for externref and anyref

### DIFF
--- a/JSTests/wasm/stress/table-set-externref.js
+++ b/JSTests/wasm/stress/table-set-externref.js
@@ -1,0 +1,39 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+  (table $table 1 externref)
+  (func (export "get") (param i32) (result externref)
+    (table.get $table (local.get 0)))
+  (func (export "set") (param i32 externref)
+    (table.set $table (local.get 0) (local.get 1)))
+  (func (export "setNull") (param i32)
+    (table.set $table (local.get 0) (ref.null extern)))
+  (func (export "grow") (param i32) (result i32)
+    (table.grow $table (ref.null extern) (local.get 0)))
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { reference_types: true });
+    const { get, set, setNull, grow } = instance.exports;
+    const obj = { x: 1 };
+
+    assert.eq(get(0), null);
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        set(0, obj);
+        assert.eq(get(0), obj);
+        setNull(0);
+        assert.eq(get(0), null);
+    }
+
+    assert.eq(grow(1), 1);
+    set(1, obj);
+    assert.eq(get(1), obj);
+
+    assert.throws(() => set(2, obj), WebAssembly.RuntimeError, "Out of bounds table access (evaluating 'func(...args)')");
+    assert.throws(() => get(2), WebAssembly.RuntimeError, "Out of bounds table access (evaluating 'func(...args)')");
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -202,6 +202,7 @@ namespace JSC::B3 {
     macro(WasmRTT_displaySizeExcludingThis, Wasm::RTT::offsetOfDisplaySizeExcludingThis(), Mutability::Immutable) \
     macro(WasmRTT_kind, Wasm::RTT::offsetOfKind(), Mutability::Immutable) \
     macro(WasmTable_length, Wasm::Table::offsetOfLength(), Mutability::Mutable) \
+    macro(WasmTable_owner, Wasm::Table::offsetOfOwner(), Mutability::Immutable) \
     macro(WasmExternOrAnyRefTable_jsValues, Wasm::ExternOrAnyRefTable::offsetOfJSValues(), Mutability::Mutable) \
     macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity(), Mutability::Mutable) \
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer(), Mutability::Mutable) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -826,33 +826,6 @@ void BBQJIT::emitZeroExtendAddressOperand(bool is64Bit, Value operand)
 
 // Tables
 
-[[nodiscard]] PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
-{
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    ASSERT(index.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
-
-    emitZeroExtendAddressOperand(m_info.table(tableIndex).addressType().is64Bit(), index);
-
-    Vector<Value, 8> arguments = {
-        instanceValue(),
-        Value::fromI32(tableIndex),
-        index,
-        value
-    };
-
-    Value shouldThrow = topValue(TypeKind::I32);
-    emitCCall(&operationSetWasmTableElement, arguments, shouldThrow);
-    Location shouldThrowLocation = loadIfNecessary(shouldThrow);
-
-    LOG_INSTRUCTION("TableSet", tableIndex, index, value);
-
-    recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
-
-    consume(shouldThrow);
-
-    return { };
-}
-
 [[nodiscard]] PartialResult BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
 {
     ASSERT(dstOffset.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -154,6 +154,74 @@ Value BBQJIT::instanceValue()
 }
 
 // Tables
+[[nodiscard]] PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
+{
+    auto& table = m_info.table(tableIndex);
+    ASSERT(index.type() == table.addressType().asWasmTypeKind());
+
+    emitZeroExtendAddressOperand(table.addressType().is64Bit(), index);
+
+    if (table.type() == TableElementType::Funcref) {
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(tableIndex),
+            index,
+            value
+        };
+
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationSetWasmTableElement, arguments, shouldThrow);
+        Location shouldThrowLocation = loadIfNecessary(shouldThrow);
+
+        LOG_INSTRUCTION("TableSet", tableIndex, index, value);
+
+        recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
+        consume(shouldThrow);
+        return { };
+    }
+
+    Location valueLocation;
+    if (!value.isConst())
+        valueLocation = loadIfNecessary(value);
+
+    {
+        ScratchScope<3, 0> scratches(*this, value.isConst() ? Location::none() : valueLocation);
+        if (value.isConst()) {
+            valueLocation = Location::fromGPR(scratches.gpr(2));
+            emitMoveConst(value, valueLocation);
+        }
+
+        GPRReg tableGPR = scratches.gpr(0);
+        GPRReg scratchGPR = scratches.gpr(1);
+
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)), tableGPR);
+        m_jit.load32(Address(tableGPR, Table::offsetOfLength()), scratchGPR);
+
+        GPRReg indexGPR;
+        if (index.isConst()) {
+            uint64_t indexValue = table.addressType().is64Bit() ? static_cast<uint64_t>(index.asI64()) : static_cast<uint32_t>(index.asI32());
+            recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branch64(RelationalCondition::BelowOrEqual, scratchGPR, TrustedImm64(indexValue)));
+            m_jit.move(TrustedImm64(indexValue), scratchGPR);
+            indexGPR = scratchGPR;
+        } else {
+            indexGPR = loadIfNecessary(index).asGPR();
+            recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, indexGPR, scratchGPR));
+        }
+
+        m_jit.loadPtr(Address(tableGPR, Table::offsetOfOwner()), wasmScratchGPR);
+        m_jit.loadPtr(Address(tableGPR, ExternOrAnyRefTable::offsetOfJSValues()), tableGPR);
+        static_assert(sizeof(WriteBarrier<Unknown>) == 8);
+        m_jit.store64(valueLocation.asGPR(), MacroAssembler::BaseIndex(tableGPR, indexGPR, MacroAssembler::TimesEight));
+        emitWriteBarrier(wasmScratchGPR);
+    }
+
+    consume(index);
+    consume(value);
+
+    LOG_INSTRUCTION("TableSet", tableIndex, index, value);
+    return { };
+}
+
 [[nodiscard]] PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     auto& table = m_info.table(tableIndex);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1769,18 +1769,49 @@ auto OMGIRGenerator::addTableGet(unsigned tableIndex, ExpressionType index, Expr
 
 auto OMGIRGenerator::addTableSet(unsigned tableIndex, ExpressionType index, ExpressionType value) -> PartialResult
 {
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    auto shouldThrow = callWasmOperation(m_currentBlock, B3::Int32, operationSetWasmTableElement,
-        instanceValue(), constant(Int32, tableIndex), addressOperand(m_info.table(tableIndex).addressType().is64Bit(), index), get(value));
-    {
+    auto& tableInformation = m_info.table(tableIndex);
+    if (tableInformation.type() == TableElementType::Funcref) {
+        auto shouldThrow = callWasmOperation(m_currentBlock, B3::Int32, operationSetWasmTableElement,
+            instanceValue(), constant(Int32, tableIndex), addressOperand(tableInformation.addressType().is64Bit(), index), get(value));
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), shouldThrow, constant(Int32, 0)));
-
         check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsTableAccess);
         });
+        return { };
     }
 
+    auto* table = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)));
+    m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_tables[tableIndex], table);
+    table->setReadsMutability(B3::Mutability::Immutable);
+    table->setControlDependent(false);
+
+    Value* indexValue = addressOperand(tableInformation.addressType().is64Bit(), index);
+    auto* length32 = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), table, safeCast<int32_t>(Table::offsetOfLength()));
+    m_heaps.decorateMemory(&m_heaps.WasmTable_length, length32);
+    Value* length = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), length32);
+
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), indexValue, length));
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsTableAccess);
+    });
+
+    auto* owner = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), table, safeCast<int32_t>(Table::offsetOfOwner()));
+    m_heaps.decorateMemory(&m_heaps.WasmTable_owner, owner);
+    owner->setReadsMutability(B3::Mutability::Immutable);
+    owner->setControlDependent(false);
+
+    auto* jsValues = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), table, safeCast<int32_t>(ExternOrAnyRefTable::offsetOfJSValues()));
+    m_heaps.decorateMemory(&m_heaps.WasmExternOrAnyRefTable_jsValues, jsValues);
+
+    static_assert(sizeof(WriteBarrier<Unknown>) == 8);
+    Value* offset = m_currentBlock->appendNew<Value>(m_proc, Shl, origin(), indexValue, constant(Int32, 3));
+    Value* slot = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), jsValues, offset);
+    auto* store = m_currentBlock->appendNew<MemoryValue>(m_proc, Store, origin(), get(value), slot);
+    m_heaps.decorateMemory(&m_heaps.WasmExternOrAnyRefTable_jsValuesBuffer.atAnyIndex(), store);
+
+    emitWriteBarrier(owner);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -63,6 +63,7 @@ public:
     uint32_t length() const { return m_length; }
 
     static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(Table, m_length); }
+    static constexpr ptrdiff_t offsetOfOwner() { return OBJECT_OFFSETOF(Table, m_owner); }
 
     static uint32_t NODELETE allocatedLength(uint32_t length);
 


### PR DESCRIPTION
#### 98f4e43d7234b514fe1bf6f23c8e3c75b544fa36
<pre>
[JSC][Wasm] Inline table.set for externref and anyref
<a href="https://bugs.webkit.org/show_bug.cgi?id=322519">https://bugs.webkit.org/show_bug.cgi?id=322519</a>

Reviewed by NOBODY (OOPS!).

BBQ and OMG emit a bounds check against Table length, store into
m_jsValues, and write-barrier the owner.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmTable.h:
* JSTests/wasm/stress/table-set-externref.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f4e43d7234b514fe1bf6f23c8e3c75b544fa36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143207 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99433 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43899 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5600 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12441 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43498 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4872 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44752 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195636 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57070 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152404 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130053 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126352 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56282 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18507 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->