### PR TITLE
[Grid Lanes]

### DIFF
--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -34,39 +34,25 @@
 
 namespace WebCore {
 
-void GridLanesLayout::initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection)
+GridLanesLayout::GridLanesLayout(RenderGrid& renderGrid, unsigned gridAxisTracksCount, Style::GridTrackSizingDirection stackingAxisDirection)
+    : m_gridAxisTracksCount(gridAxisTracksCount)
+    , m_runningPositions(gridAxisTracksCount)
+    , m_renderGrid(renderGrid)
+    , m_stackingAxisGridGap(renderGrid.gridGap(stackingAxisDirection))
+    , m_stackingAxisDirection(stackingAxisDirection)
 {
-    // Reset global variables as they may contain state from previous runs of grid lanes layout.
-    m_stackingAxisDirection = stackingAxisDirection;
-    m_stackingAxisGridGap = m_renderGrid->gridGap(m_stackingAxisDirection);
-    m_gridAxisTracksCount = gridAxisTracks;
-    m_gridContentSize = 0;
-    m_itemOffsets.clear();
-
     m_renderGrid->currentGrid().setupForGridLanesLayout();
     m_renderGrid->populateExplicitGridAndOrderIterator();
-
-    resizeAndResetRunningPositions();
 }
 
-void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
+void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
-    initializeGridLanes(gridAxisTracks, stackingAxisDirection);
-
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns, std::cref(*this));
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows, std::cref(*this));
 
     // 4.4 Grid Lanes Layout and Placement Algorithm
     // https://drafts.csswg.org/css-grid-3/#grid-lanes-layout-algorithm
-    // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
-    m_autoFlowNextCursor = 0;
-
     placeGridLanesItems(algorithm, fitTolerance, layoutPhase);
-}
-
-void GridLanesLayout::resizeAndResetRunningPositions()
-{
-    m_runningPositions.fill(LayoutUnit(), m_gridAxisTracksCount);
 }
 
 void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)

--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -29,9 +29,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderGrid.h"
 #include "StyleComputedStyle+GettersInlines.h"
-#include "StyleFitTolerance.h"
 #include "StyleGridPositionsResolver.h"
-#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "WritingMode.h"
 
 namespace WebCore {
@@ -51,7 +49,7 @@ void GridLanesLayout::initializeGridLanes(unsigned gridAxisTracks, Style::GridTr
     resizeAndResetRunningPositions();
 }
 
-void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase layoutPhase)
+void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
     initializeGridLanes(gridAxisTracks, stackingAxisDirection);
 
@@ -63,7 +61,7 @@ void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& 
     // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
     m_autoFlowNextCursor = 0;
 
-    placeGridLanesItems(algorithm, layoutPhase);
+    placeGridLanesItems(algorithm, fitTolerance, layoutPhase);
 }
 
 void GridLanesLayout::resizeAndResetRunningPositions()
@@ -71,7 +69,7 @@ void GridLanesLayout::resizeAndResetRunningPositions()
     m_runningPositions.fill(LayoutUnit(), m_gridAxisTracksCount);
 }
 
-void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)
+void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
     if (!m_gridAxisTracksCount)
         return;
@@ -81,7 +79,7 @@ void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algori
         if (grid.orderIterator().shouldSkipChild(*gridItem))
             continue;
 
-        auto gridArea = hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()) ? gridAreaForDefiniteGridAxisItem(*gridItem) : gridAreaForIndefiniteGridAxisItem(*gridItem);
+        auto gridArea = hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()) ? gridAreaForDefiniteGridAxisItem(*gridItem) : gridAreaForIndefiniteGridAxisItem(*gridItem, fitTolerance);
         insertIntoGridAndLayoutItem(algorithm, *gridItem, gridArea, layoutPhase);
     }
 }
@@ -213,15 +211,12 @@ LayoutUnit GridLanesLayout::maxRunningPositionForSpan(unsigned startLine, unsign
     return maxPosition;
 }
 
-GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
+GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance fitTolerance)
 {
     auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), m_gridAxisTracksCount);
     auto gridAxisLines = m_gridAxisTracksCount + 1;
 
-    // Get fit-tolerance from the grid lanes container's style
-    const auto& tolerance = m_renderGrid->style().fitTolerance();
-
-    if (tolerance.isInfinite()) {
+    if (WTF::holdsAlternative<CSS::Keyword::Infinite>(fitTolerance)) {
         // Infinite tolerance: place items strictly in order without considering track lengths
         // Use round-robin placement starting from the cursor position
         auto startingLine = m_autoFlowNextCursor;
@@ -235,31 +230,7 @@ GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& ite
     }
 
     // For normal and length-percentage tolerances, find positions within tolerance of the shortest track
-    // Calculate tolerance value
-    auto contentBoxSize = gridAxisDirection() == Style::GridTrackSizingDirection::Columns
-        ? m_renderGrid->contentBoxLogicalHeight()
-        : m_renderGrid->contentBoxLogicalWidth();
-
-    LayoutUnit toleranceValue = tolerance.switchOn(
-        [&](const CSS::Keyword::Normal&) -> LayoutUnit {
-            // Normal resolves to 1em
-            return LayoutUnit { m_renderGrid->style().computedFontSize() };
-        },
-        [&](const typename Style::FitTolerance::Fixed& fixed) -> LayoutUnit {
-            return LayoutUnit { fixed.resolveZoom(m_renderGrid->style().usedZoomForLength()) };
-        },
-        [&](const typename Style::FitTolerance::Percentage& percentage) -> LayoutUnit {
-            return Style::evaluate<LayoutUnit>(percentage, contentBoxSize);
-        },
-        [&](const typename Style::FitTolerance::Calc& calc) -> LayoutUnit {
-            return Style::evaluate<LayoutUnit>(calc, contentBoxSize, m_renderGrid->style().usedZoomForLength());
-        },
-        [](const CSS::Keyword::Infinite&) -> LayoutUnit {
-            // This case shouldn't be reached due to the outer if check
-            ASSERT_NOT_REACHED();
-            return LayoutUnit { };
-        }
-    );
+    auto toleranceValue = std::get<LayoutUnit>(fitTolerance);
 
     // Step 1: Find the absolute shortest position across all tracks
     auto maxStartingLine = gridAxisLines - itemSpanLength;

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -52,17 +52,19 @@ public:
         MaxContent
     };
 
-    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase);
+    using ResolvedFitTolerance = Variant<LayoutUnit, CSS::Keyword::Infinite>;
+
+    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, ResolvedFitTolerance, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 
 private:
     void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
 
-    GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
+    GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
-    void placeGridLanesItems(const GridTrackSizingAlgorithm&, Phase);
+    void placeGridLanesItems(const GridTrackSizingAlgorithm&, ResolvedFitTolerance, Phase);
     void setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, Phase);
     LayoutUnit calculateGridLanesIntrinsicLogicalWidth(RenderBox&, Phase);

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -41,10 +41,8 @@ class RenderGrid;
 
 class GridLanesLayout {
 public:
-    GridLanesLayout(RenderGrid& renderGrid)
-        : m_renderGrid(renderGrid)
-    {
-    }
+    // Construction repopulates the grid, so it has to happen immediately before placement.
+    GridLanesLayout(RenderGrid&, unsigned gridAxisTracksCount, Style::GridTrackSizingDirection stackingAxisDirection);
 
     enum class Phase : uint8_t {
         Layout,
@@ -54,13 +52,11 @@ public:
 
     using ResolvedFitTolerance = Variant<LayoutUnit, CSS::Keyword::Infinite>;
 
-    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, ResolvedFitTolerance, Phase);
+    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, ResolvedFitTolerance, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 
 private:
-    void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
-
     GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
@@ -69,7 +65,6 @@ private:
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, Phase);
     LayoutUnit calculateGridLanesIntrinsicLogicalWidth(RenderBox&, Phase);
 
-    void resizeAndResetRunningPositions();
     LayoutUnit stackingAxisMarginBoxForItem(const RenderBox& gridItem);
     void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
     void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
@@ -80,15 +75,15 @@ private:
     GridArea NODELETE gridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
 
-    unsigned m_gridAxisTracksCount { 0 };
+    const unsigned m_gridAxisTracksCount;
 
     Vector<LayoutUnit> m_runningPositions;
     HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;
     const CheckedRef<RenderGrid> m_renderGrid;
-    LayoutUnit m_stackingAxisGridGap;
+    const LayoutUnit m_stackingAxisGridGap;
     LayoutUnit m_gridContentSize;
 
-    Style::GridTrackSizingDirection m_stackingAxisDirection { };
+    const Style::GridTrackSizingDirection m_stackingAxisDirection;
     const GridSpan m_stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
 
     unsigned m_autoFlowNextCursor { 0 };

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -45,6 +45,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
+#include "StyleFitTolerance.h"
 #include "StyleGridPositionsResolver.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <ranges>
@@ -592,6 +593,40 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     return true;
 }
 
+static GridLanesLayout::ResolvedFitTolerance resolveFitTolerance(const RenderGrid& grid, Style::GridTrackSizingDirection stackingAxisDirection)
+{
+    const auto& tolerance = grid.style().fitTolerance();
+    if (tolerance.isInfinite())
+        return CSS::Keyword::Infinite { };
+
+    // Placement tolerance is a distance measured along the stacking axis, so a percentage
+    // resolves against the stacking axis content box size.
+    auto stackingAxisContentBoxSize = stackingAxisDirection == Style::GridTrackSizingDirection::Rows
+        ? grid.contentBoxLogicalHeight()
+        : grid.contentBoxLogicalWidth();
+
+    return tolerance.switchOn(
+        [&](const CSS::Keyword::Normal&) -> LayoutUnit {
+            // Normal resolves to 1em
+            return LayoutUnit { grid.style().computedFontSize() };
+        },
+        [&](const Style::FitTolerance::Fixed& fixed) -> LayoutUnit {
+            return LayoutUnit { fixed.resolveZoom(grid.style().usedZoomForLength()) };
+        },
+        [&](const Style::FitTolerance::Percentage& percentage) -> LayoutUnit {
+            return Style::evaluate<LayoutUnit>(percentage, stackingAxisContentBoxSize);
+        },
+        [&](const Style::FitTolerance::Calc& calc) -> LayoutUnit {
+            return Style::evaluate<LayoutUnit>(calc, stackingAxisContentBoxSize, grid.style().usedZoomForLength());
+        },
+        [](const CSS::Keyword::Infinite&) -> LayoutUnit {
+            // Handled by the isInfinite() early return above.
+            ASSERT_NOT_REACHED();
+            return LayoutUnit { };
+        }
+    );
+}
+
 void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
     LayoutRepainter repainter(*this);
@@ -657,7 +692,7 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
             auto gridAxisDirection = stackingAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
             unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
 
-            gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, GridLanesLayout::Phase::Layout);
+            gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, resolveFitTolerance(*this, stackingAxisDirection), GridLanesLayout::Phase::Layout);
 
             // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
             // placement, but its min-content and max-content results are not what the overlay should
@@ -867,11 +902,12 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
         // To determine the width of the grid when we have a grid lanes layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
         auto gridLanesLayout = GridLanesLayout { const_cast<RenderGrid&>(*this) };
+        auto fitTolerance = resolveFitTolerance(*this, Style::GridTrackSizingDirection::Columns);
 
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MinContent);
+        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, fitTolerance, GridLanesLayout::Phase::MinContent);
         minLogicalWidth = gridLanesLayout.gridContentSize();
 
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MaxContent);
+        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, fitTolerance, GridLanesLayout::Phase::MaxContent);
         maxLogicalWidth = gridLanesLayout.gridContentSize();
     }
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -629,6 +629,8 @@ static GridLanesLayout::ResolvedFitTolerance resolveFitTolerance(const RenderGri
 
 void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
+    ASSERT(isGridLanes());
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -686,24 +688,17 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
         } else
             computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection::Rows, availableLogicalHeight(AvailableLogicalHeightType::ExcludeMarginBorderPadding), gridLayoutState);
 
-        auto gridLanesLayout = GridLanesLayout { *this };
+        auto stackingAxisDirection = hasStackingAxisRows() ? Style::GridTrackSizingDirection::Rows : Style::GridTrackSizingDirection::Columns;
+        auto gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(orthogonalDirection(stackingAxisDirection));
+        auto fitTolerance = resolveFitTolerance(*this, stackingAxisDirection);
 
-        auto performGridLanesPlacement = [&](const Style::GridTrackSizingDirection stackingAxisDirection) {
-            auto gridAxisDirection = stackingAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
-            unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
+        auto gridLanesLayout = GridLanesLayout { *this, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection };
+        gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, fitTolerance, GridLanesLayout::Phase::Layout);
 
-            gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, resolveFitTolerance(*this, stackingAxisDirection), GridLanesLayout::Phase::Layout);
-
-            // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
-            // placement, but its min-content and max-content results are not what the overlay should
-            // be drawing.
-            m_gridLanesContentSizeForWebInspectorOverlay = gridLanesLayout.gridContentSize();
-        };
-
-        if (hasStackingAxisRows())
-            performGridLanesPlacement(Style::GridTrackSizingDirection::Rows);
-        else if (hasStackingAxisColumns())
-            performGridLanesPlacement(Style::GridTrackSizingDirection::Columns);
+        // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
+        // placement, but its min-content and max-content results are not what the overlay should
+        // be drawing.
+        m_gridLanesContentSizeForWebInspectorOverlay = gridLanesLayout.gridContentSize();
 
         LayoutUnit trackBasedLogicalHeight = borderAndPaddingLogicalHeight() + scrollbarLogicalHeight();
         if (auto size = explicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection::Rows))
@@ -901,14 +896,17 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
 
         // To determine the width of the grid when we have a grid lanes layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
-        auto gridLanesLayout = GridLanesLayout { const_cast<RenderGrid&>(*this) };
         auto fitTolerance = resolveFitTolerance(*this, Style::GridTrackSizingDirection::Columns);
 
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, fitTolerance, GridLanesLayout::Phase::MinContent);
-        minLogicalWidth = gridLanesLayout.gridContentSize();
+        // Constructing a GridLanesLayout clears the grid, so the track count both runs are given
+        // has to be the one taken before either of them placed anything.
+        auto minContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
+        minContentLayout.performGridLanesPlacement(algorithm, fitTolerance, GridLanesLayout::Phase::MinContent);
+        minLogicalWidth = minContentLayout.gridContentSize();
 
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, fitTolerance, GridLanesLayout::Phase::MaxContent);
-        maxLogicalWidth = gridLanesLayout.gridContentSize();
+        auto maxContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
+        maxContentLayout.performGridLanesPlacement(algorithm, fitTolerance, GridLanesLayout::Phase::MaxContent);
+        maxLogicalWidth = maxContentLayout.gridContentSize();
     }
 
     m_grid.resetCurrentGrid();


### PR DESCRIPTION
#### d4b79307d417d13c63affd76d1f56b4cffcdd521
<pre>
[Grid Lanes] Initialize GridLanesLayout in its constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=322532">https://bugs.webkit.org/show_bug.cgi?id=322532</a>
<a href="https://rdar.apple.com/problem/185827725">rdar://problem/185827725</a>

Reviewed by NOBODY (OOPS!).

GridLanesLayout had an initializeGridLanes() that reset every member at the start
of each placement run, because the object used to live on RenderGrid and was reused
across layouts. Now that it is a stack local the only thing still forcing a reset
was computeIntrinsicLogicalWidths(), which performed two placement runs on a single
object. Give each run its own GridLanesLayout and the setup can move into the
constructor, where it is harder to end up with a half initialized object.

Every mutable member was already reset per run, so a new object per run is
equivalent to resetting one. m_gridContentSize, m_itemOffsets and
m_autoFlowNextCursor now rely on default construction, and the rest is set in the
member initializer list.

* Source/WebCore/rendering/GridLanesLayout.cpp:
(WebCore::GridLanesLayout::GridLanesLayout):
Take the grid axis track count and the stacking axis direction, and do what
initializeGridLanes() used to do. resizeAndResetRunningPositions() had no other
caller so it is folded in here.

(WebCore::GridLanesLayout::performGridLanesPlacement):
Drop the two parameters that moved to the constructor. The explicit
m_autoFlowNextCursor reset goes with them, since a freshly constructed object
already starts at 0.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGridLanes):
The stacking axis direction is now needed before the object is constructed.
isGridLanes() is defined as &quot;one of the two axes is the stacking axis&quot;, so there is
always one here and it can be picked with a ternary. That removes the need for the
lambda, which only existed to share a body between the rows and columns cases.

(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
Construct a GridLanesLayout per phase. Both are given the track count computed
before either run placed anything, which is what the single reused object was
given.
</pre>
----------------------------------------------------------------------
#### 24a9adc98369b82240e35ed67602099f7ad05444
<pre>
[Grid Lanes] Resolve fit-tolerance outside of GridLanesLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=322508">https://bugs.webkit.org/show_bug.cgi?id=322508</a>
<a href="https://rdar.apple.com/problem/185811508">rdar://problem/185811508</a>

Reviewed by NOBODY (OOPS!).

GridLanesLayout should not need to know about the legacy render tree grid
implementation. As a step in that direction, stop having it consult the grid
container&apos;s style to resolve fit-tolerance. RenderGrid now resolves the style
value into a used value up front and passes it in, so the placement code only
ever deals with an already resolved length, or the infinite keyword.

This removes the reads on the grid container that existed solely to compute the
tolerance: style().fitTolerance(), style().computedFontSize(),
style().usedZoomForLength(), contentBoxLogicalWidth() and
contentBoxLogicalHeight().

Resolving once per placement run instead of once per auto placed item is not a
behavior change. Nothing in the placement loop mutates the container&apos;s content
box, and the container&apos;s logical height is not set until after placement has
finished.

* Source/WebCore/rendering/GridLanesLayout.h:
Add ResolvedFitTolerance, which is either the used length or the infinite
keyword. It is only needed while items are being placed, so it is threaded
through placement rather than stored as a member.

* Source/WebCore/rendering/GridLanesLayout.cpp:
Drop the StyleFitTolerance.h and StylePrimitiveNumericTypes+Evaluation.h includes,
which were only needed by the resolution that moved out.
(WebCore::GridLanesLayout::performGridLanesPlacement):
(WebCore::GridLanesLayout::placeGridLanesItems):
(WebCore::GridLanesLayout::gridAreaForIndefiniteGridAxisItem):
Take the resolved tolerance as a parameter and pass it down to
gridAreaForIndefiniteGridAxisItem(), which is the only thing that uses it.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::resolveFitTolerance):
The moved resolution, which is why StyleFitTolerance.h is now included here. A
percentage resolves against the stacking axis content box size, since the
tolerance is a distance measured along the stacking axis. The local is named for
that axis so it is harder to misread which one applies.
(WebCore::RenderGrid::layoutGridLanes):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
Resolve the tolerance and hand it to performGridLanesPlacement(). The intrinsic
width path runs placement twice, so it resolves once and reuses the value.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4b79307d417d13c63affd76d1f56b4cffcdd521

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193104 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55e4b664-a5c1-4749-a845-2d48a92d1517) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f1b8017-47c5-486d-986c-3cbd2347a481) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46463 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123176 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b39e5746-d58e-4df3-9880-71a37e96cd69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45155 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43036 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4277 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49457 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195045 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56479 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152204 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57184 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151901 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46464 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125537 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55692 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18046 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->