### PR TITLE
[Grid Lanes] Initialize GridLanesLayout in its constructor

### DIFF
--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -36,39 +36,25 @@
 
 namespace WebCore {
 
-void GridLanesLayout::initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection)
+GridLanesLayout::GridLanesLayout(RenderGrid& renderGrid, unsigned gridAxisTracksCount, Style::GridTrackSizingDirection stackingAxisDirection)
+    : m_gridAxisTracksCount(gridAxisTracksCount)
+    , m_runningPositions(gridAxisTracksCount)
+    , m_renderGrid(renderGrid)
+    , m_stackingAxisGridGap(renderGrid.gridGap(stackingAxisDirection))
+    , m_stackingAxisDirection(stackingAxisDirection)
 {
-    // Reset global variables as they may contain state from previous runs of grid lanes layout.
-    m_stackingAxisDirection = stackingAxisDirection;
-    m_stackingAxisGridGap = m_renderGrid->gridGap(m_stackingAxisDirection);
-    m_gridAxisTracksCount = gridAxisTracks;
-    m_gridContentSize = 0;
-    m_itemOffsets.clear();
-
     m_renderGrid->currentGrid().setupForGridLanesLayout();
     m_renderGrid->populateExplicitGridAndOrderIterator();
-
-    resizeAndResetRunningPositions();
 }
 
-void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase layoutPhase)
+void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)
 {
-    initializeGridLanes(gridAxisTracks, stackingAxisDirection);
-
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Columns, std::cref(*this));
     m_renderGrid->populateGridPositionsForDirection(algorithm, Style::GridTrackSizingDirection::Rows, std::cref(*this));
 
     // 4.4 Grid Lanes Layout and Placement Algorithm
     // https://drafts.csswg.org/css-grid-3/#grid-lanes-layout-algorithm
-    // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
-    m_autoFlowNextCursor = 0;
-
     placeGridLanesItems(algorithm, layoutPhase);
-}
-
-void GridLanesLayout::resizeAndResetRunningPositions()
-{
-    m_runningPositions.fill(LayoutUnit(), m_gridAxisTracksCount);
 }
 
 void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, Phase layoutPhase)

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -41,10 +41,8 @@ class RenderGrid;
 
 class GridLanesLayout {
 public:
-    GridLanesLayout(RenderGrid& renderGrid)
-        : m_renderGrid(renderGrid)
-    {
-    }
+    // Construction repopulates the grid, so it has to happen immediately before placement.
+    GridLanesLayout(RenderGrid&, unsigned gridAxisTracksCount, Style::GridTrackSizingDirection stackingAxisDirection);
 
     enum class Phase : uint8_t {
         Layout,
@@ -52,13 +50,11 @@ public:
         MaxContent
     };
 
-    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection, Phase);
+    void performGridLanesPlacement(const GridTrackSizingAlgorithm&, Phase);
     LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 
 private:
-    void initializeGridLanes(unsigned gridAxisTracks, Style::GridTrackSizingDirection stackingAxisDirection);
-
     GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
@@ -67,7 +63,6 @@ private:
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, Phase);
     LayoutUnit calculateGridLanesIntrinsicLogicalWidth(RenderBox&, Phase);
 
-    void resizeAndResetRunningPositions();
     LayoutUnit stackingAxisMarginBoxForItem(const RenderBox& gridItem);
     void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
     void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
@@ -78,15 +73,15 @@ private:
     GridArea NODELETE gridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
 
-    unsigned m_gridAxisTracksCount { 0 };
+    const unsigned m_gridAxisTracksCount;
 
     Vector<LayoutUnit> m_runningPositions;
     HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;
     const CheckedRef<RenderGrid> m_renderGrid;
-    LayoutUnit m_stackingAxisGridGap;
+    const LayoutUnit m_stackingAxisGridGap;
     LayoutUnit m_gridContentSize;
 
-    Style::GridTrackSizingDirection m_stackingAxisDirection { };
+    const Style::GridTrackSizingDirection m_stackingAxisDirection;
     const GridSpan m_stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
 
     unsigned m_autoFlowNextCursor { 0 };

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -594,6 +594,8 @@ bool RenderGrid::layoutUsingGridFormattingContext()
 
 void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
+    ASSERT(isGridLanes());
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -651,24 +653,16 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
         } else
             computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection::Rows, availableLogicalHeight(AvailableLogicalHeightType::ExcludeMarginBorderPadding), gridLayoutState);
 
-        auto gridLanesLayout = GridLanesLayout { *this };
+        auto stackingAxisDirection = hasStackingAxisRows() ? Style::GridTrackSizingDirection::Rows : Style::GridTrackSizingDirection::Columns;
+        auto gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(orthogonalDirection(stackingAxisDirection));
 
-        auto performGridLanesPlacement = [&](const Style::GridTrackSizingDirection stackingAxisDirection) {
-            auto gridAxisDirection = stackingAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
-            unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
+        auto gridLanesLayout = GridLanesLayout { *this, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection };
+        gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, GridLanesLayout::Phase::Layout);
 
-            gridLanesLayout.performGridLanesPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, stackingAxisDirection, GridLanesLayout::Phase::Layout);
-
-            // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
-            // placement, but its min-content and max-content results are not what the overlay should
-            // be drawing.
-            m_gridLanesContentSizeForWebInspectorOverlay = gridLanesLayout.gridContentSize();
-        };
-
-        if (hasStackingAxisRows())
-            performGridLanesPlacement(Style::GridTrackSizingDirection::Rows);
-        else if (hasStackingAxisColumns())
-            performGridLanesPlacement(Style::GridTrackSizingDirection::Columns);
+        // Only the layout phase records this. computeIntrinsicLogicalWidths() also performs
+        // placement, but its min-content and max-content results are not what the overlay should
+        // be drawing.
+        m_gridLanesContentSizeForWebInspectorOverlay = gridLanesLayout.gridContentSize();
 
         LayoutUnit trackBasedLogicalHeight = borderAndPaddingLogicalHeight() + scrollbarLogicalHeight();
         if (auto size = explicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection::Rows))
@@ -866,13 +860,15 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeIntrinsicLogicalWidths() co
 
         // To determine the width of the grid when we have a grid lanes layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
-        auto gridLanesLayout = GridLanesLayout { const_cast<RenderGrid&>(*this) };
+        // Constructing a GridLanesLayout clears the grid, so the track count both runs are given
+        // has to be the one taken before either of them placed anything.
+        auto minContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
+        minContentLayout.performGridLanesPlacement(algorithm, GridLanesLayout::Phase::MinContent);
+        minLogicalWidth = minContentLayout.gridContentSize();
 
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MinContent);
-        minLogicalWidth = gridLanesLayout.gridContentSize();
-
-        gridLanesLayout.performGridLanesPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns, GridLanesLayout::Phase::MaxContent);
-        maxLogicalWidth = gridLanesLayout.gridContentSize();
+        auto maxContentLayout = GridLanesLayout { const_cast<RenderGrid&>(*this), gridAxisTracksCountBeforeAutoPlacement, Style::GridTrackSizingDirection::Columns };
+        maxContentLayout.performGridLanesPlacement(algorithm, GridLanesLayout::Phase::MaxContent);
+        maxLogicalWidth = maxContentLayout.gridContentSize();
     }
 
     m_grid.resetCurrentGrid();


### PR DESCRIPTION
#### 4087ab818e4949f1d63a8c4c54fd08369b48f420
<pre>
[Grid Lanes] Initialize GridLanesLayout in its constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=322532">https://bugs.webkit.org/show_bug.cgi?id=322532</a>
<a href="https://rdar.apple.com/problem/185827725">rdar://problem/185827725</a>

Reviewed by Tim Nguyen.

GridLanesLayout had an initializeGridLanes() that reset every member at the start
of each placement run, because the object used to live on RenderGrid and was reused
across layouts. Now that it is a stack local the only thing still forcing a reset
was computeIntrinsicLogicalWidths(), which performed two placement runs on a single
object. Give each run its own GridLanesLayout and the setup can move into the
constructor, where it is harder to end up with a half initialized object.

Every mutable member was already reset per run, so a new object per run is
equivalent to resetting one. m_gridContentSize, m_itemOffsets and
m_autoFlowNextCursor now rely on default construction, and the rest is set in the
member initializer list.

* Source/WebCore/rendering/GridLanesLayout.cpp:
(WebCore::GridLanesLayout::GridLanesLayout):
Take the grid axis track count and the stacking axis direction, and do what
initializeGridLanes() used to do. resizeAndResetRunningPositions() had no other
caller so it is folded in here.

(WebCore::GridLanesLayout::performGridLanesPlacement):
Drop the two parameters that moved to the constructor. The explicit
m_autoFlowNextCursor reset goes with them, since a freshly constructed object
already starts at 0.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGridLanes):
The stacking axis direction is now needed before the object is constructed.
isGridLanes() is defined as &quot;one of the two axes is the stacking axis&quot;, so there is
always one here and it can be picked with a ternary. That removes the need for the
lambda, which only existed to share a body between the rows and columns cases.

(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
Construct a GridLanesLayout per phase. Both are given the track count computed
before either run placed anything, which is what the single reused object was
given.

Canonical link: <a href="https://commits.webkit.org/319840@main">https://commits.webkit.org/319840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/697d2e9da7999e0d2f9be24d78c5cc6875fd3405

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147178 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7209ddb-140e-4c90-8ab3-8943976811ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5054c1a7-8036-4f58-a4e5-3e00fa6844f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46469 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/188bb4a2-356c-4a13-975a-92f94be0ef55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43406 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43043 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4280 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195048 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56482 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40787 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57187 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151904 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46471 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129456 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55695 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18053 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->