### PR TITLE
[GFC][Cleanup] Move the grid sizing algorithm into a GridSizer class

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2079,6 +2079,7 @@ layout/formattingContexts/grid/GridItemPlacer.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/GridItemSizingFunctions.cpp
 layout/formattingContexts/grid/GridLayout.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/GridLayoutUtils.cpp @header:RenderStyleGetters
+layout/formattingContexts/grid/GridSizer.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/ImplicitGrid.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/PlacedGridItem.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/TrackSizingAlgorithm.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4440,6 +4440,7 @@
 		A52460C12FF48CE4003567A5 /* GridItemSizingFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460BE2FF48CE4003567A5 /* GridItemSizingFunctions.h */; };
 		A52460C22FF48CE4003567A5 /* GridSizeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460C02FF48CE4003567A5 /* GridSizeTypes.h */; };
 		A52460C52FF48CE4003567A5 /* GridItemPlacer.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460C32FF48CE4003567A5 /* GridItemPlacer.h */; };
+		A52460C82FF48CE4003567A5 /* GridSizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A52460C62FF48CE4003567A5 /* GridSizer.h */; };
 		A52B348F1FA3BDA6008B6246 /* ServiceWorkerDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B34961FA3E290008B6246 /* ServiceWorkerInspectorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B349E1FA41703008B6246 /* WorkerDebuggerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B349C1FA416F8008B6246 /* WorkerDebuggerProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -17663,6 +17664,8 @@
 		A52460C02FF48CE4003567A5 /* GridSizeTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSizeTypes.h; sourceTree = "<group>"; };
 		A52460C32FF48CE4003567A5 /* GridItemPlacer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridItemPlacer.h; sourceTree = "<group>"; };
 		A52460C42FF48CE4003567A5 /* GridItemPlacer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridItemPlacer.cpp; sourceTree = "<group>"; };
+		A52460C62FF48CE4003567A5 /* GridSizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSizer.h; sourceTree = "<group>"; };
+		A52460C72FF48CE4003567A5 /* GridSizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridSizer.cpp; sourceTree = "<group>"; };
 		A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggable.h; sourceTree = "<group>"; };
 		A52B348E1FA3BD79008B6246 /* ServiceWorkerDebuggable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggable.cpp; sourceTree = "<group>"; };
 		A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerInspectorProxy.h; sourceTree = "<group>"; };
@@ -34626,6 +34629,8 @@
 				A5CE23262F35106900179F07 /* GridLayoutState.h */,
 				A5AFABC22E8C5D4900485152 /* GridLayoutUtils.cpp */,
 				A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */,
+				A52460C72FF48CE4003567A5 /* GridSizer.cpp */,
+				A52460C62FF48CE4003567A5 /* GridSizer.h */,
 				A52460C02FF48CE4003567A5 /* GridSizeTypes.h */,
 				A5FA576D2E85F8A400EF058F /* GridTypeAliases.h */,
 				A532262E2E7492C100DDFA5E /* ImplicitGrid.cpp */,
@@ -45943,6 +45948,7 @@
 				A5AC7CAD2F4E9AC700981859 /* GridLayoutConstraints.h in Headers */,
 				A5CE23272F35106E00179F07 /* GridLayoutState.h in Headers */,
 				A5AFABC32E8C5D5000485152 /* GridLayoutUtils.h in Headers */,
+				A52460C82FF48CE4003567A5 /* GridSizer.h in Headers */,
 				A52460C22FF48CE4003567A5 /* GridSizeTypes.h in Headers */,
 				A51432582DE0CE6E0059FFA1 /* GridSpan.h in Headers */,
 				E12DE7181E4B74A600F9ACCF /* GridTrackSizingAlgorithm.h in Headers */,

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -31,17 +31,15 @@
 #include "GridItemRect.h"
 #include "GridLayoutState.h"
 #include "GridLayoutUtils.h"
+#include "GridSizer.h"
 #include "ImplicitGrid.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutElementBox.h"
-#include "NotImplemented.h"
 #include "PlacedGridItem.h"
 #include "StyleComputedStyle+GettersInlines.h"
-#include "TrackSizingAlgorithm.h"
 #include "TrackSizingFunctions.h"
 #include "UnplacedGridItem.h"
 #include "UsedTrackSizes.h"
-#include <wtf/Range.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -127,14 +125,14 @@ GridLayoutResult GridLayout::layout(const UnplacedGridItems& unplacedGridItems, 
     // on its block size). Steps 2-4 cannot change the column sizes, so size the columns alone and
     // skip row sizing, grid-item layout, and alignment.
     if (scope == GridLayoutScope::ColumnSizingOnly) {
-        TrackSizes columnSizes = sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList, gridLayoutState);
+        TrackSizes columnSizes = GridSizer { formattingContext, gridLayoutState }.sizeColumnsOnlyFastPath(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
         return { { columnSizes, { } }, { } };
     }
 
     // 2. FIXME: Find the size of the grid container.
 
     // 3. Given the resulting grid container size, run the Grid Sizing Algorithm to size the grid.
-    UsedTrackSizes usedTrackSizes = performGridSizingAlgorithm(gridLayoutState, placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
+    UsedTrackSizes usedTrackSizes = GridSizer { formattingContext, gridLayoutState }.sizeGrid(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
 
     CheckedRef formattingContextRootStyle = formattingContext.root().style();
     auto gridAreaSizes = computeGridAreaSizes(placedGridItems, gridLayoutState.usedColumnGap, gridLayoutState.usedRowGap, usedTrackSizes);
@@ -299,145 +297,6 @@ TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCoun
 
     ASSERT(trackSizingFunctions.size() == totalTracksCount);
     return trackSizingFunctions;
-}
-
-// If calculating the layout of a grid item in this step depends on the available space in the block axis,
-// assume the available space that it would have if any row with a definite max track sizing function
-// had that size and all other rows were infinite.
-static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizingFunctionsList& rowTrackSizingFunctionsList, std::optional<LayoutUnit> gridContainerInnerInlineSize)
-{
-    return rowTrackSizingFunctionsList.map([&gridContainerInnerInlineSize](const TrackSizingFunctions& trackSizingFunctions) {
-        return WTF::switchOn(trackSizingFunctions.max,
-            [&](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
-                return Style::evaluate<LayoutUnit>(fixedValue, trackSizingFunctions.zoom);
-            },
-            [&](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
-                ASSERT(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
-                return Style::evaluate<LayoutUnit>(percentageValue, *gridContainerInnerInlineSize);
-            },
-            [&](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
-                ASSERT(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
-                return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, trackSizingFunctions.zoom);
-            },
-            [](const CSS::Keyword::MinContent&) -> LayoutUnit {
-                return LayoutUnit::max();
-            },
-            [](const CSS::Keyword::MaxContent&) {
-                return LayoutUnit::max();
-            },
-            [](const CSS::Keyword::Auto&) -> LayoutUnit {
-                return LayoutUnit::max();
-            },
-            [](const Style::GridTrackBreadth::Flex&) -> LayoutUnit {
-                return LayoutUnit::max();
-            },
-            [](const auto&) -> LayoutUnit {
-                ASSERT_NOT_IMPLEMENTED_YET();
-                return { };
-            });
-    });
-}
-
-// During track sizing we may need to get different types of size contributions for a grid item.
-// Getting a contribution in a specific dimension may require knowing the available space in
-// the opposite dimension. For each of these cases, the spec defines how to compute the available space.
-static LayoutUnit NODELETE oppositeAxisConstraintForTrackSizing(const Vector<LayoutUnit>& oppositeAxisTrackSizes, const WTF::Range<size_t> oppositeAxisSpan)
-{
-    auto totalAvailableSpaceFromSpannedTracks = 0_lu;
-    for (auto oppositeAxisLineIndex : std::views::iota(oppositeAxisSpan.begin(), oppositeAxisSpan.end())) {
-        auto& oppositeAxisTrackSize = oppositeAxisTrackSizes[oppositeAxisLineIndex];
-        if (oppositeAxisTrackSize == LayoutUnit::max())
-            return oppositeAxisTrackSize;
-
-        totalAvailableSpaceFromSpannedTracks += oppositeAxisTrackSize;
-    }
-    return totalAvailableSpaceFromSpannedTracks;
-}
-
-// 1. https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 1.
-// First, the track sizing algorithm is used to resolve the sizes of the grid columns.
-// If calculating the layout of a grid item in this step depends on the available space in the block axis,
-// assume the available space that it would have if any row with a definite max track sizing function had
-// that size and all other rows were infinite. If both the grid container and all tracks have definite sizes,
-// also apply align-content to find the final effective size of any gaps spanned by such items; otherwise
-// ignore the effects of track alignment in this estimation.
-TrackSizes GridLayout::sizeColumnTracks(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
-    const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridLayoutState& layoutState) const
-{
-    auto& layoutConstraints = layoutState.gridLayoutConstraints;
-
-    auto columnFreeSpaceScenario = layoutConstraints.inlineAxis.scenario();
-    std::optional<LayoutUnit> inlineAxisAvailableSpace = columnFreeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite
-        ? std::optional(layoutConstraints.inlineAxis.availableSpace())
-        : std::nullopt;
-    auto rowSizesForFirstColumnSizing = rowSizesForFirstIterationColumnSizing(rowTrackSizingFunctionsList, inlineAxisAvailableSpace);
-
-    auto columnTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
-        auto rowSpan = WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
-        // The inline grid area is indefinite while sizing columns, so the item's cyclic percentage padding resolves against zero.
-        auto usedInlineBorderAndPadding = formattingContext().integrationUtils().borderAndPaddingForGridItem(gridItem.layoutBox(), 0_lu).first;
-        return { gridItem, gridItem.inlineAxisSizes(), usedInlineBorderAndPadding,
-            { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraintForTrackSizing(rowSizesForFirstColumnSizing, rowSpan) };
-    });
-
-    return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
-        layoutConstraints.inlineAxis, GridItemSizingFunctions::inlineAxis(formattingContext().integrationUtils()),
-        layoutState.usedColumnGap, layoutState.usedJustifyContent);
-}
-
-// 2. https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 2.
-// Next, the track sizing algorithm resolves the sizes of the grid rows.
-// To find the inline-axis available space for any items whose block-axis size contributions
-// require it, use the grid column sizes calculated in the previous step.
-TrackSizes GridLayout::sizeRowTracks(const PlacedGridItems& placedGridItems, const TrackSizes& columnSizes,
-    const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridLayoutState& layoutState) const
-{
-    auto& layoutConstraints = layoutState.gridLayoutConstraints;
-
-    auto rowTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
-        auto columnSpan = WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
-        auto columnConstraint = oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan);
-        auto gridAreaInlineSize = GridLayoutUtils::gridAreaDimensionSize(gridItem.columnStartLine(), gridItem.columnEndLine(), columnSizes, layoutState.usedColumnGap);
-        auto usedBlockBorderAndPadding = formattingContext().integrationUtils().borderAndPaddingForGridItem(gridItem.layoutBox(), gridAreaInlineSize).second;
-        return { gridItem, gridItem.blockAxisSizes(), usedBlockBorderAndPadding,
-            { gridItem.rowStartLine(), gridItem.rowEndLine() }, columnConstraint };
-    });
-
-    return TrackSizingAlgorithm::sizeTracks(rowTrackSizingItems, rowTrackSizingFunctionsList,
-        layoutConstraints.blockAxis, GridItemSizingFunctions::blockAxis(formattingContext()),
-        layoutState.usedRowGap, layoutState.usedAlignContent);
-}
-
-// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
-UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& layoutState, const PlacedGridItems& placedGridItems,
-    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
-{
-    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
-    // If both the grid container and all tracks have definite sizes, also apply align-content
-    // to find the final effective size of any gaps spanned by such items; otherwise ignore
-    // the effects of track alignment in this estimation.
-    auto columnSizes = sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList, layoutState);
-
-    // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
-    auto rowSizes = sizeRowTracks(placedGridItems, columnSizes, rowTrackSizingFunctionsList, layoutState);
-
-    // 3. Then, if the min-content contribution of any grid item has changed based on the
-    // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid
-    // columns with the new min-content and max-content contributions (once only).
-    auto resolveGridColumnSizesIfAnyMinContentContributionChanged = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(resolveGridColumnSizesIfAnyMinContentContributionChanged);
-
-    // 4. Next, if the min-content contribution of any grid item has changed based on the
-    // column sizes and alignment calculated in step 3, re-resolve the sizes of the grid
-    // rows with the new min-content and max-content contributions (once only).
-    auto resolveGridRowSizesIfAnyMinContentContributionChanged = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(resolveGridRowSizesIfAnyMinContentContributionChanged);
-
-    return { columnSizes, rowSizes };
 }
 
 // https://drafts.csswg.org/css-grid-1/#auto-margins

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -61,10 +61,6 @@ private:
     static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t implicitTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
     static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, size_t leadingImplicitTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
 
-    UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
-    TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;
-    TrackSizes sizeRowTracks(const PlacedGridItems&, const TrackSizes& columnSizes, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;
-
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&,
         const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridSizer.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridSizer.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GridSizer.h"
+
+#include "GridLayoutState.h"
+#include "GridLayoutUtils.h"
+#include "NotImplemented.h"
+#include "StyleComputedStyle+GettersInlines.h"
+#include "TrackSizingAlgorithm.h"
+#include "TrackSizingFunctions.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+namespace Layout {
+
+GridSizer::GridSizer(const GridFormattingContext& gridFormattingContext, const GridLayoutState& gridLayoutState)
+    : m_gridFormattingContext(gridFormattingContext)
+    , m_gridLayoutState(gridLayoutState)
+{
+}
+
+// If calculating the layout of a grid item in this step depends on the available space in the block axis,
+// assume the available space that it would have if any row with a definite max track sizing function
+// had that size and all other rows were infinite.
+static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizingFunctionsList& rowTrackSizingFunctionsList, std::optional<LayoutUnit> gridContainerInnerInlineSize)
+{
+    return rowTrackSizingFunctionsList.map([&gridContainerInnerInlineSize](const TrackSizingFunctions& trackSizingFunctions) {
+        return WTF::switchOn(trackSizingFunctions.max,
+            [&](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
+                return Style::evaluate<LayoutUnit>(fixedValue, trackSizingFunctions.zoom);
+            },
+            [&](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
+                ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
+                return Style::evaluate<LayoutUnit>(percentageValue, *gridContainerInnerInlineSize);
+            },
+            [&](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
+                ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
+                return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, trackSizingFunctions.zoom);
+            },
+            [](const CSS::Keyword::MinContent&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
+            [](const CSS::Keyword::MaxContent&) {
+                return LayoutUnit::max();
+            },
+            [](const CSS::Keyword::Auto&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
+            [](const Style::GridTrackBreadth::Flex&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
+            [](const auto&) -> LayoutUnit {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            });
+    });
+}
+
+// During track sizing we may need to get different types of size contributions for a grid item.
+// Getting a contribution in a specific dimension may require knowing the available space in
+// the opposite dimension. For each of these cases, the spec defines how to compute the available space.
+static LayoutUnit NODELETE oppositeAxisConstraintForTrackSizing(const Vector<LayoutUnit>& oppositeAxisTrackSizes, const WTF::Range<size_t> oppositeAxisSpan)
+{
+    auto totalAvailableSpaceFromSpannedTracks = 0_lu;
+    for (auto oppositeAxisLineIndex : std::views::iota(oppositeAxisSpan.begin(), oppositeAxisSpan.end())) {
+        auto& oppositeAxisTrackSize = oppositeAxisTrackSizes[oppositeAxisLineIndex];
+        if (oppositeAxisTrackSize == LayoutUnit::max())
+            return oppositeAxisTrackSize;
+
+        totalAvailableSpaceFromSpannedTracks += oppositeAxisTrackSize;
+    }
+    return totalAvailableSpaceFromSpannedTracks;
+}
+
+// Runs the track sizing algorithm over the grid columns. Grid items whose inline-axis contribution
+// depends on the available space in the block axis are given an estimate derived from the row track
+// sizing functions, since the row sizes are not resolved yet.
+TrackSizes GridSizer::sizeColumnTracks(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+{
+    auto& layoutState = this->layoutState();
+    auto& layoutConstraints = layoutState.gridLayoutConstraints;
+
+    auto columnFreeSpaceScenario = layoutConstraints.inlineAxis.scenario();
+    std::optional<LayoutUnit> inlineAxisAvailableSpace = columnFreeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite
+        ? std::optional(layoutConstraints.inlineAxis.availableSpace())
+        : std::nullopt;
+    auto rowSizesForFirstColumnSizing = rowSizesForFirstIterationColumnSizing(rowTrackSizingFunctionsList, inlineAxisAvailableSpace);
+
+    auto columnTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
+        auto rowSpan = WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
+        // The inline grid area is indefinite while sizing columns, so the item's cyclic percentage padding resolves against zero.
+        auto usedInlineBorderAndPadding = formattingContext().integrationUtils().borderAndPaddingForGridItem(gridItem.layoutBox(), 0_lu).first;
+        return { gridItem, gridItem.inlineAxisSizes(), usedInlineBorderAndPadding,
+            { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraintForTrackSizing(rowSizesForFirstColumnSizing, rowSpan) };
+    });
+
+    return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
+        layoutConstraints.inlineAxis, GridItemSizingFunctions::inlineAxis(formattingContext().integrationUtils()),
+        layoutState.usedColumnGap, layoutState.usedJustifyContent);
+}
+
+// Runs the track sizing algorithm over the grid rows. The given column sizes supply the inline-axis
+// available space for grid items whose block-axis contribution needs it.
+TrackSizes GridSizer::sizeRowTracks(const PlacedGridItems& placedGridItems, const TrackSizes& columnSizes,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+{
+    auto& layoutState = this->layoutState();
+
+    auto rowTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
+        auto columnSpan = WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
+        auto columnConstraint = oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan);
+        auto gridAreaInlineSize = GridLayoutUtils::gridAreaDimensionSize(gridItem.columnStartLine(), gridItem.columnEndLine(), columnSizes, layoutState.usedColumnGap);
+        auto usedBlockBorderAndPadding = formattingContext().integrationUtils().borderAndPaddingForGridItem(gridItem.layoutBox(), gridAreaInlineSize).second;
+        return { gridItem, gridItem.blockAxisSizes(), usedBlockBorderAndPadding,
+            { gridItem.rowStartLine(), gridItem.rowEndLine() }, columnConstraint };
+    });
+
+    return TrackSizingAlgorithm::sizeTracks(rowTrackSizingItems, rowTrackSizingFunctionsList,
+        layoutState.gridLayoutConstraints.blockAxis, GridItemSizingFunctions::blockAxis(formattingContext()),
+        layoutState.usedRowGap, layoutState.usedAlignContent);
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-grid-sizing
+// Steps 2-4 cannot change the column sizes, so a caller that only needs those can stop after
+// step 1 and skip row sizing, grid-item layout, and alignment.
+TrackSizes GridSizer::sizeColumnsOnlyFastPath(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+{
+    return sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-grid-sizing
+UsedTrackSizes GridSizer::sizeGrid(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+{
+    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
+    // If calculating the layout of a grid item in this step depends on the available space in the
+    // block axis, assume the available space that it would have if any row with a definite max
+    // track sizing function had that size and all other rows were infinite. If both the grid
+    // container and all tracks have definite sizes, also apply align-content to find the final
+    // effective size of any gaps spanned by such items; otherwise ignore the effects of track
+    // alignment in this estimation.
+    auto columnSizes = sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
+
+    // 2. Next, the track sizing algorithm resolves the sizes of the grid rows. To find the
+    // inline-axis available space for any items whose block-axis size contributions require it,
+    // use the grid column sizes calculated in the previous step.
+    auto rowSizes = sizeRowTracks(placedGridItems, columnSizes, rowTrackSizingFunctionsList);
+
+    // 3. Then, if the min-content contribution of any grid item has changed based on the
+    // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid
+    // columns with the new min-content and max-content contributions (once only).
+    auto resolveGridColumnSizesIfAnyMinContentContributionChanged = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(resolveGridColumnSizesIfAnyMinContentContributionChanged);
+
+    // 4. Next, if the min-content contribution of any grid item has changed based on the
+    // column sizes and alignment calculated in step 3, re-resolve the sizes of the grid
+    // rows with the new min-content and max-content contributions (once only).
+    auto resolveGridRowSizesIfAnyMinContentContributionChanged = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(resolveGridRowSizesIfAnyMinContentContributionChanged);
+
+    return { columnSizes, rowSizes };
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridSizer.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridSizer.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GridFormattingContext.h"
+#include "GridTypeAliases.h"
+#include "UsedTrackSizes.h"
+
+namespace WebCore {
+namespace Layout {
+
+struct GridLayoutState;
+
+class GridSizer {
+public:
+    GridSizer(const GridFormattingContext&, const GridLayoutState&);
+
+    // Runs step 1 of the grid sizing algorithm alone. Steps 2-4 cannot change the column sizes, so
+    // a caller that only needs those can stop here and skip row sizing, grid-item layout, and
+    // alignment.
+    TrackSizes sizeColumnsOnlyFastPath(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;
+
+    // Runs the whole grid sizing algorithm.
+    UsedTrackSizes sizeGrid(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;
+
+private:
+    TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;
+    TrackSizes sizeRowTracks(const PlacedGridItems&, const TrackSizes& columnSizes, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;
+
+    const GridFormattingContext& formattingContext() const LIFETIME_BOUND { return m_gridFormattingContext; }
+    const GridLayoutState& layoutState() const LIFETIME_BOUND { return m_gridLayoutState; }
+
+    const GridFormattingContext& m_gridFormattingContext;
+    const GridLayoutState& m_gridLayoutState;
+};
+
+} // namespace Layout
+} // namespace WebCore


### PR DESCRIPTION
#### 8d29616f91ef6b902037c77ff921ee89a2083940
<pre>
[GFC][Cleanup] Move the grid sizing algorithm into a GridSizer class
<a href="https://bugs.webkit.org/show_bug.cgi?id=322534">https://bugs.webkit.org/show_bug.cgi?id=322534</a>
<a href="https://rdar.apple.com/problem/185829927">rdar://problem/185829927</a>

Reviewed by Tim Nguyen.

GridLayout::layout() ran the grid sizing algorithm inline, alongside grid item
placement, grid item layout, and alignment. Move this logic into its own class
so that it is a bit more modular.

GridSizer takes the grid formatting context and the layout state, and each entry
point takes the placed grid items plus the track sizing functions for both axes.
Building those track sizing functions stays in GridLayout, since grid item sizing
still needs them once the tracks have been sized, so there is nothing to be
gained from moving their construction and handing it back out again.

The fast path where the caller only needs the column sizes resolved by step 1 is
sizeColumnsOnlyFastPath(), which delegates to sizeColumnTracks(), the counterpart
to sizeRowTracks().

No change in behavior.

Canonical link: <a href="https://commits.webkit.org/319845@main">https://commits.webkit.org/319845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/307a3ed1cf2c254dee8cf86727cd033763fef604

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147262 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aaf02504-ddde-4539-b546-561d63e8fb8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c383818-fd33-40ac-8fd5-ce1fa637c9e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46540 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123241 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/411905c3-79cf-481d-8c77-a9b63db42b8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45232 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155628 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4364 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195132 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56566 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152280 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40791 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57271 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151976 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46541 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55779 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->