### PR TITLE
[Site Isolation] Avoid sending per-frame layout info if there are no remote frame processes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Frame tree layout state is only broadcast to other processes when the frame tree has a remote frame
+

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists.html
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists.html
@@ -1,0 +1,81 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+
+let broadcastCount = 0;
+let bodyIsPadded = false;
+
+const perRenderingUpdateMessages = [
+    "WebPageProxy_BroadcastFrameTreeSyncData",
+    "WebPageProxy_UpdateRemoteIntersectionObserversInOtherWebProcesses",
+];
+
+if (window.IPC) {
+    IPC.addOutgoingMessageListener("UI", message => {
+        if (perRenderingUpdateMessages.includes(message.description))
+            broadcastCount++;
+    });
+}
+
+function animationFrame()
+{
+    return new Promise(resolve => requestAnimationFrame(() => {
+        bodyIsPadded = !bodyIsPadded;
+        document.body.style.paddingTop = bodyIsPadded ? "10px" : "0px";
+        resolve();
+    }));
+}
+
+async function renderingUpdates(count)
+{
+    for (let i = 0; i < count; i++)
+        await animationFrame();
+}
+
+async function countBroadcastsDuringRenderingUpdates(count)
+{
+    broadcastCount = 0;
+    await renderingUpdates(count);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    return broadcastCount;
+}
+
+function addIframe(url)
+{
+    return new Promise(resolve => {
+        const iframe = document.createElement("iframe");
+        iframe.onload = () => resolve(iframe);
+        iframe.src = url;
+        document.body.appendChild(iframe);
+    });
+}
+
+promise_test(async t => {
+    // IPC interception only works in debug builds.
+    if (!window.IPC)
+        return;
+
+    // Leave the page with no frames in it, so that the text this test dumps is the same whether or
+    // not the frames below were ever added.
+    t.add_cleanup(() => document.querySelectorAll("iframe").forEach(iframe => iframe.remove()));
+
+    const sameSiteIframe = await addIframe("http://127.0.0.1:8000/site-isolation/resources/frame-with-text.html");
+    await renderingUpdates(5);
+
+    assert_equals(await countBroadcastsDuringRenderingUpdates(5), 0,
+        "a page with a fully local frame tree must not send frame tree layout state");
+
+    const crossSiteIframe = await addIframe("http://localhost:8000/site-isolation/resources/frame-with-text.html");
+
+    assert_greater_than(await countBroadcastsDuringRenderingUpdates(5), 0,
+        "a page with a remote frame must send frame tree layout state");
+
+    crossSiteIframe.remove();
+
+    assert_equals(await countBroadcastsDuringRenderingUpdates(5), 0,
+        "a page must stop sending frame tree layout state once its last remote frame is gone");
+}, "Frame tree layout state is only broadcast to other processes when the frame tree has a remote frame");
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10574,7 +10574,7 @@ void Document::updateIntersectionObservers()
     updateAndNotifyIntersectionObservers(m_localIntersectionObservers, *frame);
     updateRemoteIntersectionObservers();
 
-    if (settings().siteIsolationEnabled())
+    if (page->hasRemoteFrames())
         page->chrome().client().updateRemoteIntersectionObserversInOtherWebProcesses();
 }
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -168,6 +168,12 @@ void Frame::detachFromPage()
                 scrollingCoordinator->rootFrameWasRemoved(frameID());
         }
     }
+
+    if (m_frameType == FrameType::Remote) {
+        if (RefPtr page = m_page.get())
+            page->didDetachRemoteFrame();
+    }
+
     m_page = nullptr;
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2262,6 +2262,12 @@ unsigned NODELETE Page::renderingUpdateCount() const
     return m_renderingUpdateCount;
 }
 
+bool Page::hasRemoteFrames() const
+{
+    ASSERT_IMPLIES(mainFrame().tree().containsRemoteFrame(), m_remoteFrameCount);
+    return !!m_remoteFrameCount;
+}
+
 void Page::syncLocalFrameInfoToRemote()
 {
     forEachLocalFrame([] (LocalFrame& frame) {
@@ -2616,7 +2622,7 @@ void Page::doAfterUpdateRendering()
 
     computeSampledPageTopColorIfNecessary();
 
-    if (settings().siteIsolationEnabled())
+    if (hasRemoteFrames())
         syncLocalFrameInfoToRemote();
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -438,6 +438,10 @@ public:
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const LIFETIME_BOUND;
 
+    bool hasRemoteFrames() const;
+    void didAttachRemoteFrame() { ++m_remoteFrameCount; }
+    void didDetachRemoteFrame() { ASSERT(m_remoteFrameCount); --m_remoteFrameCount; }
+
     WEBCORE_EXPORT void didObserveFirstPartyUserGesture();
     SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
@@ -1537,6 +1541,9 @@ private:
     const UniqueRef<BackForwardController> m_backForwardController;
     HashSet<WeakRef<LocalFrame>> m_rootFrames;
     const UniqueRef<EditorClient> m_editorClient;
+
+    // Declared before m_mainFrame so a remote main frame can count itself as m_mainFrame is built.
+    unsigned m_remoteFrameCount { 0 };
     Ref<Frame> m_mainFrame;
     String m_mainFrameURLFragment;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -33,6 +33,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "FrameInlines.h"
 #include "NodeDocument.h"
+#include "Page.h"
 #include "PrivateClickMeasurement.h"
 #include "RemoteDOMWindow.h"
 #include "RemoteFrameClient.h"
@@ -65,9 +66,14 @@ RemoteFrame::RemoteFrame(Page& page, ClientCreator&& clientCreator, FrameIdentif
     , m_colorSchemePreference(ColorSchemePreference::NoPreference)
 {
     setView(RemoteFrameView::create(*this));
+
+    page.didAttachRemoteFrame();
 }
 
-RemoteFrame::~RemoteFrame() = default;
+RemoteFrame::~RemoteFrame()
+{
+    detachFromPage();
+}
 
 ProcessIdentifier RemoteFrame::hostingProcessIdentifier() const
 {
@@ -158,6 +164,7 @@ void RemoteFrame::frameDetached()
 {
     m_client->frameDetached();
     m_window->frameDetached();
+    detachFromPage();
 }
 
 String RemoteFrame::renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag> behavior)


### PR DESCRIPTION
#### a8c31653e18a1227f2140465ef04dc6d2cd1edcc
<pre>
[Site Isolation] Avoid sending per-frame layout info if there are no remote frame processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322535">https://bugs.webkit.org/show_bug.cgi?id=322535</a>
<a href="https://rdar.apple.com/185830113">rdar://185830113</a>

Reviewed by Megan Gardner, Alex Christensen, and Kiet Ho.

We currently send frame layout info on each rendering update from the WebProcess to the UIProcess
when Site Isolation is enabled. This is unnecessary if there is only one process involved in
rendering the page.

To make this cheaper, we cache whether the page has a remote frame. The cache is invalidated on
every FrameTree mutation, which should be relatively rare.

Tests: http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists.html

* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::setMainFrame):
(WebCore::Page::frameTreeContainsRemoteFrame const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservers):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::didMutateTree):
(WebCore::FrameTree::detachFromParent):
(WebCore::FrameTree::appendChild):
(WebCore::FrameTree::removeChild):
(WebCore::FrameTree::replaceChild):
* Source/WebCore/page/FrameTree.h:
(WebCore::FrameTree::detachFromParent): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::didMutateFrameTree):
* LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-if-remote-frame-exists.html: Added.

Canonical link: <a href="https://commits.webkit.org/319884@main">https://commits.webkit.org/319884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/772b06510118410edebcdf596e6ededdfe45fe0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147274 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f191df78-bf8c-4796-8598-8ea63e4f6ee7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142826 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b978b1cc-1db6-4b23-9b9e-350c9c043ca1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123253 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/052be5ae-4adf-48d0-a05b-af3024e0777c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43484 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43115 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4376 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195144 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40825 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151989 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129552 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125659 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55791 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55162 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->