### PR TITLE
[JSC] Add JSString::isDefinitelyAtom

### DIFF
--- a/JSTests/stress/jsstring-definitely-atom-bit.js
+++ b/JSTests/stress/jsstring-definitely-atom-bit.js
@@ -1,0 +1,78 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected} but got ${actual}`);
+}
+
+// The per-cell bit is one-sided: set implies the string holds an AtomStringImpl, clear proves
+// nothing. Every assertion below either checks that implication or checks a path required to set it.
+function checkInvariant(string, message) {
+    if ($vm.isDefinitelyAtomString(string) && !$vm.isAtomString(string))
+        throw new Error(`${message}: per-cell bit set on a string that is not an atom`);
+}
+
+function makeString(n) {
+    return "jsStringDefinitelyAtomPrefix" + n;
+}
+
+function makeRope(n) {
+    return makeString(n) + "ropeTail";
+}
+
+// A string literal reaches JSString::create wrapping the AtomStringImpl of the bytecode generator's
+// Identifier, so it is flagged before anything touches it. SmallStrings are built from
+// AtomStringImpl::add and the empty string from StringImpl::empty(), so they are flagged too.
+checkInvariant("multiCharacterStringLiteral", "string literal");
+shouldBe($vm.isDefinitelyAtomString("multiCharacterStringLiteral"), true, "string literal is a definite atom");
+shouldBe($vm.isDefinitelyAtomString("a"), true, "single character string is a definite atom");
+shouldBe($vm.isDefinitelyAtomString(""), true, "empty string is a definite atom");
+
+function exercise(n) {
+    // Using a rope as a property key resolves it straight to an AtomStringImpl.
+    let key = makeRope(n);
+    checkInvariant(key, "rope before use as key");
+
+    let object = {};
+    object[key] = n;
+    shouldBe($vm.isAtomString(key), true, "rope atomized by property key use");
+    shouldBe($vm.isDefinitelyAtomString(key), true, "rope flagged by property key use");
+    shouldBe(object[key], n, "property lookup by atomized rope");
+
+    // Property names handed back by the runtime are built from the property table's AtomStringImpls.
+    for (let name of Object.keys(object)) {
+        shouldBe($vm.isAtomString(name), true, "Object.keys result is an atom");
+        shouldBe($vm.isDefinitelyAtomString(name), true, "Object.keys result is a definite atom");
+    }
+
+    for (let name in object)
+        shouldBe($vm.isDefinitelyAtomString(name), true, "for-in key is a definite atom");
+
+    // A second, equal rope reaches JSString::toExistingAtomString, which finds the atom the first
+    // key already created.
+    let equalKey = makeRope(n);
+    shouldBe(object[equalKey], n, "property lookup by an equal rope");
+    shouldBe($vm.isDefinitelyAtomString(equalKey), true, "equal rope flagged by lookup");
+
+    // Map hashes string keys without atomizing them, so the bit must stay clear here while lookup by
+    // an equal string keeps working.
+    let map = new Map();
+    let mapKey = makeRope(n);
+    map.set(mapKey, n);
+    checkInvariant(mapKey, "Map key");
+    shouldBe(map.get(makeRope(n)), n, "Map lookup by an equal string");
+
+    // Strings that never get atomized must keep working, and must never be flagged.
+    let plain = makeString(n).slice(1);
+    checkInvariant(plain, "unatomized substring");
+    shouldBe(plain === makeString(n).slice(1), true, "substring equality");
+
+    let unusedRope = makeRope(n) + "unusedTail";
+    checkInvariant(unusedRope, "unresolved rope");
+    shouldBe(unusedRope.length, makeRope(n).length + "unusedTail".length, "rope length");
+    shouldBe(unusedRope === makeRope(n) + "unusedTail", true, "rope equality");
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    exercise(i);
+    if (!(i % 2000))
+        gc();
+}

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -591,7 +591,12 @@ SpeculatedType speculationFromStructure(Structure* structure)
     return speculatedTypeMapping[type];
 }
 
-SpeculatedType speculationFromCell(JSCell* cell)
+// avoidStringDereference restricts this to words stored within the cell itself. A value profile
+// bucket is written with no ordering against the stores that initialize a JSString, so a compiler
+// thread reading the bucket can observe the cell before the StringImpl pointer inside it. Stale
+// flags or pointer bits only cost a wrong prediction; a stale pointer, dereferenced, is a crash.
+template<bool avoidStringDereference>
+static ALWAYS_INLINE SpeculatedType speculationFromCellImpl(JSCell* cell)
 {
     // FIXME: rdar://69036888: remove isSanePointer checks when no longer needed.
     if (!Integrity::isSanePointer(cell)) [[unlikely]] {
@@ -601,23 +606,37 @@ SpeculatedType speculationFromCell(JSCell* cell)
 
     if (cell->isString()) {
         JSString* string = uncheckedDowncast<JSString>(cell);
-        if (const StringImpl* impl = string->tryGetValueImpl()) {
-            if (!Integrity::isSanePointer(impl)) [[unlikely]] {
-                ASSERT_NOT_REACHED();
-                return SpecNone;
-            }
-            if (impl->isAtom())
+        if constexpr (avoidStringDereference) {
+            if (string->isDefinitelyAtom())
                 return SpecStringIdent;
+            if (string->isRope())
+                return SpecString;
             return SpecStringResolved;
+        } else {
+            if (const StringImpl* impl = string->tryGetValueImpl()) {
+                if (!Integrity::isSanePointer(impl)) [[unlikely]] {
+                    ASSERT_NOT_REACHED();
+                    return SpecNone;
+                }
+                if (impl->isAtom())
+                    return SpecStringIdent;
+                return SpecStringResolved;
+            }
+            return SpecString;
         }
-        return SpecString;
     }
 
     JSType type = cell->type();
     return speculatedTypeMapping[type];
 }
 
-SpeculatedType speculationFromValue(JSValue value)
+SpeculatedType speculationFromCell(JSCell* cell)
+{
+    return speculationFromCellImpl<false>(cell);
+}
+
+template<bool avoidStringDereference>
+static ALWAYS_INLINE SpeculatedType speculationFromValueImpl(JSValue value)
 {
     if (value.isEmpty())
         return SpecEmpty;
@@ -637,11 +656,21 @@ SpeculatedType speculationFromValue(JSValue value)
     if (value.isBigInt32())
         return SpecBigInt32;
     if (value.isCell())
-        return speculationFromCell(value.asCell());
+        return speculationFromCellImpl<avoidStringDereference>(value.asCell());
     if (value.isBoolean())
         return SpecBoolean;
     ASSERT(value.isUndefinedOrNull());
     return SpecOther;
+}
+
+SpeculatedType speculationFromValue(JSValue value)
+{
+    return speculationFromValueImpl<false>(value);
+}
+
+SpeculatedType speculationFromValueForProfiling(JSValue value)
+{
+    return speculationFromValueImpl<true>(value);
 }
 
 SpeculatedType int52AwareSpeculationFromValue(JSValue value)

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -564,6 +564,10 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo*);
 SpeculatedType NODELETE speculationFromStructure(Structure*);
 SpeculatedType NODELETE speculationFromCell(JSCell*);
 SpeculatedType NODELETE speculationFromValue(JSValue);
+// For collecting a value profile, which merges what it is told and so may be given a broader type
+// than the truth. This never dereferences a JSString's StringImpl, so it must not be used where the
+// exact type is required, such as constant reasoning or OSR entry validation.
+SpeculatedType NODELETE speculationFromValueForProfiling(JSValue);
 // If it's an anyInt(), it'll return speculated types from the Int52 lattice.
 // Otherwise, it'll return types from the JSValue lattice.
 JS_EXPORT_PRIVATE SpeculatedType NODELETE int52AwareSpeculationFromValue(JSValue);

--- a/Source/JavaScriptCore/bytecode/ValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/ValueProfile.h
@@ -67,17 +67,6 @@ struct ValueProfileBase {
             clearEncodedJSValueConcurrent(m_buckets[i]);
     }
     
-    const ClassInfo* classInfo(unsigned bucket) const
-    {
-        JSValue value = JSValue::decodeConcurrent(&m_buckets[bucket]);
-        if (!!value) {
-            if (!value.isCell())
-                return nullptr;
-            return value.asCell()->classInfo();
-        }
-        return nullptr;
-    }
-    
     unsigned numberOfSamples() const
     {
         unsigned result = 0;
@@ -109,7 +98,7 @@ struct ValueProfileBase {
         out.print("sampled before = ", isSampledBefore(), " live samples = ", numberOfSamples(), " prediction = ", SpeculationDump(m_prediction));
         bool first = true;
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i) {
-            JSValue value = JSValue::decode(m_buckets[i]);
+            JSValue value = JSValue::decodeConcurrent(&m_buckets[i]);
             if (!!value) {
                 if (first) {
                     out.printf(": ");
@@ -129,7 +118,7 @@ struct ValueProfileBase {
             if (!value)
                 continue;
             
-            mergeSpeculation(merged, speculationFromValue(value));
+            mergeSpeculation(merged, speculationFromValueForProfiling(value));
 
             updateEncodedJSValueConcurrent(m_buckets[i], JSValue::encode(JSValue()));
         }
@@ -142,7 +131,7 @@ struct ValueProfileBase {
     void computeUpdatedPredictionForExtraValue(const ConcurrentJSLocker&, JSValue& value)
     {
         if (value)
-            mergeSpeculation(m_prediction, speculationFromValue(value));
+            mergeSpeculation(m_prediction, speculationFromValueForProfiling(value));
         value = JSValue();
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12118,13 +12118,11 @@ void SpeculativeJIT::speculateStringOrOther(Edge edge)
 void SpeculativeJIT::speculateStringIdentAndLoadStorage(Edge edge, GPRReg string, GPRReg storage)
 {
     loadPtr(Address(string, JSString::offsetOfValue()), storage);
-    
+
     if (!needsTypeCheck(edge, SpecStringIdent | ~SpecString))
         return;
 
-    if (canBeRope(edge))
-        speculationCheck(BadStringType, JSValueSource::unboxedCell(string), edge, branchIfRopeStringImpl(storage));
-    speculationCheck(BadStringType, JSValueSource::unboxedCell(string), edge, branchTest32(Zero, Address(storage, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+    speculationCheck(BadStringType, JSValueSource::unboxedCell(string), edge, branchIfNotAtomStringImpl(string, storage, canBeRope(edge)));
 
     m_interpreter.filter(edge, SpecStringIdent | ~SpecString);
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -26119,6 +26119,13 @@ IGNORE_CLANG_WARNINGS_END
         return m_out.testIsZeroPtr(m_out.loadPtr(string, m_heaps.JSString_value), m_out.constIntPtr(JSString::isRopeInPointer));
     }
 
+    // True only when the string is known to be a non-rope holding an AtomStringImpl. False proves
+    // nothing, so callers must keep their full check on the false path.
+    LValue isDefinitelyAtomString(LValue string)
+    {
+        return m_out.testNonZero32(m_out.load8ZeroExt32(string, m_heaps.JSCell_typeInfoFlags), m_out.constInt32(TypeInfoPerCellBit));
+    }
+
     LValue isNotSymbol(LValue cell, SpeculatedType type = SpecFullTop)
     {
         if (LValue proven = isProvenValue(type & SpecCell, ~SpecSymbol))
@@ -26608,12 +26615,21 @@ IGNORE_CLANG_WARNINGS_END
         if (!m_interpreter.needsTypeCheck(edge, SpecStringIdent | ~SpecString))
             return;
 
+        LBasicBlock checkCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        m_out.branch(isDefinitelyAtomString(string), usually(continuation), rarely(checkCase));
+
+        LBasicBlock lastNext = m_out.appendTo(checkCase, continuation);
         speculate(BadStringType, jsValueValue(string), edge.node(), isRopeString(string));
         speculate(
             BadStringType, jsValueValue(string), edge.node(),
             m_out.testIsZero32(
                 m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags),
                 m_out.constInt32(StringImpl::flagIsAtom())));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
         m_interpreter.filter(edge, SpecStringIdent | ~SpecString);
     }
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -736,9 +736,7 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadCacheableIdentifierImpl(GPRReg pr
     JumpList slowCases;
     if (propertyIsString) {
         loadPtr(Address(propertyGPR, JSString::offsetOfValue()), destGPR);
-        if (canBeRope)
-            slowCases.append(branchIfRopeStringImpl(destGPR));
-        slowCases.append(branchTest32(Zero, Address(destGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+        slowCases.append(branchIfNotAtomStringImpl(propertyGPR, destGPR, canBeRope));
     } else if (propertyIsSymbol)
         loadPtr(Address(propertyGPR, Symbol::offsetOfSymbolImpl()), destGPR);
     else {
@@ -750,9 +748,7 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadCacheableIdentifierImpl(GPRReg pr
 
         isString.link(this);
         loadPtr(Address(propertyGPR, JSString::offsetOfValue()), destGPR);
-        if (canBeRope)
-            slowCases.append(branchIfRopeStringImpl(destGPR));
-        slowCases.append(branchTest32(Zero, Address(destGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+        slowCases.append(branchIfNotAtomStringImpl(propertyGPR, destGPR, canBeRope));
 
         done.link(this);
     }

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -893,6 +893,22 @@ public:
         return branchTestPtr(Zero, stringImplGPR, TrustedImm32(JSString::isRopeInPointer));
     }
 
+    // Returns the cases where implGPR, already loaded from stringGPR, is not an AtomStringImpl. The
+    // per-cell bit lets both checks be skipped when it is set; a clear bit proves nothing, so the
+    // checks remain on the fall-through path. stringGPR must survive the impl load, so the two
+    // registers cannot be the same: the flags byte of a JSCell overlaps StringImpl::m_length.
+    JumpList branchIfNotAtomStringImpl(GPRReg stringGPR, GPRReg implGPR, bool canBeRope = true)
+    {
+        ASSERT(noOverlap(stringGPR, implGPR));
+        JumpList notAtomCases;
+        Jump knownAtom = branchTest8(NonZero, Address(stringGPR, JSCell::typeInfoFlagsOffset()), TrustedImm32(TypeInfoPerCellBit));
+        if (canBeRope)
+            notAtomCases.append(branchIfRopeStringImpl(implGPR));
+        notAtomCases.append(branchTest32(Zero, Address(implGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+        knownAtom.link(this);
+        return notAtomCases;
+    }
+
     JumpList branchIfInlineWatchpointSetIsStillValid(GPRReg setThenScratchGPR)
     {
         JumpList result;

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -745,8 +745,7 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
 
         fallThrough.append(branchIfNotString(stringGPR));
         loadPtr(Address(stringGPR, JSString::offsetOfValue()), regT5);
-        addSlowCase(branchIfRopeStringImpl(regT5));
-        addSlowCase(branchTest32(Zero, Address(regT5, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+        addSlowCase(branchIfNotAtomStringImpl(stringGPR, regT5));
         fallThrough.append(branchPtr(NotEqual, regT5, TrustedImmPtr(string->tryGetValueImpl())));
 
         equals.link(this);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -154,8 +154,14 @@ private:
         return TypeInfoBlob::typeInfoBlob(NonArray, defaultTypeInfo().type(), defaultTypeInfo().inlineTypeFlags());
     }
 
+    static constexpr int32_t typeInfoBlobForAtomness(bool isAtom)
+    {
+        auto flags = static_cast<TypeInfo::InlineTypeFlags>(defaultTypeInfo().inlineTypeFlags() | (isAtom ? TypeInfoPerCellBit : 0));
+        return TypeInfoBlob::typeInfoBlob(NonArray, defaultTypeInfo().type(), flags);
+    }
+
     JSString(VM& vm, Ref<StringImpl>&& value)
-        : JSCell(CreatingWellDefinedBuiltinCell, vm.stringStructure.get()->id(), defaultTypeInfoBlob())
+        : JSCell(CreatingWellDefinedBuiltinCell, vm.stringStructure.get()->id(), typeInfoBlobForAtomness(value->isAtom()))
     {
         new (&uninitializedValueInternal()) String(WTF::move(value));
     }
@@ -275,6 +281,30 @@ public:
     }
 
     bool is8Bit() const;
+
+    // Set only when this string is known to hold an AtomStringImpl. A clear bit proves nothing, since
+    // AtomStringImpl::add can atomize a StringImpl that several JSStrings already share, so never
+    // conclude from it that a string is not an atom. A reader that sees the bit set must not go on to
+    // load the StringImpl: it has no ordering against the impl store, which is the whole reason value
+    // profiling consults the bit.
+    ALWAYS_INLINE bool isDefinitelyAtom() const { return perCellBit(); }
+
+    void markAsAtom() const
+    {
+        ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
+        ASSERT(!isRope() && getValueImpl()->isAtom());
+        const_cast<JSString*>(this)->setPerCellBit(true);
+    }
+
+    AtomStringImpl* existingAtomOrNull() const
+    {
+        StringImpl* impl = valueInternal().impl();
+        if (!impl->isAtom())
+            return nullptr;
+        // Record for profiling.
+        markAsAtom();
+        return static_cast<AtomStringImpl*>(impl);
+    }
 
     ALWAYS_INLINE JSString* tryReplaceOneChar(JSGlobalObject*, char16_t, JSString* replacement);
     inline std::optional<size_t> tryFindOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
@@ -853,9 +883,12 @@ ALWAYS_INLINE void JSString::swapToAtomString(VM& vm, RefPtr<AtomStringImpl>&& a
     // Heap::clearConcurrentRetainedDataIfPossible clears the vector entirely when no JS is executing
     // and no JIT compilations are in progress.
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
+    ASSERT(atom && atom->isAtom());
     String target(WTF::move(atom));
     WTF::storeStoreFence(); // Ensure AtomStringImpl's string is fully initialized when it is exposed to concurrent threads.
     valueInternal().swap(target);
+    WTF::storeStoreFence(); // Publish the impl before the per-cell bit that advertises it.
+    markAsAtom();
     vm.heap.appendPossiblyAccessedStringFromConcurrentThreadsOrGCOwnedDataScope(this, WTF::move(target));
 }
 
@@ -866,16 +899,16 @@ ALWAYS_INLINE Identifier JSString::toIdentifier(JSGlobalObject* globalObject) co
     if (isRope())
         return static_cast<const JSRopeString*>(this)->toIdentifier(globalObject);
     VM& vm = getVM(globalObject);
-    if (valueInternal().impl()->isAtom())
-        return Identifier::fromString(vm, Ref { *static_cast<AtomStringImpl*>(valueInternal().impl()) });
+    if (SUPPRESS_UNCOUNTED_LOCAL AtomStringImpl* atom = existingAtomOrNull())
+        return Identifier::fromString(vm, Ref { *atom });
     if (vm.lastAtomizedIdentifierStringImpl.ptr() != valueInternal().impl()) {
         vm.lastAtomizedIdentifierStringImpl = *valueInternal().impl();
         vm.lastAtomizedIdentifierAtomStringImpl = AtomStringImpl::add(valueInternal().impl()).releaseNonNull();
+        // It is possible that AtomStringImpl::add converts existing valueInternal()'s StringImpl to AtomicStringImpl,
+        // thus we need to recheck atomicity status here.
+        if (!existingAtomOrNull())
+            swapToAtomString(vm, RefPtr { vm.lastAtomizedIdentifierAtomStringImpl.ptr() });
     }
-    // It is possible that AtomStringImpl::add converts existing valueInternal()'s StringImpl to AtomicStringImpl,
-    // thus we need to recheck atomicity status here.
-    if (!valueInternal().impl()->isAtom())
-        swapToAtomString(vm, RefPtr { vm.lastAtomizedIdentifierAtomStringImpl.ptr() });
     return Identifier::fromString(vm, Ref { vm.lastAtomizedIdentifierAtomStringImpl });
 }
 
@@ -885,8 +918,8 @@ ALWAYS_INLINE GCOwnedDataScope<AtomStringImpl*> JSString::toAtomString(JSGlobalO
         getVM(globalObject).verifyCanGC();
     if (isRope())
         return { this, static_cast<const JSRopeString*>(this)->resolveRopeToAtomString(globalObject) };
-    if (valueInternal().impl()->isAtom())
-        return { this, static_cast<AtomStringImpl*>(valueInternal().impl()) };
+    if (SUPPRESS_UNCOUNTED_LOCAL AtomStringImpl* atom = existingAtomOrNull())
+        return { this, atom };
     AtomString atom(valueInternal());
     swapToAtomString(getVM(globalObject), atom.releaseImpl());
     return { this, static_cast<AtomStringImpl*>(valueInternal().impl()) };
@@ -898,8 +931,8 @@ ALWAYS_INLINE GCOwnedDataScope<AtomStringImpl*> JSString::toExistingAtomString(J
         getVM(globalObject).verifyCanGC();
     if (isRope())
         return static_cast<const JSRopeString*>(this)->resolveRopeToExistingAtomString(globalObject);
-    if (valueInternal().impl()->isAtom())
-        return { this, static_cast<AtomStringImpl*>(valueInternal().impl()) };
+    if (SUPPRESS_UNCOUNTED_LOCAL AtomStringImpl* atom = existingAtomOrNull())
+        return { this, atom };
     if (auto atom = AtomStringImpl::lookUp(valueInternal().impl())) {
         swapToAtomString(getVM(globalObject), WTF::move(atom));
         return { this, static_cast<AtomStringImpl*>(valueInternal().impl()) };

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -384,11 +384,16 @@ inline void JSRopeString::convertToNonRope(String&& string) const
     // Concurrent compiler threads can access String held by JSString. So we always emit
     // store-store barrier here to ensure concurrent compiler threads see initialized String.
     ASSERT(JSString::isRope());
+    bool isAtom = string.impl() && string.impl()->isAtom();
     WTF::storeStoreFence();
     new (&uninitializedValueInternal()) String(WTF::move(string));
     static_assert(sizeof(String) == sizeof(RefPtr<StringImpl>), "JSString's String initialization must be done in one pointer move.");
     // We do not clear the trailing fibers and length information (fiber1 and fiber2) because we could be reading the length concurrently.
     ASSERT(!JSString::isRope());
+    if (isAtom) {
+        WTF::storeStoreFence(); // Publish the impl before the per-cell bit that advertises it.
+        markAsAtom();
+    }
     notifyNeedsDestruction();
 }
 
@@ -619,6 +624,9 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
 
 inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* string)
 {
+    if (string->isDefinitelyAtom())
+        return string;
+
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     unsigned length = string->length();
@@ -631,7 +639,7 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
     if (!string->isRope()) {
         auto createFromNonRope = [&](VM& vm, auto&) {
             AtomString atom(string->valueInternal());
-            if (!string->valueInternal().impl()->isAtom())
+            if (!string->existingAtomOrNull())
                 string->swapToAtomString(vm, RefPtr { atom.impl() });
             return string;
         };

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2244,6 +2244,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionIsGigacageEnabled);
 static JSC_DECLARE_HOST_FUNCTION(functionToCacheableDictionary);
 static JSC_DECLARE_HOST_FUNCTION(functionToUncacheableDictionary);
 static JSC_DECLARE_HOST_FUNCTION(functionIsPrivateSymbol);
+static JSC_DECLARE_HOST_FUNCTION(functionIsDefinitelyAtomString);
+static JSC_DECLARE_HOST_FUNCTION(functionIsAtomString);
 static JSC_DECLARE_HOST_FUNCTION(functionDumpAndResetPasDebugSpectrum);
 static JSC_DECLARE_HOST_FUNCTION(functionMonotonicTimeNow);
 static JSC_DECLARE_HOST_FUNCTION(functionWallTimeNow);
@@ -4302,6 +4304,29 @@ JSC_DEFINE_HOST_FUNCTION(functionIsPrivateSymbol, (JSGlobalObject*, CallFrame* c
     return JSValue::encode(jsBoolean(asSymbol(callFrame->argument(0))->uid().isPrivate()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionIsDefinitelyAtomString, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+
+    JSValue value = callFrame->argument(0);
+    if (!value.isString())
+        return JSValue::encode(jsBoolean(false));
+
+    return JSValue::encode(jsBoolean(asString(value)->isDefinitelyAtom()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionIsAtomString, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+
+    JSValue value = callFrame->argument(0);
+    if (!value.isString())
+        return JSValue::encode(jsBoolean(false));
+
+    const StringImpl* impl = asString(value)->tryGetValueImpl();
+    return JSValue::encode(jsBoolean(impl && impl->isAtom()));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionDumpAndResetPasDebugSpectrum, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -4735,6 +4760,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, allowIfNotFuzz, "toUncacheableDictionary"_s, functionToUncacheableDictionary, 1);
 
     addFunction(vm, allowIfNotFuzz, "isPrivateSymbol"_s, functionIsPrivateSymbol, 1);
+    addFunction(vm, allowIfNotFuzz, "isDefinitelyAtomString"_s, functionIsDefinitelyAtomString, 1);
+    addFunction(vm, allowIfNotFuzz, "isAtomString"_s, functionIsAtomString, 1);
     addFunction(vm, allowIfNotFuzz, "dumpAndResetPasDebugSpectrum"_s, functionDumpAndResetPasDebugSpectrum, 0);
 
     addFunction(vm, alwaysAllow, "monotonicTimeNow"_s, functionMonotonicTimeNow, 0);


### PR DESCRIPTION
#### 24f0a336557e9618836f7025396888bc42f25ff1
<pre>
[JSC] Add JSString::isDefinitelyAtom
<a href="https://bugs.webkit.org/show_bug.cgi?id=322536">https://bugs.webkit.org/show_bug.cgi?id=322536</a>
<a href="https://rdar.apple.com/185830225">rdar://185830225</a>

Reviewed by Keith Miller.

This patch uses JSString&apos;s perCellBit for `isDefinitelyAtom` flag. This
indicates that this JSString is *definitely* having AtomStringImpl
without querying to the actual AtomStringImpl content. This flag can be
false-negative: it can be not-set even if JSString is actually holding
AtomStringImpl because one StringImpl can be held by multiple different
JSString* and one may upgrade it to AtomStringImpl in-place. But this
flag is totally fine as the invariant is &quot;when it is saying true, then
JSString is holding AtomStringImpl*. Otherwise, unknown, it may have
AtomStringImpl or not&quot;.

By using this flag, we replace our speculationFromCell code to use this
flag instead of looking into AtomStringImpl* actually. This resolves
memory ordering issue around ValueProfile in a conservative way. It may
say wrong result, but since it is speculation, anyway, it is fine.

Test: JSTests/stress/jsstring-definitely-atom-bit.js

* JSTests/stress/jsstring-definitely-atom-bit.js: Added.
(shouldBe):
(set makeString):
(makeRope):
(exercise):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromCellImpl):
(JSC::speculationFromCell):
(JSC::speculationFromValueImpl):
(JSC::speculationFromValue):
(JSC::speculationFromValueForProfiling):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
* Source/JavaScriptCore/bytecode/ValueProfile.h:
(JSC::ValueProfileBase::dump):
(JSC::ValueProfileBase::computeUpdatedPrediction):
(JSC::ValueProfileBase::computeUpdatedPredictionForExtraValue):
(JSC::ValueProfileBase::classInfo const): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::speculateStringIdentAndLoadStorage):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadCacheableIdentifierImpl):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::branchIfNotAtomStringImpl):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::compileOpStrictEq):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::typeInfoBlobForAtomness):
(JSC::JSString::JSString):
(JSC::JSString::isDefinitelyAtom const):
(JSC::JSString::markAsAtom const):
(JSC::JSString::existingAtomOrNull const):
(JSC::JSString::swapToAtomString const):
(JSC::JSString::toIdentifier const):
(JSC:: const):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::convertToNonRope const):
(JSC::jsAtomString):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/319852@main">https://commits.webkit.org/319852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b09937b6687c57c1c557c08a4b91b0cfb232106

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4efaa110-9add-42a7-95a3-4429be0cc773) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e766213-847c-4ee8-9cf7-f845167d110c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123238 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45225 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43472 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5208 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12042 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43102 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4359 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44239 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195127 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152275 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57266 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39718 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151971 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46532 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129535 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55774 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18113 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55145 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->