### PR TITLE
[JSC][Wasm] Fast-path i31ref in the JS-to-Wasm entry stub

### DIFF
--- a/JSTests/wasm/stress/js-to-wasm-i31ref.js
+++ b/JSTests/wasm/stress/js-to-wasm-i31ref.js
@@ -1,0 +1,36 @@
+import { instantiate } from "../gc/wast-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+  (func (export "get") (param (ref i31)) (result i32)
+    (i31.get_s (local.get 0)))
+  (func (export "getNullable") (param i31ref) (result i32)
+    (if (result i32)
+      (ref.is_null (local.get 0))
+      (then (i32.const -1))
+      (else (i31.get_s (local.get 0)))))
+)
+`;
+
+async function test() {
+    const instance = instantiate(wat);
+    const { get, getNullable } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        assert.eq(get(0), 0);
+        assert.eq(get(2), 2);
+        assert.eq(get(2 ** 30 - 1), 2 ** 30 - 1);
+        assert.eq(get(-(2 ** 30)), -(2 ** 30));
+        assert.eq(getNullable(null), -1);
+        assert.eq(getNullable(7), 7);
+    }
+
+    assert.throws(() => get(2.3), TypeError, "Argument value did not match the reference type");
+    assert.throws(() => get(2n), TypeError, "Argument value did not match the reference type");
+    assert.throws(() => get(2 ** 30), TypeError, "Argument value did not match the reference type");
+    assert.throws(() => get(-(2 ** 30) - 1), TypeError, "Argument value did not match the reference type");
+    assert.throws(() => get(null), TypeError, "Argument value did not match the reference type");
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -602,9 +602,17 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
 
                 if (type.isNullable())
                     isNull.link(&jit);
+            } else if (Wasm::isI31ref(type)) {
+                jit.loadValue(jsParam, scratchJSR);
+                auto isNull = jit.branchIfNull(scratchJSR);
+                if (!type.isNullable())
+                    slowPath.append(isNull);
+                slowPath.append(jit.branchIfNotInt32(scratchJSR, DoNotHaveTagRegisters));
+                slowPath.append(jit.branch32(CCallHelpers::GreaterThan, scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::maxI31ref)));
+                slowPath.append(jit.branch32(CCallHelpers::LessThan, scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::minI31ref)));
+                if (type.isNullable())
+                    isNull.link(&jit);
             } else if (!Wasm::isExternref(type)) {
-                // FIXME: this should implement some fast paths for, e.g., i31refs and other
-                // types that can be easily handled.
                 slowPath.append(jit.jump());
             }
 


### PR DESCRIPTION
#### d3e6e0f710a4f913cc4281834f9810ab07962797
<pre>
[JSC][Wasm] Fast-path i31ref in the JS-to-Wasm entry stub
<a href="https://bugs.webkit.org/show_bug.cgi?id=322525">https://bugs.webkit.org/show_bug.cgi?id=322525</a>

Reviewed by Yusuke Suzuki.

The JS-to-Wasm IC sent every non-externref to the slow path. Accept a JS
int32 in the i31 range, and null if the type is nullable.

* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
* JSTests/wasm/stress/js-to-wasm-i31ref.js: Added.

Canonical link: <a href="https://commits.webkit.org/320055@main">https://commits.webkit.org/320055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3782774e32536956ea84a1ec799c6ee504a54867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147203 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142764 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99132 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43425 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5162 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11995 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43055 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4305 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44185 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195073 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56507 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152226 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57212 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151923 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46488 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129481 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125569 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55720 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->