### PR TITLE
[Quirks] Clean up the QuirksMatch API

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2355,6 +2355,7 @@ page/PointerCaptureController.cpp
 page/PointerLockController.cpp
 page/PrintContext.cpp @header:RenderStyleGetters @cost:7
 page/ProcessWarming.cpp
+page/QuirkMatch.cpp
 page/Quirks.cpp @header:RenderStyleGetters @cost:11
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -14986,6 +14986,7 @@
 		7ABA250D28AEF4FC005D4F6D /* ReportBody.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReportBody.cpp; sourceTree = "<group>"; };
 		7ABA250E28B40370005D4F6D /* ReportingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportingClient.h; sourceTree = "<group>"; };
 		7ABB0F5F2CE7C170009A837D /* QuirksData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirksData.h; sourceTree = "<group>"; };
+		05D47709FFB4C18C6BA6928A /* QuirkMatch.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = QuirkMatch.cpp; sourceTree = "<group>"; };
 		05D47707FFB4C18C6BA6928A /* QuirkMatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirkMatch.h; sourceTree = "<group>"; };
 		7ABF02D621D7EBA2AFFD021A /* UnifiedSource35-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource35-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7AC09F3628BFD45B004568FC /* JSReportBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSReportBody.h; sourceTree = "<group>"; };
@@ -31514,6 +31515,7 @@
 				B776D43A1104525D00BEB0EC /* PrintContext.h */,
 				E42050162141901B0066EF3B /* ProcessWarming.cpp */,
 				E42050142141901A0066EF3B /* ProcessWarming.h */,
+				05D47709FFB4C18C6BA6928A /* QuirkMatch.cpp */,
 				05D47707FFB4C18C6BA6928A /* QuirkMatch.h */,
 				CD9A87F9215D6CF3006F17B5 /* Quirks.cpp */,
 				CD9A87FB215D6CF3006F17B5 /* Quirks.h */,

--- a/Source/WebCore/page/QuirkMatch.cpp
+++ b/Source/WebCore/page/QuirkMatch.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "QuirkMatch.h"
+
+#include "PublicSuffixStore.h"
+#include "RegistrableDomain.h"
+
+namespace WebCore {
+
+const String& QuirkMatchContext::topRegistrableDomain() const
+{
+    if (!m_topRegistrableDomain)
+        m_topRegistrableDomain = RegistrableDomain { m_topURL }.string();
+    return *m_topRegistrableDomain;
+}
+
+const String& QuirkMatchContext::topDomainWithoutPublicSuffix() const
+{
+    if (!m_topDomainWithoutPublicSuffix)
+        m_topDomainWithoutPublicSuffix = PublicSuffixStore::singleton().domainWithoutPublicSuffix(topRegistrableDomain());
+    return *m_topDomainWithoutPublicSuffix;
+}
+
+const String& QuirkMatchContext::documentRegistrableDomain() const
+{
+    if (!m_documentRegistrableDomain)
+        m_documentRegistrableDomain = RegistrableDomain { m_documentURL }.string();
+    return *m_documentRegistrableDomain;
+}
+
+bool QuirkMatch::RefinementSet::matchesPathPattern(const URL& topURL) const
+{
+    switch (pathComparison) {
+    case PathComparison::PathContains:
+        return topURL.path().contains(pathPattern);
+    case PathComparison::PathStartsWith:
+        return startsWithLettersIgnoringASCIICase(topURL.path(), pathPattern);
+    case PathComparison::PathOrFragmentContains:
+        return topURL.path().contains(pathPattern) || topURL.fragmentIdentifier().contains(pathPattern);
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+bool QuirkMatch::RefinementSet::matches(const QuirkMatchContext& context) const
+{
+    if (!pathPattern.isNull() && !matchesPathPattern(context.topURL()))
+        return false;
+
+    if (environment && !evaluateQuirkEnvironment(*environment))
+        return false;
+
+    if (requiresEmbeddedDocument && context.isTopDocument())
+        return false;
+
+    if (!documentDomains.isEmpty() && !documentDomains.contains(context.documentRegistrableDomain()))
+        return false;
+
+    if (!hosts.isEmpty() && !hosts.contains(context.topHost()))
+        return false;
+
+    return true;
+}
+
+bool QuirkMatch::matchesSite(const QuirkMatchContext& context) const
+{
+    switch (m_kind) {
+    case Kind::Domain:
+        return m_patterns.contains(context.topRegistrableDomain());
+    case Kind::Host:
+        return m_patterns.contains(context.topHost());
+    case Kind::HostOrSubdomainOf:
+        return m_patterns.containsMatching([&](ASCIILiteral pattern) { return context.topURL().isMatchingDomain(pattern); });
+    case Kind::AnyTopLevelDomain:
+        return m_patterns.contains(context.topDomainWithoutPublicSuffix());
+    case Kind::AnySite:
+        // about:, data:, and other URLs without a host are not sites.
+        return !context.topHost().isEmpty();
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+bool QuirkMatch::matches(const QuirkMatchContext& context) const
+{
+    if (!matchesSite(context)) [[likely]]
+        return false;
+
+    if (!m_refinements.matches(context))
+        return false;
+
+    if (m_exception && m_exception->matches(context))
+        return false;
+
+    return true;
+}
+
+void Quirk::apply(QuirksData& quirksData) const
+{
+    quirksData.activeQuirks.merge(behaviors.bits());
+
+    if (site)
+        quirksData.addSite(*site);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/QuirkMatch.h
+++ b/Source/WebCore/page/QuirkMatch.h
@@ -25,13 +25,10 @@
 
 #pragma once
 
-#include <WebCore/PublicSuffixStore.h>
 #include <WebCore/QuirksData.h>
-#include <WebCore/RegistrableDomain.h>
 #include <array>
 #include <initializer_list>
 #include <optional>
-#include <ranges>
 #include <span>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
@@ -42,19 +39,19 @@
 
 namespace WebCore {
 
-enum class QuirkCondition : uint8_t {
+enum class QuirkEnvironment : uint8_t {
     SmallScreen,
     TubularApp,
     LensApp,
 };
 
-WEBCORE_EXPORT bool evaluateQuirkCondition(QuirkCondition);
+WEBCORE_EXPORT bool evaluateQuirkEnvironment(QuirkEnvironment);
 
 enum class IsTopDocument : bool { No, Yes };
 
 class QuirkMatchContext {
 public:
-    QuirkMatchContext(URL topURL, URL documentURL, IsTopDocument isTopDocument = IsTopDocument::Yes)
+    QuirkMatchContext(URL topURL, URL documentURL, IsTopDocument isTopDocument)
         : m_topURL(WTF::move(topURL))
         , m_documentURL(WTF::move(documentURL))
         , m_isTopDocument(isTopDocument)
@@ -65,77 +62,188 @@ public:
 
     bool isTopDocument() const { return m_isTopDocument == IsTopDocument::Yes; }
 
-    StringView host() const LIFETIME_BOUND { return m_topURL.host(); }
+    StringView topHost() const LIFETIME_BOUND { return m_topURL.host(); }
 
-    const String& registrableDomain() const LIFETIME_BOUND
-    {
-        if (!m_registrableDomain)
-            m_registrableDomain = RegistrableDomain { m_topURL }.string();
-        return *m_registrableDomain;
-    }
+    WEBCORE_EXPORT const String& topRegistrableDomain() const LIFETIME_BOUND;
 
-    const String& domainWithoutPublicSuffix() const LIFETIME_BOUND
-    {
-        if (!m_domainWithoutPublicSuffix)
-            m_domainWithoutPublicSuffix = PublicSuffixStore::singleton().domainWithoutPublicSuffix(registrableDomain());
-        return *m_domainWithoutPublicSuffix;
-    }
+    WEBCORE_EXPORT const String& topDomainWithoutPublicSuffix() const LIFETIME_BOUND;
 
-    const String& documentDomain() const LIFETIME_BOUND
-    {
-        if (!m_documentDomain)
-            m_documentDomain = RegistrableDomain { m_documentURL }.string();
-        return *m_documentDomain;
-    }
+    WEBCORE_EXPORT const String& documentRegistrableDomain() const LIFETIME_BOUND;
 
 private:
     const URL m_topURL;
     const URL m_documentURL;
     const IsTopDocument m_isTopDocument;
-    mutable std::optional<String> m_registrableDomain;
-    mutable std::optional<String> m_domainWithoutPublicSuffix;
-    mutable std::optional<String> m_documentDomain;
+    mutable std::optional<String> m_topRegistrableDomain;
+    mutable std::optional<String> m_topDomainWithoutPublicSuffix;
+    mutable std::optional<String> m_documentRegistrableDomain;
 };
+
+class QuirkPatternList {
+public:
+    constexpr QuirkPatternList() = default;
+
+    constexpr QuirkPatternList(ASCIILiteral pattern)
+        : m_single(pattern)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!pattern.isNull());
+    }
+
+    template<size_t size> constexpr QuirkPatternList(const std::array<ASCIILiteral, size>& patterns LIFETIME_BOUND)
+        : m_multiple(patterns)
+    {
+        static_assert(size, "A quirk pattern list must name at least one pattern.");
+    }
+
+    constexpr bool isEmpty() const { return m_single.isNull() && m_multiple.empty(); }
+
+    bool contains(StringView value) const
+    {
+        return containsMatching([&](ASCIILiteral pattern) { return value == pattern; });
+    }
+
+    bool containsMatching(NOESCAPE const Invocable<bool(ASCIILiteral)> auto& predicate) const
+    {
+        for (auto pattern : span()) {
+            if (predicate(pattern))
+                return true;
+        }
+        return false;
+    }
+
+private:
+    constexpr std::span<const ASCIILiteral> span() const LIFETIME_BOUND
+    {
+        if (!m_multiple.empty())
+            return m_multiple;
+        if (m_single.isNull())
+            return { };
+        return singleElementSpan(m_single);
+    }
+
+    ASCIILiteral m_single;
+    std::span<const ASCIILiteral> m_multiple;
+};
+
+namespace QuirkRefinement {
+
+struct PathContains {
+    ASCIILiteral substring;
+};
+
+struct PathStartsWith {
+    ASCIILiteral prefix;
+};
+
+struct PathOrFragmentContains {
+    ASCIILiteral substring;
+};
+
+struct DocumentDomainIs {
+    QuirkPatternList domains;
+};
+
+struct HostIs {
+    QuirkPatternList hosts;
+};
+
+struct EnvironmentIs {
+    QuirkEnvironment environment;
+};
+
+struct Embedded { };
+
+constexpr PathContains pathContains(ASCIILiteral substring)
+{
+    return { substring };
+}
+
+constexpr PathStartsWith pathStartsWith(ASCIILiteral prefix)
+{
+    return { prefix };
+}
+
+constexpr PathOrFragmentContains pathOrFragmentContains(ASCIILiteral substring)
+{
+    return { substring };
+}
+
+constexpr DocumentDomainIs documentDomainIs(QuirkPatternList domains)
+{
+    return { domains };
+}
+
+constexpr HostIs hostIs(QuirkPatternList hosts)
+{
+    return { hosts };
+}
+
+constexpr Embedded embedded()
+{
+    return { };
+}
+
+constexpr EnvironmentIs smallScreen()
+{
+    return { QuirkEnvironment::SmallScreen };
+}
+
+constexpr EnvironmentIs tubularApp()
+{
+    return { QuirkEnvironment::TubularApp };
+}
+
+constexpr EnvironmentIs lensApp()
+{
+    return { QuirkEnvironment::LensApp };
+}
+
+} // namespace QuirkRefinement
 
 // QuirkMatch represents a declarative description of which pages a quirk applies to
 //
-// Every match starts with exactly one static factory, which picks how the site
-// is identified, and is then optionally narrowed by chained refinements. All
-// conditions are ANDed together:
+// Every match starts with exactly one static factory, which picks how the site is
+// identified. Each takes a single pattern or a list of them:
 //
-//     QuirkMatch::anyTopLevelDomain("apple"_s).pathStartsWith("/store"_s)
+//     domain()             the registrable domain, so "youtube.com" also covers
+//                          player.youtube.com but not youtube.co.uk
+//     host()               the exact host, so "docs.google.com" covers nothing else
+//     hostOrSubdomainOf()  the host or any subdomain of it, respecting label boundaries,
+//                          for HTTP-family URLs only
+//     anyTopLevelDomain()  the domain under every public suffix, so "amazon" covers
+//                          amazon.com and amazon.co.uk
+//     anySite()            every page with a host, for quirks keyed only on refinements
+//
+// when() then narrows the match with QuirkRefinement refinements, all of which are ANDed
+// together:
+//
+//     QuirkMatch::anyTopLevelDomain("apple"_s).when(pathStartsWith("/store"_s))
+//
+// exceptWhen() takes the same refinements to carve matching pages back out, so a
+// refinement reads identically in either position and its scope is bounded by the call:
+//
+//     QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s))
 //
 class QuirkMatch {
 public:
-    static constexpr QuirkMatch domain(ASCIILiteral domain)
+    static constexpr QuirkMatch domain(QuirkPatternList domains)
     {
-        return QuirkMatch { Kind::Domain, domain };
+        return QuirkMatch { Kind::Domain, domains };
     }
 
-    template<const auto& patterns> static constexpr QuirkMatch domains()
+    static constexpr QuirkMatch host(QuirkPatternList hosts)
     {
-        static_assert(std::size(patterns), "A quirk must match at least one domain.");
-        return QuirkMatch { Kind::Domain, std::span<const ASCIILiteral> { patterns } };
+        return QuirkMatch { Kind::Host, hosts };
     }
 
-    static constexpr QuirkMatch host(ASCIILiteral host)
+    static constexpr QuirkMatch hostOrSubdomainOf(QuirkPatternList hosts)
     {
-        return QuirkMatch { Kind::Host, host };
+        return QuirkMatch { Kind::HostOrSubdomainOf, hosts };
     }
 
-    static constexpr QuirkMatch hostOrSubdomainOf(ASCIILiteral host)
+    static constexpr QuirkMatch anyTopLevelDomain(QuirkPatternList names)
     {
-        return QuirkMatch { Kind::HostOrSubdomainOf, host };
-    }
-
-    static constexpr QuirkMatch hostEndingWith(ASCIILiteral suffix)
-    {
-        return QuirkMatch { Kind::HostEndingWith, suffix };
-    }
-
-    static constexpr QuirkMatch anyTopLevelDomain(ASCIILiteral name)
-    {
-        return QuirkMatch { Kind::AnyTopLevelDomain, name };
+        return QuirkMatch { Kind::AnyTopLevelDomain, names };
     }
 
     static constexpr QuirkMatch anySite()
@@ -143,258 +251,143 @@ public:
         return QuirkMatch { Kind::AnySite };
     }
 
-    constexpr QuirkMatch&& pathContains(ASCIILiteral substring) &&
+    template<typename... Refinements> constexpr QuirkMatch when(Refinements... refinements) &&
     {
-        return WTF::move(*this).setPathConstraint(PathConstraintKind::PathContains, substring);
-    }
+        static_assert(sizeof...(refinements), "when() must name at least one refinement to match.");
 
-    constexpr QuirkMatch&& pathStartsWith(ASCIILiteral prefix) &&
-    {
-        return WTF::move(*this).setPathConstraint(PathConstraintKind::PathStartsWith, prefix);
-    }
-
-    constexpr QuirkMatch&& pathOrFragmentContains(ASCIILiteral substring) &&
-    {
-        return WTF::move(*this).setPathConstraint(PathConstraintKind::PathOrFragmentContains, substring);
-    }
-
-    constexpr QuirkMatch&& onlyIf(QuirkCondition condition) &&
-    {
-        currentRefinements().condition = condition;
+        (applyRefinement(m_refinements, refinements), ...);
         return WTF::move(*this);
     }
 
-    constexpr QuirkMatch&& documentDomainIs(ASCIILiteral pattern) &&
+    template<typename... Refinements> constexpr QuirkMatch exceptWhen(Refinements... refinements) &&
     {
-        currentRefinements().documentDomains = PatternList { pattern };
+        static_assert(sizeof...(refinements), "exceptWhen() must name at least one refinement to exclude.");
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!m_exception);
+
+        RefinementSet exception;
+        (applyRefinement(exception, refinements), ...);
+        m_exception = exception;
         return WTF::move(*this);
     }
 
-    template<const auto& patterns> constexpr QuirkMatch&& documentDomainIsOneOf() &&
-    {
-        static_assert(std::size(patterns), "A quirk must match at least one document domain.");
-        currentRefinements().documentDomains = PatternList { std::span<const ASCIILiteral> { patterns } };
-        return WTF::move(*this);
-    }
-
-    template<const auto& patterns> constexpr QuirkMatch&& hostIsOneOf() &&
-    {
-        static_assert(std::size(patterns), "A quirk must match at least one host.");
-        currentRefinements().hosts = std::span<const ASCIILiteral> { patterns };
-        return WTF::move(*this);
-    }
-
-    constexpr QuirkMatch&& onlyIfEmbedded() &&
-    {
-        currentRefinements().requiresEmbeddedDocument = true;
-        return WTF::move(*this);
-    }
-
-    constexpr QuirkMatch&& exceptWhen() &&
-    {
-        m_refiningException = true;
-        return WTF::move(*this);
-    }
-
-    bool matches(const QuirkMatchContext& context) const
-    {
-        if (!matchesSite(context)) [[likely]]
-            return false;
-
-        if (!matchesRefinements(m_refinements, context))
-            return false;
-
-        if (!m_exception.isEmpty() && matchesRefinements(m_exception, context))
-            return false;
-
-        return true;
-    }
+    WEBCORE_EXPORT bool matches(const QuirkMatchContext&) const;
 
 private:
     enum class Kind : uint8_t {
         Domain,
         Host,
         HostOrSubdomainOf,
-        HostEndingWith,
         AnyTopLevelDomain,
         AnySite,
     };
 
-    enum class PathConstraintKind : uint8_t {
+    enum class PathComparison : uint8_t {
         PathContains,
         PathStartsWith,
         PathOrFragmentContains,
     };
 
-    class PatternList {
-    public:
-        constexpr PatternList() = default;
-
-        constexpr explicit PatternList(ASCIILiteral pattern)
-            : m_single(pattern)
-        {
-            ASSERT_UNDER_CONSTEXPR_CONTEXT(!pattern.isNull());
-        }
-
-        constexpr explicit PatternList(std::span<const ASCIILiteral> patterns)
-            : m_multiple(patterns)
-        {
-            ASSERT_UNDER_CONSTEXPR_CONTEXT(!patterns.empty());
-        }
-
-        std::span<const ASCIILiteral> span() const LIFETIME_BOUND
-        {
-            if (!m_multiple.empty())
-                return m_multiple;
-            if (m_single.isNull())
-                return { };
-            return singleElementSpan(m_single);
-        }
-
-        constexpr bool isEmpty() const { return m_multiple.empty() && m_single.isNull(); }
-
-    private:
-        ASCIILiteral m_single;
-        std::span<const ASCIILiteral> m_multiple;
-    };
-
-    struct Refinements {
-        PathConstraintKind pathConstraintKind { PathConstraintKind::PathContains };
-        ASCIILiteral pathConstraint;
-        std::optional<QuirkCondition> condition;
-        PatternList documentDomains;
-        std::span<const ASCIILiteral> hosts;
+    struct RefinementSet {
+        PathComparison pathComparison { PathComparison::PathContains };
+        ASCIILiteral pathPattern;
+        std::optional<QuirkEnvironment> environment;
+        QuirkPatternList documentDomains;
+        QuirkPatternList hosts;
         bool requiresEmbeddedDocument { false };
 
-        constexpr bool isEmpty() const
-        {
-            return !requiresEmbeddedDocument && pathConstraint.isNull() && !condition && documentDomains.isEmpty() && hosts.empty();
-        }
+        bool matches(const QuirkMatchContext&) const;
+
+    private:
+        bool matchesPathPattern(const URL& topURL) const;
     };
+
+    static constexpr void setPathPattern(RefinementSet& set, PathComparison comparison, ASCIILiteral pattern)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(set.pathPattern.isNull());
+        set.pathComparison = comparison;
+        set.pathPattern = pattern;
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::PathContains refinement)
+    {
+        setPathPattern(set, PathComparison::PathContains, refinement.substring);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::PathStartsWith refinement)
+    {
+        setPathPattern(set, PathComparison::PathStartsWith, refinement.prefix);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::PathOrFragmentContains refinement)
+    {
+        setPathPattern(set, PathComparison::PathOrFragmentContains, refinement.substring);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::DocumentDomainIs refinement)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(set.documentDomains.isEmpty());
+        set.documentDomains = refinement.domains;
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::HostIs refinement)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(set.hosts.isEmpty());
+        set.hosts = refinement.hosts;
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::EnvironmentIs refinement)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!set.environment);
+        set.environment = refinement.environment;
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::Embedded)
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!set.requiresEmbeddedDocument);
+        set.requiresEmbeddedDocument = true;
+    }
 
     constexpr explicit QuirkMatch(Kind kind)
         : m_kind(kind)
     {
     }
 
-    constexpr QuirkMatch(Kind kind, ASCIILiteral pattern)
-        : m_kind(kind)
-        , m_patterns(pattern)
-    {
-    }
-
-    constexpr QuirkMatch(Kind kind, std::span<const ASCIILiteral> patterns)
+    constexpr QuirkMatch(Kind kind, QuirkPatternList patterns)
         : m_kind(kind)
         , m_patterns(patterns)
     {
     }
 
-    constexpr Refinements& currentRefinements() LIFETIME_BOUND
-    {
-        return m_refiningException ? m_exception : m_refinements;
-    }
-
-    constexpr QuirkMatch&& setPathConstraint(PathConstraintKind kind, ASCIILiteral value) &&
-    {
-        auto& refinements = currentRefinements();
-        refinements.pathConstraintKind = kind;
-        refinements.pathConstraint = value;
-        return WTF::move(*this);
-    }
-
-    template<typename Function> bool anyPattern(NOESCAPE Function&& match) const
-    {
-        return std::ranges::any_of(m_patterns.span(), match);
-    }
-
-    bool matchesSite(const QuirkMatchContext& context) const
-    {
-        switch (m_kind) {
-        case Kind::Domain:
-            return anyPattern([&](ASCIILiteral pattern) { return context.registrableDomain() == pattern; });
-        case Kind::Host:
-            return anyPattern([&](ASCIILiteral pattern) { return context.host() == pattern; });
-        case Kind::HostOrSubdomainOf:
-            return anyPattern([&](ASCIILiteral pattern) { return context.topURL().isMatchingDomain(pattern); });
-        case Kind::HostEndingWith:
-            return anyPattern([&](ASCIILiteral pattern) { return context.host().endsWithIgnoringASCIICase(pattern); });
-        case Kind::AnyTopLevelDomain:
-            return anyPattern([&](ASCIILiteral pattern) { return context.domainWithoutPublicSuffix() == pattern; });
-        case Kind::AnySite:
-            return !context.host().isEmpty();
-        }
-
-        ASSERT_NOT_REACHED();
-        return false;
-    }
-
-    bool matchesRefinements(const Refinements& refinements, const QuirkMatchContext& context) const
-    {
-        if (!refinements.pathConstraint.isNull() && !matchesPathConstraint(refinements, context.topURL()))
-            return false;
-
-        if (refinements.condition && !evaluateQuirkCondition(*refinements.condition))
-            return false;
-
-        if (refinements.requiresEmbeddedDocument && context.isTopDocument())
-            return false;
-
-        if (!refinements.documentDomains.isEmpty() && !anyOf(refinements.documentDomains.span(), context.documentDomain()))
-            return false;
-
-        if (!refinements.hosts.empty() && !anyOf(refinements.hosts, context.host()))
-            return false;
-
-        return true;
-    }
-
-    template<typename StringType> static bool anyOf(std::span<const ASCIILiteral> patterns, const StringType& value)
-    {
-        return std::ranges::any_of(patterns, [&](ASCIILiteral pattern) { return value == pattern; });
-    }
-
-    bool matchesPathConstraint(const Refinements& refinements, const URL& topURL) const
-    {
-        switch (refinements.pathConstraintKind) {
-        case PathConstraintKind::PathContains:
-            return topURL.path().contains(refinements.pathConstraint);
-        case PathConstraintKind::PathStartsWith:
-            return startsWithLettersIgnoringASCIICase(topURL.path(), refinements.pathConstraint);
-        case PathConstraintKind::PathOrFragmentContains:
-            return topURL.path().contains(refinements.pathConstraint) || topURL.fragmentIdentifier().contains(refinements.pathConstraint);
-        }
-
-        ASSERT_NOT_REACHED();
-        return false;
-    }
+    bool matchesSite(const QuirkMatchContext&) const;
 
     Kind m_kind;
-    PatternList m_patterns;
-    Refinements m_refinements;
-    Refinements m_exception;
-    bool m_refiningException { false };
+    QuirkPatternList m_patterns;
+    RefinementSet m_refinements;
+    std::optional<RefinementSet> m_exception;
 };
 
-consteval QuirksData::QuirkBitSet quirkBehaviors(std::initializer_list<QuirksData::SiteSpecificQuirk> quirks)
-{
-    QuirksData::QuirkBitSet bits;
-    for (auto quirk : quirks)
-        bits.set(static_cast<size_t>(quirk));
-    return bits;
-}
+class QuirkBehaviors {
+public:
+    constexpr QuirkBehaviors() = default;
+
+    consteval QuirkBehaviors(std::initializer_list<QuirksData::SiteSpecificQuirk> quirks)
+    {
+        for (auto quirk : quirks)
+            m_bits.set(static_cast<size_t>(quirk));
+    }
+
+    constexpr const QuirksData::QuirkBitSet& bits() const LIFETIME_BOUND { return m_bits; }
+
+private:
+    QuirksData::QuirkBitSet m_bits;
+};
 
 struct Quirk {
     QuirkMatch match;
-    QuirksData::QuirkBitSet behaviors { };
+    QuirkBehaviors behaviors { };
     std::optional<QuirkSite> site { };
 
-    void apply(QuirksData& quirksData) const
-    {
-        quirksData.activeQuirks.merge(behaviors);
-
-        if (site)
-            quirksData.addSite(*site);
-    }
+    void apply(QuirksData&) const;
 };
 
 WEBCORE_EXPORT QuirksData resolveSiteSpecificQuirks(const QuirkMatchContext&);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2844,22 +2844,22 @@ void Quirks::setTopDocumentURLForTesting(URL&& url)
     determineRelevantQuirks();
 }
 
-bool evaluateQuirkCondition(QuirkCondition condition)
+bool evaluateQuirkEnvironment(QuirkEnvironment environment)
 {
-    switch (condition) {
-    case QuirkCondition::SmallScreen:
+    switch (environment) {
+    case QuirkEnvironment::SmallScreen:
 #if PLATFORM(IOS_FAMILY)
         return PAL::currentUserInterfaceIdiomIsSmallScreen();
 #else
         return false;
 #endif
-    case QuirkCondition::TubularApp:
+    case QuirkEnvironment::TubularApp:
 #if PLATFORM(IOS_FAMILY)
         return WTF::IOSApplication::isTubular();
 #else
         return false;
 #endif
-    case QuirkCondition::LensApp:
+    case QuirkEnvironment::LensApp:
 #if PLATFORM(IOS_FAMILY)
         return WTF::IOSApplication::isLensApp();
 #else
@@ -2887,33 +2887,34 @@ static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-noco
 
 namespace SiteSpecificQuirks {
 using enum QuirksData::SiteSpecificQuirk;
+using namespace QuirkRefinement;
 
 static constexpr Quirk table[] = {
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // 365scores.com rdar://116491386
     { .match = QuirkMatch::domain("365scores.com"_s),
-        .behaviors = quirkBehaviors({ ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting }) },
+        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 
 #if ENABLE(MEDIA_STREAM)
     // actesting.org rdar://124017544
     { .match = QuirkMatch::domain("actesting.org"_s),
-        .behaviors = quirkBehaviors({ ShouldEnableLegacyGetUserMediaQuirk }) },
+        .behaviors = { ShouldEnableLegacyGetUserMediaQuirk } },
 #endif
 
     // airindiaexpress.com https://webkit.org/b/317375
     { .match = QuirkMatch::domain("airindiaexpress.com"_s),
-        .behaviors = quirkBehaviors({ NeedsAirIndiaExpressLayeringQuirk }) },
+        .behaviors = { NeedsAirIndiaExpressLayeringQuirk } },
 
     // Note: There is a userAgent override for rdar://117771731, see needsCustomUserAgentOverride()
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // airtable.com rdar://49124313
     { .match = QuirkMatch::domain("airtable.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+        .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
     { .match = QuirkMatch::anyTopLevelDomain("amazon"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // amazon.com rdar://49124529
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
 #if PLATFORM(MAC)
@@ -2924,93 +2925,93 @@ static constexpr Quirk table[] = {
             // amazon.com rdar://49124313
             ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Amazon },
 
 #if PLATFORM(IOS_FAMILY)
     { .match = QuirkMatch::domain("amazon.design"_s),
-        .behaviors = quirkBehaviors({ NeedsAmazonDesignMenuViewportUnitQuirk }) },
+        .behaviors = { NeedsAmazonDesignMenuViewportUnitQuirk } },
 #endif
 
     // apple.com rdar://154434137
     // FIXME: Maybe EnsureCaptionVisibilityInFullscreenAndPictureInPicture should apply to apple.com.cn too?
     { .match = QuirkMatch::domain("apple.com"_s),
-        .behaviors = quirkBehaviors({ EnsureCaptionVisibilityInFullscreenAndPictureInPicture }) },
+        .behaviors = { EnsureCaptionVisibilityInFullscreenAndPictureInPicture } },
 
     // Quirk added for rdar://181007316, remove when rdar://182134549 is fixed.
-    { .match = QuirkMatch::anyTopLevelDomain("apple"_s).pathContains("/retail"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableScrollAnchoringQuirk }) },
+    { .match = QuirkMatch::anyTopLevelDomain("apple"_s).when(pathContains("/retail"_s)),
+        .behaviors = { ShouldDisableScrollAnchoringQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // as.com: rdar://121014613
-    { .match = QuirkMatch::domain("as.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::domain("as.com"_s).when(smallScreen()),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // att.com rdar://55185021
     { .match = QuirkMatch::domain("att.com"_s),
-        .behaviors = quirkBehaviors({ ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk }) },
+        .behaviors = { ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk } },
 #endif
 
     // Login issue on bankofamerica.com (rdar://104938789).
     { .match = QuirkMatch::domain("bankofamerica.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             MaybeBypassBackForwardCache,
-        }),
+        },
         .site = QuirkSite::BankOfAmerica },
 
     // bbc.co.uk rdar://126494734
     // bbc.com rdar://157499149
-    { .match = QuirkMatch::domains<bbcDomains>(),
-        .behaviors = quirkBehaviors({ ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk }) },
+    { .match = QuirkMatch::domain(bbcDomains),
+        .behaviors = { ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk } },
 
     // bestbuy.com rdar://136235936
     { .match = QuirkMatch::domain("bestbuy.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::BestBuy },
 
     { .match = QuirkMatch::domain("bing.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // bing.com rdar://133223599
             MaybeBypassBackForwardCache,
             // bing.com rdar://126573838
             NeedsMediaRewriteRangeRequestQuirk,
-        }),
+        },
         .site = QuirkSite::Bing },
 
     // bungalow.com rdar://61658940
     { .match = QuirkMatch::domain("bungalow.com"_s),
-        .behaviors = quirkBehaviors({ ShouldBypassAsyncScriptDeferring }) },
+        .behaviors = { ShouldBypassAsyncScriptDeferring } },
 
     { .match = QuirkMatch::domain("capitalgroup.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDelayReloadWhenRegisteringServiceWorker }) },
+        .behaviors = { ShouldDelayReloadWhenRegisteringServiceWorker } },
 
 #if PLATFORM(IOS_FAMILY)
     // Remove this once rdar://139478801 is resolved.
     { .match = QuirkMatch::domain("cbssports.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk,
-        }),
+        },
         .site = QuirkSite::CBSSports },
 #endif
 
     { .match = QuirkMatch::hostOrSubdomainOf("ceac.state.gov"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(MAC)
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
             NeedsFormControlToBeMouseFocusableQuirk,
 #endif
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=311383
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::CEAC },
 #if PLATFORM(IOS)
-    { .match = QuirkMatch::domain("chess.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen }) },
+    { .match = QuirkMatch::domain("chess.com"_s).when(smallScreen()),
+        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
 #endif
     { .match = QuirkMatch::domain("claude.ai"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             NeedsClaudeSidebarViewportUnitQuirk,
 #endif
@@ -3018,16 +3019,16 @@ static constexpr Quirk table[] = {
             // causing redirect loop on next /chat boot.
             // See Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded().
             NeedsLogoutCookieCleanupQuirk,
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::domains<claudeDomains>(),
-        .behaviors = quirkBehaviors({ NeedsHideSelectionDuringOverflowScrollQuirk }) },
+    { .match = QuirkMatch::domain(claudeDomains),
+        .behaviors = { NeedsHideSelectionDuringOverflowScrollQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     { .match = QuirkMatch::domain("cnn.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // cnn.com rdar://119640248
             NeedsFullscreenObjectFitQuirk,
 #if PLATFORM(COCOA)
@@ -3037,63 +3038,63 @@ static constexpr Quirk table[] = {
             // cnn.com rdar://176539646
             ShouldDisableThreadedAnimationsQuirk,
 #endif
-        }) },
+        } },
 #endif
 
 #if ENABLE(MEDIA_STREAM)
     { .match = QuirkMatch::host("codepen.io"_s),
-        .behaviors = quirkBehaviors({ ShouldEnableSpeakerSelectionPermissionsPolicyQuirk }) },
+        .behaviors = { ShouldEnableSpeakerSelectionPermissionsPolicyQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("crunchyroll.com"_s),
-        .behaviors = quirkBehaviors({ NeedsSuppressPostLayoutBoundaryEventsQuirk }) },
+        .behaviors = { NeedsSuppressPostLayoutBoundaryEventsQuirk } },
 
     { .match = QuirkMatch::domain("dailymail.co.uk"_s),
-        .behaviors = quirkBehaviors({ ShouldUnloadHeavyFrames }) },
+        .behaviors = { ShouldUnloadHeavyFrames } },
 
     { .match = QuirkMatch::host("digits.t-mobile.com"_s),
-        .behaviors = quirkBehaviors({ NeedsNavigatorUserAgentDataQuirk, NeedsCustomUserAgentData }) },
+        .behaviors = { NeedsNavigatorUserAgentDataQuirk, NeedsCustomUserAgentData } },
 
     // descript.com rdar://156024693
     { .match = QuirkMatch::domain("descript.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableDOMAudioSession }) },
+        .behaviors = { ShouldDisableDOMAudioSession } },
 
     { .match = QuirkMatch::domain("dictionary.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
 #endif
 #if PLATFORM(COCOA)
             NeedsAnchorToBeMouseFocusableQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Dictionary },
 
 #if PLATFORM(IOS_FAMILY)
     // digitaltrends.com rdar://121014613
-    { .match = QuirkMatch::domain("digitaltrends.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::domain("digitaltrends.com"_s).when(smallScreen()),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // discord.com rdar://162719481
     { .match = QuirkMatch::domain("discord.com"_s),
-        .behaviors = quirkBehaviors({ ShouldUseLayoutViewportForClientRectsQuirk }) },
+        .behaviors = { ShouldUseLayoutViewportForClientRectsQuirk } },
 
     { .match = QuirkMatch::domain("disneyplus.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // disneyplus rdar://137613110
             ShouldHideCoarsePointerCharacteristicsQuirk,
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
             // disneyplus rdar://151715964
             NeedsZeroMaxTouchPointsQuirk,
 #endif
-        }) },
+        } },
 #endif
 
     { .match = QuirkMatch::domain("ea.com"_s),
         .site = QuirkSite::EA },
 
     { .match = QuirkMatch::domain("espn.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(IOS)
             // espn.com rdar://154903596
             NeedsPauseBeforeFullscreenExitQuirk,
@@ -3106,18 +3107,18 @@ static constexpr Quirk table[] = {
             // espn.com rdar://problem/73227900
             ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk,
 #endif
-        }) },
+        } },
 
     // Expedia Group rdar://126631968
-    { .match = QuirkMatch::domains<expediaGroupDomains>(),
-        .behaviors = quirkBehaviors({ NeedsExpediaGroupAnimationQuirk }) },
+    { .match = QuirkMatch::domain(expediaGroupDomains),
+        .behaviors = { NeedsExpediaGroupAnimationQuirk } },
     { .match = QuirkMatch::anyTopLevelDomain("ebookers"_s),
-        .behaviors = quirkBehaviors({ NeedsExpediaGroupAnimationQuirk }) },
+        .behaviors = { NeedsExpediaGroupAnimationQuirk } },
     { .match = QuirkMatch::anyTopLevelDomain("expedia"_s),
-        .behaviors = quirkBehaviors({ NeedsExpediaGroupAnimationQuirk }) },
+        .behaviors = { NeedsExpediaGroupAnimationQuirk } },
 
     { .match = QuirkMatch::domain("facebook.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // facebook.com rdar://100871402
             NeedsFacebookRemoveNotSupportedQuirk,
             // facebook.com rdar://174179871
@@ -3143,39 +3144,39 @@ static constexpr Quirk table[] = {
             // facebook.com rdar://174179871
             ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Facebook },
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // flipkart.com rdar://49648520
     { .match = QuirkMatch::domain("flipkart.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+        .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // forbes.com rdar://67273166
     { .match = QuirkMatch::domain("forbes.com"_s),
-        .behaviors = quirkBehaviors({ RequiresUserGestureToPauseInPictureInPictureQuirk }) },
+        .behaviors = { RequiresUserGestureToPauseInPictureInPictureQuirk } },
 #endif
 
     { .match = QuirkMatch::host("play.geforcenow.com"_s),
-        .behaviors = quirkBehaviors({ NeedsGeforcenowWarningDisplayNoneQuirk }) },
+        .behaviors = { NeedsGeforcenowWarningDisplayNoneQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // gizmodo.com rdar://102227302
     { .match = QuirkMatch::domain("gizmodo.com"_s),
-        .behaviors = quirkBehaviors({ NeedsFullscreenDisplayNoneQuirk }) },
+        .behaviors = { NeedsFullscreenDisplayNoneQuirk } },
 #endif
 
     { .match = QuirkMatch::anyTopLevelDomain("google"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // docs.google.com rdar://59893415
             MaybeBypassBackForwardCache,
-        }),
+        },
         .site = QuirkSite::GoogleProperty },
 
-    { .match = QuirkMatch::anyTopLevelDomain("google"_s).pathStartsWith("/maps/"_s),
-        .behaviors = quirkBehaviors({
+    { .match = QuirkMatch::anyTopLevelDomain("google"_s).when(pathStartsWith("/maps/"_s)),
+        .behaviors = {
 #if ENABLE(TWO_PHASE_CLICKS)
             // maps.google.com rdar://152194074
             MayNeedToIgnoreContentObservation,
@@ -3190,11 +3191,11 @@ static constexpr Quirk table[] = {
             // maps.google.com rdar://49124313
             ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::GoogleMaps },
 
     { .match = QuirkMatch::host("docs.google.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             InputMethodUsesCorrectKeyEventOrder,
 #if PLATFORM(MAC)
             InputMethodMustUseCompositionEvents,
@@ -3205,46 +3206,46 @@ static constexpr Quirk table[] = {
             // docs.google.com rdar://49864669
             ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::GoogleDocs },
 
 #if PLATFORM(IOS_FAMILY)
     // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
-    { .match = QuirkMatch::host("docs.google.com"_s).pathStartsWith("/spreadsheets/"_s),
-        .behaviors = quirkBehaviors({ NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk }) },
+    { .match = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/spreadsheets/"_s)),
+        .behaviors = { NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk } },
 
-    { .match = QuirkMatch::host("docs.google.com"_s).pathStartsWith("/presentation/"_s),
-        .behaviors = quirkBehaviors({ ShouldIgnoreInputModeNone }) },
+    { .match = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/presentation/"_s)),
+        .behaviors = { ShouldIgnoreInputModeNone } },
 
     // mail.google.com rdar://49403416
     { .match = QuirkMatch::host("mail.google.com"_s),
-        .behaviors = quirkBehaviors({ NeedsGMailOverflowScrollQuirk }) },
+        .behaviors = { NeedsGMailOverflowScrollQuirk } },
 
     { .match = QuirkMatch::host("translate.google.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // translate.google.com rdar://106539018
             NeedsGoogleTranslateScrollingQuirk,
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }) },
+        } },
 #endif
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // sites.google.com rdar://58653069
     { .match = QuirkMatch::host("sites.google.com"_s),
-        .behaviors = quirkBehaviors({ ShouldPreventDispatchOfTouchEventQuirk }) },
+        .behaviors = { ShouldPreventDispatchOfTouchEventQuirk } },
 #endif
 
 #if ENABLE(MEDIA_STREAM)
     { .match = QuirkMatch::host("meet.google.com"_s),
-        .behaviors = quirkBehaviors({ ShouldEnableCameraBackgroundPlayback }) },
+        .behaviors = { ShouldEnableCameraBackgroundPlayback } },
 #endif
 
     // hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
     { .match = QuirkMatch::domain("hbomax.com"_s),
-        .behaviors = quirkBehaviors({ ShouldEnableFontLoadingAPIQuirk }) },
+        .behaviors = { ShouldEnableFontLoadingAPIQuirk } },
 
     { .match = QuirkMatch::host("play.hbomax.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if HAVE(PIP_SKIP_PREROLL)
             // play.hbomax.com rdar://158430821
             ShouldDisableAdSkippingInPip,
@@ -3255,81 +3256,81 @@ static constexpr Quirk table[] = {
             // hbomax.com: rdar://138806698
             ShouldSupportHoverMediaQueriesQuirk,
 #endif
-        }) },
+        } },
 
     { .match = QuirkMatch::domain("hulu.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // hulu.com rdar://55041979
             NeedsCanPlayAfterSeekedQuirk,
             // hulu.com rdar://100199996
             NeedsVideoShouldMaintainAspectRatioQuirk,
             // hulu.com rdar://126096361
             ImplicitMuteWhenVolumeSetToZero,
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // icloud.com rdar://131836301
-    { .match = QuirkMatch::domain("icloud.com"_s).pathOrFragmentContains("mail"_s),
-        .behaviors = quirkBehaviors({ ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting }) },
+    { .match = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s)),
+        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 #if PLATFORM(MAC)
     // icloud.com rdar://26013388
-    { .match = QuirkMatch::domain("icloud.com"_s).pathOrFragmentContains("notes"_s),
-        .behaviors = quirkBehaviors({ IsNeverRichlyEditableForTouchBarQuirk }) },
+    { .match = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("notes"_s)),
+        .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("iheart.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::IHeart },
 
     { .match = QuirkMatch::domain("imdb.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // imdb.com: rdar://137991466
             NeedsChromeMediaControlsPseudoElementQuirk,
             // imdb.com: rdar://162684936
             NeedsZeroMaxTouchPointsQuirk,
-        }) },
+        } },
 
     { .match = QuirkMatch::domain("instagram.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // rdar://166400170
             NeedsInstagramResizingReelsQuirk,
 #if PLATFORM(IOS_FAMILY)
             // instagram.com: rdar://174936655
             ShouldSendFakeTouchForceChangeEvent,
 #endif
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // instagram.com rdar://121014613
     { .match = QuirkMatch::domain("instagram.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 #endif
 
     // invideo.io rdar://171741842 https://webkit.org/b/311602
     { .match = QuirkMatch::domain("invideo.io"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::InVideo },
 
     { .match = QuirkMatch::domain("linkedin.com"_s),
         .site = QuirkSite::LinkedIn },
 
     { .match = QuirkMatch::domain("live.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             // live.com: rdar://167489768
             NeedsChromeOSNavigatorUserAgentQuirk,
 #endif
             // live.com rdar://52116170
             ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
-        }) },
+        } },
 
     { .match = QuirkMatch::host("outlook.live.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // outlook.live.com: rdar://136624720
             NeedsMozillaFileTypeForDataTransferQuirk,
 #if ENABLE(TWO_PHASE_CLICKS)
@@ -3340,57 +3341,57 @@ static constexpr Quirk table[] = {
             // outlook.live.com rdar://48008837
             ShouldPreventDispatchOfTouchEventQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Outlook },
 
     // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
-    { .match = QuirkMatch::hostEndingWith("officeapps.live.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableDataURLPaddingValidation }) },
-    { .match = QuirkMatch::hostEndingWith("onedrive.live.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableDataURLPaddingValidation }) },
+    { .match = QuirkMatch::hostOrSubdomainOf("officeapps.live.com"_s),
+        .behaviors = { ShouldDisableDataURLPaddingValidation } },
+    { .match = QuirkMatch::hostOrSubdomainOf("onedrive.live.com"_s),
+        .behaviors = { ShouldDisableDataURLPaddingValidation } },
 
 #if PLATFORM(MAC)
     // onedrive.live.com rdar://26013388
     { .match = QuirkMatch::host("onedrive.live.com"_s),
-        .behaviors = quirkBehaviors({ IsNeverRichlyEditableForTouchBarQuirk }) },
+        .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 
     // madisoncity.k12.al.us https://bugs.webkit.org/show_bug.cgi?id=296989
     { .match = QuirkMatch::domain("madisoncity.k12.al.us"_s),
-        .behaviors = quirkBehaviors({ NeedsFormControlToBeMouseFocusableQuirk }) },
+        .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     // mailchimp.com rdar://47868965
     { .match = QuirkMatch::domain("mailchimp.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisablePointerEventsQuirk }) },
+        .behaviors = { ShouldDisablePointerEventsQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("marcus.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // Marcus: <rdar://101086391>.
             ShouldExposeShowModalDialog,
 #if PLATFORM(IOS_FAMILY)
             // marcus.com rdar://102959860
             ShouldNavigatorPluginsBeEmpty,
 #endif
-        }) },
+        } },
 
     // medium.com rdar://50457837
     { .match = QuirkMatch::domain("medium.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk }) },
+        .behaviors = { ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // m365.cloud.microsoft rdar://157794706
-    { .match = QuirkMatch::hostEndingWith("m365.cloud.microsoft"_s),
-        .behaviors = quirkBehaviors({ ShouldAllowPopupFromMicrosoftOfficeToOneDrive }) },
+    { .match = QuirkMatch::hostOrSubdomainOf("m365.cloud.microsoft"_s),
+        .behaviors = { ShouldAllowPopupFromMicrosoftOfficeToOneDrive } },
 #endif
 
     // safe.menlosecurity.com rdar://135114489
     { .match = QuirkMatch::host("safe.menlosecurity.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableWritingSuggestionsByDefaultQuirk }) },
+        .behaviors = { ShouldDisableWritingSuggestionsByDefaultQuirk } },
 
     { .match = QuirkMatch::domain("messenger.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if ENABLE(MEDIA_STREAM)
             // facebook.com rdar://158736355
             ShouldEnableCameraAndMicrophonePermissionStateQuirk,
@@ -3402,34 +3403,34 @@ static constexpr Quirk table[] = {
             // facebook.com rdar://158736355
             ShouldEnableRTCEncodedStreamsQuirk,
 #endif
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // rdar://147429596
     { .match = QuirkMatch::domain("nba.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::NBA },
 #if PLATFORM(IOS)
-    { .match = QuirkMatch::domain("nba.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen }) },
+    { .match = QuirkMatch::domain("nba.com"_s).when(smallScreen()),
+        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
 #endif
 #endif
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // mybinder.org rdar://51770057
     { .match = QuirkMatch::domain("mybinder.org"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }),
+        .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk },
         .site = QuirkSite::MyBinder },
 
     // naver.com rdar://48068610
-    { .match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen().hostIsOneOf<naverHostsWithoutSimulatedMouseEvents>(),
-        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+    { .match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs(naverHostsWithoutSimulatedMouseEvents)),
+        .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("netflix.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
             NeedsSeekingSupportDisabledQuirk,
 #if PLATFORM(VISION)
@@ -3443,49 +3444,49 @@ static constexpr Quirk table[] = {
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=304608
             ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick,
 #endif
-        }),
+        },
         .site = QuirkSite::Netflix },
 
     { .match = QuirkMatch::domain("nfl.com"_s),
-        .behaviors = quirkBehaviors({ ShouldSuppressHLSSubtitles }) },
+        .behaviors = { ShouldSuppressHLSSubtitles } },
 
     { .match = QuirkMatch::domain("nhl.com"_s),
-        .behaviors = quirkBehaviors({ NeedsWebKitMediaTextTrackDisplayQuirk }) },
+        .behaviors = { NeedsWebKitMediaTextTrackDisplayQuirk } },
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // nytimes.com: rdar://problem/5976384
     { .match = QuirkMatch::domain("nytimes.com"_s),
-        .behaviors = quirkBehaviors({ ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting }) },
+        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 
     // Pandora: <rdar://100243111>.
     { .match = QuirkMatch::domain("pandora.com"_s),
-        .behaviors = quirkBehaviors({ ShouldExposeShowModalDialog }) },
+        .behaviors = { ShouldExposeShowModalDialog } },
 
     // pinterest.com rdar://104979314
     // FIXME: Remove this Quirk if Pinterest decides to trigger this notification from an user gesture (rdar://165745719)
     { .match = QuirkMatch::domain("pinterest.com"_s),
-        .behaviors = quirkBehaviors({ ShouldAllowNotificationPermissionWithoutUserGesture }) },
+        .behaviors = { ShouldAllowNotificationPermissionWithoutUserGesture } },
 
     { .match = QuirkMatch::domain("premierleague.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // premierleague.com: rdar://123721211
             ShouldIgnorePlaysInlineRequirementQuirk,
             // premierleague.com: rdar://68938833
             ShouldDispatchPlayPauseEventsOnResume,
             // premierleague.com: rdar://136791737
             ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // ralphlauren.com rdar://55629493
     { .match = QuirkMatch::domain("ralphlauren.com"_s),
-        .behaviors = quirkBehaviors({ ShouldIgnoreAriaForFastPathContentObservationCheckQuirk }) },
+        .behaviors = { ShouldIgnoreAriaForFastPathContentObservationCheckQuirk } },
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE) || PLATFORM(IOS_FAMILY)
     { .match = QuirkMatch::domain("reddit.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
             // reddit.com: rdar://80550715
             RequiresUserGestureToPauseInPictureInPictureQuirk,
@@ -3494,32 +3495,32 @@ static constexpr Quirk table[] = {
             // reddit.com with Sink It extension: rdar://176377447.
             ShouldDisableScrollAnchoringQuirk,
 #endif
-        }) },
+        } },
 #endif
 
     { .match = QuirkMatch::domain("scribd.com"_s),
-        .behaviors = quirkBehaviors({ NeedsReuseLiveRangeForSelectionUpdateQuirk }) },
+        .behaviors = { NeedsReuseLiveRangeForSelectionUpdateQuirk } },
 
     // sfusd.edu: rdar://116292738
     { .match = QuirkMatch::domain("sfusd.edu"_s),
-        .behaviors = quirkBehaviors({ ShouldBypassAsyncScriptDeferring }) },
+        .behaviors = { ShouldBypassAsyncScriptDeferring } },
 
     // sharepoint.com rdar://52116170
     { .match = QuirkMatch::domain("sharepoint.com"_s),
-        .behaviors = quirkBehaviors({ ShouldAvoidResizingWhenInputViewBoundsChangeQuirk }) },
+        .behaviors = { ShouldAvoidResizingWhenInputViewBoundsChangeQuirk } },
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(META_VIEWPORT)
     { .match = QuirkMatch::domain("slack.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // slack.com: rdar://138614711
             ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk,
             // slack.com: rdar://171190689
             ShouldUseDynamicViewportUnitsAsDefaultQuirk,
-        }) },
+        } },
 #endif
 
     { .match = QuirkMatch::domain("soundcloud.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // soundcloud.com rdar://52915981
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
             // Soundcloud: rdar://102913500
@@ -3528,18 +3529,18 @@ static constexpr Quirk table[] = {
             // soundcloud.com rdar://52915981
             ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::SoundCloud },
 
 #if ENABLE(TOUCH_EVENTS)
     // soylent.*: rdar://113314067
     { .match = QuirkMatch::anyTopLevelDomain("soylent"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick }) },
+        .behaviors = { ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick } },
 #endif
 
     // spotify.com rdar://138918575
     { .match = QuirkMatch::host("open.spotify.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsBodyScrollbarWidthNoneDisabledQuirk,
             ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
             ShouldLimitHLSPlaybackRate,
@@ -3549,36 +3550,36 @@ static constexpr Quirk table[] = {
 #if PLATFORM(COCOA)
             NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk,
 #endif
-        }) },
+        } },
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     // Remove this once rdar://142573562 is resolved.
     { .match = QuirkMatch::domain("steampowered.com"_s),
-        .behaviors = quirkBehaviors({ ShouldTreatAddingMouseOutEventListenerAsContentChange }) },
+        .behaviors = { ShouldTreatAddingMouseOutEventListenerAsContentChange } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     { .match = QuirkMatch::anyTopLevelDomain("theguardian"_s),
-        .behaviors = quirkBehaviors({ ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk }) },
+        .behaviors = { ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk } },
 
     // theguardian.com rdar://166727225
-    { .match = QuirkMatch::anyTopLevelDomain("theguardian"_s).documentDomainIsOneOf<youTubeEmbedDomains>(),
-        .behaviors = quirkBehaviors({ NeedsYouTubeEmbedAutoplayQuirk }) },
+    { .match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(documentDomainIs(youTubeEmbedDomains)),
+        .behaviors = { NeedsYouTubeEmbedAutoplayQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("thesaurus.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
 #endif
 #if PLATFORM(COCOA)
             NeedsAnchorToBeMouseFocusableQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Thesaurus },
 
     { .match = QuirkMatch::domain("tiktok.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsTikTokOverflowingContentQuirk,
             // tiktok.com rdar://174179805
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
@@ -3586,31 +3587,31 @@ static constexpr Quirk table[] = {
             // tiktok.com rdar://174179805
             ShouldDispatchSimulatedMouseEventsQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::TikTok },
 
 #if PLATFORM(MAC)
     // trix-editor.org rdar://28242210
     { .match = QuirkMatch::domain("trix-editor.org"_s),
-        .behaviors = quirkBehaviors({ IsNeverRichlyEditableForTouchBarQuirk }) },
+        .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
     // twitch.tv rdar://102420527
     { .match = QuirkMatch::domain("twitch.tv"_s),
-        .behaviors = quirkBehaviors({ ShouldReportDocumentAsVisibleIfActivePIPQuirk }) },
+        .behaviors = { ShouldReportDocumentAsVisibleIfActivePIPQuirk } },
 #endif
 
     // https://tympanus.net/Tutorials/WebGPUFluid/ does not load (rdar://143839620).
     { .match = QuirkMatch::domain("tympanus.net"_s),
-        .behaviors = quirkBehaviors({ ShouldBlockFetchWithNewlineAndLessThan }) },
+        .behaviors = { ShouldBlockFetchWithNewlineAndLessThan } },
 
     // Breaks express checkout on victoriassecret.com (rdar://104818312).
     { .match = QuirkMatch::domain("victoriassecret.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableFetchMetadata }) },
+        .behaviors = { ShouldDisableFetchMetadata } },
 
     { .match = QuirkMatch::domain("vimeo.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // vimeo.com rdar://56996057
             MaybeBypassBackForwardCache,
 #if PLATFORM(IOS_FAMILY)
@@ -3627,70 +3628,70 @@ static constexpr Quirk table[] = {
             // vimeo.com: rdar://problem/70788878
             BlocksReturnToFullscreenFromPictureInPictureQuirk,
 #endif
-        }),
+        },
         .site = QuirkSite::Vimeo },
 
 #if PLATFORM(IOS_FAMILY)
     // rdar://116531089
-    { .match = QuirkMatch::domain("vimeo.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::domain("vimeo.com"_s).when(smallScreen()),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
     // walmart.com: rdar://123734840
     { .match = QuirkMatch::domain("walmart.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             MayNeedToIgnoreContentObservation,
-        }),
+        },
         .site = QuirkSite::Walmart },
 #endif
 
 #if PLATFORM(MAC)
     // weather.com rdar://139689157
     { .match = QuirkMatch::domain("weather.com"_s),
-        .behaviors = quirkBehaviors({ NeedsFormControlToBeMouseFocusableQuirk }) },
+        .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
     { .match = QuirkMatch::domain("webex.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        }),
+        },
         .site = QuirkSite::WebEx },
 #endif
 
     // weebly.com rdar://48003980
     { .match = QuirkMatch::domain("weebly.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk }) },
+        .behaviors = { ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk } },
 
     { .match = QuirkMatch::domain("wikipedia.org"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // wikipedia.org rdar://54856323
             ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk,
 #if ENABLE(META_VIEWPORT)
             // wikipedia.org https://webkit.org/b/247636
             ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk,
 #endif
-        }) },
+        } },
 
     // rdar://170412045, https://bugs.webkit.org/show_bug.cgi?id=307933
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // wix.com rdar://49124313, except while picking a template.
-    { .match = QuirkMatch::domain("wix.com"_s).exceptWhen().pathStartsWith("/website/templates/"_s),
-        .behaviors = quirkBehaviors({ ShouldDispatchSimulatedMouseEventsQuirk }) },
+    { .match = QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s)),
+        .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("workspaces.xyz"_s),
-        .behaviors = quirkBehaviors({ ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions }) },
+        .behaviors = { ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions } },
 
 #if PLATFORM(MAC)
     // wpdevelopment.ca rdar://156109518
     { .match = QuirkMatch::domain("wpdevelopment.ca"_s),
-        .behaviors = quirkBehaviors({ NeedsFormControlToBeMouseFocusableQuirk }) },
+        .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("x.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
 #if PLATFORM(VISION)
             // x.com: rdar://132850672
             ShouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk,
@@ -3709,10 +3710,10 @@ static constexpr Quirk table[] = {
             // x.com: rdar://73369869
             RequiresUserGestureToPauseInPictureInPictureQuirk,
 #endif
-        }) },
+        } },
 
     { .match = QuirkMatch::anyTopLevelDomain("yahoo"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // yahoo.com: rdar://170502516
             NeedsYahooVolumeSliderQuirk,
             // yahoo.com: rdar://136767005
@@ -3721,16 +3722,16 @@ static constexpr Quirk table[] = {
             // yahoo.com : rdar://142894603
             ShouldPreventDispatchOfTouchEventQuirk,
 #endif
-        }) },
+        } },
 
 #if ENABLE(TEXT_AUTOSIZING)
     // news.ycombinator.com: rdar://127246368
     { .match = QuirkMatch::host("news.ycombinator.com"_s),
-        .behaviors = quirkBehaviors({ ShouldIgnoreTextAutoSizingQuirk }) },
+        .behaviors = { ShouldIgnoreTextAutoSizingQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("youtube.com"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
             HasBrokenEncryptedMediaAPISupportQuirk,
             // youtube.com rdar://135886305
@@ -3742,58 +3743,58 @@ static constexpr Quirk table[] = {
             // youtube.com: rdar://110097836
             ShouldSilenceResizeObservers,
 #endif
-        }) },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
-    { .match = QuirkMatch::domain("youtube.com"_s).onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::domain("youtube.com"_s).when(smallScreen()),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // tiny. (Ref: rdar://121471373, rdar://121473410)
-    { .match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIsOneOf<youTubeEmbedDomains>().onlyIf(QuirkCondition::SmallScreen),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains), smallScreen()),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
-    { .match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIs("x.com"_s),
-        .behaviors = quirkBehaviors({ ShouldDisableElementFullscreenQuirk }) },
+    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs("x.com"_s)),
+        .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // youtube.com rdar://49582231
     { .match = QuirkMatch::host("www.youtube.com"_s),
-        .behaviors = quirkBehaviors({ NeedsYouTubeOverflowScrollQuirk }) },
+        .behaviors = { NeedsYouTubeOverflowScrollQuirk } },
 
-    { .match = QuirkMatch::domain("youtube.com"_s).onlyIf(QuirkCondition::TubularApp),
-        .behaviors = quirkBehaviors({ ShouldSuppressMediaSessionPauseActionOnInterruption }) },
+    { .match = QuirkMatch::domain("youtube.com"_s).when(tubularApp()),
+        .behaviors = { ShouldSuppressMediaSessionPauseActionOnInterruption } },
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
     // www.youtube.com rdar://52361019
     { .match = QuirkMatch::host("www.youtube.com"_s),
-        .behaviors = quirkBehaviors({ NeedsYouTubeMouseOutQuirk }) },
+        .behaviors = { NeedsYouTubeMouseOutQuirk } },
 #endif
 
 #if PLATFORM(VISION) && ENABLE(FULLSCREEN_API)
     // Lens.app rdar://178769976
-    { .match = QuirkMatch::domain("youtube.com"_s).onlyIf(QuirkCondition::LensApp),
-        .behaviors = quirkBehaviors({ RequiresUserGestureToPlayInFullscreenQuirk }) },
+    { .match = QuirkMatch::domain("youtube.com"_s).when(lensApp()),
+        .behaviors = { RequiresUserGestureToPlayInFullscreenQuirk } },
 #endif
 
     // zillow.com rdar://53103732
     { .match = QuirkMatch::host("www.zillow.com"_s),
-        .behaviors = quirkBehaviors({ ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk }) },
+        .behaviors = { ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk } },
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // zillow.com rdar://110097836
     { .match = QuirkMatch::domain("zillow.com"_s),
-        .behaviors = quirkBehaviors({ ShouldSilenceResizeObservers }) },
+        .behaviors = { ShouldSilenceResizeObservers } },
 #endif
 
 #if PLATFORM(MAC)
     { .match = QuirkMatch::domain("zomato.com"_s),
-        .behaviors = quirkBehaviors({ NeedsZomatoEmailLoginLabelQuirk }) },
+        .behaviors = { NeedsZomatoEmailLoginLabelQuirk } },
 #endif
 
     { .match = QuirkMatch::domain("zoom.us"_s),
-        .behaviors = quirkBehaviors({
+        .behaviors = {
             // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
             ShouldAutoplayWebAudioForArbitraryUserGestureQuirk,
 #if ENABLE(MEDIA_STREAM)
@@ -3801,7 +3802,7 @@ static constexpr Quirk table[] = {
             ShouldDisableImageCaptureQuirk,
             ShouldAllowMediaStreamTrackSerializationQuirk,
 #endif
-        }) },
+        } },
 };
 
 } // namespace SiteSpecificQuirks

--- a/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
@@ -32,13 +32,14 @@
 
 namespace TestWebKitAPI {
 
-using WebCore::QuirkCondition;
+using WebCore::QuirkEnvironment;
 using WebCore::QuirkMatch;
 using WebCore::QuirkMatchContext;
+using namespace WebCore::QuirkRefinement;
 
 static bool matchesURL(const QuirkMatch& match, ASCIILiteral urlString)
 {
-    return match.matches(QuirkMatchContext { URL { urlString }, URL { urlString } });
+    return match.matches(QuirkMatchContext { URL { urlString }, URL { urlString }, WebCore::IsTopDocument::Yes });
 }
 
 static bool matchesEmbeddedURL(const QuirkMatch& match, ASCIILiteral topURLString, ASCIILiteral documentURLString)
@@ -78,7 +79,7 @@ TEST(QuirkMatchTest, DomainUnderstandsMultiLabelPublicSuffixes)
 
 TEST(QuirkMatchTest, DomainsMatchesAnyPatternInTheList)
 {
-    auto match = QuirkMatch::domains<expediaGroupDomains>();
+    auto match = QuirkMatch::domain(expediaGroupDomains);
 
     EXPECT_TRUE(matchesURL(match, "https://www.hotels.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://orbitz.com/flights"_s));
@@ -113,17 +114,15 @@ TEST(QuirkMatchTest, HostOrSubdomainOfRespectsLabelBoundaries)
     EXPECT_FALSE(matchesURL(match, "ftp://ceac.state.gov/"_s));
 }
 
-TEST(QuirkMatchTest, HostEndingWithIgnoresLabelBoundaries)
+TEST(QuirkMatchTest, HostOrSubdomainOfCoversShardedHosts)
 {
-    auto match = QuirkMatch::hostEndingWith("onedrive.live.com"_s);
+    auto match = QuirkMatch::hostOrSubdomainOf("onedrive.live.com"_s);
 
     EXPECT_TRUE(matchesURL(match, "https://onedrive.live.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://p123.onedrive.live.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://ONEDRIVE.LIVE.COM/"_s));
-    EXPECT_TRUE(matchesURL(match, "ftp://onedrive.live.com/"_s));
 
-    EXPECT_TRUE(matchesURL(match, "https://myonedrive.live.com/"_s));
-
+    EXPECT_FALSE(matchesURL(match, "https://myonedrive.live.com/"_s));
     EXPECT_FALSE(matchesURL(match, "https://live.com/"_s));
     EXPECT_FALSE(matchesURL(match, "https://onedrive.live.com.evil.com/"_s));
 }
@@ -145,7 +144,7 @@ TEST(QuirkMatchTest, AnyTopLevelDomainMatchesEveryPublicSuffix)
 
 TEST(QuirkMatchTest, PathContainsMatchesAnywhereInThePath)
 {
-    auto match = QuirkMatch::anyTopLevelDomain("apple"_s).pathContains("/retail"_s);
+    auto match = QuirkMatch::anyTopLevelDomain("apple"_s).when(pathContains("/retail"_s));
 
     EXPECT_TRUE(matchesURL(match, "https://www.apple.com/retail/"_s));
     EXPECT_TRUE(matchesURL(match, "https://www.apple.com/us/retail/store"_s));
@@ -161,7 +160,7 @@ TEST(QuirkMatchTest, PathContainsMatchesAnywhereInThePath)
 
 TEST(QuirkMatchTest, PathStartsWithIsAnchored)
 {
-    auto match = QuirkMatch::host("docs.google.com"_s).pathStartsWith("/spreadsheets/"_s);
+    auto match = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/spreadsheets/"_s));
 
     EXPECT_TRUE(matchesURL(match, "https://docs.google.com/spreadsheets/d/abc/edit"_s));
     EXPECT_TRUE(matchesURL(match, "https://docs.google.com/SpreadSheets/d/abc"_s));
@@ -173,7 +172,7 @@ TEST(QuirkMatchTest, PathStartsWithIsAnchored)
 
 TEST(QuirkMatchTest, PathOrFragmentContainsSearchesBoth)
 {
-    auto match = QuirkMatch::domain("icloud.com"_s).pathOrFragmentContains("mail"_s);
+    auto match = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s));
 
     EXPECT_TRUE(matchesURL(match, "https://www.icloud.com/mail/"_s));
     EXPECT_TRUE(matchesURL(match, "https://www.icloud.com/#mail"_s));
@@ -184,34 +183,26 @@ TEST(QuirkMatchTest, PathOrFragmentContainsSearchesBoth)
     EXPECT_FALSE(matchesURL(match, "https://www.icloud.com/?app=mail"_s));
 }
 
-TEST(QuirkMatchTest, OnlyTheLastPathConstraintIsKept)
+TEST(QuirkMatchTest, EnvironmentIsANDedWithTheSiteMatch)
 {
-    auto match = QuirkMatch::domain("example.com"_s).pathStartsWith("/first"_s).pathContains("/second"_s);
+    auto smallScreenOnly = QuirkMatch::domain("youtube.com"_s).when(smallScreen());
 
-    EXPECT_TRUE(matchesURL(match, "https://example.com/second"_s));
-    EXPECT_FALSE(matchesURL(match, "https://example.com/first"_s));
-}
-
-TEST(QuirkMatchTest, ConditionIsANDedWithTheSiteMatch)
-{
-    auto smallScreenOnly = QuirkMatch::domain("youtube.com"_s).onlyIf(QuirkCondition::SmallScreen);
-
-    EXPECT_EQ(matchesURL(smallScreenOnly, "https://www.youtube.com/"_s), WebCore::evaluateQuirkCondition(QuirkCondition::SmallScreen));
+    EXPECT_EQ(matchesURL(smallScreenOnly, "https://www.youtube.com/"_s), WebCore::evaluateQuirkEnvironment(QuirkEnvironment::SmallScreen));
 
     EXPECT_FALSE(matchesURL(smallScreenOnly, "https://www.example.com/"_s));
 
 #if !PLATFORM(IOS_FAMILY)
-    EXPECT_FALSE(WebCore::evaluateQuirkCondition(QuirkCondition::SmallScreen));
-    EXPECT_FALSE(WebCore::evaluateQuirkCondition(QuirkCondition::TubularApp));
-    EXPECT_FALSE(WebCore::evaluateQuirkCondition(QuirkCondition::LensApp));
+    EXPECT_FALSE(WebCore::evaluateQuirkEnvironment(QuirkEnvironment::SmallScreen));
+    EXPECT_FALSE(WebCore::evaluateQuirkEnvironment(QuirkEnvironment::TubularApp));
+    EXPECT_FALSE(WebCore::evaluateQuirkEnvironment(QuirkEnvironment::LensApp));
 
     EXPECT_FALSE(matchesURL(smallScreenOnly, "https://www.youtube.com/"_s));
 #endif
 }
 
-TEST(QuirkMatchTest, DocumentDomainIsOneOfMatchesEmbeddedDocuments)
+TEST(QuirkMatchTest, DocumentDomainIsMatchesEmbeddedDocuments)
 {
-    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).documentDomainIsOneOf<youTubeEmbedDomains>();
+    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(documentDomainIs(youTubeEmbedDomains));
 
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.co.uk/film"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
@@ -225,9 +216,9 @@ TEST(QuirkMatchTest, DocumentDomainIsOneOfMatchesEmbeddedDocuments)
     EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.youtube.com/"_s, "https://www.theguardian.com/film"_s));
 }
 
-TEST(QuirkMatchTest, DocumentDomainIsMatchesASingleEmbeddedDomain)
+TEST(QuirkMatchTest, DocumentDomainIsAcceptsASinglePattern)
 {
-    auto match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIs("x.com"_s);
+    auto match = QuirkMatch::anySite().when(embedded(), documentDomainIs("x.com"_s));
 
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://x.com/i/status/123"_s));
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://platform.x.com/embed/Tweet.html"_s));
@@ -238,7 +229,7 @@ TEST(QuirkMatchTest, DocumentDomainIsMatchesASingleEmbeddedDomain)
 
 TEST(QuirkMatchTest, AnySiteWithOnlyIfEmbeddedMatchesEmbedsAnywhereButNeverTheTopDocument)
 {
-    auto match = QuirkMatch::anySite().onlyIfEmbedded().documentDomainIsOneOf<youTubeEmbedDomains>();
+    auto match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains));
 
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
@@ -259,7 +250,7 @@ TEST(QuirkMatchTest, AnySiteMatchesEverySiteWithoutFurtherRefinement)
 
 TEST(QuirkMatchTest, ExceptWhenCarvesOutPagesOfAMatchedSite)
 {
-    auto match = QuirkMatch::domain("wix.com"_s).exceptWhen().pathStartsWith("/website/templates/"_s);
+    auto match = QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s));
 
     EXPECT_TRUE(matchesURL(match, "https://www.wix.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://www.wix.com/website/other"_s));
@@ -275,20 +266,42 @@ TEST(QuirkMatchTest, ExceptWhenCarvesOutPagesOfAMatchedSite)
 
 TEST(QuirkMatchTest, ExceptWhenCarvesOutHostsOfAMatchedSite)
 {
-    auto match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen().hostIsOneOf<excludedNaverHosts>();
+    auto match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs(excludedNaverHosts));
 
     EXPECT_TRUE(matchesURL(match, "https://naver.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://news.naver.com/"_s));
 
     EXPECT_FALSE(matchesURL(match, "https://tv.naver.com/"_s));
     EXPECT_FALSE(matchesURL(match, "https://m.naver.com/"_s));
-    // hostIsOneOf() names exact hosts, so subdomains of an excluded host are not excluded.
+
     EXPECT_TRUE(matchesURL(match, "https://sub.tv.naver.com/"_s));
+}
+
+TEST(QuirkMatchTest, ExceptWhenCarvesOutASingleHost)
+{
+    auto match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs("tv.naver.com"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://naver.com/"_s));
+    EXPECT_TRUE(matchesURL(match, "https://news.naver.com/"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://tv.naver.com/"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://sub.tv.naver.com/"_s));
+}
+
+TEST(QuirkMatchTest, HostIsNarrowsAMatchToOneHost)
+{
+    auto match = QuirkMatch::domain("naver.com"_s).when(hostIs("tv.naver.com"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://tv.naver.com/"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://naver.com/"_s));
+    EXPECT_FALSE(matchesURL(match, "https://news.naver.com/"_s));
 }
 
 TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)
 {
-    auto match = QuirkMatch::domain("theguardian.com"_s).exceptWhen().onlyIfEmbedded().documentDomainIsOneOf<vimeoDomains>();
+    auto match = QuirkMatch::domain("theguardian.com"_s).exceptWhen(embedded(), documentDomainIs(vimeoDomains));
 
     EXPECT_TRUE(matchesURL(match, "https://www.theguardian.com/film"_s));
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
@@ -298,18 +311,22 @@ TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)
 
 TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)
 {
-    auto match = QuirkMatch::domain("example.com"_s).pathStartsWith("/app"_s).exceptWhen().pathStartsWith("/app/legacy"_s);
+    auto match = QuirkMatch::domain("example.com"_s).when(pathStartsWith("/app"_s)).exceptWhen(pathStartsWith("/app/legacy"_s));
 
     EXPECT_TRUE(matchesURL(match, "https://www.example.com/app/main"_s));
     EXPECT_FALSE(matchesURL(match, "https://www.example.com/other"_s));
     EXPECT_FALSE(matchesURL(match, "https://www.example.com/app/legacy/page"_s));
 }
 
-TEST(QuirkMatchTest, ExceptWhenWithNothingChainedIsANoOp)
+TEST(QuirkMatchTest, ExceptWhenRequiresEveryRefinementToExclude)
 {
-    auto match = QuirkMatch::domain("example.com"_s).exceptWhen();
+    auto match = QuirkMatch::domain("example.com"_s).exceptWhen(pathStartsWith("/embed"_s), embedded());
 
-    EXPECT_TRUE(matchesURL(match, "https://www.example.com/"_s));
+    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/embed/abc"_s, "https://vimeo.com/12345"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://www.example.com/embed/abc"_s));
+    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/other"_s, "https://vimeo.com/12345"_s));
+
     EXPECT_FALSE(matchesURL(match, "https://webkit.org/"_s));
 }
 
@@ -323,7 +340,7 @@ TEST(QuirkMatchTest, MatchesIgnoreTheDocumentURLByDefault)
 
 TEST(QuirkMatchTest, RefinementsOfDifferentKindsAreAllANDed)
 {
-    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).pathStartsWith("/film/"_s).documentDomainIsOneOf<youTubeEmbedDomains>();
+    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(pathStartsWith("/film/"_s), documentDomainIs(youTubeEmbedDomains));
 
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film/2026/trailer"_s, "https://www.youtube.com/embed/abc"_s));
     EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.co.uk/film/2026/trailer"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
@@ -333,11 +350,11 @@ TEST(QuirkMatchTest, RefinementsOfDifferentKindsAreAllANDed)
     EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/film/2026/trailer"_s, "https://vimeo.com/12345"_s));
 }
 
-TEST(QuirkMatchTest, ConditionStacksWithAPathRefinement)
+TEST(QuirkMatchTest, EnvironmentStacksWithAPathRefinement)
 {
-    auto match = QuirkMatch::domain("youtube.com"_s).pathStartsWith("/shorts/"_s).onlyIf(QuirkCondition::SmallScreen);
+    auto match = QuirkMatch::domain("youtube.com"_s).when(pathStartsWith("/shorts/"_s), smallScreen());
 
-    EXPECT_EQ(matchesURL(match, "https://www.youtube.com/shorts/abc"_s), WebCore::evaluateQuirkCondition(QuirkCondition::SmallScreen));
+    EXPECT_EQ(matchesURL(match, "https://www.youtube.com/shorts/abc"_s), WebCore::evaluateQuirkEnvironment(QuirkEnvironment::SmallScreen));
     EXPECT_FALSE(matchesURL(match, "https://www.youtube.com/watch?v=abc"_s));
 }
 
@@ -345,23 +362,23 @@ TEST(QuirkMatchTest, ContextDerivesValuesFromTheRightURL)
 {
     URL topURL { "https://www.bbc.co.uk/news?live=1#top"_s };
     URL documentURL { "https://player.youtube-nocookie.com/embed/abc"_s };
-    QuirkMatchContext context { topURL, documentURL };
+    QuirkMatchContext context { topURL, documentURL, WebCore::IsTopDocument::Yes };
 
     EXPECT_EQ(context.topURL(), topURL);
-    EXPECT_EQ(context.host(), "www.bbc.co.uk"_s);
-    EXPECT_EQ(context.registrableDomain(), "bbc.co.uk"_s);
-    EXPECT_EQ(context.domainWithoutPublicSuffix(), "bbc"_s);
-    EXPECT_EQ(context.documentDomain(), "youtube-nocookie.com"_s);
+    EXPECT_EQ(context.topHost(), "www.bbc.co.uk"_s);
+    EXPECT_EQ(context.topRegistrableDomain(), "bbc.co.uk"_s);
+    EXPECT_EQ(context.topDomainWithoutPublicSuffix(), "bbc"_s);
+    EXPECT_EQ(context.documentRegistrableDomain(), "youtube-nocookie.com"_s);
 }
 
 TEST(QuirkMatchTest, ContextCachesDerivedValues)
 {
     URL url { "https://www.example.com/"_s };
-    QuirkMatchContext context { url, url };
+    QuirkMatchContext context { url, url, WebCore::IsTopDocument::Yes };
 
-    EXPECT_EQ(&context.registrableDomain(), &context.registrableDomain());
-    EXPECT_EQ(&context.domainWithoutPublicSuffix(), &context.domainWithoutPublicSuffix());
-    EXPECT_EQ(&context.documentDomain(), &context.documentDomain());
+    EXPECT_EQ(&context.topRegistrableDomain(), &context.topRegistrableDomain());
+    EXPECT_EQ(&context.topDomainWithoutPublicSuffix(), &context.topDomainWithoutPublicSuffix());
+    EXPECT_EQ(&context.documentRegistrableDomain(), &context.documentRegistrableDomain());
 }
 
 TEST(QuirkMatchTest, HostsWithoutAPublicSuffixFallBackToTheHost)
@@ -375,12 +392,11 @@ TEST(QuirkMatchTest, URLsWithoutAHostMatchNothing)
 {
     for (auto urlString : { "about:blank"_s, "data:text/html,hello"_s, ""_s }) {
         URL url { urlString };
-        QuirkMatchContext context { url, url };
+        QuirkMatchContext context { url, url, WebCore::IsTopDocument::Yes };
 
         EXPECT_FALSE(QuirkMatch::domain("example.com"_s).matches(context));
         EXPECT_FALSE(QuirkMatch::host("example.com"_s).matches(context));
         EXPECT_FALSE(QuirkMatch::hostOrSubdomainOf("example.com"_s).matches(context));
-        EXPECT_FALSE(QuirkMatch::hostEndingWith("example.com"_s).matches(context));
         EXPECT_FALSE(QuirkMatch::anyTopLevelDomain("example"_s).matches(context));
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
@@ -48,7 +48,7 @@ static std::optional<String> customUserAgentFor(ASCIILiteral urlString)
 
 static WebCore::QuirksData resolveQuirksForTopURL(ASCIILiteral urlString)
 {
-    return WebCore::resolveSiteSpecificQuirks({ URL { urlString }, URL { urlString } });
+    return WebCore::resolveSiteSpecificQuirks({ URL { urlString }, URL { urlString }, WebCore::IsTopDocument::Yes });
 }
 
 TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)


### PR DESCRIPTION
#### aa73fff0f62234af069fdab28c58d154f275fe0a
<pre>
[Quirks] Clean up the QuirksMatch API
<a href="https://bugs.webkit.org/show_bug.cgi?id=322538">https://bugs.webkit.org/show_bug.cgi?id=322538</a>
<a href="https://rdar.apple.com/185834375">rdar://185834375</a>

Reviewed by Brent Fulgham.

This patch addresses some of the rough edges around the QuirkMatch API.

I renamed some things:
QuirkCondition -&gt; QuirkEnvironment
host() -&gt; topHost()
registrableDomain() -&gt; topRegistrableDomain()
domainWithPublicSuffix() -&gt; topDomainWithPublicSuffix()
documentDomain() -&gt; documentRegistrableDomain()

I introduced QuirkPatternList to combine the single and multiple pattern cases.
Now, you can pass one or multiple patterns to domain(), documentDomainIs(),
and hostIs(), which allowed me to remove domains(), documentDomainIsOneOf(), and
hostIsOneOf().

I removed the quirkBehaviors() function in favor of a new QuirkBehaviors class
that wraps a QuirkBitSet. It has a constructor that takes an initializer list,
which cleans up the quirk table significantly.

I also introduced a new QuirkMatch::when() to go along with the
QuirkMatch::exceptWhen(). These now take any structure defined in the
QuirkRefinement namespace. The refinements are stored in a RefinementSet which
is either in QuirkMatch::m_refinements or QuirkMatch::m_exception.

This cleans up the QuirkMatch interface to look like this:
     QuirkMatch::anyTopLevelDomain(&quot;apple&quot;_s).when(pathStartsWith(&quot;/store&quot;_s))
     QuirkMatch::domain(&quot;wix.com&quot;_s).exceptWhen(pathStartsWith(&quot;/website/templates/&quot;_s))

Tests: Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
       Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/QuirkMatch.cpp: Added.
(WebCore::QuirkMatchContext::topRegistrableDomain const):
(WebCore::QuirkMatchContext::topDomainWithoutPublicSuffix const):
(WebCore::QuirkMatchContext::documentRegistrableDomain const):
(WebCore::QuirkMatch::RefinementSet::matchesPathPattern const):
(WebCore::QuirkMatch::RefinementSet::matches const):
(WebCore::QuirkMatch::matchesSite const):
(WebCore::QuirkMatch::matches const):
(WebCore::Quirk::apply const):
* Source/WebCore/page/QuirkMatch.h:
(WebCore::QuirkMatchContext::QuirkMatchContext):
(WebCore::QuirkPatternList::QuirkPatternList):
(WebCore::QuirkPatternList::isEmpty const):
(WebCore::QuirkPatternList::contains const):
(WebCore::QuirkPatternList::containsMatching const):
(WebCore::QuirkRefinement::pathContains):
(WebCore::QuirkRefinement::pathStartsWith):
(WebCore::QuirkRefinement::pathOrFragmentContains):
(WebCore::QuirkRefinement::documentDomainIs):
(WebCore::QuirkRefinement::hostIs):
(WebCore::QuirkRefinement::embedded):
(WebCore::QuirkRefinement::smallScreen):
(WebCore::QuirkRefinement::tubularApp):
(WebCore::QuirkRefinement::lensApp):
(WebCore::QuirkMatch::domain):
(WebCore::QuirkMatch::host):
(WebCore::QuirkMatch::hostOrSubdomainOf):
(WebCore::QuirkMatch::anyTopLevelDomain):
(WebCore::QuirkMatch::anySite):
(WebCore::QuirkMatch::when):
(WebCore::QuirkMatch::exceptWhen):
(WebCore::QuirkMatch::setPathPattern):
(WebCore::QuirkMatch::applyRefinement):
(WebCore::QuirkMatch::QuirkMatch):
(WebCore::QuirkBehaviors::QuirkBehaviors):
(WebCore::QuirkMatch::domains): Deleted.
(WebCore::QuirkMatch::hostEndingWith): Deleted.
(WebCore::QuirkMatch::pathContains): Deleted.
(WebCore::QuirkMatch::pathStartsWith): Deleted.
(WebCore::QuirkMatch::pathOrFragmentContains): Deleted.
(WebCore::QuirkMatch::onlyIf): Deleted.
(WebCore::QuirkMatch::documentDomainIs): Deleted.
(WebCore::QuirkMatch::documentDomainIsOneOf): Deleted.
(WebCore::QuirkMatch::hostIsOneOf): Deleted.
(WebCore::QuirkMatch::onlyIfEmbedded): Deleted.
(WebCore::QuirkMatch::matches const): Deleted.
(WebCore::QuirkMatch::PatternList::PatternList): Deleted.
(WebCore::QuirkMatch::PatternList::isEmpty const): Deleted.
(WebCore::QuirkMatch::Refinements::isEmpty const): Deleted.
(WebCore::QuirkMatch::setPathConstraint): Deleted.
(WebCore::QuirkMatch::anyPattern const): Deleted.
(WebCore::QuirkMatch::matchesSite const): Deleted.
(WebCore::QuirkMatch::matchesRefinements const): Deleted.
(WebCore::QuirkMatch::anyOf): Deleted.
(WebCore::QuirkMatch::matchesPathConstraint const): Deleted.
(WebCore::quirkBehaviors): Deleted.
(WebCore::Quirk::apply const): Deleted.
* Source/WebCore/page/Quirks.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp:
(TestWebKitAPI::matchesURL):
(TestWebKitAPI::TEST(QuirkMatchTest, DomainsMatchesAnyPatternInTheList)):
(TestWebKitAPI::TEST(QuirkMatchTest, HostOrSubdomainOfCoversShardedHosts)):
(TestWebKitAPI::TEST(QuirkMatchTest, PathContainsMatchesAnywhereInThePath)):
(TestWebKitAPI::TEST(QuirkMatchTest, PathStartsWithIsAnchored)):
(TestWebKitAPI::TEST(QuirkMatchTest, PathOrFragmentContainsSearchesBoth)):
(TestWebKitAPI::TEST(QuirkMatchTest, EnvironmentIsANDedWithTheSiteMatch)):
(TestWebKitAPI::TEST(QuirkMatchTest, DocumentDomainIsMatchesEmbeddedDocuments)):
(TestWebKitAPI::TEST(QuirkMatchTest, DocumentDomainIsAcceptsASinglePattern)):
(TestWebKitAPI::TEST(QuirkMatchTest, AnySiteWithOnlyIfEmbeddedMatchesEmbedsAnywhereButNeverTheTopDocument)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenCarvesOutPagesOfAMatchedSite)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenCarvesOutHostsOfAMatchedSite)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenCarvesOutASingleHost)):
(TestWebKitAPI::TEST(QuirkMatchTest, HostIsNarrowsAMatchToOneHost)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)):
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenRequiresEveryRefinementToExclude)):
(TestWebKitAPI::TEST(QuirkMatchTest, RefinementsOfDifferentKindsAreAllANDed)):
(TestWebKitAPI::TEST(QuirkMatchTest, EnvironmentStacksWithAPathRefinement)):
(TestWebKitAPI::TEST(QuirkMatchTest, ContextDerivesValuesFromTheRightURL)):
(TestWebKitAPI::TEST(QuirkMatchTest, ContextCachesDerivedValues)):
(TestWebKitAPI::TEST(QuirkMatchTest, URLsWithoutAHostMatchNothing)):
(TestWebKitAPI::TEST(QuirkMatchTest, HostEndingWithIgnoresLabelBoundaries)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, OnlyTheLastPathConstraintIsKept)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, ConditionIsANDedWithTheSiteMatch)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, DocumentDomainIsOneOfMatchesEmbeddedDocuments)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, DocumentDomainIsMatchesASingleEmbeddedDomain)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, ExceptWhenWithNothingChainedIsANoOp)): Deleted.
(TestWebKitAPI::TEST(QuirkMatchTest, ConditionStacksWithAPathRefinement)): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp:
(TestWebKitAPI::resolveQuirksForTopURL):

Canonical link: <a href="https://commits.webkit.org/319883@main">https://commits.webkit.org/319883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58251dae321eab26cd356d2de74380aabe58fb0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182918 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147206 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1254981-6767-4dd1-b2e8-10fc8bd37beb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03862132-ecc0-485e-a5f7-590d4e683f50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c89a84e-14c5-4683-a3a2-e50bd3bd5e52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45177 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43429 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43058 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4308 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195076 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56510 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40824 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151929 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46491 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129484 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125572 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55723 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18068 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55094 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->