### PR TITLE
Re-enable PDF decoding of WebExtension icons

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -42,6 +42,7 @@
 #import <CoreFoundation/CFBundle.h>
 #import <WebCore/DataURLDecoder.h>
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/MIMETypeRegistry.h>
 #import <wtf/FileSystem.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/MakeString.h>
@@ -355,6 +356,16 @@ Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> WebExtension::iconForPath(const
         result = [UIImage _imageWithCGSVGDocument:document scale:displayScale orientation:UIImageOrientationUp];
 #endif
     }
+
+#if USE(APPKIT)
+    if (WebCore::MIMETypeRegistry::isPDFMIMEType(imageType)) {
+        RetainPtr<NSImageRep> pdfImageRep = adoptNS([[NSPDFImageRep alloc] initWithData:imageData]);
+        if (pdfImageRep && !NSEqualSizes([pdfImageRep size], NSZeroSize)) {
+            result = [[NSImage alloc] initWithSize:[pdfImageRep size]];
+            [result addRepresentation:pdfImageRep.get()];
+        }
+    }
+#endif
 
     if (!result) {
 #if USE(APPKIT)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
@@ -37,9 +37,12 @@ using CocoaImage = UIImage;
 using CocoaColor = UIColor;
 #endif
 
+OBJC_CLASS NSData;
+
 namespace TestWebKitAPI::Util {
 
 CocoaColor *pixelColor(CocoaImage *, CGPoint = CGPointZero);
+NSData *makePDFData(CGSize, SEL colorSelector);
 CocoaColor *toSRGBColor(CocoaColor *);
 bool compareColors(CocoaColor *, CocoaColor *, float tolerance = 0.01);
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
@@ -25,6 +25,8 @@
 
 #import "config.h"
 #import "Helpers/cocoa/TestCocoaImageAndCocoaColor.h"
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace TestWebKitAPI::Util {
 
@@ -83,6 +85,27 @@ bool compareColors(CocoaColor *color1, CocoaColor *color2, float tolerance)
     [color2 getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
 
     return fabs(red1 - red2) < tolerance && fabs(green1 - green2) < tolerance && fabs(blue1 - blue2) < tolerance && fabs(alpha1 - alpha2) < tolerance;
+}
+
+NSData *makePDFData(CGSize size, SEL colorSelector)
+{
+    NSMutableData *data = [NSMutableData data];
+    RetainPtr consumer = adoptCF(CGDataConsumerCreateWithCFData((__bridge CFMutableDataRef)data));
+
+    auto mediaBox = CGRectMake(0, 0, size.width, size.height);
+    RetainPtr context = adoptCF(CGPDFContextCreate(consumer.get(), &mediaBox, nullptr));
+
+    NSDictionary *pageInfo = @{ bridge_cast(kCGPDFContextMediaBox): [NSData dataWithBytes:&mediaBox length:sizeof(mediaBox)] };
+    CGPDFContextBeginPage(context.get(), (__bridge CFDictionaryRef)pageInfo);
+
+    CocoaColor *color = [CocoaColor performSelector:colorSelector];
+    CGContextSetFillColorWithColor(context.get(), color.CGColor);
+    CGContextFillRect(context.get(), mediaBox);
+
+    CGPDFContextEndPage(context.get());
+    CGPDFContextClose(context.get());
+
+    return data;
 }
 
 } // namespace TestWebKitAPI::Util

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
@@ -409,6 +409,116 @@ TEST(WKWebExtension, SVGIconViaIconsKeyLoads)
     EXPECT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
 }
 
+#if PLATFORM(MAC)
+
+TEST(WKWebExtension, PDFIconLoads)
+{
+    // PDF is a supported icon format on macOS, for both the `icons` key and an action's `default_icon`.
+    auto *iconPDF = Util::makePDFData(CGSizeMake(128, 128), @selector(blackColor));
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"128": @"icon-128.pdf" },
+        @"action": @{ @"default_icon": @{ @"128": @"action-icon-128.pdf" } }
+    };
+
+    auto *resources = @{
+        @"icon-128.pdf": iconPDF,
+        @"action-icon-128.pdf": iconPDF,
+    };
+
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+
+    auto *icon = [testExtension iconForSize:CGSizeMake(128, 128)];
+    EXPECT_NOT_NULL(icon);
+    if (icon)
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(icon), [CocoaColor blackColor]));
+
+    EXPECT_NOT_NULL([testExtension actionIconForSize:CGSizeMake(128, 128)]);
+
+    EXPECT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
+TEST(WKWebExtension, MixedBitmapAndPDFIconsBothResolve)
+{
+    // A manifest mixing a vector format with a bitmap one, where neither may be handed back in place of
+    // the other. bestIconSize() picks the smallest size at or above the ideal pixel size, falling back to
+    // the largest, so these two requests select their formats at any screen scale.
+    auto *iconPDF = Util::makePDFData(CGSizeMake(16, 16), @selector(blackColor));
+    auto *iconPNG = Util::makePNGData(CGSizeMake(128, 128), @selector(whiteColor));
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"16": @"icon-16.pdf", @"128": @"icon-128.png" }
+    };
+
+    auto *resources = @{ @"icon-16.pdf": iconPDF, @"icon-128.png": iconPNG };
+
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+
+    // Nothing at or above this ideal size, so the largest entry wins: the bitmap.
+    auto *bitmapIcon = [testExtension iconForSize:CGSizeMake(128, 128)];
+    EXPECT_NOT_NULL(bitmapIcon);
+    if (bitmapIcon)
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(bitmapIcon), [CocoaColor whiteColor]));
+
+    auto *pdfIcon = [testExtension iconForSize:CGSizeMake(8, 8)];
+    EXPECT_NOT_NULL(pdfIcon);
+    if (pdfIcon)
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(pdfIcon), [CocoaColor blackColor]));
+
+    EXPECT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
+TEST(WKWebExtension, PDFActionIconAsStringLoads)
+{
+    // The Firefox string form of `default_icon`, rather than a size-to-path object. It resolves through
+    // populateActionPropertiesIfNeeded(), which calls iconForPath() directly rather than via bestIcon().
+    auto *iconPDF = Util::makePDFData(CGSizeMake(128, 128), @selector(blackColor));
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"action": @{ @"default_icon": @"action-icon.pdf" }
+    };
+
+    // No `icons` key, so the extension-icon fallback cannot mask a failure here.
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"action-icon.pdf": iconPDF }];
+
+    EXPECT_NOT_NULL([testExtension actionIconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
+TEST(WKWebExtension, MalformedPDFIconIsReported)
+{
+    // A PDF that cannot be rasterized must still be reported, matching the other formats.
+    auto *malformedPDF = [@"%PDF-1.7 truncated, no objects or trailer" dataUsingEncoding:NSUTF8StringEncoding];
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"128": @"icon-128.pdf" }
+    };
+
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"icon-128.pdf": malformedPDF }];
+
+    EXPECT_NULL([testExtension iconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
+#endif // PLATFORM(MAC)
+
+
 TEST(WKWebExtension, SymbolImageIcon)
 {
     auto *testManifestDictionary = @{


### PR DESCRIPTION
#### 8d764ee4313bf77fd932bb97788e43cb44c9a4f7
<pre>
Decode WebExtension PDF icons in WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321984">https://bugs.webkit.org/show_bug.cgi?id=321984</a>
<a href="https://rdar.apple.com/185159613">rdar://185159613</a>

Reviewed by Timothy Hatcher.

<a href="https://commits.webkit.org/315453@main">https://commits.webkit.org/315453@main</a> added an allowlist of
WebExtension icon types which were permitted to be decoded in the
UIProcess.

PDFs were not on the allowlist, but they are a supported extension icon
image format.

This patch adds back PDF decoding in the UIProcess for WebExtension
icons via NSPDFImageRep matching how it was decoded with NSImage before
315453@main. Note that this only affects macOS since UIImage never
decoded PDFs.

I couldn&apos;t simply add PDFs to the allowlist of supported images since
PDFs are not handled by CGImageSource (which is what the
WebCore::isSupportedImageType allowlist gates). So, I had to explicitly
decode PDFs separately like I did for SVGs in 315453@main.

Adds API tests: PDFIconLoads, PDFActionIconAsStringLoads,
MixedBitmapAndPDFIconsBothResolve and MalformedPDFIconIsReported.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::iconForPath):
    Add a case to decode PDF WebExtension icons with NSPDFImageRep.
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm:
(TestWebKitAPI::Util::makePDFData):
    Helper to construct an array of bytes which represents a PDF.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, PDFIconLoads)):
    Test that we can load the PDF icon of a WKWebExtension.
(TestWebKitAPI::TEST(WKWebExtension, MixedBitmapAndPDFIconsBothResolve)):
    Tests that different types of icon formats can be combined with PDFs in the
    extension manifest { &quot;16&quot;: &quot;icon-16.pdf&quot;, &quot;128&quot;: &quot;icon-128.png&quot; }
(TestWebKitAPI::TEST(WKWebExtension, PDFActionIconAsStringLoads)):
    Test for when an icon is described using the &quot;action&quot; manifest key:
        &quot;action&quot;: { &quot;default_icon&quot;: &quot;action-icon.pdf&quot; }
(TestWebKitAPI::TEST(WKWebExtension, MalformedPDFIconIsReported)):
    Check that a PDF decoding error shows up after the decode fails.

Canonical link: <a href="https://commits.webkit.org/319970@main">https://commits.webkit.org/319970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b31fcccb67e6f8b508eea16fa7b785af79bd6f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34408390-dcdf-4374-96a4-e5006ff2853d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142974 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ca0567d-5f4b-4eed-b4ef-c887852b0cdf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123401 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43647 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43264 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4573 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195340 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56773 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40892 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57478 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152155 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46711 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129748 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55986 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18275 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55595 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55424 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->