### PR TITLE
[Quirks] Remove isDomain and isEmbedDomain

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -234,24 +234,6 @@ bool Quirks::shouldDisableBlobFileAccessEnforcement()
     return shouldDisableBlobFileAccessEnforcementInternal();
 }
 
-// FIXME: Add more options to the helper to cover more patterns.
-// - end of domain
-// - full domain
-// - path?
-// or make different helpers
-bool Quirks::isDomain(const String& domainString) const
-{
-    return RegistrableDomain(topDocumentURL()).string() == domainString;
-}
-
-bool Quirks::isEmbedDomain(const String& domainString) const
-{
-    RefPtr document = m_document.get();
-    if (document->isTopDocument())
-        return false;
-    return RegistrableDomain(document->url()).string() == domainString;
-}
-
 // thesaurus.com, dictionary.com https://bugs.webkit.org/show_bug.cgi?id=312692 rdar://174959285
 bool Quirks::needsAnchorToBeMouseFocusable() const
 {
@@ -468,11 +450,6 @@ String Quirks::storageAccessUserAgentStringQuirkForDomain(const URL& url)
     if (domain == "live.com"_s && url.host() != "teams.live.com"_s)
         return { };
     return iterator->value;
-}
-
-bool Quirks::isYoutubeEmbedDomain() const
-{
-    return isEmbedDomain("youtube.com"_s) || isEmbedDomain("youtube-nocookie.com"_s);
 }
 
 // apple.com rdar://154434137
@@ -1768,7 +1745,7 @@ bool Quirks::shouldDisableScrollAnchoringQuirk() const
 
 #if PLATFORM(IOS_FAMILY)
     // reddit.com only disables scroll anchoring while the Sink It extension's element is present.
-    if (isDomain("reddit.com"_s)) {
+    if (m_quirksData.isSite(QuirkSite::Reddit)) {
         RefPtr document = m_document.get();
         if (!document)
             return false;
@@ -2581,7 +2558,9 @@ bool Quirks::needsAmazonDesignMenuViewportUnitQuirk(const Style::ComputedStyle& 
 bool Quirks::needsLimitedMatroskaSupport() const
 {
 #if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
-    return isDomain("zencastr.com"_s);
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsLimitedMatroskaSupportQuirk);
 #else
     return false;
 #endif
@@ -2590,7 +2569,9 @@ bool Quirks::needsLimitedMatroskaSupport() const
 #if ENABLE(MEDIA_SOURCE)
 bool Quirks::needsSupportsProgressMonitoring() const
 {
-    return isDomain("ui.com"_s);
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsSupportsProgressMonitoringQuirk);
 }
 #endif
 
@@ -2880,9 +2861,11 @@ static constexpr std::array expediaGroupDomains {
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
 static constexpr std::array naverHostsWithoutSimulatedMouseEvents { "tv.naver.com"_s, "mail.naver.com"_s, "m.naver.com"_s };
 #endif
+#if PLATFORM(COCOA)
+static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
+#endif
 #if PLATFORM(IOS_FAMILY)
 static constexpr std::array claudeDomains { "claude.ai"_s, "claude.com"_s };
-static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
 #endif
 
 namespace SiteSpecificQuirks {
@@ -3495,7 +3478,8 @@ static constexpr Quirk table[] = {
             // reddit.com with Sink It extension: rdar://176377447.
             ShouldDisableScrollAnchoringQuirk,
 #endif
-        } },
+        },
+        .site = QuirkSite::Reddit },
 #endif
 
     { .match = QuirkMatch::domain("scribd.com"_s),
@@ -3605,6 +3589,12 @@ static constexpr Quirk table[] = {
     // https://tympanus.net/Tutorials/WebGPUFluid/ does not load (rdar://143839620).
     { .match = QuirkMatch::domain("tympanus.net"_s),
         .behaviors = { ShouldBlockFetchWithNewlineAndLessThan } },
+
+#if ENABLE(MEDIA_SOURCE)
+    // unifi.ui.com rdar://180411019
+    { .match = QuirkMatch::domain("ui.com"_s),
+        .behaviors = { NeedsSupportsProgressMonitoringQuirk } },
+#endif
 
     // Breaks express checkout on victoriassecret.com (rdar://104818312).
     { .match = QuirkMatch::domain("victoriassecret.com"_s),
@@ -3745,6 +3735,12 @@ static constexpr Quirk table[] = {
 #endif
         } },
 
+#if PLATFORM(COCOA)
+    // Embedded youtube.com players need the caption quirk regardless of the embedding site.
+    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains)),
+        .behaviors = { NeedsYouTubeCaptionQuirk } },
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
@@ -3776,6 +3772,12 @@ static constexpr Quirk table[] = {
     // Lens.app rdar://178769976
     { .match = QuirkMatch::domain("youtube.com"_s).when(lensApp()),
         .behaviors = { RequiresUserGestureToPlayInFullscreenQuirk } },
+#endif
+
+#if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
+    // zencastr.com rdar://143087016
+    { .match = QuirkMatch::domain("zencastr.com"_s),
+        .behaviors = { NeedsLimitedMatroskaSupportQuirk } },
 #endif
 
     // zillow.com rdar://53103732
@@ -3841,10 +3843,6 @@ void Quirks::determineRelevantQuirks()
 
     // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldDisablePushStateFilePathRestrictions, shouldDisablePushStateFilePathRestrictions);
-#endif
-
-#if PLATFORM(COCOA)
-    m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionQuirk, isYoutubeEmbedDomain());
 #endif
 
     auto quirksURL = topDocumentURL();

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -386,9 +386,6 @@ public:
 
 private:
     bool needsQuirks() const;
-    bool isDomain(const String&) const;
-    bool isEmbedDomain(const String&) const;
-    bool isYoutubeEmbedDomain() const;
 
     static bool domainNeedsAvoidResizingWhenInputViewBoundsChangeQuirk(const URL&, QuirksData&);
     static bool domainNeedsScrollbarWidthThinDisabledQuirk(const URL&, QuirksData&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -51,6 +51,7 @@ enum class QuirkSite : uint8_t {
     NBA,
     Netflix,
     Outlook,
+    Reddit,
     SoundCloud,
     Thesaurus,
     TikTok,
@@ -89,6 +90,9 @@ struct QuirksData {
         NeedsChromeMediaControlsPseudoElementQuirk,
 #if PLATFORM(COCOA)
         NeedsCNNCaptionQuirk,
+#endif
+#if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
+        NeedsLimitedMatroskaSupportQuirk,
 #endif
         NeedsLogoutCookieCleanupQuirk,
 #if PLATFORM(IOS_FAMILY)
@@ -134,6 +138,9 @@ struct QuirksData {
         NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
         NeedsScrollbarWidthThinDisabledQuirk,
         NeedsSeekingSupportDisabledQuirk,
+#if ENABLE(MEDIA_SOURCE)
+        NeedsSupportsProgressMonitoringQuirk,
+#endif
         NeedsSuppressPostLayoutBoundaryEventsQuirk,
         NeedsTikTokOverflowingContentQuirk,
         NeedsVideoShouldMaintainAspectRatioQuirk,


### PR DESCRIPTION
#### 46357e1e9c0005ef59cf21f008a40a59bfca156b
<pre>
[Quirks] Remove isDomain and isEmbedDomain
<a href="https://rdar.apple.com/185837295">rdar://185837295</a>

Reviewed by Brent Fulgham.

Quirks::isDomain and Quirks::isEmbedDomain have no place in the Quirks
implementation after the introduction of QuirkMatch. I removed them and
converted their callers to named site specific quirks. This introduced
two new quirks: NeedsLimitedMatroskaSupportQuirk and
NeedsSupportsProgressMonitoringQuirk. I also needed to add Reddit to
QuirkSites to remove one of the callers.

* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/319890@main">https://commits.webkit.org/319890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b689489dae287d41789712e1aed37f326286f4c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db26c703-1e3b-4b16-9710-d5b9b22fa3b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e241b93a-8fb4-4a69-a43b-8b4acbf01e3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46647 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123348 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e76579c-1aea-4dd3-a01b-7351a9648fd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45339 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43213 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4500 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195268 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56701 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40827 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57406 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152091 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46647 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55914 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18224 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55285 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->