### PR TITLE
REGRESSION(315609@main): Stack overflow in NetworkProcess aborting the queued transactions of a suspended process

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -216,21 +216,21 @@ void IDBConnectionToClient::connectionToClientClosed()
     ASSERT(m_databaseConnections.isEmptyIgnoringNullReferences());
 }
 
-void IDBConnectionToClient::setClientProcessSuspended(bool isSuspended)
+void IDBConnectionToClient::setClientSuspended(bool isSuspended)
 {
-    if (m_isClientProcessSuspended == isSuspended)
+    if (m_isClientSuspended == isSuspended)
         return;
 
-    m_isClientProcessSuspended = isSuspended;
-    if (!isSuspended)
-        return;
+    m_isClientSuspended = isSuspended;
 
-    // Transactions from other clients may already be queued behind this client's
-    // in-progress transactions, which cannot finish while the client is suspended.
-    m_databaseConnections.forEach([](UniqueIDBDatabaseConnection& connection) {
+    HashSet<CheckedPtr<UniqueIDBDatabase>> databases;
+    m_databaseConnections.forEach([&](UniqueIDBDatabaseConnection& connection) {
         if (CheckedPtr database = connection.database())
-            database->abortInProgressTransactionsBlockedOnSuspendedClients();
+            databases.add(database);
     });
+
+    for (auto& database : databases)
+        database->handleTransactionsAfterAbortingSuspendedClientTransactions();
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -84,8 +84,8 @@ public:
     bool isClosed() { return m_isClosed; }
     void clearDelegate() { m_delegate = nullptr; }
 
-    WEBCORE_EXPORT void setClientProcessSuspended(bool);
-    bool isClientProcessSuspended() const { return m_isClientProcessSuspended; }
+    WEBCORE_EXPORT void setClientSuspended(bool);
+    bool isClientSuspended() const { return m_isClientSuspended; }
 
 private:
     IDBConnectionToClient(IDBConnectionToClientDelegate&);
@@ -93,7 +93,7 @@ private:
     CheckedPtr<IDBConnectionToClientDelegate> m_delegate;
     WeakHashSet<UniqueIDBDatabaseConnection> m_databaseConnections;
     bool m_isClosed { false };
-    bool m_isClientProcessSuspended { false };
+    bool m_isClientSuspended { false };
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1397,8 +1397,7 @@ void UniqueIDBDatabase::enqueueTransaction(Ref<UniqueIDBDatabaseTransaction>&& t
     ASSERT(transaction->info().mode() != IDBTransactionMode::Versionchange);
 
     m_pendingTransactions.append(WTF::move(transaction));
-
-    handleTransactions();
+    handleTransactionsAfterAbortingSuspendedClientTransactions();
 }
 
 void UniqueIDBDatabase::handleTransactions()
@@ -1424,10 +1423,6 @@ void UniqueIDBDatabase::handleTransactions()
         transaction = takeNextRunnableTransaction(hadDeferredTransactions);
     }
     LOG(IndexedDB, "UniqueIDBDatabase::handleTransactions - There are %zu pending after this round of handling", m_pendingTransactions.size());
-
-    // In-progress transactions of a suspended client process can never finish while the client
-    // stays suspended, so transactions queued behind them would be blocked indefinitely.
-    abortInProgressTransactionsBlockedOnSuspendedClients();
 }
 
 void UniqueIDBDatabase::activateTransactionInBackingStore(UniqueIDBDatabaseTransaction& transaction)
@@ -1451,6 +1446,12 @@ template<typename T> bool NODELETE scopesOverlap(const T& aScopes, const Vector<
     return false;
 }
 
+static bool isTransactionOfSuspendedClient(const UniqueIDBDatabaseTransaction& transaction)
+{
+    RefPtr databaseConnection = transaction.databaseConnection();
+    return databaseConnection && databaseConnection->connectionToClient().isClientSuspended();
+}
+
 RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransaction(bool& hadDeferredTransactions)
 {
     hadDeferredTransactions = false;
@@ -1471,15 +1472,22 @@ RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransact
     HashSet<IDBObjectStoreIdentifier> deferredReadWriteScopes;
 
     while (!m_pendingTransactions.isEmpty()) {
+        // Avoid starting transaction of suspended client since they cannot make any progress on it.
         currentTransaction = m_pendingTransactions.takeFirst();
+        if (isTransactionOfSuspendedClient(*currentTransaction)) {
+            deferredTransactions.append(currentTransaction.releaseNonNull());
+            continue;
+        }
 
         switch (currentTransaction->info().mode()) {
         case IDBTransactionMode::Readonly: {
             bool hasOverlappingScopes = scopesOverlap(deferredReadWriteScopes, currentTransaction->objectStoreIdentifiers());
             hasOverlappingScopes |= scopesOverlap(m_objectStoreWriteTransactions, currentTransaction->objectStoreIdentifiers());
 
-            if (hasOverlappingScopes)
+            if (hasOverlappingScopes) {
                 deferredTransactions.append(currentTransaction.releaseNonNull());
+                hadDeferredTransactions = true;
+            }
 
             break;
         }
@@ -1491,6 +1499,7 @@ RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransact
                 for (auto objectStore : currentTransaction->objectStoreIdentifiers())
                     deferredReadWriteScopes.add(objectStore);
                 deferredTransactions.append(currentTransaction.releaseNonNull());
+                hadDeferredTransactions = true;
             }
 
             break;
@@ -1504,10 +1513,6 @@ RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransact
         if (currentTransaction)
             break;
     }
-
-    hadDeferredTransactions = !deferredTransactions.isEmpty();
-    if (!hadDeferredTransactions)
-        return currentTransaction;
 
     // Prepend the deferred transactions back on the beginning of the deque for future scheduling passes.
     while (!deferredTransactions.isEmpty())
@@ -1622,6 +1627,9 @@ bool UniqueIDBDatabase::transactionBlocksPendingTransactions(UniqueIDBDatabaseTr
     bool serializesReadWrites = backingStore && !backingStore->supportsSimultaneousReadWriteTransactions();
 
     for (auto& pendingTransaction : m_pendingTransactions) {
+        if (isTransactionOfSuspendedClient(pendingTransaction))
+            continue;
+
         if (pendingTransaction->isReadOnly()) {
             // A pending read-only transaction is only blocked by an overlapping in-progress write.
             if (!inProgressIsReadOnly && scopesOverlap(inProgressScopes, pendingTransaction->objectStoreIdentifiers()))
@@ -1639,20 +1647,31 @@ bool UniqueIDBDatabase::transactionBlocksPendingTransactions(UniqueIDBDatabaseTr
     return false;
 }
 
-void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
+void UniqueIDBDatabase::handleTransactionsAfterAbortingSuspendedClientTransactions()
 {
-    if (m_pendingTransactions.isEmpty() || m_inProgressTransactions.isEmpty())
-        return;
+    if (abortInProgressTransactionsOfSuspendedClientsIfNeeded() == DidAbortAnyTransaction::Yes) {
+        // Previously blocked requests might be able to run now.
+        handleDatabaseOperations();
+    }
 
-    SetForScope recursionScope(m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth, m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth + 1);
-    if (m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth > 5)
-        RELEASE_LOG_ERROR(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients - recursion depth reaches %u", m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth);
+    handleTransactions();
+}
+
+UniqueIDBDatabase::DidAbortAnyTransaction UniqueIDBDatabase::abortInProgressTransactionsOfSuspendedClientsIfNeeded()
+{
+#if ASSERT_ENABLED
+    ASSERT(!m_isAbortingTransactionsOfSuspendedClients);
+    SetForScope abortingScope(m_isAbortingTransactionsOfSuspendedClients, true);
+#endif
+
+    if (m_pendingTransactions.isEmpty() || m_inProgressTransactions.isEmpty())
+        return DidAbortAnyTransaction::No;
 
     Vector<Ref<UniqueIDBDatabaseTransaction>> transactionsToAbort;
     for (auto& transaction : m_inProgressTransactions.values()) {
-        RefPtr databaseConnection = transaction->databaseConnection();
-        if (!databaseConnection || !databaseConnection->connectionToClient().isClientProcessSuspended())
+        if (!isTransactionOfSuspendedClient(transaction))
             continue;
+
         if (transactionBlocksPendingTransactions(transaction))
             transactionsToAbort.append(transaction);
     }
@@ -1664,7 +1683,7 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
         if (!takenTransaction)
             continue;
 
-        LOG(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients - Aborting transaction %s of suspended client", transactionIdentifier.loggingString().utf8().data());
+        LOG(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsOfSuspendedClientsIfNeeded - Aborting transaction %s of suspended client", transactionIdentifier.loggingString().utf8().data());
 
         // Aborting a versionchange transaction must roll back the in-memory schema and clear the
         // version-change connection, matching the standard abort path, so an interrupted upgrade
@@ -1691,10 +1710,7 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
         abortedAnyTransaction = true;
     }
 
-    if (abortedAnyTransaction) {
-        handleDatabaseOperations();
-        handleTransactions();
-    }
+    return abortedAnyTransaction ? DidAbortAnyTransaction::Yes : DidAbortAnyTransaction::No;
 }
 
 void UniqueIDBDatabase::close()

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -121,7 +121,7 @@ public:
 
     bool NODELETE hasActiveTransactions() const;
     WEBCORE_EXPORT void abortActiveTransactions();
-    void abortInProgressTransactionsBlockedOnSuspendedClients();
+    void handleTransactionsAfterAbortingSuspendedClientTransactions();
     WEBCORE_EXPORT bool tryClose();
 
     WEBCORE_EXPORT String filePath() const;
@@ -149,6 +149,9 @@ private:
     void handleTransactions();
     RefPtr<UniqueIDBDatabaseTransaction> takeNextRunnableTransaction(bool& hadDeferredTransactions);
     bool transactionBlocksPendingTransactions(UniqueIDBDatabaseTransaction&);
+
+    enum class DidAbortAnyTransaction : bool { No, Yes };
+    DidAbortAnyTransaction abortInProgressTransactionsOfSuspendedClientsIfNeeded();
 
     void activateTransactionInBackingStore(UniqueIDBDatabaseTransaction&);
 
@@ -189,7 +192,9 @@ private:
     // These sets help to decide which transactions can be started and which must be deferred.
     HashCountedSet<IDBObjectStoreIdentifier> m_objectStoreTransactionCounts;
     HashSet<IDBObjectStoreIdentifier> m_objectStoreWriteTransactions;
-    unsigned m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth { 0 };
+#if ASSERT_ENABLED
+    bool m_isAbortingTransactionsOfSuspendedClients { false };
+#endif
 };
 
 } // namespace IDBServer

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1653,7 +1653,7 @@ void NetworkStorageManager::setWebProcessSuspended(WebCore::ProcessIdentifier pr
     workQueue().dispatch([this, protectedThis = Ref { *this }, processIdentifier, isSuspended] {
         assertIsCurrent(workQueue());
         if (RefPtr connectionToClient = m_idbStorageRegistry->existingConnectionToClient(processIdentifier))
-            connectionToClient->setClientProcessSuspended(isSuspended);
+            connectionToClient->setClientSuspended(isSuspended);
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -535,3 +535,263 @@ TEST(IndexedDB, AbortMultipleTransactionsOfSuspendedProcess)
     EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
     EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"all first transactions aborted");
 }
+
+TEST(IndexedDB, ManyQueuedTransactionsOfSuspendedProcessAreDeferredNotAborted)
+{
+    static NSString *firstClientString = @"<script> \
+        var transactionCount = 100; \
+        var completedCount = 0; \
+        var abortedCount = 0; \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        function checkQueuedTransactionsSettled() { \
+            if (completedCount + abortedCount === transactionCount - 1) \
+                post('queued transactions settled completed=' + completedCount + ' aborted=' + abortedCount); \
+        } \
+        var request = indexedDB.open('ManyQueuedSuspendedTransactionsDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('Store'); \
+        }; \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var db = event.target.result; \
+            var firstTransaction = db.transaction('Store', 'readwrite'); \
+            firstTransaction.onabort = function() { \
+                post('first transaction aborted'); \
+            }; \
+            var objectStore = firstTransaction.objectStore('Store'); \
+            function keepTransactionAlive() { \
+                objectStore.get('TestKey').onsuccess = keepTransactionAlive; \
+            } \
+            keepTransactionAlive(); \
+            for (var i = 1; i < transactionCount; i++) { \
+                var transaction = db.transaction('Store', 'readwrite'); \
+                transaction.onabort = function() { \
+                    abortedCount++; \
+                    checkQueuedTransactionsSettled(); \
+                }; \
+                transaction.oncomplete = function() { \
+                    completedCount++; \
+                    checkQueuedTransactionsSettled(); \
+                }; \
+                transaction.objectStore('Store').put('Value' + i, 'Key' + i); \
+            } \
+            objectStore.get('TestKey').onsuccess = function() { \
+                post('first transactions queued'); \
+            }; \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('ManyQueuedSuspendedTransactionsDatabase'); \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('Store', 'readwrite'); \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore('Store').put('OtherValue', 'OtherKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    // This request is issued after every transaction, so its reply means the server has them all.
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transactions queued");
+    pid_t networkProcessIdentifier = [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier];
+    EXPECT_NE(networkProcessIdentifier, 0);
+
+    [firstWebView _setThrottleStateForTesting:0];
+
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction aborted");
+
+    // The network process must not have crashed and relaunched.
+    EXPECT_EQ(networkProcessIdentifier, [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier]);
+
+    [firstWebView _setThrottleStateForTesting:2];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"queued transactions settled completed=99 aborted=0");
+}
+
+TEST(IndexedDB, TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction)
+{
+    static NSString *clientString = @"<script> \
+        var stopFirstTransaction = false; \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('OwnQueuedTransactionDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('Store'); \
+        }; \
+        request.onerror = function() { \
+            post('database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var db = event.target.result; \
+            var firstTransaction = db.transaction('Store', 'readwrite'); \
+            firstTransaction.onabort = function() { \
+                post('first transaction aborted'); \
+            }; \
+            firstTransaction.oncomplete = function() { \
+                post('first transaction completed'); \
+            }; \
+            var objectStore = firstTransaction.objectStore('Store'); \
+            function keepTransactionAlive() { \
+                if (stopFirstTransaction) \
+                    return; \
+                objectStore.get('TestKey').onsuccess = keepTransactionAlive; \
+            } \
+            keepTransactionAlive(); \
+            var secondTransaction = db.transaction('Store', 'readwrite'); \
+            secondTransaction.onabort = function() { \
+                post('second transaction aborted'); \
+            }; \
+            secondTransaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            secondTransaction.objectStore('Store').put('OtherValue', 'OtherKey'); \
+            objectStore.get('TestKey').onsuccess = function() { \
+                post('second transaction queued'); \
+            }; \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadHTMLString:clientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    // This request is issued after the second transaction, so its reply means the server has it.
+    EXPECT_WK_STREQ([handler waitForMessage].body, @"second transaction queued");
+
+    // The in-progress transaction only blocks a transaction of the same, suspended client, so there
+    // is no live client waiting on it and it must be left alone.
+    [webView _setThrottleStateForTesting:0];
+    [webView _setThrottleStateForTesting:2];
+
+    [webView evaluateJavaScript:@"stopFirstTransaction = true;" completionHandler:nil];
+    EXPECT_WK_STREQ([handler waitForMessage].body, @"first transaction completed");
+    EXPECT_WK_STREQ([handler waitForMessage].body, @"second transaction completed");
+}
+
+TEST(IndexedDB, TransactionOfSuspendedProcessIsAbortedWhenAnotherSuspendedProcessResumes)
+{
+    static NSString *holderString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('SuspendedContentionOnResumeDatabase', 1); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('Store'); \
+            event.target.result.createObjectStore('Sync'); \
+        }; \
+        request.onerror = function() { \
+            post('holder database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('Store', 'readwrite'); \
+            transaction.onabort = function() { \
+                post('holder transaction aborted'); \
+            }; \
+            var objectStore = transaction.objectStore('Store'); \
+            var started = false; \
+            function keepTransactionAlive() { \
+                objectStore.put('HolderValue', 'HolderKey').onsuccess = function() { \
+                    if (!started) { \
+                        started = true; \
+                        post('holder transaction started'); \
+                    } \
+                    keepTransactionAlive(); \
+                }; \
+            } \
+            keepTransactionAlive(); \
+        }; \
+        </script>";
+
+    static NSString *waiterString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('SuspendedContentionOnResumeDatabase'); \
+        request.onerror = function() { \
+            post('waiter database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var db = event.target.result; \
+            var blockedTransaction = db.transaction('Store', 'readwrite'); \
+            blockedTransaction.oncomplete = function() { \
+                post('waiter transaction completed'); \
+            }; \
+            blockedTransaction.objectStore('Store').put('WaiterValue', 'WaiterKey'); \
+            var syncTransaction = db.transaction('Sync', 'readonly'); \
+            syncTransaction.oncomplete = function() { \
+                post('waiter transaction queued'); \
+            }; \
+            syncTransaction.objectStore('Sync').get('TestKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr holderHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr holderConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [holderConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[holderConfiguration userContentController] addScriptMessageHandler:holderHandler.get() name:@"testHandler"];
+    RetainPtr holderWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:holderConfiguration.get()]);
+    [holderWebView loadHTMLString:holderString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([holderHandler waitForMessage].body, @"holder transaction started");
+
+    // The transaction on the other object store is not blocked, so its completion means the server
+    // has already received the blocked one ahead of it on the same connection.
+    RetainPtr waiterHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr waiterConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [waiterConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[waiterConfiguration userContentController] addScriptMessageHandler:waiterHandler.get() name:@"testHandler"];
+    RetainPtr waiterWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:waiterConfiguration.get()]);
+    [waiterWebView loadHTMLString:waiterString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([waiterHandler waitForMessage].body, @"waiter transaction queued");
+
+    [waiterWebView _setThrottleStateForTesting:0];
+    [holderWebView _setThrottleStateForTesting:0];
+
+    [waiterWebView _setThrottleStateForTesting:2];
+    EXPECT_WK_STREQ([waiterHandler waitForMessage].body, @"waiter transaction completed");
+    EXPECT_WK_STREQ([holderHandler waitForMessage].body, @"holder transaction aborted");
+}


### PR DESCRIPTION
#### 03efc9761a39b4849f8c849c455b4f6806c250f9
<pre>
REGRESSION(315609@main): Stack overflow in NetworkProcess aborting the queued transactions of a suspended process
<a href="https://bugs.webkit.org/show_bug.cgi?id=322386">https://bugs.webkit.org/show_bug.cgi?id=322386</a>
<a href="https://rdar.apple.com/184669941">rdar://184669941</a>

Reviewed by Chris Dumez.

A page that queues many read-write transactions operating on the same object store and is then suspended crashed the
network process. The cause is that handleTransactions() ended every scheduling pass by calling
abortInProgressTransactionsBlockedOnSuspendedClients(), and that pass ended by calling handleTransactions() again. When
the scopes all overlap, takeNextRunnableTransaction() starts exactly one transaction before deferring the rest, so each
cycle handled a single queued transaction and cost one frame pair; the reported crash recursed over 3000 levels.
Batching the aborts in 318222@main did not help, because there is never more than one transaction to abort per pass.

This patch breaks the cycle at both ends. handleTransactions() no longer calls the abort pass, and
takeNextRunnableTransaction() no longer picks transactions of suspended clients: such a client cannot send requests, so
starting its transaction only holds the scope without making progress, and since the SQLite backing stores serialize
writes it blocks every other client&apos;s writes as well.

The abort pass now runs only from the three points where the blocked set can change, each followed by
handleTransactions() to start whatever became runnable:
- Suspending a client marks it suspended and aborts its in-progress transactions that block an active client.
- Resuming a client marks it active and aborts the in-progress transactions of still-suspended clients that now block
it.
- Queuing a transaction aborts the in-progress transactions of suspended clients that block it.

All three are IPC entry points, so the abort pass is unreachable from the scheduler and the recursion is structurally
impossible; a debug-only re-entrancy assertion replaces the recursion-depth counter from 318222@main. A suspended
client&apos;s queued transactions are now kept rather than started and rolled back, so their writes are no longer lost.

Also renamed setClientProcessSuspended() to setClientSuspended(), since a client connection in this layer is already
identified by a ProcessIdentifier.

Added 3 IndexedDB API tests to expand coverage:
- ManyQueuedTransactionsOfSuspendedProcessAreDeferredNotAborted covers the reported crash and checks that only the
in-progress transaction is aborted, that the 99 queued ones complete after resume, and that the network process
survived.
- TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction checks that a suspended client&apos;s in-progress
transaction is left alone when the only thing waiting on it is that client&apos;s own queued transaction.
- TransactionOfSuspendedProcessIsAbortedWhenAnotherSuspendedProcessResumes checks that with two suspended clients,
resuming one aborts the other&apos;s in-progress transaction and starts the resumed client&apos;s.

* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::setClientSuspended):
(WebCore::IDBServer::IDBConnectionToClient::setClientProcessSuspended): Deleted.
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
(WebCore::IDBServer::IDBConnectionToClient::isClientSuspended const):
(WebCore::IDBServer::IDBConnectionToClient::isClientProcessSuspended const): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::enqueueTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::handleTransactions):
(WebCore::IDBServer::isTransactionOfSuspendedClient):
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::transactionBlocksPendingTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::handleTransactionsAfterAbortingSuspendedClientTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::abortInProgressTransactionsOfSuspendedClientsIfNeeded):
(WebCore::IDBServer::UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::setWebProcessSuspended):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm:
(ManyQueuedTransactionsOfSuspendedProcessAreDeferredNotAborted)):
(TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction)):
(TransactionOfSuspendedProcessIsAbortedWhenAnotherSuspendedProcessResumes)):

Canonical link: <a href="https://commits.webkit.org/319873@main">https://commits.webkit.org/319873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c84d28722a1adf4b26f495142fd4116c44028b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147222 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cb523ad-ae18-4627-a293-2262f7d0fb2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/499a6424-c161-4f39-9896-671d11f7a98c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c423c3fd-7306-4886-bf7d-5ea27ba05cad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43443 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43075 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4324 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56526 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152246 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151943 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46505 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129500 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125588 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55739 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55110 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55347 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->