### PR TITLE
[interactive-widget] lvh and svh do not respect resizes-content value

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2150,10 +2150,13 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 #if PLATFORM(IOS_FAMILY)
     if (_overriddenLayoutParameters)
         return;
-#endif
 
+    [self _dispatchSetMinimumUnobscuredSize:minimumUnobscuredSize];
+    [self _dispatchSetMaximumUnobscuredSize:maximumUnobscuredSize];
+#else
     _page->setMinimumUnobscuredSize(minimumUnobscuredSize);
     _page->setMaximumUnobscuredSize(maximumUnobscuredSize);
+#endif
 }
 
 #if PLATFORM(MAC) && HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -173,6 +173,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)_setOpaqueInternal:(BOOL)opaque;
 - (NSString *)_contentSizeCategory;
 - (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation;
+- (void)_dispatchSetMinimumUnobscuredSize:(WebCore::FloatSize)minimumUnobscuredSize;
+- (void)_dispatchSetMaximumUnobscuredSize:(WebCore::FloatSize)maximumUnobscuredSize;
 - (WebCore::FloatSize)activeViewLayoutSize:(const CGRect&)bounds;
 - (WebCore::InteractiveWidgetValue)_viewportMetaTagInteractiveWidget;
 - (void)_updateScrollViewInsetAdjustmentBehavior;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1250,9 +1250,9 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
             if (needsOverrideLayoutSizeUpdate) {
                 [self _dispatchSetViewLayoutSize:WebCore::FloatSize(_overriddenLayoutParameters->viewLayoutSize)];
-                _page->setMinimumUnobscuredSize(WebCore::FloatSize(_overriddenLayoutParameters->minimumUnobscuredSize));
-                _page->setDefaultUnobscuredSize(WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize));
-                _page->setMaximumUnobscuredSize(WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize));
+                [self _dispatchSetMinimumUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->minimumUnobscuredSize)];
+                [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize)];
+                [self _dispatchSetMaximumUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize)];
                 needUpdateVisibleContentRects = true;
             }
         }
@@ -1286,6 +1286,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
         if (interactiveWidgetValueChanged) {
             [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
+            [self _dispatchSetActiveUnobscuredSizes];
             needUpdateVisibleContentRects = true;
         }
 
@@ -2559,19 +2560,26 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     return WebCore::FloatSize { UIEdgeInsetsInsetRect(bounds, layoutInsets).size };
 }
 
+- (WebCore::FloatSize)_sizeResizedByInteractiveWidget:(WebCore::FloatSize)size
+{
+    if (_perProcessState.viewportMetaTagInteractiveWidget != WebCore::InteractiveWidgetValue::ResizesContent)
+        return size;
+
+    CGRect keyboardInView = [self convertRect:[self _inputViewBoundsForViewportCalculations] fromView:nil];
+    if (CGRectIsEmpty(keyboardInView))
+        return size;
+
+    CGFloat maxHeight = CGRectGetMinY(keyboardInView) - [self _computedObscuredInset].top;
+    size.setHeight(std::max<float>(0, std::min<float>(size.height(), maxHeight)));
+    return size;
+}
+
 - (void)_dispatchSetViewLayoutSize:(WebCore::FloatSize)viewLayoutSize
 {
     if (!_page)
         return;
 
-    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidgetValue::ResizesContent) {
-        CGRect keyboardInView = [self convertRect:[self _inputViewBoundsForViewportCalculations] fromView:nil];
-        if (!CGRectIsEmpty(keyboardInView)) {
-            CGFloat contentTop = [self _computedObscuredInset].top;
-            CGFloat maxHeight = CGRectGetMinY(keyboardInView) - contentTop;
-            viewLayoutSize.setHeight(std::max<float>(0, std::min<float>(viewLayoutSize.height(), maxHeight)));
-        }
-    }
+    viewLayoutSize = [self _sizeResizedByInteractiveWidget:viewLayoutSize];
 
     auto newMinimumEffectiveDeviceWidth = _page->minimumEffectiveDeviceWidth();
     if (_perProcessState.lastSentViewLayoutSize && CGSizeEqualToSize(_perProcessState.lastSentViewLayoutSize.value(), viewLayoutSize) && _perProcessState.lastSentMinimumEffectiveDeviceWidth && _perProcessState.lastSentMinimumEffectiveDeviceWidth == newMinimumEffectiveDeviceWidth)
@@ -2581,6 +2589,43 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     _page->setViewportConfigurationViewLayoutSize(viewLayoutSize, _page->layoutSizeScaleFactorFromClient(), newMinimumEffectiveDeviceWidth);
     _perProcessState.lastSentViewLayoutSize = viewLayoutSize;
     _perProcessState.lastSentMinimumEffectiveDeviceWidth = newMinimumEffectiveDeviceWidth;
+}
+
+- (void)_dispatchSetMinimumUnobscuredSize:(WebCore::FloatSize)minimumUnobscuredSize
+{
+    if (!_page)
+        return;
+
+    _page->setMinimumUnobscuredSize([self _sizeResizedByInteractiveWidget:minimumUnobscuredSize]);
+}
+
+- (void)_dispatchSetMaximumUnobscuredSize:(WebCore::FloatSize)maximumUnobscuredSize
+{
+    if (!_page)
+        return;
+
+    _page->setMaximumUnobscuredSize([self _sizeResizedByInteractiveWidget:maximumUnobscuredSize]);
+}
+
+- (void)_dispatchSetDefaultUnobscuredSize:(WebCore::FloatSize)defaultUnobscuredSize
+{
+    if (!_page)
+        return;
+
+    _page->setDefaultUnobscuredSize([self _sizeResizedByInteractiveWidget:defaultUnobscuredSize]);
+}
+
+- (void)_dispatchSetActiveUnobscuredSizes
+{
+    if (_overriddenLayoutParameters) {
+        [self _dispatchSetMinimumUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->minimumUnobscuredSize)];
+        [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize)];
+        [self _dispatchSetMaximumUnobscuredSize:WebCore::FloatSize(_overriddenLayoutParameters->maximumUnobscuredSize)];
+        return;
+    }
+
+    [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(self.bounds.size)];
+    [self _recalculateViewportSizesWithMinimumViewportInset:_minimumViewportInset maximumViewportInset:_maximumViewportInset throwOnInvalidInput:NO];
 }
 
 - (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation
@@ -2867,7 +2912,7 @@ static CGFloat liveResizeMinimumWidthDifference()
     ) {
         if (!_overriddenLayoutParameters) {
             [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
-            _page->setDefaultUnobscuredSize(WebCore::FloatSize(bounds.size));
+            [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(bounds.size)];
         }
 
         [self _recalculateViewportSizesWithMinimumViewportInset:_minimumViewportInset maximumViewportInset:_maximumViewportInset throwOnInvalidInput:NO];
@@ -3503,9 +3548,9 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
         [self _dispatchSetViewLayoutSize:newViewLayoutSize];
 
     if (_overriddenLayoutParameters) {
-        _page->setMinimumUnobscuredSize(WebCore::FloatSize(newMinimumUnobscuredSize));
-        _page->setDefaultUnobscuredSize(WebCore::FloatSize(newMaximumUnobscuredSize));
-        _page->setMaximumUnobscuredSize(WebCore::FloatSize(newMaximumUnobscuredSize));
+        [self _dispatchSetMinimumUnobscuredSize:WebCore::FloatSize(newMinimumUnobscuredSize)];
+        [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(newMaximumUnobscuredSize)];
+        [self _dispatchSetMaximumUnobscuredSize:WebCore::FloatSize(newMaximumUnobscuredSize)];
     }
     [self _recalculateViewportSizesWithMinimumViewportInset:_minimumViewportInset maximumViewportInset:_maximumViewportInset throwOnInvalidInput:NO];
 
@@ -3579,8 +3624,10 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
     if (selectionWasVisible && [_contentView _hasFocusedElement] && !CGRectIsEmpty(previousInputViewBounds) && !CGRectIsEmpty(_inputViewBoundsInWindow) && !CGRectEqualToRect(previousInputViewBounds, _inputViewBoundsInWindow))
         [self _scrollToAndRevealSelectionIfNeeded];
 
-    if (keyboardShouldResizeContent)
+    if (keyboardShouldResizeContent) {
         [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
+        [self _dispatchSetActiveUnobscuredSizes];
+    }
 
     [self _scheduleVisibleContentRectUpdate];
 }
@@ -4853,9 +4900,9 @@ static bool isLockdownModeWarningNeeded()
         [self _frameOrBoundsMayHaveChanged];
         if (_overriddenLayoutParameters) {
             [self _dispatchSetViewLayoutSize:newViewLayoutSize];
-            _page->setMinimumUnobscuredSize(WebCore::FloatSize(newMinimumUnobscuredSize));
-            _page->setDefaultUnobscuredSize(WebCore::FloatSize(newMaximumUnobscuredSize));
-            _page->setMaximumUnobscuredSize(WebCore::FloatSize(newMaximumUnobscuredSize));
+            [self _dispatchSetMinimumUnobscuredSize:WebCore::FloatSize(newMinimumUnobscuredSize)];
+            [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(newMaximumUnobscuredSize)];
+            [self _dispatchSetMaximumUnobscuredSize:WebCore::FloatSize(newMaximumUnobscuredSize)];
         }
         if (_overridesInterfaceOrientation)
             [self _dispatchSetDeviceOrientation:newOrientation];
@@ -4936,7 +4983,8 @@ static bool isLockdownModeWarningNeeded()
     _perProcessState.lastSentDeviceOrientation = newOrientation;
     _perProcessState.lastSentMinimumEffectiveDeviceWidth = newMinimumEffectiveDeviceWidth;
 
-    _page->dynamicViewportSizeUpdate({ newViewLayoutSize, newMinimumUnobscuredSize, newMaximumUnobscuredSize, visibleRectInContentCoordinates, unobscuredRectInContentCoordinates, futureUnobscuredRectInSelfCoordinates, unobscuredSafeAreaInsetsExtent, targetScale, newOrientation, newMinimumEffectiveDeviceWidth, ++_currentDynamicViewportSizeUpdateID });
+    _page->dynamicViewportSizeUpdate({ newViewLayoutSize, [self _sizeResizedByInteractiveWidget:WebCore::FloatSize(newMinimumUnobscuredSize)], [self _sizeResizedByInteractiveWidget:WebCore::FloatSize(newMaximumUnobscuredSize)], visibleRectInContentCoordinates, unobscuredRectInContentCoordinates, futureUnobscuredRectInSelfCoordinates, unobscuredSafeAreaInsetsExtent, targetScale, newOrientation, newMinimumEffectiveDeviceWidth, ++_currentDynamicViewportSizeUpdateID });
+
     if (RefPtr drawingArea = _page->drawingArea())
         drawingArea->setSize(WebCore::IntSize(newBounds.size));
 
@@ -5087,9 +5135,9 @@ static bool isLockdownModeWarningNeeded()
 
     if (self._shouldDispatchOverridenLayoutParametersImmediately) {
         [self _dispatchSetViewLayoutSize:WebCore::FloatSize(overriddenLayoutParameters.viewLayoutSize)];
-        _page->setMinimumUnobscuredSize(WebCore::FloatSize(overriddenLayoutParameters.minimumUnobscuredSize));
-        _page->setDefaultUnobscuredSize(WebCore::FloatSize(overriddenLayoutParameters.maximumUnobscuredSize));
-        _page->setMaximumUnobscuredSize(WebCore::FloatSize(overriddenLayoutParameters.maximumUnobscuredSize));
+        [self _dispatchSetMinimumUnobscuredSize:WebCore::FloatSize(overriddenLayoutParameters.minimumUnobscuredSize)];
+        [self _dispatchSetDefaultUnobscuredSize:WebCore::FloatSize(overriddenLayoutParameters.maximumUnobscuredSize)];
+        [self _dispatchSetMaximumUnobscuredSize:WebCore::FloatSize(overriddenLayoutParameters.maximumUnobscuredSize)];
     }
 }
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/InteractiveWidgetViewportUnits.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/InteractiveWidgetViewportUnits.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style>
+body {
+    margin: 0;
+}
+div {
+    display: inline-block;
+    width: 1px;
+}
+input {
+    width: 200px;
+    height: 50px;
+}
+    </style>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <div id="vw" style="height: 100vw;"></div>
+    <div id="vh" style="height: 100vh;"></div>
+
+    <div id="svh" style="height: 100svh;"></div>
+    <div id="lvh" style="height: 100lvh;"></div>
+    <div id="dvh" style="height: 100dvh;"></div>
+</body>

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -994,6 +994,7 @@
 				WebKit/WKWebView/ios/FullscreenTouchSecheuristicTests.cpp,
 				WebKit/WKWebView/ios/GestureRecognizerTests.mm,
 				WebKit/WKWebView/ios/GrantAccessToMobileAssets.mm,
+				WebKit/WKWebView/ios/InteractiveWidget.mm,
 				WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm,
 				WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm,
 				WebKit/WKWebView/ios/OverflowScrollViewTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/InteractiveWidget.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/InteractiveWidget.mm
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "TestInputDelegate.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTestingIOS.h>
+#import <wtf/RetainPtr.h>
+
+constexpr CGFloat keyboardHeight = 300;
+
+static double viewportUnitLength(RetainPtr<TestWKWebView>& webView, NSString *viewportUnit)
+{
+    NSString *script = [NSString stringWithFormat:@"document.getElementById('%@').getBoundingClientRect().height", viewportUnit];
+    return [(NSNumber *)[webView objectByEvaluatingJavaScript:script] doubleValue];
+}
+
+static void setInteractiveWidget(RetainPtr<TestWKWebView>& webView, NSString *value)
+{
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"document.querySelector('meta[name=viewport]').content = 'width=device-width, initial-scale=1, interactive-widget=%@'", value]];
+}
+
+static void simulateKeyboardOfHeight(RetainPtr<TestWKWebView>& webView, CGFloat height)
+{
+    RetainPtr window = [webView window];
+    CGRect frameInWindow = [webView convertRect:CGRectMake(0, CGRectGetHeight([webView bounds]) - height, CGRectGetWidth([webView bounds]), height) toView:window];
+    CGRect frameInScreen = [window convertRect:frameInWindow toCoordinateSpace:[window screen].coordinateSpace];
+
+    [NSNotificationCenter.defaultCenter postNotificationName:UIKeyboardDidChangeFrameNotification object:nil userInfo:@{
+        UIKeyboardFrameEndUserInfoKey: [NSValue valueWithCGRect:frameInScreen],
+        UIKeyboardIsLocalUserInfoKey: @YES,
+    }];
+
+    EXPECT_FALSE(CGRectIsEmpty([webView _inputViewBoundsInWindow]));
+    [webView waitForNextPresentationUpdate];
+}
+
+static void focusInput(RetainPtr<TestWKWebView>& webView, RetainPtr<TestInputDelegate>& inputDelegate)
+{
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView _setInputDelegate:inputDelegate];
+    [webView focusInWindow];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.getElementById('input').focus()"];
+    EXPECT_WK_STREQ("input", [webView stringByEvaluatingJavaScript:@"document.activeElement.id"]);
+}
+
+TEST(InteractiveWidget, ViewportUnitsOverlaysContent)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+
+    [webView synchronouslyLoadTestPageNamed:@"InteractiveWidgetViewportUnits"];
+    setInteractiveWidget(webView, @"overlays-content");
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"dvh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"lvh"));
+
+    focusInput(webView, inputDelegate);
+    simulateKeyboardOfHeight(webView, keyboardHeight);
+
+    double dvh = viewportUnitLength(webView, @"dvh");
+    EXPECT_FLOAT_EQ(500, dvh);
+    EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"lvh"));
+}
+
+TEST(InteractiveWidget, ViewportUnitsResizesContent)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+
+    [webView synchronouslyLoadTestPageNamed:@"InteractiveWidgetViewportUnits"];
+    setInteractiveWidget(webView, @"resizes-content");
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"dvh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"lvh"));
+
+    focusInput(webView, inputDelegate);
+    simulateKeyboardOfHeight(webView, keyboardHeight);
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(500 - keyboardHeight, viewportUnitLength(webView, @"vh"));
+
+    double dvh = viewportUnitLength(webView, @"dvh");
+    EXPECT_FLOAT_EQ(500 - keyboardHeight, dvh);
+    EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"lvh"));
+}
+
+TEST(InteractiveWidget, ViewportUnitsResizesContentWithOverriddenLayoutParameters)
+{
+    constexpr CGFloat viewHeight = 500;
+    constexpr CGFloat topBarHeight = 50;
+    constexpr CGFloat bottomBarHeight = 44;
+    constexpr CGFloat minimumUnobscuredHeight = viewHeight - topBarHeight - bottomBarHeight;
+    constexpr CGFloat maximumUnobscuredHeight = viewHeight - topBarHeight;
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+
+    [webView _setObscuredInsets:UIEdgeInsetsMake(topBarHeight, 0, bottomBarHeight, 0)];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(320, minimumUnobscuredHeight) minimumUnobscuredSizeOverride:CGSizeMake(320, minimumUnobscuredHeight) maximumUnobscuredSizeOverride:CGSizeMake(320, maximumUnobscuredHeight)];
+
+    [webView synchronouslyLoadTestPageNamed:@"InteractiveWidgetViewportUnits"];
+    setInteractiveWidget(webView, @"resizes-content");
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(maximumUnobscuredHeight, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(minimumUnobscuredHeight, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(maximumUnobscuredHeight, viewportUnitLength(webView, @"lvh"));
+
+    focusInput(webView, inputDelegate);
+    simulateKeyboardOfHeight(webView, keyboardHeight);
+
+    constexpr CGFloat resizedHeight = viewHeight - keyboardHeight - topBarHeight;
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(resizedHeight, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(resizedHeight, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(resizedHeight, viewportUnitLength(webView, @"lvh"));
+    EXPECT_FLOAT_EQ(resizedHeight, viewportUnitLength(webView, @"dvh"));
+}
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### a2ccf3506fc2a4ae4a5c8e6d0b7a752a0341068d
<pre>
[interactive-widget] lvh and svh do not respect resizes-content value
<a href="https://bugs.webkit.org/show_bug.cgi?id=322531">https://bugs.webkit.org/show_bug.cgi?id=322531</a>
<a href="https://rdar.apple.com/185827264">rdar://185827264</a>

Reviewed by Wenson Hsieh.

Currently, lvh and svh do not work with resizes-content. Based on the
spec, when resizing the layout viewport, the CSS viewport units should
reflect such changes.

So, implement support for lvh and svh to respect resizes-content while
also respecting override layout parameters. Key changes include:

- _sizeResizedByInteractiveWidget: takes in the size passed and if
resizes-content, will clamp to keyboard top (old logic in
_dispatchSetViewLayoutSize which is now extracted to this function)

- _dispatchSetMinimumUnobscuredSize and others: replaces setMinimumUnobscuredSize
and alike by still calling setMinimumUnobscuredSize, but uses the size of what
is passed in, and the clamp if it exists. This takes into account override layout
parameters, will only clamp for resizes-content, and if override layout parameters
are present with resizes-content, the clamp value only wins if the keyboard is up.

- _dispatchSetActiveUnobscuredSizes: is called if interactiveWidgetValueChanged or
if keyboardShouldResizeContent, where it will re-push override layout parameters if
they exist, and then calls the dispatch functions (taking account of the resizes-content
clamping if it exists).

Additionally, add API tests for these cases:
- overlays-content viewport units
- resizes-content viewport units
- override layout parameters with resizes-content viewport units

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKWebView _sizeResizedByInteractiveWidget:]):
(-[WKWebView _dispatchSetViewLayoutSize:]):
(-[WKWebView _dispatchSetMinimumUnobscuredSize:]):
(-[WKWebView _dispatchSetMaximumUnobscuredSize:]):
(-[WKWebView _dispatchSetDefaultUnobscuredSize:]):
(-[WKWebView _dispatchSetActiveUnobscuredSizes]):
(-[WKWebView _frameOrBoundsMayHaveChanged]):
(-[WKWebView _didStopDeferringGeometryUpdates]):
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
(-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:minimumUnobscuredSizeOverride:maximumUnobscuredSizeOverride:]):
* Tools/TestWebKitAPI/Resources/cocoa/InteractiveWidgetViewportUnits.html: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/InteractiveWidget.mm: Added.
(viewportUnitLength):
(setInteractiveWidget):
(simulateKeyboardOfHeight):
(focusInput):
(TEST(InteractiveWidget, ViewportUnitsOverlaysContent)):
(TEST(InteractiveWidget, ViewportUnitsResizesContent)):
(TEST(InteractiveWidget, ViewportUnitsResizesContentWithOverriddenLayoutParameters)):

Canonical link: <a href="https://commits.webkit.org/319997@main">https://commits.webkit.org/319997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bc2e537756b5942ef5e1a2bc82baf5ec974caaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193602 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/004fda76-230e-4730-a005-95a8a76ab362) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/335dcf71-d182-4fde-84af-48b20c97b20f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123557 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c02bcdd4-7094-478a-aaf4-699a1f994e7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45591 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43438 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4776 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195541 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56975 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152644 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57679 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152329 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46882 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56187 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18448 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55558 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->