### PR TITLE
[CFNetwork] Honor Expires cookie dates that use JS Date.toString() dates (month-before-day Expires values)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires-expected.txt
@@ -4,9 +4,22 @@ PASS Set cookie with expires value followed by comma via HTTP headers
 PASS Set cookie with future expiration via HTTP headers
 PASS Set expired cookie along with valid cookie via HTTP headers
 PASS Don't set cookie with expires set to the past via HTTP headers
+PASS Set cookie with the month before the day of the month in expires via HTTP headers
+FAIL Don't set cookie with the month before the day of the month in an expires in the past via HTTP headers assert_equals: The cookie was rejected. expected "" but got "test=7"
+FAIL Don't set cookie with no day name and the month before the day of the month in an expires in the past via HTTP headers assert_equals: The cookie was rejected. expected "" but got "test=8"
+FAIL Don't set cookie with an expires in the past in Date.prototype.toString() format via HTTP headers assert_equals: The cookie was rejected. expected "" but got "test=9"
+PASS Set cookie whose Max-Age overrides an expires in the past via HTTP headers
+PASS Set cookie with an asctime format expires, whose time precedes the year via HTTP headers
 PASS Set cookie with expires value containing a comma via document.cookie
 PASS Set cookie with expires value followed by comma via document.cookie
 PASS Set cookie with future expiration via document.cookie
 PASS Set expired cookie along with valid cookie via document.cookie
 PASS Don't set cookie with expires set to the past via document.cookie
+PASS Set cookie with the month before the day of the month in expires via document.cookie
+PASS Don't set cookie with the month before the day of the month in an expires in the past via document.cookie
+PASS Don't set cookie with no day name and the month before the day of the month in an expires in the past via document.cookie
+PASS Don't set cookie with an expires in the past in Date.prototype.toString() format via document.cookie
+PASS Set cookie whose Max-Age overrides an expires in the past via document.cookie
+PASS Set cookie with an asctime format expires, whose time precedes the year via document.cookie
+PASS Don't set cookie with an expires in the past and a non-ASCII timezone comment via document.cookie
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires.html
@@ -40,6 +40,49 @@
           expected: "",
           name: "Don't set cookie with expires set to the past",
         },
+        // RFC 6265 section 5.1.1 finds the day of the month, the month and the year by matching each
+        // date token independently, so either ordering parses: "10 Apr 1980" and "Apr 10 1980" are
+        // both valid and denote the same date. Month-first is what JavaScript's
+        // Date.prototype.toString() produces, and sites pass that to document.cookie in place of
+        // toUTCString(), so interoperability here is important.
+        //
+        // Note that only the past-expiration cases below actually distinguish a conforming
+        // implementation: if the Expires attribute is ignored, the cookie is stored as a session
+        // cookie and is therefore still present, so a future expiration looks identical either way.
+        {
+          cookie: "test=6; Expires=Fri Jan 01 2038 00:00:00 GMT",
+          expected: "test=6",
+          name: "Set cookie with the month before the day of the month in expires",
+        },
+        {
+          cookie: "test=7; Expires=Thu Apr 10 1980 16:33:12 GMT",
+          expected: "",
+          name: "Don't set cookie with the month before the day of the month in an expires in the past",
+        },
+        {
+          cookie: "test=8; Expires=Apr 10 1980 16:33:12 GMT",
+          expected: "",
+          name: "Don't set cookie with no day name and the month before the day of the month in an expires in the past",
+        },
+        {
+          cookie: "test=9; Expires=Thu Apr 10 1980 16:33:12 GMT-0700 (Pacific Daylight Time)",
+          expected: "",
+          name: "Don't set cookie with an expires in the past in Date.prototype.toString() format",
+        },
+        {
+          cookie: "test=10; Expires=Thu Apr 10 1980 16:33:12 GMT; Max-Age=1000",
+          expected: "test=10",
+          name: "Set cookie whose Max-Age overrides an expires in the past",
+        },
+        // The asctime form is also month-first, but it puts the time where Date.prototype.toString()
+        // puts the year: "Thu Apr 10 16:33:12 1980". It must not be reordered as though the token
+        // after the day of the month were a year, because "Fri 01 Jan 03:14:07 2038" denotes a date in
+        // the past, which would drop the cookie instead of storing it.
+        {
+          cookie: "test=12; Expires=Fri Jan 01 03:14:07 2038",
+          expected: "test=12",
+          name: "Set cookie with an asctime format expires, whose time precedes the year",
+        },
       ];
 
       // These tests evaluate setting cookies with expiration via HTTP headers.
@@ -51,6 +94,15 @@
       for (const test of expiresTests) {
         domCookieTest(test.cookie, test.expected, test.name + " via document.cookie");
       }
+
+      // A timezone name is localized, so it can be non-ASCII. Date.prototype.toString() only reaches
+      // a cookie through script, and sending non-ASCII in a response header would exercise header
+      // encoding at the same time, so this case covers document.cookie only. Same date as test=9,
+      // written with escapes to keep this file ASCII-only.
+      domCookieTest(
+        "test=11; Expires=Thu Apr 10 1980 16:33:12 GMT-0700 (\u0398\u03b5\u03c1\u03b9\u03bd\u03ae \u03ce\u03c1\u03b1 \u0395\u03b9\u03c1\u03b7\u03bd\u03b9\u03ba\u03bf\u03cd)",
+        "",
+        "Don't set cookie with an expires in the past and a non-ASCII timezone comment via document.cookie");
     </script>
   </body>
 </html>

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -15020,6 +15020,7 @@
 		7AEAD8AD290289C9008B5675 /* ScrollingTreeOverflowScrollProxyNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreeOverflowScrollProxyNode.cpp; sourceTree = "<group>"; };
 		7AEAD8AE290289E1008B5675 /* ScrollingTreeOverflowScrollProxyNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeOverflowScrollProxyNode.h; sourceTree = "<group>"; };
 		7AEFEA122D52A89D007B21AC /* DocumentEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DocumentEnums.h; sourceTree = "<group>"; };
+		7AF0423D303F4F8F006FB27D /* Cookie.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Cookie.cpp; sourceTree = "<group>"; };
 		7AF9B1FC18CFB2DF00C64BEF /* VTTRegion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VTTRegion.cpp; sourceTree = "<group>"; };
 		7AF9B1FD18CFB2DF00C64BEF /* VTTRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VTTRegion.h; sourceTree = "<group>"; };
 		7AF9B1FE18CFB2DF00C64BEF /* VTTRegion.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VTTRegion.idl; sourceTree = "<group>"; };
@@ -31006,6 +31007,7 @@
 				E43AF8E41AC5B7DD00CA717E /* CacheValidation.cpp */,
 				E43AF8E51AC5B7DD00CA717E /* CacheValidation.h */,
 				91B8F0B321953D65000C2B00 /* CertificateSummary.h */,
+				7AF0423D303F4F8F006FB27D /* Cookie.cpp */,
 				7A56996E2086C618000E0433 /* CookieRequestHeaderFieldProxy.h */,
 				E13F01EA1270E10D00DFBA71 /* CookieStorage.h */,
 				514C76590CE923A1007EF3CD /* Credential.h */,

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Joseph Pecoraro. All rights reserved.
- * Copyright (C) 2017-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,10 @@
 
 #pragma once
 
+#include <optional>
+#include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
-#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 #ifdef __OBJC__
@@ -126,6 +127,8 @@ struct Cookie {
 namespace CookieUtil {
 
 WEBCORE_EXPORT String defaultPathForURL(const URL&);
+
+std::optional<String> cookieStringWithDayFirstExpires(StringView);
 
 } // namespace CookieUtil
 

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,14 @@
 
 #include "config.h"
 #include "Cookie.h"
+
+#include <algorithm>
+#include <wtf/ASCIICType.h>
+#include <wtf/DateMath.h>
+#include <wtf/NotFound.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/StringView.h>
 
 namespace WebCore {
     
@@ -58,6 +66,97 @@ String defaultPathForURL(const URL& url)
         return "/"_s;
 
     return path.left(lastSlashPosition);
+}
+
+static bool isMonthNameToken(StringView token)
+{
+    // RFC 6265 section 5.1.1 matches a month by its first three characters, case-insensitively.
+    if (token.length() < 3)
+        return false;
+    auto prefix = token.left(3);
+    return std::ranges::any_of(WTF::monthName, [&](auto month) {
+        return equalIgnoringASCIICase(prefix, month);
+    });
+}
+
+std::optional<String> cookieStringWithDayFirstExpires(StringView cookieString)
+{
+    auto firstSemicolon = cookieString.find(';');
+    if (firstSemicolon == notFound)
+        return std::nullopt;
+
+    // Locate the Expires value within the original string. The last one wins, per RFC 6265
+    // section 5.3.
+    size_t valueStart = notFound;
+    size_t valueEnd = notFound;
+    for (size_t position = firstSemicolon + 1; position <= cookieString.length();) {
+        auto semicolon = cookieString.find(';', position);
+        auto attributeEnd = semicolon == notFound ? cookieString.length() : semicolon;
+        auto attribute = cookieString.substring(position, attributeEnd - position);
+        if (auto equals = attribute.find('='); equals != notFound) {
+            if (equalLettersIgnoringASCIICase(attribute.left(equals).trim(isTabOrSpace<char16_t>), "expires"_s)) {
+                valueStart = position + equals + 1;
+                valueEnd = attributeEnd;
+            }
+        }
+        if (semicolon == notFound)
+            break;
+        position = semicolon + 1;
+    }
+
+    if (valueStart == notFound)
+        return std::nullopt;
+
+    // Find a month name immediately followed by a one or two digit day of the month. In a day-first
+    // value the token after the month is the four digit year, so this does not match and nothing is
+    // rewritten.
+    auto isSeparator = [](char16_t character) {
+        return character == ' ' || character == '\t';
+    };
+    size_t monthStart = notFound;
+    size_t monthEnd = notFound;
+    size_t dayStart = notFound;
+    size_t dayEnd = notFound;
+    for (size_t position = valueStart; position < valueEnd;) {
+        while (position < valueEnd && isSeparator(cookieString[position]))
+            ++position;
+        size_t tokenStart = position;
+        while (position < valueEnd && !isSeparator(cookieString[position]))
+            ++position;
+        if (tokenStart == position)
+            break;
+        if (monthStart == notFound) {
+            if (isMonthNameToken(cookieString.substring(tokenStart, position - tokenStart))) {
+                monthStart = tokenStart;
+                monthEnd = position;
+            }
+            continue;
+        }
+        dayStart = tokenStart;
+        dayEnd = position;
+        break;
+    }
+
+    if (monthStart == notFound || dayStart == notFound)
+        return std::nullopt;
+
+    auto day = cookieString.substring(dayStart, dayEnd - dayStart);
+    if (day.length() > 2 || !day.containsOnly<isASCIIDigit<char16_t>>())
+        return std::nullopt;
+
+    size_t yearStart = dayEnd;
+    while (yearStart < valueEnd && isSeparator(cookieString[yearStart]))
+        ++yearStart;
+    size_t yearEnd = yearStart;
+    while (yearEnd < valueEnd && !isSeparator(cookieString[yearEnd]))
+        ++yearEnd;
+    auto year = cookieString.substring(yearStart, yearEnd - yearStart);
+    if (year.length() != 4 || !year.containsOnly<isASCIIDigit<char16_t>>())
+        return std::nullopt;
+
+    // Return a new string where we have swapped the two tokens.
+    return makeString(cookieString.left(monthStart), day, cookieString.substring(monthEnd, dayStart - monthEnd),
+        cookieString.substring(monthStart, monthEnd - monthStart), cookieString.substring(dayEnd));
 }
 
 } // namespace CookieUtil

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
+#import <wtf/text/StringView.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
 
 @interface NSURL ()
@@ -521,6 +522,11 @@ static RetainPtr<NSHTTPCookie> parseDOMCookie(String cookieString, NSURL* cookie
     // <http://bugs.webkit.org/show_bug.cgi?id=6531>, <rdar://4409034>
     // cookiesWithResponseHeaderFields doesn't parse cookies without a value
     cookieString = cookieString.contains('=') ? cookieString : makeString(cookieString, '=');
+
+    // FIXME: <rdar://185837942> Remove this once CFNetwork's cookie-date parser accepts a date that
+    // writes the month before the day of the month. RFC 6265 section 5.1.1 accepts either ordering.
+    if (auto dayFirst = CookieUtil::cookieStringWithDayFirstExpires(cookieString))
+        cookieString = WTF::move(*dayFirst);
 
     return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:nsStringNilIfEmpty(partition).get()], cappedLifetime);
 }

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -427,7 +427,11 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     GSList* existingCookies = soup_cookie_jar_get_cookie_list(jar, origin.get(), TRUE);
 
     for (auto& cookieString : value.split('\n')) {
-        GUniquePtr<SoupCookie> cookie(soup_cookie_parse(cookieString.utf8().data(), origin.get()));
+        // FIXME: Remove this once libsoup's cookie-date parser accepts a date that writes the month
+        // before the day of the month. RFC 6265 section 5.1.1 accepts either ordering.
+        auto dayFirst = CookieUtil::cookieStringWithDayFirstExpires(cookieString);
+        auto utf8CookieString = (dayFirst ? *dayFirst : cookieString).utf8();
+        GUniquePtr<SoupCookie> cookie(soup_cookie_parse(utf8CookieString.data(), origin.get()));
 
         if (!cookie)
             continue;


### PR DESCRIPTION
#### d01d085ea0fdef14a17d1c9765c49b8fee40fa67
<pre>
[CFNetwork] Honor Expires cookie dates that use JS Date.toString() dates (month-before-day Expires values)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322546">https://bugs.webkit.org/show_bug.cgi?id=322546</a>
<a href="https://rdar.apple.com/185840799">rdar://185840799</a>

Reviewed by Matthew Finkel.

CFNetwork&apos;s cookie-date parser rejects a cookie-date containing a month-before-day date
format. Unfortunately, this is the format JavaScript&apos;s Date.prototype.toString() method
produces (at least in some locales). This causes cookies with an Expires attribute of
that form to be silently ignored, converting the cookie from a persistent value to a
session cookie (which disappears when the browser quits).

This patch introduces an initial scan for month-first date formats, and fixes up the
string if necessary. We perform the date fix-up prior to handing off to CFNetwork (or
libSOUP) so that we only have to perform the cookie parsing logic once. The cURL ports
never rejected month-before-day strings, so did not suffer from this behavior.

While this patch is largely a workaround until CFNetwork and libSOUP fix their underlying
implementations, it also allows us to improve behavior for downlevel shipment of Safari
as well as Safari Technology Preview.

This fix can only cover document.cookie cases. The Set-Cookie response-header path is parsed
inside NSURLSession before WebKit sees the response, so there is no interception point;
that half is fixed only by <a href="https://rdar.apple.com/185837942">rdar://185837942</a>.

* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires.html:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/Cookie.h:
* Source/WebCore/platform/network/Cookie.cpp:
(WebCore::CookieUtil::isMonthNameToken):
(WebCore::CookieUtil::cookieStringWithDayFirstExpires):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::parseDOMCookie): Repair the parsed cookie before adjusting it.
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookiesFromDOM const):

Canonical link: <a href="https://commits.webkit.org/320016@main">https://commits.webkit.org/320016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bb55bab8525bd8542c00455c1c216a97e23dc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147757 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/616d9791-be1f-4561-bfb0-60cb1449e217) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143198 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99426 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74dae758-feb9-4e7d-902d-f470a08055f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43889 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43488 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4862 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40922 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57764 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152396 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46948 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130043 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18497 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->