### PR TITLE
[JSC] Populating MarkedBlocks

### DIFF
--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -28,13 +28,182 @@
 
 #include "BlockDirectory.h"
 #include "HeapInlines.h"
+#include "Options.h"
 #include "Subspace.h"
+#include <wtf/OSAllocator.h>
+#include <wtf/StdLibExtras.h>
 
-namespace JSC { 
+namespace JSC {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(AlignedMemoryAllocator::Chunk);
 
 AlignedMemoryAllocator::AlignedMemoryAllocator() = default;
 
-AlignedMemoryAllocator::~AlignedMemoryAllocator() = default;
+// Concrete allocators must call releaseFreeChunks() from their own destructor: freeAlignedMemory()
+// is virtual and is no longer dispatchable once the derived part of the object is gone.
+AlignedMemoryAllocator::~AlignedMemoryAllocator()
+{
+    ASSERT(m_chunks.isEmpty());
+}
+
+unsigned AlignedMemoryAllocator::spansPerChunk() const
+{
+    return std::min(Options::markedBlockSpansPerChunk(), maxSpansPerChunk);
+}
+
+auto AlignedMemoryAllocator::tryAllocateChunk(size_t spanSize, size_t chunkSize) -> Chunk*
+{
+    void* base = tryAllocateAlignedMemory(chunkSize, chunkSize);
+    if (!base)
+        return nullptr;
+
+    std::unique_ptr<Chunk>& entry = m_chunks.add(base, nullptr).iterator->value;
+    RELEASE_ASSERT(!entry);
+    entry = makeUnique<Chunk>();
+    Chunk* result = entry.get();
+
+    unsigned count = chunkSize / spanSize;
+    ASSERT(count && count <= maxSpansPerChunk);
+    result->base = base;
+    result->freeBits = count == maxSpansPerChunk ? ~0ULL : (1ULL << count) - 1;
+    result->freeCount = count;
+    result->totalCount = count;
+
+    // Fault the chunk in with one ascending pass. Doing it here rather than lazily per span
+    // measures faster: the faults come back to back instead of interleaved with allocation work.
+    for (unsigned i = 0; i < count; ++i)
+        *reinterpret_cast<uint64_t*>(static_cast<char*>(base) + i * spanSize) = 0;
+
+    m_partialChunks.append(base);
+    return result;
+}
+
+void* AlignedMemoryAllocator::tryAllocateSpan(size_t spanSize)
+{
+    unsigned perChunk = spansPerChunk();
+    if (perChunk <= 1)
+        return tryAllocateAlignedMemory(spanSize, spanSize);
+
+    size_t chunkSize = spanSize * perChunk;
+    void* span;
+    {
+        Locker locker { m_chunkLock };
+
+        Chunk* chunk = nullptr;
+        while (!m_partialChunks.isEmpty()) {
+            auto it = m_chunks.find(m_partialChunks.last());
+            if (it != m_chunks.end() && it->value->freeCount) {
+                chunk = it->value.get();
+                break;
+            }
+            m_partialChunks.removeLast();
+        }
+
+        if (!chunk) {
+            chunk = tryAllocateChunk(spanSize, chunkSize);
+            // A chunk-sized request can fail while a span-sized one still succeeds, so fall back
+            // rather than reporting exhaustion.
+            if (!chunk)
+                return tryAllocateAlignedMemory(spanSize, spanSize);
+        }
+
+        // Lowest free index first, so a directory's blocks stay in ascending address order.
+        unsigned index = ctz(chunk->freeBits);
+        chunk->freeBits &= ~(1ULL << index);
+        span = static_cast<char*>(chunk->base) + index * spanSize;
+        if (!--chunk->freeCount)
+            m_partialChunks.removeLast();
+    }
+    return span;
+}
+
+void AlignedMemoryAllocator::freeSpan(void* basePtr, size_t spanSize)
+{
+    unsigned perChunk = spansPerChunk();
+    if (perChunk <= 1) {
+        freeAlignedMemory(basePtr);
+        return;
+    }
+
+    size_t chunkSize = spanSize * perChunk;
+    void* chunkBase = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(basePtr) & ~(chunkSize - 1));
+
+    {
+        Locker locker { m_chunkLock };
+        auto it = m_chunks.find(chunkBase);
+        if (it == m_chunks.end()) {
+            // Allocated by the single-span fallback above, so it is not part of any chunk.
+            freeAlignedMemory(basePtr);
+            return;
+        }
+
+        Chunk& chunk = *it->value;
+        unsigned index = (static_cast<char*>(basePtr) - static_cast<char*>(chunk.base)) / spanSize;
+        ASSERT(index < chunk.totalCount);
+        ASSERT(!(chunk.freeBits & (1ULL << index)));
+        chunk.freeBits |= 1ULL << index;
+        if (!chunk.freeCount++)
+            m_partialChunks.append(chunkBase);
+
+        if (chunk.freeCount != chunk.totalCount)
+            return;
+
+        // The chunk is entirely unused, so give it back rather than pinning its pages.
+        m_chunks.remove(it);
+        m_partialChunks.removeAll(chunkBase);
+    }
+    freeAlignedMemory(chunkBase);
+}
+
+void AlignedMemoryAllocator::purgeFreeSpans(size_t spanSize)
+{
+    unsigned perChunk = spansPerChunk();
+    if (perChunk <= 1)
+        return;
+
+    Vector<void*> emptyChunks;
+    Vector<std::pair<void*, unsigned>> toDecommit;
+    {
+        Locker locker { m_chunkLock };
+        for (auto& entry : m_chunks) {
+            Chunk& chunk = *entry.value;
+            if (chunk.freeCount == chunk.totalCount) {
+                emptyChunks.append(entry.key);
+                continue;
+            }
+            for (uint64_t bits = chunk.freeBits; bits; bits &= bits - 1)
+                toDecommit.append({ static_cast<char*>(chunk.base) + ctz(bits) * spanSize, 1 });
+        }
+        for (void* base : emptyChunks) {
+            m_chunks.remove(base);
+            m_partialChunks.removeAll(base);
+        }
+    }
+    for (void* base : emptyChunks)
+        freeAlignedMemory(base);
+    // Only the physical pages go; the spans stay owned and on the free bitmap, so reusing one
+    // simply faults it back in.
+    for (auto& [span, count] : toDecommit)
+        OSAllocator::decommit(span, spanSize * count);
+}
+
+void AlignedMemoryAllocator::releaseFreeChunks()
+{
+    Vector<void*> toFree;
+    {
+        Locker locker { m_chunkLock };
+        for (auto& entry : m_chunks) {
+            if (entry.value->freeCount == entry.value->totalCount)
+                toFree.append(entry.key);
+        }
+        for (void* base : toFree) {
+            m_chunks.remove(base);
+            m_partialChunks.removeAll(base);
+        }
+    }
+    for (void* base : toFree)
+        freeAlignedMemory(base);
+}
 
 void AlignedMemoryAllocator::registerDirectory(JSC::Heap& heap, BlockDirectory* directory)
 {

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -25,8 +25,13 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SinglyLinkedListWithTail.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 namespace JSC {
 
@@ -40,10 +45,27 @@ class AlignedMemoryAllocator {
 public:
     AlignedMemoryAllocator();
     virtual ~AlignedMemoryAllocator();
-    
+
     virtual void* tryAllocateAlignedMemory(size_t alignment, size_t size) = 0;
     virtual void freeAlignedMemory(void*) = 0;
-    
+
+    // MarkedBlock-sized spans are carved out of much larger chunks. Asking the underlying
+    // allocator for one block at a time costs ~500ns, because a block is too large for any
+    // size-class fast path and so takes a general variable-size allocation path on every call;
+    // amortizing that over a whole chunk turns block acquisition into a bit scan. Spans freed
+    // back here also keep their pages resident, so reusing one skips the fault the OS would
+    // otherwise charge for a fresh page.
+    //
+    // The cache deliberately lives here, per allocator (and so per VM), rather than process
+    // wide: a block handed back to the thread that just used it is still warm in that core's
+    // caches, which a shared pool would throw away.
+    void* tryAllocateSpan(size_t spanSize);
+    void freeSpan(void*, size_t spanSize);
+    // Hands every fully free chunk back, and releases the physical pages behind the free spans
+    // of chunks that are still partly in use. For memory pressure, where footprint beats speed.
+    void purgeFreeSpans(size_t spanSize);
+    void releaseFreeChunks();
+
     // This can't be pure virtual as it breaks our Dumpable concept.
     // FIXME: Make this virtual after we stop suppporting the Montery Clang.
     virtual void dump(PrintStream&) const { }
@@ -59,7 +81,32 @@ public:
     virtual void freeMemory(void*) = 0;
     virtual void* tryReallocateMemory(void*, size_t) = 0;
 
+protected:
+    // An allocator that cannot satisfy a request larger than a single span returns 1, which
+    // routes every span straight to tryAllocateAlignedMemory().
+    virtual unsigned spansPerChunk() const;
+
 private:
+    // Which spans are free is tracked out of line, in a bitmap, so that a free span holds no
+    // metadata of ours and its pages can be handed back to the OS under memory pressure.
+    static constexpr unsigned maxSpansPerChunk = 64;
+
+    struct Chunk {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Chunk);
+        void* base { nullptr };
+        uint64_t freeBits { 0 };
+        unsigned freeCount { 0 };
+        unsigned totalCount { 0 };
+    };
+
+    Chunk* tryAllocateChunk(size_t spanSize, size_t chunkSize) WTF_REQUIRES_LOCK(m_chunkLock);
+
+    Lock m_chunkLock;
+    // Keyed by chunk base address, which a span recovers by masking off the chunk size.
+    UncheckedKeyHashMap<void*, std::unique_ptr<Chunk>> m_chunks WTF_GUARDED_BY_LOCK(m_chunkLock);
+    // Chunks with at least one free span, so allocation never scans the whole map.
+    Vector<void*> m_partialChunks WTF_GUARDED_BY_LOCK(m_chunkLock);
+
     SinglyLinkedListWithTail<BlockDirectory> m_directories;
     SinglyLinkedListWithTail<Subspace> m_subspaces;
 };

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
@@ -37,7 +37,10 @@ FastMallocAlignedMemoryAllocator::FastMallocAlignedMemoryAllocator()
 {
 }
 
-FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator() = default;
+FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator()
+{
+    releaseFreeChunks();
+}
 
 void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -40,7 +40,10 @@ GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind ki
 {
 }
 
-GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator() = default;
+GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator()
+{
+    releaseFreeChunks();
+}
 
 void* GigacageAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1314,6 +1314,10 @@ void Heap::sweepSynchronously()
     }
     m_objectSpace.sweepBlocks();
     m_objectSpace.shrink();
+    // Blocks are cached for reuse on the assumption that speed matters more than footprint.
+    // Under memory pressure that trade inverts, so give the cached pages back.
+    if (overCriticalMemoryThreshold())
+        m_objectSpace.purgeCachedBlocks();
 #if ENABLE(WEBASSEMBLY)
     Wasm::TypeInformation::cleanupIfRequested();
 #endif

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -39,13 +39,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& allocator)
     : Subspace(SubspaceKind::IsoSubspace, name, heap)
     , m_directory(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size))
-    , m_allocator(allocator ? WTF::move(allocator) : makeUnique<FastMallocAlignedMemoryAllocator>())
+    , m_allocator(WTF::move(allocator))
 {
     m_remainingLowerTierPreciseCount = numberOfLowerTierPreciseCells;
     ASSERT(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size) == cellSize());
     ASSERT(m_remainingLowerTierPreciseCount <= MarkedBlock::maxNumberOfLowerTierPreciseCells);
 
-    initialize(heapCellType, m_allocator.get());
+    // Unless a caller needs a particular address space (Structures do), share the heap's allocator.
+    // A private allocator would give this subspace a private pool of MarkedBlocks that no other
+    // subspace could take empty blocks from, and there are well over a hundred IsoSubspaces.
+    initialize(heapCellType, m_allocator ? m_allocator.get() : heap.fastMallocAllocator.get());
 
     Locker locker { m_space.directoryLock() };
     m_directory.setSubspace(this);

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -59,7 +59,7 @@ MarkedBlock::Handle* MarkedBlock::tryCreate(JSC::Heap& heap, AlignedMemoryAlloca
         if (!(balance % 10))
             dataLog("MarkedBlock Balance: ", balance, "\n");
     }
-    void* blockSpace = alignedMemoryAllocator->tryAllocateAlignedMemory(blockSize, blockSize);
+    void* blockSpace = alignedMemoryAllocator->tryAllocateSpan(blockSize);
     if (!blockSpace)
         return nullptr;
     if (scribbleFreeCells())
@@ -85,7 +85,7 @@ MarkedBlock::Handle::~Handle()
     }
     m_directory->removeBlock(this, BlockDirectory::WillDeleteBlock::Yes);
     m_block->~MarkedBlock();
-    m_alignedMemoryAllocator->freeAlignedMemory(m_block);
+    m_alignedMemoryAllocator->freeSpan(m_block, blockSize);
     heap.didFreeBlock(blockSize);
 }
 

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -197,11 +197,28 @@ void MarkedSpace::freeMemory()
         [&] (MarkedBlock::Handle* block) {
             freeBlock(block);
         });
+    releaseCachedBlocks();
     for (PreciseAllocation* allocation : m_preciseAllocations)
         allocation->destroy();
     forEachSubspace([&](Subspace& subspace) {
         if (subspace.isIsoSubspace())
             static_cast<IsoSubspace&>(subspace).destroyLowerTierPreciseFreeList();
+        return IterationStatus::Continue;
+    });
+}
+
+void MarkedSpace::releaseCachedBlocks()
+{
+    forEachSubspace([&](Subspace& subspace) {
+        subspace.alignedMemoryAllocator()->releaseFreeChunks();
+        return IterationStatus::Continue;
+    });
+}
+
+void MarkedSpace::purgeCachedBlocks()
+{
+    forEachSubspace([&](Subspace& subspace) {
+        subspace.alignedMemoryAllocator()->purgeFreeSpans(MarkedBlock::blockSize);
         return IterationStatus::Continue;
     });
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -129,6 +129,8 @@ public:
     template<typename Functor> void forEachSubspace(const Functor&);
 
     void shrink();
+    void releaseCachedBlocks();
+    void purgeCachedBlocks();
     void freeBlock(MarkedBlock::Handle*);
 
     void didAddBlock(MarkedBlock::Handle*);

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
@@ -50,6 +50,11 @@ public:
     void freeAlignedMemory(void*) final;
 
     static void initializeStructureAddressSpace();
+
+private:
+    // Structure blocks come out of a dedicated reservation that only ever hands out one block at
+    // a time, so there is nothing to carve chunks from.
+    unsigned spansPerChunk() const final { return 1; }
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -244,6 +244,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, preciseAllocationCutoff, 100000, Normal, nullptr) \
     v(Bool, dumpSizeClasses, false, Normal, nullptr) \
     v(Bool, stealEmptyBlocksFromOtherAllocators, true, Normal, nullptr) \
+    v(Unsigned, markedBlockSpansPerChunk, 8, Normal, "how many MarkedBlock-sized spans to carve from each chunk obtained from the underlying allocator; 1 allocates every block separately"_s) \
     v(Bool, eagerlyUpdateTopCallFrame, false, Normal, nullptr) \
     v(Bool, dumpZappedCellCrashData, false, Normal, nullptr) \
     \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1048,6 +1048,7 @@ void VM::shrinkFootprintWhenIdle()
         sanitizeStackForVM(*this);
         deleteAllCode(DeleteAllCodeIfNotCollecting);
         heap.collectNow(Synchronousness::Sync, CollectionScope::Full);
+        heap.objectSpace().purgeCachedBlocks();
         // FIXME: Consider stopping various automatic threads here.
         // https://bugs.webkit.org/show_bug.cgi?id=185447
         WTF::releaseFastMallocFreeMemory();


### PR DESCRIPTION
#### 0fe12ae05d93aa9b183c6075d0c5a17ea35c9938
<pre>
[JSC] Populating MarkedBlocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=322548">https://bugs.webkit.org/show_bug.cgi?id=322548</a>
<a href="https://rdar.apple.com/185841698">rdar://185841698</a>

Reviewed by NOBODY (OOPS!).

WIP. A/B testing and still exploring the further better approach.

* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
(JSC::AlignedMemoryAllocator::~AlignedMemoryAllocator):
(JSC::AlignedMemoryAllocator::spansPerChunk const):
(JSC::AlignedMemoryAllocator::tryAllocateChunk):
(JSC::AlignedMemoryAllocator::tryAllocateSpan):
(JSC::AlignedMemoryAllocator::freeSpan):
(JSC::AlignedMemoryAllocator::purgeFreeSpans):
(JSC::AlignedMemoryAllocator::releaseFreeChunks):
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp:
(JSC::FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator):
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp:
(JSC::GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::tryCreate):
(JSC::MarkedBlock::Handle::~Handle):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::freeMemory):
(JSC::MarkedSpace::releaseCachedBlocks):
(JSC::MarkedSpace::purgeCachedBlocks):
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::shrinkFootprintWhenIdle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe12ae05d93aa9b183c6075d0c5a17ea35c9938

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182940 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56863 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193157 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147228 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61cba0d7-9b78-46ae-9b2d-6a7302567b90) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58205 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56598 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/193157 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99161 "3 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a78813b-f3b1-4cfd-b36f-acc524dcfded) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185895 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/58205 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/193157 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0932922-dc62-447b-b19a-f9da70b10bff) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/58205 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/56598 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/193157 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/58205 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4330 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44210 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49510 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/56598 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195098 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56532 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/195098 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57237 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/195098 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/57237 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129506 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125594 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55745 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50676 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55116 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55353 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55183 "Hash 0fe12ae0 for PR 72458 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->