### PR TITLE
[block-in-inline] A relatively positioned block level box on a line reports scrollable overflow as wide as the line

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt
@@ -1,0 +1,5 @@
+text
+text
+
+PASS A relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as a block sibling
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta name="assert" content="This ensures that a relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as it does as a block sibling.">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.container { width: 100px; height: 50px; font: 16px/18px monospace; }
+.shifted { width: 10px; height: 10px; position: relative; left: 20px; background-color: green; }
+</style>
+
+<div class="container" id="nested">text<span><div class="shifted"></div></span></div>
+<div class="container" id="sibling">text<div class="shifted"></div></div>
+
+<script>
+test(() => {
+    assert_equals(document.getElementById("nested").scrollWidth, document.getElementById("sibling").scrollWidth);
+}, "A relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as a block sibling");
+</script>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -150,10 +150,10 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
 
     for (size_t lineIndex = startIndex; lineIndex < lines.size(); ++lineIndex) {
         auto& line = lines[lineIndex];
-        auto lineScrollableOverflowRect = line.scrollableOverflow();
+        auto lineScrollableOverflowRect = line.hasBlockLevelBox() ? FloatRect { } : line.scrollableOverflow();
         auto adjustOverflowLogicalWidthWithBlockFlowQuirk = [&] {
             if (line.hasBlockLevelBox()) {
-                // A block box contributes its own through layoutOverflowRectForPropagation(), which uses the margin the box ended up with. See InlineDisplayLineBuilder::collectEnclosingLineGeometry.
+                // A block box contributes its own through layoutOverflowRectForPropagation(), which uses the margin the box ended up with.
                 return;
             }
             auto scrollableOverflowLogicalWidth = isHorizontalWritingMode ? lineScrollableOverflowRect.width() : lineScrollableOverflowRect.height();
@@ -177,8 +177,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             inlineContent.setHasPaintedInlineLevelBoxes();
 
         auto firstBoxIndex = boxIndex;
-        // A block level box on a line contributes its own ink overflow below, and only when it is not self painting.
-        auto lineInkOverflowRect = line.hasBlockLevelBox() ? FloatRect { } : lineScrollableOverflowRect;
+        auto lineInkOverflowRect = lineScrollableOverflowRect;
         // Collect overflow from boxes.
         // Note while we compute ink overflow for all type of boxes including atomic inline level boxes (e.g. <iframe> <img>) as part of constructing
         // display boxes (see InlineDisplayContentBuilder) RenderBlockFlow expects visual overflow.
@@ -211,9 +210,6 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
                     childInkOverflow.move(box.left(), box.top());
                     lineInkOverflowRect.unite(childInkOverflow);
                 }
-
-                if (box.isBlockLevelBox() && renderer->isInFlowPositioned())
-                    lineScrollableOverflowRect.move(renderer->offsetForInFlowPosition());
 
                 if (!renderer->hasControlClip()) {
                     auto childScrollableOverflow = renderer->layoutOverflowRectForPropagation(renderer->parent()->writingMode());


### PR DESCRIPTION
#### 30db96c6470b0c261bf6a74694a892357e392200
<pre>
[block-in-inline] A relatively positioned block level box on a line reports scrollable overflow as wide as the line
<a href="https://bugs.webkit.org/show_bug.cgi?id=322539">https://bugs.webkit.org/show_bug.cgi?id=322539</a>
&lt;<a href="https://rdar.apple.com/problem/185835450">rdar://problem/185835450</a>&gt;

Reviewed by NOBODY (OOPS!).

A block level box gets a line of its own, and that line box is as wide as the container&apos;s content box.
Ink overflow already leaves that rect out and lets the box contribute its own, since the box is what the line
holds. Let&apos;s apply it to scrollable overflow too.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30db96c6470b0c261bf6a74694a892357e392200

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2913c5bd-b156-4c7e-a4fa-62d1cdf08918) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56605 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142796 "Found 3 new test failures: fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/repaint/transform-absolute-in-positioned-container.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d17eb58f-e895-4731-aac8-6c7a91415a7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea62457f-bfaa-4ede-8f4c-a155e14001c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43452 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155600 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43083 "Found 3 new test failures: fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/repaint/transform-absolute-in-positioned-container.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4337 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49517 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47715 "Found 3 new test failures: fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/repaint/transform-absolute-in-positioned-container.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195105 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163048 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152257 "Found 3 new test failures: fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/repaint/transform-absolute-in-positioned-container.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57244 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39698 "Found 3 new test failures: fast/encoding/utf-16-big-endian.html fast/encoding/utf-16-little-endian.html fast/repaint/transform-absolute-in-positioned-container.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151954 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46515 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129513 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55752 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18094 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->