### PR TITLE
Do not compute shared preferences for a dummy process proxy

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -633,6 +633,11 @@ void WebProcessProxy::initializeWebProcess(WebProcessCreationParameters&& parame
 
 void WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy& page)
 {
+    // A dummy process proxy is shared by session and never launches a process, so its shared preferences
+    // are never used and pages that disagree on them may legitimately share the same dummy proxy.
+    if (isDummyProcessProxy())
+        return;
+
     if (!m_sharedPreferencesForWebProcess.version) {
         updateSharedPreferences(page.preferences().store());
         ASSERT(m_sharedPreferencesForWebProcess.version);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preferences.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preferences.mm
@@ -28,9 +28,13 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPool.h>
 #import <WebKit/WKUIDelegate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>
 #import <wtf/RetainPtr.h>
 
@@ -84,6 +88,40 @@ TEST(WebKit, WebAudioPreference)
     };
     EXPECT_WK_STREQ(check(true), "true");
     EXPECT_WK_STREQ(check(false), "false");
+}
+
+static RetainPtr<WKWebViewConfiguration> configurationWithStorageBlockingPolicy(WKProcessPool *processPool, _WKStorageBlockingPolicy policy)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:processPool];
+    [configuration _setDelaysWebProcessLaunchUntilFirstLoad:YES];
+    [[configuration preferences] _setStorageBlockingPolicy:policy];
+    return configuration;
+}
+
+TEST(WebKit, StorageBlockingPolicyMismatchWithDelayedProcessLaunch)
+{
+    auto check = [](_WKStorageBlockingPolicy firstPolicy, _WKStorageBlockingPolicy secondPolicy) {
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
+        RetainPtr firstConfiguration = configurationWithStorageBlockingPolicy(processPool.get(), firstPolicy);
+        RetainPtr secondConfiguration = configurationWithStorageBlockingPolicy(processPool.get(), secondPolicy);
+
+        RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+        RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+
+        // Neither web view has launched a process, so both are still on the dummy process proxy.
+        EXPECT_EQ(0, [firstWebView _webProcessIdentifier]);
+        EXPECT_EQ(0, [secondWebView _webProcessIdentifier]);
+
+        [firstWebView synchronouslyLoadHTMLString:@"<body>first</body>"];
+        [secondWebView synchronouslyLoadHTMLString:@"<body>second</body>"];
+
+        EXPECT_NE(0, [firstWebView _webProcessIdentifier]);
+        EXPECT_NE(0, [secondWebView _webProcessIdentifier]);
+    };
+
+    check(_WKStorageBlockingPolicyBlockThirdParty, _WKStorageBlockingPolicyAllowAll);
+    check(_WKStorageBlockingPolicyAllowAll, _WKStorageBlockingPolicyBlockThirdParty);
 }
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 75da5d772467e31458a65400033d35e4eb1104eb
<pre>
Do not compute shared preferences for a dummy process proxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=322553">https://bugs.webkit.org/show_bug.cgi?id=322553</a>
<a href="https://rdar.apple.com/185844156">rdar://185844156</a>

Reviewed by Ryosuke Niwa.

WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses currently asserts that a page joining a process has the
same preferences as the shared preferences of the process. That does not hold for a dummy process proxy, which is keyed
only by session -- a dummy process proxy could be picked for a page&apos;s use even if the dummy process proxy is already
serving pages with different preferences. Picking it regardless of preferences makes sense because a dummy process is
not backed by a real process -- it only acts as a placeholder before a real web process (with a non-dummy proxy) is
launched.

To fix the assertion failure in WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses, add an early return if
the proxy is dummy. We decide to skip the whole function instead of just the assertion because the shared preferences
will only ever come into effect when there is a real process -- GPU process and network process read one
SharedPreferencesForWebProcess per web process connection; there is no point in keeping track of the preferences value
for dummy process proxy.

API test: WebKit.StorageBlockingPolicyMismatchWithDelayedProcessLaunch

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preferences.mm:
(configurationWithStorageBlockingPolicy):
(TEST(WebKit, StorageBlockingPolicyMismatchWithDelayedProcessLaunch)):

Canonical link: <a href="https://commits.webkit.org/319968@main">https://commits.webkit.org/319968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd164422a44aa9c206d2c7fee3a60384dd891cb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147238 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a80118bb-4b04-4f9d-a315-df14c51d7e13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142799 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99155 "2 flakes 3 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1314166-f029-4a2b-924d-e102a8d0ce6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123226 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2b5d134-138b-4763-bb36-da449299c82b) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182276 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45208 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43456 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12026 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43086 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4340 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44220 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195108 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182353 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56542 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152261 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57247 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151957 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46518 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129516 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55755 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55126 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55193 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->