### PR TITLE
[Site Isolation] Look Up menu and context menu are displaced on cross origin iframe src=pdf

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -55,6 +55,9 @@
 
 - (void)_setSelectedColorForColorPicker:(NSColor *)color;
 
+// The looked-up text and highlight rect, in root view coordinates. Pass nil to clear.
+- (void)_setDidPerformDictionaryLookupHandlerForTesting:(void (^)(NSString *text, CGRect textBoundingRect))handler;
+
 @property (nonatomic, readonly) BOOL _secureEventInputEnabledForTesting;
 @property (nonatomic, readonly) NSRect _windowRelativeBoundsForCustomSwipeViewsForTesting;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -55,6 +55,10 @@
 
 - (void)_setSelectedColorForColorPicker:(NSColor *)color;
 
+// The looked-up text and the rect positioning the highlight, in root view coordinates. Pass nil to
+// clear. The force touch path reports through _WKHitTestResult instead and does not reach this.
+- (void)_setDidPerformDictionaryLookupHandlerForTesting:(void (^)(NSString *text, CGRect textBoundingRect))handler;
+
 @property (nonatomic, readonly) BOOL _secureEventInputEnabledForTesting;
 @property (nonatomic, readonly) NSRect _windowRelativeBoundsForCustomSwipeViewsForTesting;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -38,6 +38,7 @@
 #import "WebViewImpl.h"
 #import "_WKFrameHandleInternal.h"
 #import <WebCore/ColorCocoa.h>
+#import <WebCore/DictionaryPopupInfo.h>
 
 @implementation WKWebView (WKTestingMac)
 
@@ -132,6 +133,22 @@
 - (void)_setSelectedColorForColorPicker:(NSColor *)color
 {
     protect(_page->colorPickerClient())->didChooseColor(WebCore::colorFromCocoaColor(color));
+}
+
+- (void)_setDidPerformDictionaryLookupHandlerForTesting:(void (^)(NSString *, CGRect))handler
+{
+    if (!handler)
+        return _page->setDidPerformDictionaryLookupCallbackForTesting({ });
+
+    _page->setDidPerformDictionaryLookupCallbackForTesting([handler = makeBlockPtr(handler)](const WebCore::DictionaryPopupInfo& info) {
+#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+        RetainPtr text = [info.platformData.attributedString.nsAttributedString() string];
+#else
+        RetainPtr text = info.text.createNSString();
+#endif
+        RefPtr textIndicator = info.textIndicator;
+        handler(text.get(), textIndicator ? CGRect(textIndicator->textBoundingRectInRootViewCoordinates()) : CGRectNull);
+    });
 }
 
 - (void)_createFlagsChangedEventMonitorForTesting

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1696,6 +1696,9 @@ public:
     void setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
     void setUseDarkAppearanceForTesting(bool);
     void setCursorDidChangeCallbackForTesting(Function<void(const WebCore::Cursor&)>&& callback) { m_cursorDidChangeCallbackForTesting = WTF::move(callback); }
+#if PLATFORM(MAC)
+    void setDidPerformDictionaryLookupCallbackForTesting(Function<void(const WebCore::DictionaryPopupInfo&)>&& callback) { m_didPerformDictionaryLookupCallbackForTesting = WTF::move(callback); }
+#endif
 
     WebCore::DataOwnerType dataOwnerForPasteboard(PasteboardAccessIntent) const;
 
@@ -3995,6 +3998,9 @@ private:
     String m_toolTip;
 
     Function<void(const WebCore::Cursor&)> m_cursorDidChangeCallbackForTesting;
+#if PLATFORM(MAC)
+    Function<void(const WebCore::DictionaryPopupInfo&)> m_didPerformDictionaryLookupCallbackForTesting;
+#endif
 
     bool m_isEditable { false };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1703,6 +1703,9 @@ public:
     void setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
     void setUseDarkAppearanceForTesting(bool);
     void setCursorDidChangeCallbackForTesting(Function<void(const WebCore::Cursor&)>&& callback) { m_cursorDidChangeCallbackForTesting = WTF::move(callback); }
+#if PLATFORM(MAC)
+    void setDidPerformDictionaryLookupCallbackForTesting(Function<void(const WebCore::DictionaryPopupInfo&)>&& callback) { m_didPerformDictionaryLookupCallbackForTesting = WTF::move(callback); }
+#endif
 
     WebCore::DataOwnerType dataOwnerForPasteboard(PasteboardAccessIntent) const;
 
@@ -4014,6 +4017,9 @@ private:
     String m_toolTip;
 
     Function<void(const WebCore::Cursor&)> m_cursorDidChangeCallbackForTesting;
+#if PLATFORM(MAC)
+    Function<void(const WebCore::DictionaryPopupInfo&)> m_didPerformDictionaryLookupCallbackForTesting;
+#endif
 
     bool m_isEditable { false };
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -346,6 +346,9 @@ void WebPageProxy::setSmartInsertDeleteEnabled(bool isSmartInsertDeleteEnabled)
 
 void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
+    if (m_didPerformDictionaryLookupCallbackForTesting)
+        m_didPerformDictionaryLookupCallbackForTesting(dictionaryPopupInfo);
+
     if (RefPtr pageClient = this->pageClient()) {
         pageClient->didPerformDictionaryLookup(dictionaryPopupInfo);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -72,6 +72,7 @@ class FragmentedSharedBuffer;
 class GraphicsContext;
 class Element;
 class HTMLPlugInElement;
+class LocalFrameView;
 class NetscapePlugInStreamLoaderClient;
 class ResourceResponse;
 class Scrollbar;
@@ -261,6 +262,15 @@ public:
             return inverseTransform->mapPoint(value);
     }
 
+    // The root view above is this process's root frame, which under site isolation is the frame
+    // hosting the plugin, not the top-level frame. These continue the walk up the remote ancestors.
+    // FIXME: The remote hop omits the ancestor's page scale and obscured content insets.
+    // FIXME: boundsOnScreen(), the accessibility screen conversions and the autoscroll screen point
+    // need this too.
+    WebCore::FloatPoint convertFromLocalRootViewToRootView(WebCore::FloatPoint) const;
+    WebCore::FloatRect convertFromLocalRootViewToRootView(WebCore::FloatRect) const;
+    void convertTextIndicatorRectsFromLocalRootViewToRootView(WebCore::TextIndicator&) const;
+
     WebCore::IntRect boundsOnScreen() const;
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
@@ -379,6 +389,9 @@ protected:
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
     void ensureDataBufferLength(uint64_t) WTF_REQUIRES_LOCK(m_streamedDataLock);
+
+    // Where convertFromPluginToRootView() lands: the view Widget::convertToRootView() stops at.
+    RefPtr<WebCore::LocalFrameView> localRootFrameView() const;
 
     bool NODELETE haveStreamedDataForRange(uint64_t offset, size_t count) const WTF_REQUIRES_LOCK(m_streamedDataLock);
     // This just checks whether the CFData is large enough; it doesn't know if we filled this range with data.

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -69,6 +69,7 @@ namespace WebCore {
 class AXObjectCache;
 class Color;
 class FragmentedSharedBuffer;
+class FrameView;
 class GraphicsContext;
 class Element;
 class HTMLPlugInElement;
@@ -261,6 +262,16 @@ public:
             return inverseTransform->mapPoint(value);
     }
 
+    // Under site isolation the "root view" above is the local root, not the main frame. These finish
+    // the walk up the remote ancestors, in process.
+    // FIXME: The remote hop omits the ancestor's page scale and obscured content insets.
+    // FIXME: A RemoteFrameView's scroll position only syncs on change, so it reads zero for a frame
+    // that entered its process after the main frame was scrolled.
+    // FIXME: boundsOnScreen(), the accessibility screen conversions and autoscroll need this too.
+    WebCore::FloatPoint convertFromRootViewToMainFrameView(WebCore::FloatPoint) const;
+    WebCore::FloatRect convertFromRootViewToMainFrameView(WebCore::FloatRect) const;
+    void convertTextIndicatorFromRootViewToMainFrameView(WebCore::TextIndicator&) const;
+
     WebCore::IntRect boundsOnScreen() const;
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
@@ -380,6 +391,9 @@ protected:
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
     void ensureDataBufferLength(uint64_t) WTF_REQUIRES_LOCK(m_streamedDataLock);
+
+    // The view convertFromPluginToRootView() lands in: this process's root frame, whichever kind it is.
+    RefPtr<WebCore::FrameView> rootFrameView() const;
 
     bool NODELETE haveStreamedDataForRange(uint64_t offset, size_t count) const WTF_REQUIRES_LOCK(m_streamedDataLock);
     // This just checks whether the CFData is large enough; it doesn't know if we filled this range with data.

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -73,6 +73,7 @@
 #import <WebCore/LegacyNSPasteboardTypes.h>
 #import <WebCore/LoaderNSURLExtras.h>
 #import <WebCore/LocalFrameInlines.h>
+#import <WebCore/LocalFrameView.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/MouseEvent.h>
 #import <WebCore/PageIdentifier.h>
@@ -719,6 +720,46 @@ bool PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTra
 #endif
 
     return true;
+}
+
+RefPtr<LocalFrameView> PDFPluginBase::localRootFrameView() const
+{
+    RefPtr frame = m_frame.get();
+    RefPtr coreFrame = frame ? frame->coreLocalFrame() : nullptr;
+    if (!coreFrame)
+        return nullptr;
+
+    return Ref { coreFrame->rootFrame() }->view();
+}
+
+FloatPoint PDFPluginBase::convertFromLocalRootViewToRootView(FloatPoint point) const
+{
+    RefPtr view = localRootFrameView();
+    return view ? view->convertToRootViewAcrossIsolatedFrames(point) : point;
+}
+
+FloatRect PDFPluginBase::convertFromLocalRootViewToRootView(FloatRect rect) const
+{
+    RefPtr view = localRootFrameView();
+    return view ? view->convertToRootViewAcrossIsolatedFrames(rect) : rect;
+}
+
+void PDFPluginBase::convertTextIndicatorRectsFromLocalRootViewToRootView(TextIndicator& textIndicator) const
+{
+    auto boundingRect = textIndicator.textBoundingRectInRootViewCoordinates();
+    auto boundingRectInRootView = convertFromLocalRootViewToRootView(boundingRect);
+
+    textIndicator.setTextBoundingRectInRootViewCoordinates(boundingRectInRootView);
+    textIndicator.setSelectionRectInRootViewCoordinates(convertFromLocalRootViewToRootView(textIndicator.selectionRectInRootViewCoordinates()));
+    textIndicator.setContentImageWithoutSelectionRectInRootViewCoordinates(convertFromLocalRootViewToRootView(textIndicator.contentImageWithoutSelectionRectInRootViewCoordinates()));
+
+    // These are offsets from the bounding rect, so convert them absolutely and re-relativize.
+    textIndicator.setTextRectsInBoundingRectCoordinates(textIndicator.textRectsInBoundingRectCoordinates().map([&](auto rect) {
+        rect.moveBy(boundingRect.location());
+        rect = convertFromLocalRootViewToRootView(rect);
+        rect.moveBy(-boundingRectInRootView.location());
+        return rect;
+    }));
 }
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -67,6 +67,7 @@
 #import <WebCore/Frame.h>
 #import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/FrameLoader.h>
+#import <WebCore/FrameView.h>
 #import <WebCore/GraphicsContext.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/HTMLPlugInElement.h>
@@ -719,6 +720,54 @@ bool PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTra
 #endif
 
     return true;
+}
+
+RefPtr<FrameView> PDFPluginBase::rootFrameView() const
+{
+    RefPtr frame = m_frame.get();
+    // A plugin only ever lives in a local frame, so null means the frame is gone.
+    RefPtr coreFrame = frame ? frame->coreLocalFrame() : nullptr;
+    if (!coreFrame)
+        return nullptr;
+
+    return Ref { coreFrame->rootFrame() }->virtualView();
+}
+
+FloatPoint PDFPluginBase::convertFromRootViewToMainFrameView(FloatPoint point) const
+{
+    // A null view means the frame was detached, leaving no ancestor chain to walk.
+    RefPtr view = rootFrameView();
+    if (!view)
+        return point;
+
+    return view->convertToRootViewAcrossIsolatedFrames(point);
+}
+
+FloatRect PDFPluginBase::convertFromRootViewToMainFrameView(FloatRect rect) const
+{
+    RefPtr view = rootFrameView();
+    if (!view)
+        return rect;
+
+    return view->convertToRootViewAcrossIsolatedFrames(rect);
+}
+
+void PDFPluginBase::convertTextIndicatorFromRootViewToMainFrameView(TextIndicator& textIndicator) const
+{
+    auto boundingRect = textIndicator.textBoundingRectInRootViewCoordinates();
+    auto boundingRectInMainFrameView = convertFromRootViewToMainFrameView(boundingRect);
+
+    textIndicator.setTextBoundingRectInRootViewCoordinates(boundingRectInMainFrameView);
+    textIndicator.setSelectionRectInRootViewCoordinates(convertFromRootViewToMainFrameView(textIndicator.selectionRectInRootViewCoordinates()));
+    textIndicator.setContentImageWithoutSelectionRectInRootViewCoordinates(convertFromRootViewToMainFrameView(textIndicator.contentImageWithoutSelectionRectInRootViewCoordinates()));
+
+    // Relative to the bounding rect, so absolutize, convert, then re-relativize.
+    textIndicator.setTextRectsInBoundingRectCoordinates(textIndicator.textRectsInBoundingRectCoordinates().map([&](auto rect) {
+        rect.moveBy(boundingRect.location());
+        rect = convertFromRootViewToMainFrameView(rect);
+        rect.moveBy(-boundingRectInMainFrameView.location());
+        return rect;
+    }));
 }
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2617,6 +2617,10 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     if (!frameView)
         return std::nullopt;
 
+    RefPtr page = this->page();
+    if (!page)
+        return std::nullopt;
+
     auto contextMenuEventRootViewPoint = flooredIntPoint(contextMenuEvent.position());
 
     Vector<PDFContextMenuItem> menuItems;
@@ -2653,7 +2657,9 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     auto contextMenuEventDocumentPoint = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, contextMenuEventPluginPoint);
     menuItems.appendVector(navigationContextMenuItemsForPageAtIndex(protect(m_presentationController)->nearestPageIndexForDocumentPoint(contextMenuEventDocumentPoint)));
 
-    auto contextMenuPoint = frameView->contentsToScreen(IntRect(frameView->windowToContents(contextMenuEventRootViewPoint), IntSize())).location();
+    // rootViewToScreen() takes top-level coordinates; the event position is local root relative.
+    auto contextMenuPointInRootView = convertFromLocalRootViewToRootView(FloatPoint { contextMenuEventRootViewPoint });
+    auto contextMenuPoint = page->chrome().rootViewToScreen(roundedIntPoint(contextMenuPointInRootView));
 
     return PDFContextMenu {
         contextMenuPoint,
@@ -3891,6 +3897,13 @@ bool UnifiedPDFPlugin::showDefinitionForSelection(PDFSelection *selection)
         return false;
 
     auto dictionaryPopupInfo = dictionaryPopupInfoForSelection(selection, TextIndicatorPresentationTransition::Bounce);
+
+    // DidPerformDictionaryLookup carries no frame for the UI process to convert against, unlike the
+    // immediate action path's RemoteDictionaryPopupInfoToRootView.
+    dictionaryPopupInfo.origin = convertFromLocalRootViewToRootView(dictionaryPopupInfo.origin);
+    if (RefPtr textIndicator = dictionaryPopupInfo.textIndicator)
+        convertTextIndicatorRectsFromLocalRootViewToRootView(*textIndicator);
+
     page->send(Messages::WebPageProxy::DidPerformDictionaryLookup(dictionaryPopupInfo));
     return true;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2609,12 +2609,8 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
 
 std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const IntPoint& contextMenuEventRootViewPoint, WebEventInputSource inputSource) const
 {
-    RefPtr frame = m_frame.get();
-    if (!frame || !frame->coreLocalFrame())
-        return std::nullopt;
-
-    RefPtr frameView = frame->coreLocalFrame()->view();
-    if (!frameView)
+    RefPtr page = this->page();
+    if (!page)
         return std::nullopt;
 
     Vector<PDFContextMenuItem> menuItems;
@@ -2650,7 +2646,9 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const IntPoint
     auto contextMenuEventDocumentPoint = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, contextMenuEventPluginPoint);
     menuItems.appendVector(navigationContextMenuItemsForPageAtIndex(protect(m_presentationController)->nearestPageIndexForDocumentPoint(contextMenuEventDocumentPoint)));
 
-    auto contextMenuPoint = frameView->contentsToScreen(IntRect(frameView->windowToContents(contextMenuEventRootViewPoint), IntSize())).location();
+    // rootViewToScreen() takes main-frame coordinates; the event position is local-root relative.
+    auto contextMenuPointInMainFrameView = convertFromRootViewToMainFrameView(FloatPoint { contextMenuEventRootViewPoint });
+    auto contextMenuPoint = page->chrome().rootViewToScreen(roundedIntPoint(contextMenuPointInMainFrameView));
 
     return PDFContextMenu {
         contextMenuPoint,
@@ -3910,6 +3908,15 @@ bool UnifiedPDFPlugin::showDefinitionForSelection(PDFSelection *selection)
         return false;
 
     auto dictionaryPopupInfo = dictionaryPopupInfoForSelection(selection, TextIndicatorPresentationTransition::Bounce);
+
+    // Lift at the sender, not in the producer: the force touch path shares it and is still converted
+    // by RemoteDictionaryPopupInfoToRootView, so lifting there would convert twice.
+    // FIXME: That path costs an IPC per hop, walks only one hop, and mis-maps
+    // textRectsInBoundingRectCoordinates. It should lift in process like this.
+    dictionaryPopupInfo.origin = convertFromRootViewToMainFrameView(dictionaryPopupInfo.origin);
+    if (RefPtr textIndicator = dictionaryPopupInfo.textIndicator)
+        convertTextIndicatorFromRootViewToMainFrameView(*textIndicator);
+
     page->send(Messages::WebPageProxy::DidPerformDictionaryLookup(dictionaryPopupInfo));
     return true;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -461,14 +461,74 @@ UNIFIED_PDF_TEST(SelectionHighlightColorDoesNotAdaptToColorScheme)
 
 enum class PDFEmbedElement : uint8_t { IFrame, Embed, Object };
 
-using EmbeddedPDFFitsToFrameParams = std::tuple<PDFEmbedElement, bool, bool, bool>;
+static std::string testName(PDFEmbedElement embedElement)
+{
+    switch (embedElement) {
+    case PDFEmbedElement::IFrame:
+        return "IFrame";
+    case PDFEmbedElement::Embed:
+        return "Embed";
+    case PDFEmbedElement::Object:
+        return "Object";
+    }
+    ASSERT_NOT_REACHED();
+    return "";
+}
+
+struct SiteIsolationParams {
+    // Only a cross-origin frame becomes a local root.
+    bool crossOrigin;
+    bool siteIsolationEnabled;
+    bool sharedProcessEnabled;
+
+    String pdfURL() const { return makeString("https://"_s, crossOrigin ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s); }
+
+    void applyTo(WKWebViewConfiguration *configuration) const
+    {
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationEnabled forFeature:feature];
+            else if ([feature.key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+                [[configuration preferences] _setEnabled:sharedProcessEnabled forFeature:feature];
+        }
+    }
+
+    std::string testName() const
+    {
+        return std::string { crossOrigin ? "CrossOrigin" : "SameOrigin" }
+            + "_SiteIsolation" + (siteIsolationEnabled ? "Enabled" : "Disabled")
+            + "_SiteIsolationSharedProcess" + (sharedProcessEnabled ? "Enabled" : "Disabled");
+    }
+};
+
+// Site isolation ignores the shared process preference when disabled, so skip that combination.
+static constexpr SiteIsolationParams siteIsolationParams[] = {
+    { .crossOrigin = false, .siteIsolationEnabled = false, .sharedProcessEnabled = false },
+    { .crossOrigin = false, .siteIsolationEnabled = true, .sharedProcessEnabled = false },
+    { .crossOrigin = false, .siteIsolationEnabled = true, .sharedProcessEnabled = true },
+    { .crossOrigin = true, .siteIsolationEnabled = false, .sharedProcessEnabled = false },
+    { .crossOrigin = true, .siteIsolationEnabled = true, .sharedProcessEnabled = false },
+    { .crossOrigin = true, .siteIsolationEnabled = true, .sharedProcessEnabled = true },
+};
+
+template<typename Params> static std::vector<Params> withEachPDFEmbedElement()
+{
+    std::vector<Params> params;
+    for (auto embedElement : { PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object }) {
+        for (auto& siteIsolation : siteIsolationParams)
+            params.push_back(Params { embedElement, siteIsolation });
+    }
+    return params;
+}
+
+struct EmbeddedPDFFitsToFrameParams {
+    PDFEmbedElement embedElement;
+    SiteIsolationParams siteIsolation;
+};
 
 class EmbeddedPDFFitsToFrame : public testing::TestWithParam<EmbeddedPDFFitsToFrameParams> {
 public:
-    PDFEmbedElement embedElement() const { return std::get<0>(GetParam()); }
-    bool crossOrigin() const { return std::get<1>(GetParam()); }
-    bool siteIsolationEnabled() const { return std::get<2>(GetParam()); }
-    bool siteIsolationSharedProcessEnabled() const { return std::get<3>(GetParam()); }
+    PDFEmbedElement embedElement() const { return GetParam().embedElement; }
 
     void SetUp() override
     {
@@ -478,13 +538,7 @@ public:
 
         configuration = configurationForWebViewTestingUnifiedPDF();
         [configuration setWebsiteDataStore:[server->httpsProxyConfiguration() websiteDataStore]];
-        for (_WKFeature *feature in [WKPreferences _features]) {
-            NSString *key = feature.key;
-            if ([key isEqualToString:@"SiteIsolationEnabled"])
-                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
-            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
-                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
-        }
+        GetParam().siteIsolation.applyTo(configuration.get());
 
         navigationDelegate = adoptNS([TestNavigationDelegate new]);
         [navigationDelegate allowAnyTLSCertificate];
@@ -494,22 +548,7 @@ public:
 
     static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFFitsToFrameParams> info)
     {
-        std::string element = [embedElement = std::get<0>(info.param)] {
-            switch (embedElement) {
-            case PDFEmbedElement::IFrame:
-                return "IFrame";
-            case PDFEmbedElement::Embed:
-                return "Embed";
-            case PDFEmbedElement::Object:
-                return "Object";
-            }
-            ASSERT_NOT_REACHED();
-            return "";
-        }();
-        return element
-            + (std::get<1>(info.param) ? "_CrossOrigin" : "_SameOrigin")
-            + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
-            + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
+        return testName(info.param.embedElement) + "_" + info.param.siteIsolation.testName();
     }
 
     std::unique_ptr<HTTPServer> server;
@@ -526,9 +565,8 @@ TEST_P(EmbeddedPDFFitsToFrame, Test)
             return;
 #endif
 
-    auto mainHTML = [crossOrigin = crossOrigin(), embedElement = embedElement()] {
+    auto mainHTML = [pdfURL = GetParam().siteIsolation.pdfURL(), embedElement = embedElement()] {
         auto layout = "style='position:absolute; left:0; top:0; border:0; width:600px; height:0'"_s;
-        auto pdfURL = makeString("https://"_s, crossOrigin ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s);
         switch (embedElement) {
         case PDFEmbedElement::IFrame:
             return makeString("<iframe id='pdf' "_s, layout, " src='"_s, pdfURL, "'></iframe>"_s);
@@ -597,7 +635,181 @@ TEST_P(EmbeddedPDFFitsToFrame, Test)
     EXPECT_LE([[finalState objectForKey:@"maxX"] doubleValue], pluginWidth + tolerance);
 }
 
-INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFFitsToFrame, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFFitsToFrame::testNameGenerator);
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFFitsToFrame, testing::ValuesIn(withEachPDFEmbedElement<EmbeddedPDFFitsToFrameParams>()), &EmbeddedPDFFitsToFrame::testNameGenerator);
+
+#if PLATFORM(MAC)
+
+// ContextMenuItemTag::DictionaryLookup. The title is localized, so match the tag.
+static constexpr NSInteger dictionaryLookupContextMenuItemTag = 2;
+
+class EmbeddedPDFLookUp : public testing::TestWithParam<SiteIsolationParams> {
+public:
+    // Large enough that a skipped conversion is unmissable.
+    static constexpr int iframeLeft = 100;
+    static constexpr int iframeTop = 120;
+    static constexpr int iframeWidth = 400;
+    static constexpr int iframeHeight = 300;
+    static constexpr NSRect iframeFrame { { iframeLeft, iframeTop }, { iframeWidth, iframeHeight } };
+
+    void SetUp() override
+    {
+        // The spacer makes the main frame scrollable.
+        auto mainHTML = makeString("<body style='margin:0'><iframe style='position:absolute; left:"_s, iframeLeft,
+            "px; top:"_s, iframeTop, "px; width:"_s, iframeWidth, "px; height:"_s, iframeHeight,
+            "px; border:0' src='"_s, GetParam().pdfURL(), "'></iframe><div style='height:2000px'></div>"_s);
+
+        server = makeUnique<HTTPServer>(std::initializer_list<std::pair<String, HTTPResponse>> {
+            { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML } },
+            { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFDataWithLink() } },
+        }, HTTPServer::Protocol::HttpsProxy);
+
+        configuration = configurationForWebViewTestingUnifiedPDF();
+        [configuration setWebsiteDataStore:[server->httpsProxyConfiguration() websiteDataStore]];
+        GetParam().applyTo(configuration.get());
+
+        navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+        [webView _setWindowOcclusionDetectionEnabled:NO];
+        [webView setNavigationDelegate:navigationDelegate.get()];
+        [[webView window] makeKeyAndOrderFront:nil];
+        [[webView window] orderFrontRegardless];
+    }
+
+    // A point over the PDF's text, in web view coordinates. The sole annotation is the link over
+    // "our website", so its center is on text whatever the layout.
+    NSPoint loadAndFindPointOverPDFText()
+    {
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        RetainPtr<NSArray> center;
+        bool foundAnnotation = TestWebKitAPI::Util::waitFor([&] {
+            center = dynamic_objc_cast<NSArray>([webView objectByEvaluatingJavaScript:@"(() => {"
+                "  const plugin = document.querySelector('embed');"
+                "  const rects = plugin ? internals.pdfAnnotationRectsForTesting(plugin) : [];"
+                "  if (!rects.length) return null;"
+                "  const box = plugin.getBoundingClientRect();"
+                "  return [box.x + rects[0].x + rects[0].width / 2, box.y + rects[0].y + rects[0].height / 2];"
+                "})()" inFrame:[webView firstChildFrame]]);
+            return !!center;
+        });
+        EXPECT_TRUE(foundAnnotation);
+        if (!foundAnnotation)
+            return NSZeroPoint;
+
+        [webView waitForNextPresentationUpdate];
+        return NSMakePoint(iframeLeft + [[center objectAtIndex:0] doubleValue], iframeTop + [[center objectAtIndex:1] doubleValue]);
+    }
+
+    // Right-clicks and picks Look Up, returning the text indicator's bounding rect in root view
+    // coordinates. The menu is a plain NSMenu, so swizzling is the only way in.
+    NSRect lookUpAtPoint(NSPoint pointInWebView)
+    {
+        __block bool lookedUp = false;
+        __block RetainPtr<NSString> lookedUpText;
+        __block NSRect textBoundingRect = NSZeroRect;
+        [webView _setDidPerformDictionaryLookupHandlerForTesting:^(NSString *text, CGRect rect) {
+            lookedUpText = text;
+            textBoundingRect = rect;
+            lookedUp = true;
+        }];
+
+        __block bool selectedLookUp = false;
+        InstanceMethodSwizzler popUpSwizzler {
+            object_getClass([NSMenu class]),
+            @selector(popUpContextMenu:withEvent:forView:),
+            imp_implementationWithBlock(^(id, NSMenu *menu, NSEvent *, NSView *) {
+                NSInteger index = [menu indexOfItemWithTag:dictionaryLookupContextMenuItemTag];
+                if (index == -1)
+                    return;
+                [menu performActionForItemAtIndex:index];
+                selectedLookUp = true;
+            })
+        };
+
+        // Right-clicking selects the word under the cursor, putting Look Up in the menu.
+        [webView rightClickAtPoint:[webView convertPoint:pointInWebView toView:nil]];
+        bool didLookUp = TestWebKitAPI::Util::runFor(&lookedUp, 5_s);
+        [webView _setDidPerformDictionaryLookupHandlerForTesting:nil];
+
+        EXPECT_TRUE(selectedLookUp);
+        EXPECT_TRUE(didLookUp);
+        EXPECT_GT([lookedUpText length], 0u);
+        return textBoundingRect;
+    }
+
+    static std::string testNameGenerator(testing::TestParamInfo<SiteIsolationParams> info)
+    {
+        return info.param.testName();
+    }
+
+    std::unique_ptr<HTTPServer> server;
+    RetainPtr<WKWebViewConfiguration> configuration;
+    RetainPtr<TestNavigationDelegate> navigationDelegate;
+    RetainPtr<TestWKWebView> webView;
+};
+
+TEST_P(EmbeddedPDFLookUp, ContextMenuIsPositionedAtTheClick)
+{
+    auto pointInWindow = [webView convertPoint:loadAndFindPointOverPDFText() toView:nil];
+
+    __block bool poppedUpMenu = false;
+    __block NSPoint menuLocationInWindow = NSZeroPoint;
+    InstanceMethodSwizzler popUpSwizzler {
+        object_getClass([NSMenu class]),
+        @selector(popUpContextMenu:withEvent:forView:),
+        imp_implementationWithBlock(^(id, NSMenu *, NSEvent *event, NSView *) {
+            menuLocationInWindow = [event locationInWindow];
+            poppedUpMenu = true;
+        })
+    };
+
+    [webView rightClickAtPoint:pointInWindow];
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&poppedUpMenu, 10_s));
+
+    // Round-trips through root view, screen and window conversions, each rounding.
+    EXPECT_NEAR(menuLocationInWindow.x, pointInWindow.x, 2);
+    EXPECT_NEAR(menuLocationInWindow.y, pointInWindow.y, 2);
+}
+
+TEST_P(EmbeddedPDFLookUp, TextIndicatorRectCoversTheLookedUpWord)
+{
+    auto pointInWebView = loadAndFindPointOverPDFText();
+    auto textBoundingRect = lookUpAtPoint(pointInWebView);
+
+    EXPECT_FALSE(NSIsEmptyRect(textBoundingRect));
+    // Containment alone is not enough: the iframe is exactly the plugin's size, so an unconverted
+    // rect is still inside it and only misses the click.
+    EXPECT_TRUE(NSPointInRect(pointInWebView, textBoundingRect));
+    EXPECT_TRUE(NSContainsRect(iframeFrame, textBoundingRect));
+}
+
+TEST_P(EmbeddedPDFLookUp, TextIndicatorRectAccountsForMainFrameScroll)
+{
+    auto pointInWebView = loadAndFindPointOverPDFText();
+
+    static constexpr int scrollOffset = 40;
+    bool scrolled = TestWebKitAPI::Util::waitFor([&] {
+        [webView objectByEvaluatingJavaScript:@"window.scrollTo(0, 40)"];
+        return [[webView objectByEvaluatingJavaScript:@"window.scrollY"] intValue] == scrollOffset;
+    });
+    EXPECT_TRUE(scrolled);
+    [webView waitForNextPresentationUpdate];
+
+    pointInWebView.y -= scrollOffset;
+    auto textBoundingRect = lookUpAtPoint(pointInWebView);
+
+    // Under site isolation the plugin's transform does not move, so the offset must come from the
+    // conversion; a sign error moves the highlight off the word.
+    EXPECT_FALSE(NSIsEmptyRect(textBoundingRect));
+    EXPECT_TRUE(NSPointInRect(pointInWebView, textBoundingRect));
+    EXPECT_TRUE(NSContainsRect(NSOffsetRect(iframeFrame, 0, -scrollOffset), textBoundingRect));
+}
+
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFLookUp, testing::ValuesIn(siteIsolationParams), &EmbeddedPDFLookUp::testNameGenerator);
+
+#endif // PLATFORM(MAC)
 
 #if ENABLE(PDF_HUD)
 
@@ -904,18 +1116,18 @@ UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
     EXPECT_TRUE(hadRightFrame);
 }
 
-using EmbeddedPDFHUDSiteIsolationParams = std::tuple<PDFEmbedElement, bool, bool, bool>;
+struct EmbeddedPDFHUDSiteIsolationParams {
+    PDFEmbedElement embedElement;
+    SiteIsolationParams siteIsolation;
+};
 
 class EmbeddedPDFHUDSiteIsolation : public testing::TestWithParam<EmbeddedPDFHUDSiteIsolationParams> {
 public:
-    PDFEmbedElement embedElement() const { return std::get<0>(GetParam()); }
-    bool crossOrigin() const { return std::get<1>(GetParam()); }
-    bool siteIsolationEnabled() const { return std::get<2>(GetParam()); }
-    bool siteIsolationSharedProcessEnabled() const { return std::get<3>(GetParam()); }
+    PDFEmbedElement embedElement() const { return GetParam().embedElement; }
 
     String mainHTML() const
     {
-        auto pdfURL = makeString("https://"_s, crossOrigin() ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s);
+        auto pdfURL = GetParam().siteIsolation.pdfURL();
         auto layout = "width='300' height='150' style='position:absolute; left:10px; top:28px; border:0'"_s;
         switch (embedElement()) {
         case PDFEmbedElement::IFrame:
@@ -944,14 +1156,10 @@ public:
 
         configuration = server->httpsProxyConfiguration();
         for (_WKFeature *feature in [WKPreferences _features]) {
-            NSString *key = feature.key;
-            if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
+            if ([feature.key isEqualToString:@"UnifiedPDFEnabled"] || [feature.key isEqualToString:@"PDFPluginHUDEnabled"])
                 [[configuration preferences] _setEnabled:YES forFeature:feature];
-            else if ([key isEqualToString:@"SiteIsolationEnabled"])
-                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
-            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
-                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
         }
+        GetParam().siteIsolation.applyTo(configuration.get());
 
         navigationDelegate = adoptNS([TestNavigationDelegate new]);
         [navigationDelegate allowAnyTLSCertificate];
@@ -978,22 +1186,7 @@ public:
 
     static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFHUDSiteIsolationParams> info)
     {
-        std::string element = [embedElement = std::get<0>(info.param)] {
-            switch (embedElement) {
-            case PDFEmbedElement::IFrame:
-                return "IFrame";
-            case PDFEmbedElement::Embed:
-                return "Embed";
-            case PDFEmbedElement::Object:
-                return "Object";
-            }
-            ASSERT_NOT_REACHED();
-            return "";
-        }();
-        return element
-            + (std::get<1>(info.param) ? "_CrossOrigin" : "_SameOrigin")
-            + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
-            + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
+        return testName(info.param.embedElement) + "_" + info.param.siteIsolation.testName();
     }
 
     std::unique_ptr<HTTPServer> server;
@@ -1030,7 +1223,7 @@ TEST_P(EmbeddedPDFHUDSiteIsolation, HUDTracksMainFrameScroll)
     checkFrame([webView _pdfHUDs].anyObject.frame, 10, 8, 300, 150, 1);
 }
 
-INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::ValuesIn(withEachPDFEmbedElement<EmbeddedPDFHUDSiteIsolationParams>()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);
 
 UNIFIED_PDF_TEST(PDFHUDLoadPDFTypeWithPluginsBlocked)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -599,6 +599,196 @@ TEST_P(EmbeddedPDFFitsToFrame, Test)
 
 INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFFitsToFrame, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFFitsToFrame::testNameGenerator);
 
+#if PLATFORM(MAC)
+
+// UnifiedPDFPlugin::ContextMenuItemTag::DictionaryLookup. The title is localized, so match the tag.
+static constexpr NSInteger dictionaryLookupContextMenuItemTag = 2;
+
+using EmbeddedPDFLookUpParams = std::tuple<bool, bool, bool>;
+
+class EmbeddedPDFLookUp : public testing::TestWithParam<EmbeddedPDFLookUpParams> {
+public:
+    bool crossOrigin() const { return std::get<0>(GetParam()); }
+    bool siteIsolationEnabled() const { return std::get<1>(GetParam()); }
+    bool siteIsolationSharedProcessEnabled() const { return std::get<2>(GetParam()); }
+
+    // Large enough that the offset is unmissable if the conversion is skipped.
+    static constexpr int iframeLeft = 100;
+    static constexpr int iframeTop = 120;
+    static constexpr int iframeWidth = 400;
+    static constexpr int iframeHeight = 300;
+    static constexpr NSRect iframeFrame { { iframeLeft, iframeTop }, { iframeWidth, iframeHeight } };
+
+    void SetUp() override
+    {
+        auto pdfURL = makeString("https://"_s, crossOrigin() ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s);
+        // The spacer makes the main frame scrollable for TextIndicatorRectAccountsForMainFrameScroll.
+        auto mainHTML = makeString("<body style='margin:0'><iframe style='position:absolute; left:"_s, iframeLeft,
+            "px; top:"_s, iframeTop, "px; width:"_s, iframeWidth, "px; height:"_s, iframeHeight,
+            "px; border:0' src='"_s, pdfURL, "'></iframe><div style='height:2000px'></div>"_s);
+
+        server = makeUnique<HTTPServer>(std::initializer_list<std::pair<String, HTTPResponse>> {
+            { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML } },
+            { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFDataWithLink() } },
+        }, HTTPServer::Protocol::HttpsProxy);
+
+        configuration = configurationForWebViewTestingUnifiedPDF();
+        [configuration setWebsiteDataStore:[server->httpsProxyConfiguration() websiteDataStore]];
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            NSString *key = feature.key;
+            if ([key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
+        }
+
+        navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+        [webView _setWindowOcclusionDetectionEnabled:NO];
+        [webView setNavigationDelegate:navigationDelegate.get()];
+        [[webView window] makeKeyAndOrderFront:nil];
+        [[webView window] orderFrontRegardless];
+    }
+
+    // Returns a point over the PDF's text, in web view coordinates. The PDF's sole annotation is the
+    // link over "our website", so its center is on text whatever the plugin's layout. Annotation
+    // rects are in plugin coordinates, which are the generated <embed>'s content box.
+    NSPoint loadAndFindPointOverPDFText()
+    {
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        RetainPtr<NSArray> center;
+        bool foundAnnotation = TestWebKitAPI::Util::waitFor([&] {
+            center = dynamic_objc_cast<NSArray>([webView objectByEvaluatingJavaScript:@"(() => {"
+                "  const plugin = document.querySelector('embed');"
+                "  const rects = plugin ? internals.pdfAnnotationRectsForTesting(plugin) : [];"
+                "  if (!rects.length) return null;"
+                "  const box = plugin.getBoundingClientRect();"
+                "  return [box.x + rects[0].x + rects[0].width / 2, box.y + rects[0].y + rects[0].height / 2];"
+                "})()" inFrame:[webView firstChildFrame]]);
+            return !!center;
+        });
+        EXPECT_TRUE(foundAnnotation);
+        if (!foundAnnotation)
+            return NSZeroPoint;
+
+        [webView waitForNextPresentationUpdate];
+        return NSMakePoint(iframeLeft + [[center objectAtIndex:0] doubleValue], iframeTop + [[center objectAtIndex:1] doubleValue]);
+    }
+
+    // Right-clicks and picks Look Up, returning the text indicator's bounding rect in root view
+    // coordinates. The menu is a plain NSMenu from the UI process, so swizzling is the only way in.
+    NSRect lookUpAtPoint(NSPoint pointInWebView)
+    {
+        __block bool lookedUp = false;
+        __block RetainPtr<NSString> lookedUpText;
+        __block NSRect textBoundingRect = NSZeroRect;
+        [webView _setDidPerformDictionaryLookupHandlerForTesting:^(NSString *text, CGRect rect) {
+            lookedUpText = text;
+            textBoundingRect = rect;
+            lookedUp = true;
+        }];
+
+        __block bool selectedLookUp = false;
+        InstanceMethodSwizzler popUpSwizzler {
+            object_getClass([NSMenu class]),
+            @selector(popUpContextMenu:withEvent:forView:),
+            imp_implementationWithBlock(^(id, NSMenu *menu, NSEvent *, NSView *) {
+                NSInteger index = [menu indexOfItemWithTag:dictionaryLookupContextMenuItemTag];
+                if (index == -1)
+                    return;
+                [menu performActionForItemAtIndex:index];
+                selectedLookUp = true;
+            })
+        };
+
+        // Right-clicking selects the word under the cursor, which puts Look Up in the plugin's menu.
+        [webView rightClickAtPoint:[webView convertPoint:pointInWebView toView:nil]];
+        bool didLookUp = TestWebKitAPI::Util::runFor(&lookedUp, 5_s);
+        [webView _setDidPerformDictionaryLookupHandlerForTesting:nil];
+
+        EXPECT_TRUE(selectedLookUp);
+        EXPECT_TRUE(didLookUp);
+        EXPECT_GT([lookedUpText length], 0u);
+        return textBoundingRect;
+    }
+
+    static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFLookUpParams> info)
+    {
+        return std::string { std::get<0>(info.param) ? "CrossOrigin" : "SameOrigin" }
+            + "_SiteIsolation" + (std::get<1>(info.param) ? "Enabled" : "Disabled")
+            + "_SiteIsolationSharedProcess" + (std::get<2>(info.param) ? "Enabled" : "Disabled");
+    }
+
+    std::unique_ptr<HTTPServer> server;
+    RetainPtr<WKWebViewConfiguration> configuration;
+    RetainPtr<TestNavigationDelegate> navigationDelegate;
+    RetainPtr<TestWKWebView> webView;
+};
+
+TEST_P(EmbeddedPDFLookUp, ContextMenuIsPositionedAtTheClick)
+{
+    auto pointInWindow = [webView convertPoint:loadAndFindPointOverPDFText() toView:nil];
+
+    __block bool poppedUpMenu = false;
+    __block NSPoint menuLocationInWindow = NSZeroPoint;
+    InstanceMethodSwizzler popUpSwizzler {
+        object_getClass([NSMenu class]),
+        @selector(popUpContextMenu:withEvent:forView:),
+        imp_implementationWithBlock(^(id, NSMenu *, NSEvent *event, NSView *) {
+            menuLocationInWindow = [event locationInWindow];
+            poppedUpMenu = true;
+        })
+    };
+
+    [webView rightClickAtPoint:pointInWindow];
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&poppedUpMenu, 10_s));
+
+    // The position round-trips through root view, screen and window conversions, each rounding.
+    EXPECT_NEAR(menuLocationInWindow.x, pointInWindow.x, 2);
+    EXPECT_NEAR(menuLocationInWindow.y, pointInWindow.y, 2);
+}
+
+TEST_P(EmbeddedPDFLookUp, TextIndicatorRectCoversTheLookedUpWord)
+{
+    auto pointInWebView = loadAndFindPointOverPDFText();
+    auto textBoundingRect = lookUpAtPoint(pointInWebView);
+
+    EXPECT_FALSE(NSIsEmptyRect(textBoundingRect));
+    // Containment in the iframe is not enough on its own: the iframe is exactly the plugin's size, so
+    // an unconverted rect is still inside it and only misses the click.
+    EXPECT_TRUE(NSPointInRect(pointInWebView, textBoundingRect));
+    EXPECT_TRUE(NSContainsRect(iframeFrame, textBoundingRect));
+}
+
+TEST_P(EmbeddedPDFLookUp, TextIndicatorRectAccountsForMainFrameScroll)
+{
+    auto pointInWebView = loadAndFindPointOverPDFText();
+
+    static constexpr int scrollOffset = 40;
+    bool scrolled = TestWebKitAPI::Util::waitFor([&] {
+        [webView objectByEvaluatingJavaScript:@"window.scrollTo(0, 40)"];
+        return [[webView objectByEvaluatingJavaScript:@"window.scrollY"] intValue] == scrollOffset;
+    });
+    EXPECT_TRUE(scrolled);
+    [webView waitForNextPresentationUpdate];
+
+    pointInWebView.y -= scrollOffset;
+    auto textBoundingRect = lookUpAtPoint(pointInWebView);
+
+    // Scrolling does not change the plugin's transform, so the offset has to come from the
+    // conversion. A sign error moves the highlight down instead of up, off the word.
+    EXPECT_FALSE(NSIsEmptyRect(textBoundingRect));
+    EXPECT_TRUE(NSPointInRect(pointInWebView, textBoundingRect));
+    EXPECT_TRUE(NSContainsRect(NSOffsetRect(iframeFrame, 0, -scrollOffset), textBoundingRect));
+}
+
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFLookUp, testing::Combine(testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFLookUp::testNameGenerator);
+
+#endif // PLATFORM(MAC)
+
 #if ENABLE(PDF_HUD)
 
 UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)


### PR DESCRIPTION
#### 372f25818fcf2e29b1a785b6cfdfddb7ca7de08f
<pre>
[Site Isolation] Look Up menu and context menu are displaced on cross origin iframe src=pdf
<a href="https://bugs.webkit.org/show_bug.cgi?id=322555">https://bugs.webkit.org/show_bug.cgi?id=322555</a>
<a href="https://rdar.apple.com/163147553">rdar://163147553</a>

Reviewed by NOBODY (OOPS!).

A PDF in a cross-origin iframe drew its Look Up highlight and popover, and its
context menu, offset by the iframe&apos;s position in the page.

Such an iframe hosts a real plugin, and under site isolation it is a local root in
its own web process. PluginView::viewGeometryDidChange builds the plugin transform
from parent()-&gt;contentsToRootView(), which stops where there is no Widget parent,
so the plugin&apos;s &quot;root view&quot; is its local root, not the main frame. Incoming events
are already mapped into the subframe by the UI process, so only outgoing geometry
is wrong.

Add PDFPluginBase::convertFromRootViewToMainFrameView(), which finishes the walk in
process with FrameView::convertToRootViewAcrossIsolatedFrames() from this process&apos;s
root frame view. Apply it in createContextMenu(), which converts to screen
coordinates before the UI process sees the point, and in
showDefinitionForSelection(), whose DidPerformDictionaryLookup carries no frame
identifier.

Convert at the sender rather than in dictionaryPopupInfoForSelection(), because the
force touch path shares that producer and is still converted by
RemoteDictionaryPopupInfoToRootView, so converting there would convert twice.
Fixing that path -- it costs an IPC per hop, walks only one hop, and mis-maps
textRectsInBoundingRectCoordinates -- is a follow-up.

Add -[WKWebView _setDidPerformDictionaryLookupHandlerForTesting:] so a test can
observe DictionaryPopupInfo. It fires before DictionaryLookup::showPopup, so it
does not need Reveal.

Also replace the bool tuples the parameterized UnifiedPDF suites shared with a
SiteIsolationParams struct that owns the preference setup, PDF URL and test name.
Its configurations drop shared-process-without-site-isolation, which is ignored.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm

* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _setDidPerformDictionaryLookupHandlerForTesting:]):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::didPerformDictionaryLookup):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::rootFrameView const):
(WebKit::PDFPluginBase::convertFromRootViewToMainFrameView const):
(WebKit::PDFPluginBase::convertTextIndicatorFromRootViewToMainFrameView const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::showDefinitionForSelection):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::testName):
(TestWebKitAPI::SiteIsolationParams::pdfURL const):
(TestWebKitAPI::SiteIsolationParams::applyTo const):
(TestWebKitAPI::SiteIsolationParams::testName const):
(TestWebKitAPI::withEachPDFEmbedElement):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::embedElement const):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::SetUp):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::testNameGenerator):
(TestWebKitAPI::EmbeddedPDFLookUp::SetUp):
(TestWebKitAPI::EmbeddedPDFLookUp::loadAndFindPointOverPDFText):
(TestWebKitAPI::EmbeddedPDFLookUp::lookUpAtPoint):
(TestWebKitAPI::EmbeddedPDFLookUp::testNameGenerator):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::embedElement const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::mainHTML const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::SetUp):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::testNameGenerator):
(TestWebKitAPI::TEST_P):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/372f25818fcf2e29b1a785b6cfdfddb7ca7de08f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186676 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60549 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151106 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06dc4a1f-fb70-4bbe-bd0a-2c60aa432169) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188538 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61933 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60255 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145826 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101062 "6 flakes 46 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/215ef398-a5f9-4dfd-903f-d5a58fe106c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189631 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/61933 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126234 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0da31928-2a16-4295-8a70-29f0ba6adc2a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/61933 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/60255 "Hash 372f2581 for PR 72465 does not build (failure)") | | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/61933 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8018 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52973 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/60255 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198937 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60193 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155436 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60905 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155069 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/60905 "Hash 372f2581 for PR 72465 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133078 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59315 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/54294 "Hash 372f2581 for PR 72465 does not build (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->