### PR TITLE
[AppKit Gestures] Support mouse tracking with multiple gesture recognizers

### DIFF
--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -482,6 +482,7 @@ list(APPEND WebKit_SOURCES
     ${WEBKIT_DIR}/UIProcess/mac/AppKitGestures/WKDOMDoubleClickGestureRecognizer.swift
     ${WEBKIT_DIR}/UIProcess/mac/AppKitGestures/WKDirectionalScrollLockTracker.swift
     ${WEBKIT_DIR}/UIProcess/mac/AppKitGestures/WKFastScrollTracker.swift
+    ${WEBKIT_DIR}/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.swift
     ${WEBKIT_DIR}/UIProcess/mac/SpatialShim.swift
     ${WEBKIT_DIR}/UIProcess/mac/WKTextSelectionController.swift
     ${WEBKIT_DIR}/UIProcess/PDF/WKAlternatePDFHUDView.swift

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -194,7 +194,8 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     WeakObjCPtr<WKWebView> _view;
 
     RetainPtr<NSPanGestureRecognizer> _panGestureRecognizer;
-    RetainPtr<NSPressGestureRecognizer> _mouseTrackingGestureRecognizer;
+    std::array<RetainPtr<WKMouseTrackingGestureRecognizer>, WebKit::mouseTrackingGestureCount> _mouseTrackingGestureRecognizers;
+
     RetainPtr<NSPressGestureRecognizer> _singleClickGestureRecognizer;
     RetainPtr<NSClickGestureRecognizer> _doubleClickGestureRecognizer;
     RetainPtr<NSClickGestureRecognizer> _domDoubleClickGestureRecognizer;
@@ -218,6 +219,12 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     std::optional<WebKit::TransactionID> _layerTreeTransactionIdAtLastInteractionStart;
     Markable<WebKit::ClickIdentifier> _latestClickID;
 
+    // FIXME: Avoid bloat in WKAppKitGestureController by introducing a separate
+    // gesture delegate that exclusively manages the mouse tracking recognizers.
+    //
+    // See -mouseTrackingGestureRecognized: where this state is used to transition
+    // between tracking gestures when an active gesture's tracking conditions change.
+    WeakObjCPtr<WKMouseTrackingGestureRecognizer> _activeMouseTrackingGestureRecognizer;
     bool _mouseTrackingHasSentMouseDown;
     WebCore::FloatPoint _mouseTrackingStartLocationInWindow;
 
@@ -304,7 +311,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 - (void)setUpGestureRecognizers
 {
     [self setUpPanGestureRecognizer];
-    [self setUpMouseTrackingGestureRecognizer];
+    [self setUpMouseTrackingGestureRecognizers];
     [self setUpSingleClickGestureRecognizer];
     [self setUpDoubleClickGestureRecognizer];
     [self setUpDOMDoubleClickGestureRecognizer];
@@ -324,12 +331,15 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 #endif
 }
 
-- (void)setUpMouseTrackingGestureRecognizer
+- (void)setUpMouseTrackingGestureRecognizers
 {
-    _mouseTrackingGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(mouseTrackingGestureRecognized:)]);
-    [self configureForMouseTracking:_mouseTrackingGestureRecognizer.get()];
-    [_mouseTrackingGestureRecognizer setDelegate:self];
-    [_mouseTrackingGestureRecognizer setName:@"WKMouseTrackingGesture"];
+    for (auto index : std::views::iota(0uz, _mouseTrackingGestureRecognizers.size())) {
+        RetainPtr recognizer = adoptNS([[WKMouseTrackingGestureRecognizer alloc] initWithTarget:self action:@selector(mouseTrackingGestureRecognized:)]);
+        [self configureForMouseTracking:recognizer atIndex:index];
+        [recognizer setDelegate:self];
+        [recognizer setName:[self nameForMouseTrackingGesture:recognizer]];
+        _mouseTrackingGestureRecognizers[index] = WTF::move(recognizer);
+    }
 }
 
 - (void)setUpSingleClickGestureRecognizer
@@ -425,7 +435,8 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
         return;
 
     [webView addGestureRecognizer:_panGestureRecognizer.get()];
-    [webView addGestureRecognizer:_mouseTrackingGestureRecognizer.get()];
+    for (RetainPtr recognizer : _mouseTrackingGestureRecognizers)
+        [webView addGestureRecognizer:recognizer.get()];
     [webView addGestureRecognizer:_singleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_doubleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_domDoubleClickGestureRecognizer.get()];
@@ -449,7 +460,8 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 - (void)enableGesturesIfNeeded
 {
     [self enableGestureIfNeeded:_panGestureRecognizer.get()];
-    [self enableGestureIfNeeded:_mouseTrackingGestureRecognizer.get()];
+    for (RetainPtr recognizer : _mouseTrackingGestureRecognizers)
+        [self enableGestureIfNeeded:recognizer.get()];
     [self enableGestureIfNeeded:_singleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_domDoubleClickGestureRecognizer.get()];
@@ -477,7 +489,8 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     // want to avoid duplicate sets when views are decoded.
 
     [_panGestureRecognizer setShouldBeArchived:NO];
-    [_mouseTrackingGestureRecognizer setShouldBeArchived:NO];
+    for (RetainPtr recognizer : _mouseTrackingGestureRecognizers)
+        [recognizer setShouldBeArchived:NO];
     [_singleClickGestureRecognizer setShouldBeArchived:NO];
     [_doubleClickGestureRecognizer setShouldBeArchived:NO];
     [_domDoubleClickGestureRecognizer setShouldBeArchived:NO];
@@ -726,6 +739,25 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     impl->mouseUp(mouseUp.get(), WebKit::WebEventInputSource::Automation);
 }
 
+- (BOOL)_isMouseTrackingGestureRecognizer:(NSGestureRecognizer *)gesture
+{
+    return [gesture isKindOfClass:WKMouseTrackingGestureRecognizer.class];
+}
+
+- (BOOL)_mouseTrackingWillBeHandedOff
+{
+    if (!_mouseTrackingHasSentMouseDown)
+        return NO;
+
+    for (RetainPtr recognizer : _mouseTrackingGestureRecognizers) {
+        auto state = [recognizer state];
+        if (state == NSGestureRecognizerStateBegan || state == NSGestureRecognizerStateChanged)
+            return YES;
+    }
+
+    return NO;
+}
+
 - (void)mouseTrackingGestureRecognized:(NSGestureRecognizer *)gesture
 {
     RetainPtr webView = _view.get();
@@ -744,7 +776,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
     }
 
-    RELEASE_ASSERT(_mouseTrackingGestureRecognizer == gesture);
+    RetainPtr mouseTrackingGesture = dynamic_objc_cast<WKMouseTrackingGestureRecognizer>(gesture);
+    RELEASE_ASSERT(mouseTrackingGesture);
 
     CheckedPtr impl = [webView _impl];
     if (impl->ignoresAllEvents())
@@ -753,17 +786,22 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     auto modifierFlags = [gesture modifierFlags];
 ALLOW_NEW_API_WITHOUT_GUARDS_END
-    WebCore::FloatPoint locationInWindow { [gesture locationInView:nil] };
     auto windowNumber = impl->windowNumber();
     auto timestamp = GetCurrentEventTime();
 
     switch (gesture.state) {
     case NSGestureRecognizerStateBegan:
-        _mouseTrackingHasSentMouseDown = false;
-        _mouseTrackingStartLocationInWindow = locationInWindow;
+        _activeMouseTrackingGestureRecognizer = mouseTrackingGesture.get();
+        if (_mouseTrackingHasSentMouseDown)
+            [mouseTrackingGesture beginTrackingMouseInheritedFromLocationInWindow:_mouseTrackingStartLocationInWindow];
+        else
+            [mouseTrackingGesture beginTrackingMouse];
         break;
 
     case NSGestureRecognizerStateChanged: {
+        if (_activeMouseTrackingGestureRecognizer.get() != mouseTrackingGesture)
+            break;
+
         if (!_mouseTrackingHasSentMouseDown) {
             // Either the synthetic single-click path or this mouse-tracking path delivers a mouse
             // down for a given interaction, but never both. An event that stays within the single-click
@@ -773,13 +811,13 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
             // cancels and this becomes a drag — does mouse tracking take over event delivery. Sending a
             // mouse down here for a stationary click would deliver a second mouse down to the content,
             // which should be avoided.
-            auto movementInWindow = locationInWindow - _mouseTrackingStartLocationInWindow;
+            auto movementInWindow = [mouseTrackingGesture movementInWindowSinceStart];
             auto allowableMovement = [_singleClickGestureRecognizer allowableMovement];
-            if (std::abs(movementInWindow.width()) <= allowableMovement && std::abs(movementInWindow.height()) <= allowableMovement)
+            if (std::abs(movementInWindow.width) <= allowableMovement && std::abs(movementInWindow.height) <= allowableMovement)
                 break;
 
             RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
-                location:_mouseTrackingStartLocationInWindow
+                location:[mouseTrackingGesture startLocationInWindow]
                 modifierFlags:modifierFlags
                 timestamp:timestamp
                 windowNumber:windowNumber
@@ -792,7 +830,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         }
 
         RetainPtr mouseDragged = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged
-            location:locationInWindow
+            location:[mouseTrackingGesture mouseLocationInWindow]
             modifierFlags:modifierFlags
             timestamp:timestamp
             windowNumber:windowNumber
@@ -804,10 +842,23 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         break;
     }
 
-    case NSGestureRecognizerStateEnded: {
-        if (_mouseTrackingHasSentMouseDown) {
+    case NSGestureRecognizerStateEnded:
+    case NSGestureRecognizerStateCancelled:
+    case NSGestureRecognizerStateFailed:
+        if (_activeMouseTrackingGestureRecognizer.get() != mouseTrackingGesture)
+            break;
+
+        _activeMouseTrackingGestureRecognizer = nil;
+
+        if ([self _mouseTrackingWillBeHandedOff]) {
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Handing off mouse tracking to another gesture");
+            _mouseTrackingStartLocationInWindow = [mouseTrackingGesture mouseLocationInWindow];
+            break;
+        }
+
+        if (std::exchange(_mouseTrackingHasSentMouseDown, false)) {
             RetainPtr mouseUp = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
-                location:locationInWindow
+                location:[mouseTrackingGesture mouseLocationInWindow]
                 modifierFlags:modifierFlags
                 timestamp:timestamp
                 windowNumber:windowNumber
@@ -817,12 +868,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
                 pressure:0.0];
             impl->mouseUp(mouseUp.get(), WebKit::WebEventInputSource::Automation, WebCore::PlatformMouseEvent::CanInitiateDrag::No);
         }
-        [[fallthrough]];
-    }
-
-    case NSGestureRecognizerStateCancelled:
-    case NSGestureRecognizerStateFailed:
-        _mouseTrackingHasSentMouseDown = false;
         break;
 
     default:
@@ -1747,6 +1792,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 {
     [self clearGestureDragState];
     [self _handleClickCancelled];
+    _activeMouseTrackingGestureRecognizer = nil;
     _mouseTrackingHasSentMouseDown = false;
     _isMomentumActive = false;
     [self _resetCaughtDeceleratingScroll];
@@ -1775,6 +1821,32 @@ static inline bool isBuiltInScrollViewMagnificationGestureRecognizer(NSGestureRe
 static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NSGestureRecognizer *x, NSGestureRecognizer *y)
 {
     return (a == x && b == y) || (b == x && a == y);
+}
+
+- (BOOL)_shouldRecognizeSimultaneouslyWithMouseTrackingGesture:(NSGestureRecognizer *)gesture
+{
+    RetainPtr webView = _view.get();
+    if (!webView)
+        return NO;
+
+    if ([self _isMouseTrackingGestureRecognizer:gesture]
+        || gesture == _panGestureRecognizer
+        || gesture == _magnificationGestureRecognizer
+#if ENABLE(MAC_GESTURE_EVENTS)
+        || gesture == _rotationGestureRecognizer
+#endif
+        || gesture == _doubleClickGestureRecognizer
+        || gesture == _singleClickGestureRecognizer
+        || gesture == _dragPressGestureRecognizer
+        || isSystemWindowResizeGestureRecognizer(gesture))
+        return YES;
+
+    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
+        if (gesture == gestureForFailureRequirements)
+            return YES;
+    }
+
+    return NO;
 }
 
 - (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
@@ -1811,13 +1883,13 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (gestureRecognizer == _domDoubleClickGestureRecognizer || otherGestureRecognizer == _domDoubleClickGestureRecognizer)
         return YES;
 
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
+    if ([self _isMouseTrackingGestureRecognizer:gestureRecognizer] && [self _shouldRecognizeSimultaneouslyWithMouseTrackingGesture:otherGestureRecognizer])
+        return YES;
+
+    if ([self _isMouseTrackingGestureRecognizer:otherGestureRecognizer] && [self _shouldRecognizeSimultaneouslyWithMouseTrackingGesture:gestureRecognizer])
         return YES;
 
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
-        return YES;
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _mouseTrackingGestureRecognizer.get()))
         return YES;
 
     if (gestureRecognizer == _singleClickGestureRecognizer
@@ -1825,16 +1897,10 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
         && [otherGestureRecognizer.view isKindOfClass:NSScrollView.class])
         return YES;
 
-    // Don't prevent the scrollbar from scrolling even if the window resize recognizer is active.
-    if (gestureRecognizer == _mouseTrackingGestureRecognizer && isSystemWindowResizeGestureRecognizer(otherGestureRecognizer))
-        return YES;
-
-    // Allow the single click or mouse tracking GRs to be simultaneously
-    // recognized with any of those from the text selection manager.
+    // Allow the single click GR to be simultaneously recognized with any of those from the text
+    // selection manager.
     for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
         if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), gestureForFailureRequirements))
-            return YES;
-        if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), gestureForFailureRequirements))
             return YES;
     }
 
@@ -1872,7 +1938,7 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == _doubleClickGestureRecognizer)
         return YES;
 
-    if (gestureRecognizer == _mouseTrackingGestureRecognizer && otherGestureRecognizer == _panGestureRecognizer) {
+    if ([self _isMouseTrackingGestureRecognizer:gestureRecognizer] && otherGestureRecognizer == _panGestureRecognizer) {
         bool panCanScroll = [self panGestureRecognizerCanScroll];
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Mouse tracking requires pan to fail: %d", panCanScroll);
         return panCanScroll;
@@ -1904,10 +1970,10 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView.get()];
 
-    // An event over a scrollbar is a scrollbar interaction; only the mouse-tracking gesture (which drives
+    // An event over a scrollbar is a scrollbar interaction; only a mouse-tracking gesture (which drives
     // `Scrollbar::mouseDown` -> thumb drag) should handle it. The AppKit text-selection/context-menu gestures
     // are handled separately in the deferral delegate.
-    if ([self _isPointInScrollbar:locationInViewCoordinates] && gestureRecognizer != _mouseTrackingGestureRecognizer) {
+    if ([self _isPointInScrollbar:locationInViewCoordinates] && ![self _isMouseTrackingGestureRecognizer:gestureRecognizer]) {
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Denying gesture over scrollbar: %@", gestureLogDescription(gestureRecognizer));
         return NO;
     }
@@ -1935,8 +2001,13 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (gestureRecognizer == _singleClickGestureRecognizer)
         return !protect([webView _impl])->isTextSelectedAtPoint(locationInViewCoordinates);
 
-    if (gestureRecognizer == _mouseTrackingGestureRecognizer)
+    if (RetainPtr mouseTrackingGesture = dynamic_objc_cast<WKMouseTrackingGestureRecognizer>(gestureRecognizer)) {
+        if (![self mouseTrackingGestureRecognizerCanTrack:mouseTrackingGesture]) {
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Denying mouse tracking gesture: %@", gestureLogDescription(gestureRecognizer));
+            return NO;
+        }
         return !protect([webView _impl])->isTextSelectedAtPoint(locationInViewCoordinates);
+    }
 
     return YES;
 }
@@ -1981,7 +2052,7 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer
         || preventingGestureRecognizer == _secondaryClickGestureRecognizer
-        || preventingGestureRecognizer == _mouseTrackingGestureRecognizer
+        || [self _isMouseTrackingGestureRecognizer:preventingGestureRecognizer]
         || preventingGestureRecognizer == _dragPressGestureRecognizer;
 
     if (!isOurClickGesture)

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.swift
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import AppKit
+private import AppKit_Private.NSPressGestureRecognizer_Private
+
+@objc(WKMouseTrackingGestureRecognizer)
+final class WKMouseTrackingGestureRecognizer: NSPressGestureRecognizer {
+    private var mouseLocationOffsetInWindow: CGSize = .zero
+
+    override func reset() {
+        mouseLocationOffsetInWindow = .zero
+        super.reset()
+    }
+
+    @objc(beginTrackingMouse)
+    func beginTrackingMouse() {
+        mouseLocationOffsetInWindow = .zero
+    }
+
+    @objc(beginTrackingMouseInheritedFromLocationInWindow:)
+    func beginTrackingMouse(inheritedFromLocationInWindow locationInWindow: CGPoint) {
+        let start = startLocationInWindow
+        mouseLocationOffsetInWindow = CGSize(
+            width: start.x - locationInWindow.x,
+            height: start.y - locationInWindow.y
+        )
+    }
+
+    @objc
+    var startLocationInWindow: CGPoint {
+        _startLocation(in: nil)
+    }
+
+    @objc
+    var mouseLocationInWindow: CGPoint {
+        let location = self.location(in: nil)
+        return CGPoint(
+            x: location.x - mouseLocationOffsetInWindow.width,
+            y: location.y - mouseLocationOffsetInWindow.height
+        )
+    }
+
+    @objc
+    var movementInWindowSinceStart: CGSize {
+        let location = self.location(in: nil)
+        let start = startLocationInWindow
+        return CGSize(width: location.x - start.x, height: location.y - start.y)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -986,6 +986,7 @@
 		3309345B1315B9980097A7BC /* WKCookieManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 330934591315B9980097A7BC /* WKCookieManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3311023B2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3311023A2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h */; };
 		331102412B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3311023F2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h */; };
+		3323520F303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3323520E303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift */; };
 		3326F2662B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2622B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3326F2672B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5407,6 +5408,7 @@
 		3311023E2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIDeclarativeNetRequest.mm; sourceTree = "<group>"; };
 		3311023F2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIDeclarativeNetRequest.h; sourceTree = "<group>"; };
 		331102462B17CFE300B21C8C /* WebExtensionContextAPIDeclarativeNetRequestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIDeclarativeNetRequestCocoa.mm; sourceTree = "<group>"; };
+		3323520E303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKMouseTrackingGestureRecognizer.swift; sourceTree = "<group>"; };
 		33238F5D2B7EFD3B0014AE88 /* WKAccessibilityPDFDocumentObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKAccessibilityPDFDocumentObject.h; path = PDF/WKAccessibilityPDFDocumentObject.h; sourceTree = "<group>"; };
 		33238F5E2B7EFD6A0014AE88 /* WKAccessibilityPDFDocumentObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKAccessibilityPDFDocumentObject.mm; path = PDF/WKAccessibilityPDFDocumentObject.mm; sourceTree = "<group>"; };
 		3326F2612B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionDeclarativeNetRequestRule.mm; sourceTree = "<group>"; };
@@ -9648,6 +9650,7 @@
 				07F0337D3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift */,
 				078074F83029A874005492F5 /* WKDOMDoubleClickGestureRecognizer.swift */,
 				07F0337B30107D3900B69551 /* WKFastScrollTracker.swift */,
+				3323520E303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift */,
 			);
 			path = AppKitGestures;
 			sourceTree = "<group>";
@@ -22644,6 +22647,7 @@
 				5CE9120D2293C219005BEC78 /* WKMain.mm in Sources */,
 				E502E4F82D4810EA00C3D56D /* WKMaterialHostingSupport.swift in Sources */,
 				07FEBC9A2E035A8B004A6D5D /* WKMouseDeviceObserver.swift in Sources */,
+				3323520F303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift in Sources */,
 				07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */,
 				0739F9AB301572270066ED1B /* WKPDFPageNumberIndicator.mm in Sources */,
 				E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */,


### PR DESCRIPTION
#### 533420b4dcae5d17e8e5323e8444f7e1ba94232e
<pre>
[AppKit Gestures] Support mouse tracking with multiple gesture recognizers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322554">https://bugs.webkit.org/show_bug.cgi?id=322554</a>
<a href="https://rdar.apple.com/185838964">rdar://185838964</a>

Reviewed by Richard Robinson.

There are multiple conflicting configurations in which we would like
mouse tracking to be active, and it is not feasible to alter certain
gesture recognizer properties between .began and .ended. To work around
this, we teach WKAppKitGestureController to hold a set of recognizers
instead.

The bulk of the new state (and associated coordination) is to ensure a
gesture handoff is correct if gesture recognition criteria changes such
that the currently active tracking recognizer gives way to a different
tracking recognizer. As a drive-by, we also fix an existing issue where
mouseUp events were not dispatched on every terminal state.

The delegate rules that referred to the single recognizer are now
generalized over the set, and simultaneity is granted (like before)
against the pan, magnification, rotation and double-click recognizers,
and between the tracking recognizers themselves.

Canonical link: <a href="https://commits.webkit.org/319879@main">https://commits.webkit.org/319879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79c558645e9b337c5f0a79807b2b150ce024b137

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d68bf51-bd16-4788-8930-560d64fc75c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7026fcd2-2f34-44b3-8fa7-f7351b962cb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec2f0766-03b2-47c3-991e-4afa787aa0e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43516 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43146 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4417 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195185 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56619 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152323 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152019 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46580 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129593 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125710 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55832 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55203 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->