### PR TITLE
Cherry-pick(s) 17b41f27a761. rdar://185368356

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
@@ -267,8 +267,21 @@ DtlsTransportInternalImpl::DtlsTransportInternalImpl(
 }
 
 DtlsTransportInternalImpl::~DtlsTransportInternalImpl() {
+<<<<<<< HEAD
   if (dtls_in_stun_) {
     CompleteDtlsInStun(/*success=*/false);
+=======
+  if (ice_transport_) {
+    ice_transport_->ResetDtlsStunPiggybackCallbacks();
+    ice_transport_->DeregisterReceivedPacketCallback(this);
+#if WEBRTC_WEBKIT_BUILD
+    ice_transport_->UnsubscribeReceivingState(this);
+    ice_transport_->UnsubscribeWritableState(this);
+    ice_transport()->UnsubscribeReadyToSend(this);
+    ice_transport()->UnsubscribeNetworkRouteChanged(this);
+    ice_transport()->UnsubscribeSentPacket(this);
+#endif
+>>>>>>> 17b41f27a761 (missing UnsubscribeReadyToSend/NetworkRouteChanged in LibWebRTC ~DtlsTransportInternalImpl causes use-after-free)
   }
   ice_transport()->ResetDtlsStunPiggybackCallbacks();
   ice_transport()->DeregisterReceivedPacketCallback(this);


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185368356 to main. [17b41f27a761] caused a merge conflict. 

```
missing UnsubscribeReadyToSend/NetworkRouteChanged in LibWebRTC ~DtlsTransportInternalImpl causes use-after-free
rdar://177131722

Reviewed by Eric Carlson.

We unregister all callbacks that were registered when connecting to the ICE transport.
Test validated with a specific STUN server.

* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc:

Originally-landed-as: 305413.996@safari-7624.5-branch (17b41f27a761). rdar://185368356


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a73aa2a213de58d9c910af9883c890dbf2152b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182991 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56914 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193208 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147279 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58256 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56649 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/193208 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/147279 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185946 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/58256 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/193208 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/58256 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/56649 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/193208 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/58256 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4381 "") | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/56649 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195149 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56583 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/195149 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57288 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/195149 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/57288 "") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125664 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55796 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50728 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55167 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55404 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55234 "") | | | 
<!--EWS-Status-Bubble-End-->