### PR TITLE
Annotate Lock functions as NODELETE

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -121,7 +121,6 @@ runtime/JSGlobalObject.cpp
 runtime/JSObject.cpp
 runtime/JSObjectInlines.h
 runtime/JSRunLoopTimer.cpp
-runtime/JSSymbolTableObject.cpp
 runtime/ModuleProgramExecutable.cpp
 runtime/NativeExecutable.cpp
 runtime/ProgramExecutable.cpp

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -65,14 +65,14 @@ class WTF_CAPABILITY_LOCK Lock {
 public:
     constexpr Lock() = default;
 
-    void lock() WTF_ACQUIRES_LOCK()
+    SUPPRESS_NODELETE void NODELETE lock() WTF_ACQUIRES_LOCK()
     {
         if (!DefaultLockAlgorithm::lockFastAssumingZero(m_byte)) [[unlikely]]
             lockSlow();
         TSAN_ANNOTATE_HAPPENS_AFTER(this);
     }
 
-    bool tryLock() WTF_ACQUIRES_LOCK_IF(true) // NOLINT: Intentional deviation to support std::scoped_lock.
+    SUPPRESS_NODELETE bool NODELETE tryLock() WTF_ACQUIRES_LOCK_IF(true) // NOLINT: Intentional deviation to support std::scoped_lock.
     {
         bool success = DefaultLockAlgorithm::tryLock(m_byte);
         if (success)
@@ -96,7 +96,7 @@ public:
     // we check if the last time that we did a fair unlock was more than roughly 1ms ago; if so, we
     // unlock fairly. Fairness matters most for long critical sections, and this virtually
     // guarantees that long critical sections always get a fair lock.
-    void unlock() WTF_RELEASES_LOCK()
+    SUPPRESS_NODELETE void NODELETE unlock() WTF_RELEASES_LOCK()
     {
         TSAN_ANNOTATE_HAPPENS_BEFORE(this);
         if (!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)) [[unlikely]]
@@ -108,14 +108,14 @@ public:
     // to be fair anyway. However, if you plan to relock the lock right after unlocking and you want
     // to ensure that some other thread runs in the meantime, this is probably the function you
     // want.
-    void unlockFairly() WTF_RELEASES_LOCK()
+    SUPPRESS_NODELETE void NODELETE unlockFairly() WTF_RELEASES_LOCK()
     {
         TSAN_ANNOTATE_HAPPENS_BEFORE(this);
         if (!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)) [[unlikely]]
             unlockFairlySlow();
     }
     
-    void safepoint()
+    SUPPRESS_NODELETE void NODELETE safepoint()
     {
         if (!DefaultLockAlgorithm::safepointFast(m_byte)) [[unlikely]]
             safepointSlow();
@@ -165,17 +165,17 @@ inline void assertIsHeld(const Lock& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock) { ASS
 class WTF_CAPABILITY_LOCK UnfairLock {
     WTF_MAKE_NONCOPYABLE(UnfairLock);
 public:
-    void lock() WTF_ACQUIRES_LOCK()
+    SUPPRESS_NODELETE void NODELETE lock() WTF_ACQUIRES_LOCK()
     {
         os_unfair_lock_lock(&m_lock);
         TSAN_ANNOTATE_HAPPENS_AFTER(this);
     }
-    void unlock() WTF_RELEASES_LOCK()
+    SUPPRESS_NODELETE void NODELETE unlock() WTF_RELEASES_LOCK()
     {
         TSAN_ANNOTATE_HAPPENS_BEFORE(this);
         os_unfair_lock_unlock(&m_lock);
     }
-    void assertIsOwner() const
+    SUPPRESS_NODELETE void NODELETE assertIsOwner() const
     {
         os_unfair_lock_assert_owner(&m_lock);
     }

--- a/Source/WTF/wtf/WordLock.h
+++ b/Source/WTF/wtf/WordLock.h
@@ -53,7 +53,7 @@ class WTF_CAPABILITY_LOCK WordLock final {
 public:
     constexpr WordLock() = default;
 
-    void lock() WTF_ACQUIRES_LOCK()
+    SUPPRESS_NODELETE void NODELETE lock() WTF_ACQUIRES_LOCK()
     {
         if (m_word.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)) [[likely]] {
             // WordLock acquired!
@@ -65,7 +65,7 @@ public:
         TSAN_ANNOTATE_HAPPENS_AFTER(this);
     }
 
-    void unlock() WTF_RELEASES_LOCK()
+    SUPPRESS_NODELETE void NODELETE unlock() WTF_RELEASES_LOCK()
     {
         TSAN_ANNOTATE_HAPPENS_BEFORE(this);
         if (m_word.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)) [[likely]] {

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -495,7 +495,6 @@ workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerNotificationClient.cpp
 workers/WorkerOrWorkletGlobalScope.cpp
-workers/WorkerOrWorkletScriptController.cpp
 workers/WorkerRunLoop.cpp
 workers/WorkerThread.cpp
 workers/shared/context/SharedWorkerThreadProxy.cpp


### PR DESCRIPTION
#### e6f6ed997eeed2c641bbf77ad6c6f0be8a788f22
<pre>
Annotate Lock functions as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=322565">https://bugs.webkit.org/show_bug.cgi?id=322565</a>

Reviewed by Sam Weinig.

Annotate Lock functions as NODELETE.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/WordLock.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/319961@main">https://commits.webkit.org/319961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22470783fbfc3a5ed80e339847e64a2ba6c0aec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57182 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50999 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147548 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4ccf5d5-995a-4071-871d-9bb8b1d53ef4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20c9c166-0e93-4373-ab23-27f659a3b01c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f4fcbe5-3c18-4faf-8488-0824409b92c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43722 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5459 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12273 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43333 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4652 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44529 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195418 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56851 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152528 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57556 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152224 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46780 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129826 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56064 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->