### PR TITLE
[JSC] Baseline: load adjacent metadata pointer fields with a single ldp

### DIFF
--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -218,6 +218,9 @@ namespace JSC {
         void loadPtrFromMetadata(const Bytecode&, size_t offset, GPRReg);
 
         template <typename Bytecode>
+        void loadPairPtrFromMetadata(const Bytecode&, size_t offset, GPRReg, GPRReg);
+
+        template <typename Bytecode>
         void load32FromMetadata(const Bytecode&, size_t offset, GPRReg);
 
         template <typename Bytecode>

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -496,6 +496,12 @@ ALWAYS_INLINE void JIT::loadPtrFromMetadata(const Bytecode& bytecode, size_t off
 }
 
 template <typename Bytecode>
+ALWAYS_INLINE void JIT::loadPairPtrFromMetadata(const Bytecode& bytecode, size_t offset, GPRReg result1, GPRReg result2)
+{
+    loadPairPtr(Address(GPRInfo::metadataTableRegister, m_profiledCodeBlock->metadataTable()->offsetInMetadataTable(bytecode) + offset), result1, result2);
+}
+
+template <typename Bytecode>
 ALWAYS_INLINE void JIT::load32FromMetadata(const Bytecode& bytecode, size_t offset, GPRReg result)
 {
     load32(Address(GPRInfo::metadataTableRegister, m_profiledCodeBlock->metadataTable()->offsetInMetadataTable(bytecode) + offset), result);

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -85,8 +85,8 @@ void JIT::emit_op_new_object(const JSInstruction* currentInstruction)
     RegisterID scratchReg = regT2;
     RegisterID structureReg = regT3;
 
-    loadPtrFromMetadata(bytecode, OpNewObject::Metadata::offsetOfObjectAllocationProfile() + ObjectAllocationProfile::offsetOfAllocator(), allocatorReg);
-    loadPtrFromMetadata(bytecode, OpNewObject::Metadata::offsetOfObjectAllocationProfile() + ObjectAllocationProfile::offsetOfStructure(), structureReg);
+    static_assert(ObjectAllocationProfile::offsetOfStructure() == ObjectAllocationProfile::offsetOfAllocator() + sizeof(void*));
+    loadPairPtrFromMetadata(bytecode, OpNewObject::Metadata::offsetOfObjectAllocationProfile() + ObjectAllocationProfile::offsetOfAllocator(), allocatorReg, structureReg);
 
     JumpList slowCases;
     auto butterfly = TrustedImmPtr(nullptr);

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -1528,6 +1528,7 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
     static_assert(!(Metadata::offsetOfStructureID() % metadataPointerAlignment));
     static_assert(!(Metadata::offsetOfOperand() % metadataPointerAlignment));
     static_assert(!(Metadata::offsetOfWatchpointSet() % metadataPointerAlignment));
+    static_assert(Metadata::offsetOfOperand() == Metadata::offsetOfWatchpointSet() + sizeof(void*));
     auto metadataAddress = computeBaseAddressForMetadata<metadataPointerAlignment>(bytecode, metadataGPR);
     auto getPutInfoAddress = metadataAddress.withOffset(Metadata::offsetOfGetPutInfo());
     auto structureIDAddress = metadataAddress.withOffset(Metadata::offsetOfStructureID());
@@ -1571,7 +1572,7 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             emitVarInjectionCheck(needsVarInjectionChecks(resolveType), regT2);
             emitVarReadOnlyCheck(resolveType, regT2);
 
-            loadPtr(operandAddress, regT2);
+            loadPairPtr(watchpointSetAddress, regT3, regT2);
 
             if (!isInitialization(bytecode.m_getPutInfo.initializationMode()) && (resolveType == GlobalLexicalVar || resolveType == GlobalLexicalVarWithVarInjectionChecks)) {
                 // We need to do a TDZ check here because we can't always prove we need to emit TDZ checks statically.
@@ -1579,7 +1580,6 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
                 addSlowCase(branchIfEmpty(jsRegT10));
             }
 
-            loadPtr(watchpointSetAddress, regT3);
             emitNotifyWriteWatchpoint(regT3);
 
             emitGetVirtualRegister(value, jsRegT10);
@@ -1594,8 +1594,7 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             static_assert(noOverlap(jsRegT10, regT2, regT3));
             emitVarInjectionCheck(needsVarInjectionChecks(resolveType), regT3);
 
-            loadPtr(watchpointSetAddress, regT3);
-            loadPtr(operandAddress, regT2);
+            loadPairPtr(watchpointSetAddress, regT3, regT2);
             emitNotifyWriteWatchpoint(regT3);
             emitGetVirtualRegister(value, jsRegT10);
             emitGetVirtualRegister(scope, regT3);


### PR DESCRIPTION
#### 0a67a6646c829465c43ee79154632b039437957d
<pre>
[JSC] Baseline: load adjacent metadata pointer fields with a single ldp
<a href="https://bugs.webkit.org/show_bug.cgi?id=322566">https://bugs.webkit.org/show_bug.cgi?id=322566</a>

Reviewed by Keith Miller.

op_new_object and op_put_to_scope each read two adjacent pointer-sized
fields out of the metadata table with two separate loadPtr calls, which on
arm64 is two ldrs against the same base at offsets eight apart:

    ldr x1, [x25, #0x1a8]     ; ObjectAllocationProfile::m_allocator
    ldr x3, [x25, #0x1b0]     ; ObjectAllocationProfile::m_structure

becomes

    ldp x1, x3, [x25, #0x1a8]

Both pairs are laid out adjacently by construction, so this is just a
missed use of loadPairPtr(), which every 64-bit backend implements and
which degrades to the two loads it replaces when the offset is outside
ldp&apos;s imm7 range (-512..504) or on a backend without a paired load.

* op_new_object loads ObjectAllocationProfile&apos;s m_allocator and m_structure.
  A new loadPairPtrFromMetadata() spells the paired form the way
  loadPtrFromMetadata() spells the single one.

* op_put_to_scope loads OpPutToScope::Metadata&apos;s m_watchpointSet and
  m_operand. The ClosureVar case already loads them back to back. The
  GlobalVar case loaded m_operand, ran the TDZ check, then loaded
  m_watchpointSet; hoisting the watchpoint-set load above the TDZ check
  pairs them too. Nothing between the two points clobbers either register,
  and both were already live across emitNotifyWriteWatchpoint().

Both sites get a static_assert on the adjacency the paired load depends on,
so a layout change is a build error rather than a silent pessimization.

Scanning everything the JITs emit while running JetStream 3 (54.7M
instructions) reports 6601 adjacent-load pairs that ldp could fold. 2953 of
them are these two opcodes -- 1502 op_new_object and 1451 op_put_to_scope --
and all 2953 are within ldp&apos;s immediate range. The remaining 3648 are DFG
and FTL tail calls, where CallFrameShuffler restores the caller&apos;s callee-save
registers from adjacent old-frame slots one ldr at a time; that needs a
change to the shuffler&apos;s load loop and is not addressed here.

Re-dumping ARES-6 with this change: every ldp-encodable metadata pair is
gone, and 53 ldps appear where 28 pairs were folded -- the extra 25 are
GlobalLexicalVar sites whose two loads were previously separated by the TDZ
check, so armlint&apos;s adjacency matcher never counted them.

Found with armlint.

* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::loadPairPtrFromMetadata):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_new_object):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_put_to_scope):

Co-Authored-By: Claude Opus 5 (1M context) &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/319911@main">https://commits.webkit.org/319911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88f3c93266d7e9c81f7dd5f988d78f6f56228f1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142831 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43493 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5228 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12063 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155640 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAError (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43123 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44269 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56591 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152301 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40848 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57296 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39739 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151997 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129565 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125674 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55804 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18134 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55175 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->