### PR TITLE
REGRESSION(319727@main): Broke the build with clang 20 due to a self-referential ScopedLambda constraint

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCustom.h
+++ b/Source/JavaScriptCore/b3/air/AirCustom.h
@@ -59,7 +59,7 @@ namespace JSC { namespace B3 { namespace Air {
 // Definition of Patch instruction. Patch is used to delegate the behavior of the instruction to the
 // Special object, which will be the first argument to the instruction.
 struct PatchCustom {
-    static void forEachArg(Inst& inst, ScopedLambda<Inst::EachArgCallback> lambda)
+    static void forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallback>& lambda)
     {
         // This is basically bogus, but it works for analyses that model Special as an
         // immediate.

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
@@ -53,7 +53,7 @@ bool MarkingConstraintSolver::didVisitSomething() const
     return false;
 }
 
-void MarkingConstraintSolver::execute(SchedulerPreference preference, ScopedLambda<std::optional<unsigned>()> pickNext)
+void MarkingConstraintSolver::execute(SchedulerPreference preference, const ScopedLambda<std::optional<unsigned>()>& pickNext)
 {
     m_pickNextIsStillActive = true;
     RELEASE_ASSERT(!m_numThreadsThatMayProduceWork);
@@ -152,7 +152,7 @@ void MarkingConstraintSolver::addParallelTask(RefPtr<SharedTask<void(SlotVisitor
     m_toExecuteInParallel.append(TaskWithConstraint(WTF::move(task), &constraint));
 }
 
-void MarkingConstraintSolver::runExecutionThread(SlotVisitor& visitor, SchedulerPreference preference, ScopedLambda<std::optional<unsigned>()> pickNext)
+void MarkingConstraintSolver::runExecutionThread(SlotVisitor& visitor, SchedulerPreference preference, const ScopedLambda<std::optional<unsigned>()>& pickNext)
 {
     for (;;) {
         bool doParallelWorkMode;

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
@@ -56,7 +56,7 @@ public:
         NextConstraintFirst
     };
 
-    void execute(SchedulerPreference, ScopedLambda<std::optional<unsigned>()> pickNext);
+    void execute(SchedulerPreference, const ScopedLambda<std::optional<unsigned>()>& pickNext);
     
     void drain(BitVector& unexecuted);
     
@@ -68,7 +68,7 @@ public:
     void addParallelTask(RefPtr<SharedTask<void(SlotVisitor&)>>, MarkingConstraint&);
     
 private:
-    void runExecutionThread(SlotVisitor&, SchedulerPreference, ScopedLambda<std::optional<unsigned>()> pickNext);
+    void runExecutionThread(SlotVisitor&, SchedulerPreference, const ScopedLambda<std::optional<unsigned>()>& pickNext);
     
     struct TaskWithConstraint {
         TaskWithConstraint() { }

--- a/Source/WTF/wtf/ScopedLambda.h
+++ b/Source/WTF/wtf/ScopedLambda.h
@@ -66,6 +66,7 @@ public:
 
     template<typename Functor>
     requires (!std::same_as<std::remove_cvref_t<Functor>, std::nullptr_t>
+        && !std::same_as<std::remove_cvref_t<Functor>, ScopedLambda>
         && Invocable<Functor, ResultType(ArgumentTypes...)>)
     ScopedLambda(Functor&& functor LIFETIME_BOUND)
         : m_impl([] (void* argument, ArgumentTypes... arguments) -> ResultType {


### PR DESCRIPTION
#### 44d3c5c94dc71fda8748e63c60a5270f2d5e80df
<pre>
REGRESSION(319727@main): Broke the build with clang 20 due to a self-referential ScopedLambda constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=322567">https://bugs.webkit.org/show_bug.cgi?id=322567</a>

Reviewed by Carlos Garcia Campos.

319727@main gave ScopedLambda a converting constructor from any invocable,
constrained on Invocable&lt;Functor, Signature&gt; but not against ScopedLambda
itself. That makes Invocable&lt;ScopedLambda&lt;Sig&gt;, Sig&gt; circular: it asks whether
a std::function&lt;Sig&gt; is assignable from the functor, libstdc++ answers through
is_nothrow_constructible&lt;ScopedLambda, ScopedLambda&gt;, and resolving that checks
this constructor&apos;s own constraint again. clang 18 through 20 reject the cycle,
both where a ScopedLambda is copied (Air) and where the concept is applied to
one directly (Options::initialize). clang 21 and GCC accept it, so EWS did not
catch it.

Constrain the constructor against ScopedLambda, as std::optional and
CompactVariant do; the conjunction short-circuits, so Invocable is never
evaluated for ScopedLambda.

Two callees still took a ScopedLambda by value, which selected the converting
constructor rather than a copy. With it excluded, and the copy constructor
deleted by 319843@main, they have no viable constructor left. Take them by
const reference, like every other ScopedLambda parameter in the tree.

* Source/JavaScriptCore/b3/air/AirCustom.h:
(JSC::B3::Air::PatchCustom::forEachArg):
* Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp:
(JSC::MarkingConstraintSolver::execute):
(JSC::MarkingConstraintSolver::runExecutionThread):
* Source/JavaScriptCore/heap/MarkingConstraintSolver.h:
* Source/WTF/wtf/ScopedLambda.h:
(WTF::ScopedLambda&lt;ResultType):

Canonical link: <a href="https://commits.webkit.org/319872@main">https://commits.webkit.org/319872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a49815386899c28bdbb15a5964249ba1b857d3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43497 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5247 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12075 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43135 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4390 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44270 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195158 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56592 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152304 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57297 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152000 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46563 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129566 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55805 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18146 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55176 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->