### PR TITLE
ipc/serialized-type-info.html reports the wrong types off Cocoa

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -9,6 +9,9 @@
         const firstTwoTypesOnly = container == "HashMap";
 
         const set = new Set();
+        // A Variant whose alternatives are all compiled out has no types to contribute.
+        if (!list.length)
+            return set;
         let nestedTypeDepth = 0;
         let atComma = false;
         let previousTypeEnd = 0;
@@ -166,23 +169,25 @@
         // Note: This set should only be shrinking. If you need to add to this set to fix the test,
         // add IPC metadata in a *.serialization.in file instead.
         let result = [
-            "CTFontDescriptorOptions",
-            "MachSendRight",
             "GenericPromise::Result", // Added to hide the implementation details that simulate an Expected<void, void>
         ];
         if (window.testRunner) {
-            if (testRunner.isMac) {
+            if (!testRunner.isIOSFamily) {
                 result.push("WebCore::ContextMenuAction");
-                if (!testRunner.haveSecureCodingDataDetectors) {
-                    result.push("WKDDActionContext");
+            }
+            if (testRunner.isMac || testRunner.isIOSFamily) {
+                result.push("CTFontDescriptorOptions");
+                result.push("MachSendRight");
+                if (!testRunner.haveSecureCodingRequest) {
+                    result.push("NSObject<NSSecureCoding>");
+                    result.push("NSURLRequest");
                 }
-            }
-            if (!testRunner.haveSecureCodingRequest) {
-                result.push("NSObject<NSSecureCoding>");
-                result.push("NSURLRequest");
-            }
-            if (!testRunner.haveSecureCodingDataDetectors) {
-                result.push("DDScannerResult");
+                if (!testRunner.haveSecureCodingDataDetectors) {
+                    result.push("DDScannerResult");
+                    if (testRunner.isMac) {
+                        result.push("WKDDActionContext");
+                    }
+                }
             }
         }
         return result.sort();


### PR DESCRIPTION
#### a6dae4543addea4b067213bcc54e60e62bdf665d
<pre>
ipc/serialized-type-info.html reports the wrong types off Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=322570">https://bugs.webkit.org/show_bug.cgi?id=322570</a>

Reviewed by Alex Christensen.

expectedTypesNeedingDescriptions() was written when Cocoa was the only port
running this test, so five of its entries get pushed where the types do not
exist: CTFontDescriptorOptions and MachSendRight were unconditional, and
NSObject&lt;NSSecureCoding&gt;, NSURLRequest and DDScannerResult are gated on
HAVE(WK_SECURE_CODING_*), which is false off Cocoa. Gate all five on
isMac || isIOSFamily, which covers the whole family including visionOS.

WebCore::ContextMenuAction is the other way round. It was gated on isMac, but it
is an unscoped enum reached from the cross-platform
Shared/WebContextMenuItemData.serialization.in, which is guarded by
ENABLE(CONTEXT_MENUS): on by default and off only on PLATFORM(IOS_FAMILY). Key it
on !isIOSFamily so it is expected wherever the type is serialized.

Finally, WebCore::SystemImage has three subclasses and all of them are Cocoa-only,
so off Cocoa its subclasses member is generated as Variant&lt;&gt;. splitTypeFromList()
returned the empty string for that, which the test reported as a type without a
description. Return no types for an empty template argument list.

The expected set is unchanged on macOS, iOS and visionOS for every combination of
the two secure-coding predicates.

* LayoutTests/ipc/serialized-type-info.html:

Canonical link: <a href="https://commits.webkit.org/319886@main">https://commits.webkit.org/319886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8949fe3e1360055c6dfb34b800f252ca24f596db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147295 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142836 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123263 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45252 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43500 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43129 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4397 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195165 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152002 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46568 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125686 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55812 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->