### PR TITLE
[GTK][WPE] Skia compositor: use promise images for video DMA-BUF buffers

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3883,7 +3883,7 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor(IsDuplicateSample isDu
     options.info = m_videoInfo;
     auto frame = VideoFrameGStreamer::createWrappedSample(m_sample, options);
 
-    auto buffer = CoordinatedPlatformLayerBufferVideo::create(WTF::move(frame), m_videoDecoderPlatform, !m_isUsingFallbackVideoSink, m_textureMapperFlags);
+    auto buffer = CoordinatedPlatformLayerBufferVideo::create(WTF::move(frame), m_videoDecoderPlatform, !m_isUsingFallbackVideoSink, m_textureMapperFlags, proxy->threadSafeGrContext());
     if (isInitialBuffer == IsInitialBuffer::Yes)
         proxy->setInitialDisplayBuffer(WTF::move(buffer));
     else

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -43,6 +43,8 @@
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
+#include <skia/core/SkYUVAInfo.h>
+#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/private/chromium/GrPromiseImageTexture.h>
@@ -202,6 +204,8 @@ static CoordinatedPlatformLayerBufferYUV::Format yuvFormatFromDRMFourcc(uint32_t
         return CoordinatedPlatformLayerBufferYUV::Format::AYUV;
     case DRM_FORMAT_NV12:
         return CoordinatedPlatformLayerBufferYUV::Format::NV12;
+    case DRM_FORMAT_NV21:
+        return CoordinatedPlatformLayerBufferYUV::Format::NV21;
     case DRM_FORMAT_P010:
         return CoordinatedPlatformLayerBufferYUV::Format::P010;
     case DRM_FORMAT_YUV420:
@@ -218,17 +222,17 @@ static CoordinatedPlatformLayerBufferYUV::Format yuvFormatFromDRMFourcc(uint32_t
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importYUV() const
+static std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV(const Ref<DMABufBuffer>& dmabuf, OptionSet<TextureMapperFlags> flags)
 {
     OptionSet<BitmapTexture::Flags> textureFlags;
-    if (m_flags.contains(TextureMapperFlags::ShouldBlend))
+    if (flags.contains(TextureMapperFlags::ShouldBlend))
         textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
 
     Vector<RefPtr<BitmapTexture>, 4> textures;
     std::array<unsigned, 4> yuvPlane;
     std::array<unsigned, 4> yuvPlaneOffset;
 
-    const auto& attributes = m_dmabuf->attributes();
+    const auto& attributes = dmabuf->attributes();
     const auto& iter = yuvFormatPlaneInfo().find(attributes.fourcc.value);
     if (iter == yuvFormatPlaneInfo().end())
         return nullptr;
@@ -253,7 +257,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     auto format = yuvFormatFromDRMFourcc(attributes.fourcc.value);
 
     CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace yuvToRgbColorSpace;
-    switch (m_dmabuf->colorSpace().value_or(DMABufBuffer::ColorSpace::Bt601)) {
+    switch (dmabuf->colorSpace().value_or(DMABufBuffer::ColorSpace::Bt601)) {
     case DMABufBuffer::ColorSpace::Bt601:
         yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt601;
         break;
@@ -269,7 +273,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     }
 
     CoordinatedPlatformLayerBufferYUV::TransferFunction transferFunction;
-    switch (m_dmabuf->transferFunction().value_or(DMABufBuffer::TransferFunction::Bt709)) {
+    switch (dmabuf->transferFunction().value_or(DMABufBuffer::TransferFunction::Bt709)) {
     case DMABufBuffer::TransferFunction::Bt709:
         transferFunction = CoordinatedPlatformLayerBufferYUV::TransferFunction::Bt709;
         break;
@@ -279,14 +283,15 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     }
 
     unsigned numberOfPlanes = textures.size();
-    return CoordinatedPlatformLayerBufferYUV::create(format, numberOfPlanes, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
+    return CoordinatedPlatformLayerBufferYUV::create(format, numberOfPlanes, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset),
+        yuvToRgbColorSpace, transferFunction, attributes.size, flags, nullptr);
 }
 
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importDMABuf() const
 {
     const auto& attributes = m_dmabuf->attributes();
     if (formatIsYUV(attributes.fourcc.value))
-        return importYUV();
+        return importYUV(m_dmabuf, m_flags);
 
     OptionSet<BitmapTexture::Flags> textureFlags;
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
@@ -312,79 +317,250 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
 }
 
 #if USE(SKIA)
-struct PromiseDMABufImageContext {
-    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseDMABufImageContext);
+class PromiseDMABufImageContext final : public RefCounted<PromiseDMABufImageContext> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseDMABufImageContext);
+public:
+    static Ref<PromiseDMABufImageContext> create(Ref<DMABufBuffer>&& buffer, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
+    {
+        return adoptRef(*new PromiseDMABufImageContext(WTF::move(buffer), flags, WTF::move(glFence), WTF::move(fd)));
+    }
 
-    PromiseDMABufImageContext(Ref<DMABufBuffer>&& buffer, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
-        : dmabuf(WTF::move(buffer))
-        , fence(WTF::move(glFence))
-        , fenceFD(WTF::move(fd))
+    ~PromiseDMABufImageContext() = default;
+
+    sk_sp<GrPromiseImageTexture> promiseImageTexture()
+    {
+        if (!makeContextCurrentAndWaitForContentsIfNeeded())
+            return nullptr;
+
+        const auto& attributes = m_dmabuf->attributes();
+        if (!m_dmabuf->buffer()) {
+            std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
+            OptionSet<BitmapTexture::Flags> textureFlags;
+            if (m_flags.contains(TextureMapperFlags::ShouldBlend))
+                textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
+            if (auto texture = importToTexture(attributes.size, attributes, textureFlags))
+                buffer = CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), { }, nullptr);
+            m_dmabuf->setBuffer(WTF::move(buffer));
+        }
+
+        auto* buffer = m_dmabuf->buffer();
+        if (!is<CoordinatedPlatformLayerBufferRGB>(buffer))
+            return nullptr;
+
+        return createPromiseImageTexture(downcast<CoordinatedPlatformLayerBufferRGB>(*buffer).textureID(), GL_RGBA8, attributes.size);
+    }
+
+    sk_sp<GrPromiseImageTexture> promiseImageTextureForPlane(size_t planeIndex, unsigned planeFormat, const IntSize& planeSize)
+    {
+        if (!makeContextCurrentAndWaitForContentsIfNeeded())
+            return nullptr;
+
+        if (!m_dmabuf->buffer())
+            m_dmabuf->setBuffer(importYUV(m_dmabuf, m_flags));
+
+        auto* buffer = m_dmabuf->buffer();
+        if (!is<CoordinatedPlatformLayerBufferYUV>(buffer))
+            return nullptr;
+
+        auto texture = downcast<CoordinatedPlatformLayerBufferYUV>(*buffer).texture(planeIndex);
+        if (!texture)
+            return nullptr;
+
+        return createPromiseImageTexture(texture->id(), planeFormat, planeSize);
+    }
+
+private:
+    PromiseDMABufImageContext(Ref<DMABufBuffer>&& buffer, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
+        : m_dmabuf(WTF::move(buffer))
+        , m_flags(flags)
+        , m_fence(WTF::move(glFence))
+        , m_fenceFD(WTF::move(fd))
     {
     }
 
-    sk_sp<GrPromiseImageTexture> promiseImageTexture()
+    bool makeContextCurrentAndWaitForContentsIfNeeded()
     {
         auto& display = PlatformDisplay::sharedDisplay();
         auto* glContext = display.skiaGLContext();
         if (!glContext || !glContext->makeContextCurrent())
-            return nullptr;
+            return false;
 
-        if (auto glFence = WTF::move(fence))
+        if (auto glFence = WTF::move(m_fence))
             glFence->serverWait();
-        else if (fenceFD) {
-            if (auto glFence = GLFence::importFD(display.glDisplay(), WTF::move(fenceFD)))
+        else if (m_fenceFD) {
+            if (auto glFence = GLFence::importFD(display.glDisplay(), WTF::move(m_fenceFD)))
                 glFence->serverWait();
         }
 
-        const auto& attributes = dmabuf->attributes();
-        if (!dmabuf->buffer()) {
-            std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
-            if (auto texture = importToTexture(attributes.size, attributes, { }))
-                buffer = CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), { }, nullptr);
-            dmabuf->setBuffer(WTF::move(buffer));
-        }
-
-        auto* buffer = dmabuf->buffer();
-        if (is<CoordinatedPlatformLayerBufferRGB>(buffer)) {
-            GrGLTextureInfo externalTexture;
-            externalTexture.fTarget = GL_TEXTURE_2D;
-            externalTexture.fID = downcast<CoordinatedPlatformLayerBufferRGB>(*buffer).textureID();
-            externalTexture.fFormat = GL_RGBA8;
-            auto backendTexture = GrBackendTextures::MakeGL(attributes.size.width(), attributes.size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            return GrPromiseImageTexture::Make(backendTexture);
-        }
-
-        return nullptr;
+        return true;
     }
 
-    const Ref<DMABufBuffer> dmabuf;
-    std::unique_ptr<GLFence> fence;
-    WTF::UnixFileDescriptor fenceFD;
+    sk_sp<GrPromiseImageTexture> createPromiseImageTexture(unsigned id, unsigned format, const IntSize& size)
+    {
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = id;
+        externalTexture.fFormat = format;
+        auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
+        return GrPromiseImageTexture::Make(backendTexture);
+    }
+
+    const Ref<DMABufBuffer> m_dmabuf;
+    OptionSet<TextureMapperFlags> m_flags;
+    std::unique_ptr<GLFence> m_fence;
+    WTF::UnixFileDescriptor m_fenceFD;
 };
 
-WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseDMABufImageContext);
+struct PromiseDMABufYUVPlaneContext {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseDMABufYUVPlaneContext);
+
+    PromiseDMABufYUVPlaneContext(Ref<PromiseDMABufImageContext>&& dmabufContext, size_t planeIndex, unsigned glFormat, int width, int height)
+        : context(WTF::move(dmabufContext))
+        , index(planeIndex)
+        , format(glFormat)
+        , size(width, height)
+    {
+    }
+
+    Ref<PromiseDMABufImageContext> context;
+    size_t index { 0 };
+    unsigned format { 0 };
+    IntSize size;
+};
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseDMABufYUVPlaneContext);
 
 void CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
-    const auto& attributes = m_dmabuf->attributes();
-    RELEASE_ASSERT(!formatIsYUV(attributes.fourcc.value));
+    if (!threadSafeGrContext)
+        return;
 
     auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
     ASSERT(backendFormat.isValid());
 
-    auto context = makeUnique<PromiseDMABufImageContext>(m_dmabuf.copyRef(), WTF::move(m_fence), WTF::move(m_fenceFD));
+    Ref context = PromiseDMABufImageContext::create(m_dmabuf.copyRef(), m_flags, WTF::move(m_fence), WTF::move(m_fenceFD));
 
-    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
-    m_image = SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, SkISize::Make(attributes.size.width(), attributes.size.height()), skgpu::Mipmapped::kNo,
-        origin, kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB(),
-        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
-            auto& context = *static_cast<PromiseDMABufImageContext*>(userData);
-            return context.promiseImageTexture();
-        },
-        +[](void* userData) {
-            std::unique_ptr<PromiseDMABufImageContext> context(static_cast<PromiseDMABufImageContext*>(userData));
-        }, context.release());
+    const auto& attributes = m_dmabuf->attributes();
+    if (formatIsYUV(attributes.fourcc.value)) {
+        auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
+        auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
+        std::array<GrBackendFormat, 4> backendFormats;
+        std::array<PromiseDMABufYUVPlaneContext*, 4> planeContexts;
+
+        auto setPlaneFormatAndContext = [&](size_t index, unsigned glFormat, int width, int height) {
+            backendFormats[index] = GrBackendFormats::MakeGL(glFormat, GL_TEXTURE_2D);
+            planeContexts[index] = makeUnique<PromiseDMABufYUVPlaneContext>(context.copyRef(), index, glFormat, width, height).release();
+        };
+
+        auto format = yuvFormatFromDRMFourcc(attributes.fourcc.value);
+        switch (format) {
+        case CoordinatedPlatformLayerBufferYUV::Format::AYUV:
+            planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
+            subsampling = SkYUVAInfo::Subsampling::k444;
+            setPlaneFormatAndContext(0, GL_RGBA8, attributes.size.width(), attributes.size.height());
+            break;
+        case CoordinatedPlatformLayerBufferYUV::Format::NV12:
+        case CoordinatedPlatformLayerBufferYUV::Format::NV21:
+        case CoordinatedPlatformLayerBufferYUV::Format::P010: {
+            planeConfig = format == CoordinatedPlatformLayerBufferYUV::Format::NV21 ? SkYUVAInfo::PlaneConfig::kY_VU : SkYUVAInfo::PlaneConfig::kY_UV;
+            subsampling = SkYUVAInfo::Subsampling::k420;
+            setPlaneFormatAndContext(0, format == CoordinatedPlatformLayerBufferYUV::Format::P010 ? GL_R16 : GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(1, format == CoordinatedPlatformLayerBufferYUV::Format::P010 ? GL_RG16 : GL_RG8, attributes.size.width() / 2, attributes.size.height() / 2);
+            break;
+        }
+        case CoordinatedPlatformLayerBufferYUV::Format::YUV420:
+        case CoordinatedPlatformLayerBufferYUV::Format::YVU420:
+            planeConfig = format == CoordinatedPlatformLayerBufferYUV::Format::YVU420 ? SkYUVAInfo::PlaneConfig::kY_V_U : SkYUVAInfo::PlaneConfig::kY_U_V;
+            subsampling = SkYUVAInfo::Subsampling::k420;
+            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 2, attributes.size.height() / 2);
+            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 2, attributes.size.height() / 2);
+            break;
+        case CoordinatedPlatformLayerBufferYUV::Format::YUV444:
+            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+            subsampling = SkYUVAInfo::Subsampling::k444;
+            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(1, GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(2, GL_R8, attributes.size.width(), attributes.size.height());
+            break;
+        case CoordinatedPlatformLayerBufferYUV::Format::YUV411:
+            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+            subsampling = SkYUVAInfo::Subsampling::k411;
+            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 4, attributes.size.height());
+            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 4, attributes.size.height());
+            break;
+        case CoordinatedPlatformLayerBufferYUV::Format::YUV422:
+            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+            subsampling = SkYUVAInfo::Subsampling::k422;
+            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
+            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 2, attributes.size.height());
+            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 2, attributes.size.height());
+            break;
+        case CoordinatedPlatformLayerBufferYUV::Format::A420:
+            // Not supported in DMA-BUF.
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown) {
+            LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: unknown plane configuration");
+            return;
+        }
+
+        SkYUVColorSpace yuvaColorSpace = [&] {
+            switch (m_dmabuf->colorSpace().value_or(DMABufBuffer::ColorSpace::Bt601)) {
+            case DMABufBuffer::ColorSpace::Bt601:
+                return kRec601_Limited_SkYUVColorSpace;
+            case DMABufBuffer::ColorSpace::Bt709:
+                return kRec709_Full_SkYUVColorSpace;
+            case DMABufBuffer::ColorSpace::Bt2020:
+                return kBT2020_8bit_Full_SkYUVColorSpace;
+            case DMABufBuffer::ColorSpace::Smpte240M:
+                return kSMPTE240_Full_SkYUVColorSpace;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+        }();
+
+        SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
+        auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+        GrYUVABackendTextureInfo yuvaBackendTexturesInfo(info, backendFormats.data(), skgpu::Mipmapped::kNo, origin);
+        if (!yuvaBackendTexturesInfo.isValid()) {
+            LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: invalid backend texture information");
+            return;
+        }
+
+        sk_sp<SkColorSpace> colorSpace = [&] {
+            switch (m_dmabuf->transferFunction().value_or(DMABufBuffer::TransferFunction::Bt709)) {
+            case DMABufBuffer::TransferFunction::Bt709:
+                return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
+            case DMABufBuffer::TransferFunction::Pq:
+                return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+        }();
+
+        m_image = SkImages::PromiseTextureFromYUVA(threadSafeGrContext, yuvaBackendTexturesInfo, colorSpace,
+            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+                auto& planeContext = *static_cast<PromiseDMABufYUVPlaneContext*>(userData);
+                return planeContext.context->promiseImageTextureForPlane(planeContext.index, planeContext.format, planeContext.size);
+            },
+            +[](void* userData) {
+                std::unique_ptr<PromiseDMABufYUVPlaneContext> planeContext(static_cast<PromiseDMABufYUVPlaneContext*>(userData));
+            }, reinterpret_cast<void**>(planeContexts.data()));
+    } else {
+        auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+        auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
+        m_image = SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, SkISize::Make(attributes.size.width(), attributes.size.height()), skgpu::Mipmapped::kNo,
+            origin, kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB(),
+            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+                auto& context = *static_cast<PromiseDMABufImageContext*>(userData);
+                return context.promiseImageTexture();
+            },
+            +[](void* userData) {
+                Ref context = adoptRef(*static_cast<PromiseDMABufImageContext*>(userData));
+            }, &context.leakRef());
+    }
 }
 
 sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -63,7 +63,6 @@ private:
 #endif
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf() const;
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV() const;
 
     const Ref<DMABufBuffer> m_dmabuf;
     WTF::UnixFileDescriptor m_fenceFD;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
@@ -128,6 +128,14 @@ void CoordinatedPlatformLayerBufferProxy::dropCurrentBufferWhilePreservingTextur
 }
 #endif
 
+#if USE(SKIA)
+sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayerBufferProxy::threadSafeGrContext() const
+{
+    RefPtr layer = m_layer;
+    return layer ? layer->threadSafeGrContext() : nullptr;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
@@ -31,6 +31,12 @@
 #include <wtf/RunLoop.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 class CoordinatedPlatformLayer;
 class CoordinatedPlatformLayerBuffer;
@@ -52,6 +58,10 @@ public:
 #if ENABLE(VIDEO) && USE(GSTREAMER)
     enum class ShouldWait : bool { No, Yes };
     void dropCurrentBufferWhilePreservingTexture(ShouldWait);
+#endif
+
+#if USE(SKIA)
+    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const;
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -51,17 +51,17 @@
 
 namespace WebCore {
 
-std::unique_ptr<CoordinatedPlatformLayerBufferVideo> CoordinatedPlatformLayerBufferVideo::create(Ref<VideoFrameGStreamer>&& frame, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
+std::unique_ptr<CoordinatedPlatformLayerBufferVideo> CoordinatedPlatformLayerBufferVideo::create(Ref<VideoFrameGStreamer>&& frame, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     auto size = frame->presentationSize();
-    return makeUnique<CoordinatedPlatformLayerBufferVideo>(WTF::move(frame), WTF::move(size), videoDecoderPlatform, gstGLEnabled, flags);
+    return makeUnique<CoordinatedPlatformLayerBufferVideo>(WTF::move(frame), WTF::move(size), videoDecoderPlatform, gstGLEnabled, flags, threadSafeGrContext);
 }
 
-CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&& frame, IntSize&& size, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
+CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&& frame, IntSize&& size, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
     : CoordinatedPlatformLayerBuffer(Type::Video, WTF::move(size), flags, nullptr)
     , m_videoFrame(WTF::move(frame))
     , m_videoDecoderPlatform(videoDecoderPlatform)
-    , m_buffer(createBufferIfNeeded(gstGLEnabled))
+    , m_buffer(createBufferIfNeeded(gstGLEnabled, threadSafeGrContext))
 {
 }
 
@@ -103,7 +103,7 @@ static std::pair<CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace, Coordina
 }
 #endif
 
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled)
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     const auto& sample = m_videoFrame->sample();
     auto buffer = gst_sample_get_buffer(sample.get());
@@ -129,7 +129,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
 #if GST_CHECK_VERSION(1, 24, 0)
     if (gst_is_dmabuf_memory(memory))
-        return createBufferFromDMABufMemory();
+        return createBufferFromDMABufMemory(threadSafeGrContext);
 #endif // GST_CHECK_VERSION(1, 24, 0)
 #endif // USE(GBM)
 
@@ -157,7 +157,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 }
 
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory()
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     auto videoInfo = m_videoFrame->info();
     if (GST_VIDEO_INFO_HAS_ALPHA(&videoInfo))
@@ -165,7 +165,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
     auto dmabuf = m_videoFrame->getDMABuf();
     RELEASE_ASSERT(dmabuf);
-    return CoordinatedPlatformLayerBufferDMABuf::create(dmabuf.releaseNonNull(), m_flags, nullptr);
+    return CoordinatedPlatformLayerBufferDMABuf::create(dmabuf.releaseNonNull(), m_flags, nullptr, threadSafeGrContext);
 }
 #endif // USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -30,28 +30,29 @@
 #include "GStreamerCommon.h"
 #include "VideoFrameGStreamer.h"
 
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
 namespace WebCore {
 
 using DMABufFormat = std::pair<uint32_t, uint64_t>;
 
 class CoordinatedPlatformLayerBufferVideo final : public CoordinatedPlatformLayerBuffer {
 public:
-    static std::unique_ptr<CoordinatedPlatformLayerBufferVideo> create(Ref<VideoFrameGStreamer>&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
-    CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&&, IntSize&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
+    static std::unique_ptr<CoordinatedPlatformLayerBufferVideo> create(Ref<VideoFrameGStreamer>&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>, const sk_sp<GrContextThreadSafeProxy>&);
+    CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&&, IntSize&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>, const sk_sp<GrContextThreadSafeProxy>&);
     virtual ~CoordinatedPlatformLayerBufferVideo();
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> copyBuffer() const;
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
-
-#if USE(SKIA)
     sk_sp<SkImage> skiaImage() override;
-#endif
 
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled);
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled, const sk_sp<GrContextThreadSafeProxy>&);
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromDMABufMemory();
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromDMABufMemory(const sk_sp<GrContextThreadSafeProxy>&);
 #endif
 #if USE(GSTREAMER_GL)
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromGLMemory();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
@@ -43,6 +43,8 @@ public:
     CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferYUV();
 
+    const RefPtr<BitmapTexture>& texture(size_t index) const { RELEASE_ASSERT(index < m_planeCount); return m_textures[index]; }
+
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 


### PR DESCRIPTION
#### 1d650ab2580f217ea18e116bb3e62f3f3b6fc2e5
<pre>
[GTK][WPE] Skia compositor: use promise images for video DMA-BUF buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322574">https://bugs.webkit.org/show_bug.cgi?id=322574</a>

Reviewed by Nikolas Zimmermann.

For now only use promise images for video buffers using DMA-BUF, because
we can keep the DMABufBuffer alive until the promise image is released.
For other buffers we will probably have to make CoordinatedPlatformLayerBuffer
ref counted.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushTextureToCompositor):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::yuvFormatFromDRMFourcc):
(WebCore::importYUV):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importDMABuf const):
(WebCore::PromiseDMABufYUVPlaneContext::PromiseDMABufYUVPlaneContext):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importYUV const): Deleted.
(WebCore::PromiseDMABufImageContext::PromiseDMABufImageContext): Deleted.
(WebCore::PromiseDMABufImageContext::promiseImageTexture): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp:
(WebCore::CoordinatedPlatformLayerBufferProxy::threadSafeGrContext const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::create):
(WebCore::CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h:

Canonical link: <a href="https://commits.webkit.org/319943@main">https://commits.webkit.org/319943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c8cc1b729adec765996d910d5dd770637fa98e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193488 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143042 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46790 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45483 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43339 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4663 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57567 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152232 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46789 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56075 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->