### PR TITLE
[webkit-sysprof] Add a frame cycle breakdown to analyze

### DIFF
--- a/Tools/Scripts/webkit-sysprof/README.md
+++ b/Tools/Scripts/webkit-sysprof/README.md
@@ -25,11 +25,13 @@ webkit-sysprof dump [--marks|--counters] [-f csv|json] CAPTURE_FILE
 ```
 
 `--marks` is the default when neither flag is given. `-f`/`--format`: `csv` (default) or
-`json` — `json` prints the same rows as `csv`, just as a JSON array of objects.
+`json`. `json` prints the same rows as `csv`, just as a JSON array of objects. `group`
+names the kind of process a mark came from, e.g. `WebKit (Web)`, and `pid` the process
+itself, which two of one kind share a group name for.
 
 ```
 $ webkit-sysprof dump capture.syscap
-group;name;message;time;duration;end_time
+group;pid;name;message;time;duration;end_time
 ...
 
 $ webkit-sysprof dump --counters capture.syscap
@@ -37,7 +39,7 @@ category;name;description;time;offset;value
 ...
 
 $ webkit-sysprof dump -f json capture.syscap
-[{"group": "...", "name": "...", "message": "...", "time": ..., "duration": ..., "end_time": ...}, ...]
+[{"group": "...", "pid": ..., "name": "...", "message": "...", "time": ..., "duration": ..., "end_time": ...}, ...]
 ```
 
 ### `summary`
@@ -68,17 +70,21 @@ Counters: 53
 ### `analyze`
 
 Compute rendering statistics (vblank intervals, theoretical FPS, frame compositions per
-vblank) and duration/count statistics for a fixed set of WebKit-specific marks (styling,
-layout, rendering, compositing and tiles).
+vblank), a frame cycle breakdown, and duration/count statistics for a fixed set of
+marks (styling, layout, rendering, compositing and tiles).
 
 ```
-webkit-sysprof analyze CAPTURE_FILE [-f text|json] [-t TIMESPAN]
+webkit-sysprof analyze CAPTURE_FILE [-f text|json] [-t TIMESPAN] [-e]
 ```
 
 - `-f`/`--format`: `text` (default) or `json`.
 - `-t`/`--timespan`: restrict the analysis to a window in milliseconds relative to the
-  capture start, e.g. `0-5000`. Either side may be omitted (`500-` means "from 500ms to
-  the end", `-500` means "from the start to 500ms"). Defaults to the whole capture (`-`).
+  capture start, e.g. `0-5000`. Either side may be omitted (`500-` or `500` mean "from
+  500ms to the end", `-500` means "from the start to 500ms"). Defaults to the whole
+  capture (`-`), and is clamped to it.
+- `-e`/`--explain`: interleave the text report with paragraphs explaining how to read
+  it, in particular what theoretical FPS and the frame cycle phases do and do not
+  measure.
 
 ```
 $ webkit-sysprof analyze capture.syscap
@@ -90,26 +96,49 @@ Rendering:
 ...
 
 $ webkit-sysprof analyze -f json -t 0-2000 capture.syscap
-{"document": {...}, "statistics": {...}, "rendering": {...}}
+{"document": {...}, "statistics": {...}, "rendering": {...}, "frame_cycle": {...}}
 ```
 
 Restricting the timespan matters more than it looks: page load dominates the tail of
 most metrics, so a whole-capture run largely measures startup. Skipping the first
 seconds is usually what you want when comparing configurations.
 
+#### Theoretical FPS
+
+`frames rendered` counts `DidRenderFrame` marks of every process (one per composition,
+emitted once it is painted and before the frame is handed over) and
+`theoretical FPS` divides that by the analyzed duration. `analyze --explain` prints
+what that does and does not say, and how it relates to the display refresh rate.
+
+Note that `vblanks per LayerTreeHostRenderingUpdate` (and its `more than 1 per update`
+count) only covers the `LayerTreeHostRenderingUpdate` mark. A rendering update that fits
+inside one vblank interval can still miss frames, because compositing happens after it.
+Use the frame cycle for the complete per-frame budget.
+
+#### Frame cycle
+
+A frame cycle is one turn of the engine's rendering loop, split into the phases the
+frame's time went into. `analyze --explain` prints what a cycle is, which mark
+delimits each phase and how to read every number of the section.
+
 #### Reading the mark statistics
 
-Three marks are easy to misread:
+Three marks measure something other than what their name suggests:
 
-- `StyleRecalc` is an umbrella mark that nests `RenderTreeBuild`,
-  `PerformSubtreesLayout` and `CompositingUpdate`. Its duration is not style resolution
-  alone. Subtract the nested marks to get that.
-- `CompositingUpdate` runs twice per rendering update, once inside `StyleRecalc` and
-  once after it, and the second one is much shorter. Its percentiles are therefore
-  bimodal rather than centered on a typical value.
+- `StyleRecalc` is an umbrella mark: `RenderTreeBuild`, the `CompositingUpdate` that
+  follows a style change and, where style resolution interleaves layout, the layout
+  marks all run inside it, so its duration is not style resolution alone.
+- `CompositingUpdate` is emitted wherever the compositing layers are updated, after a
+  style change, after layout and on scrolling, so its samples mix runs of very
+  different lengths and its percentiles are not centered on a typical value.
 - `PaintTile` runs on the painting threads, so summing it over a frame gives aggregate
   work rather than elapsed time. Its `#pixels` statistic is the dirty area taken from
   the mark's `dirty region <x>x<y>+<width>+<height>` message.
+
+Percentiles (P25, P75 and P99) are interpolated between the samples, so they lie
+between the reported minimum and maximum, and are left out below two samples.
+`analyze --explain` prints the long form of all of this in the report itself, next to
+the table it applies to.
 
 ### `delta-histogram`
 

--- a/Tools/Scripts/webkit-sysprof/pyproject.toml
+++ b/Tools/Scripts/webkit-sysprof/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "webkitsysprof"
 version = "1.0.0"
 description = "WebKit-specific sysprof capture processing toolkit"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["matplotlib"]
 
 [project.scripts]

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/__main__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/__main__.py
@@ -2,19 +2,38 @@ import argparse
 import logging
 import os
 import sys
-from typing import Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
 
 from .analyze import analyze
 from .dump import dump
 from .histogram import delta_histogram
 from .summary import summary
+from .utils import UsageError
+
+TIMESPAN_HELP = (
+    'Window of the capture to read, as "<begin>-<end>" in milliseconds from its'
+    ' start, e.g. 0-5000. Either side may be left out: "500-" and "500" both mean'
+    ' from 500ms to the end, "-500" the first 500ms. Anything else is an error.'
+)
+
+
+def _add_subcommand(
+    subparsers: Any,
+    name: str,
+    help_text: str,
+    func: Callable[[argparse.Namespace], None],
+) -> argparse.ArgumentParser:
+    """Add a subcommand that knows its own parser, for reporting usage errors."""
+    command_parser = subparsers.add_parser(name, help=help_text)
+    command_parser.set_defaults(func=func, command_parser=command_parser)
+    return command_parser
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="webkit-sysprof")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    dump_parser = subparsers.add_parser("dump", help="Dump capture data as CSV")
+    dump_parser = _add_subcommand(subparsers, "dump", "Dump capture data as CSV", dump)
     dump_group = dump_parser.add_mutually_exclusive_group()
     dump_group.add_argument("--marks", action="store_true", help="Dump marks (default)")
     dump_group.add_argument("--counters", action="store_true", help="Dump counters")
@@ -28,17 +47,15 @@ def build_parser() -> argparse.ArgumentParser:
         default="csv",
         help="Format to be printed to STDOUT",
     )
-    dump_parser.set_defaults(func=dump)
 
-    summary_parser = subparsers.add_parser(
-        "summary", help="Print a summary of a capture"
+    summary_parser = _add_subcommand(
+        subparsers, "summary", "Print a summary of a capture", summary
     )
     summary_parser.add_argument(
         "capture_file", metavar="CAPTURE_FILE", help="Path to a .capture file"
     )
-    summary_parser.set_defaults(func=summary)
 
-    analyze_parser = subparsers.add_parser("analyze", help="Analyze capture")
+    analyze_parser = _add_subcommand(subparsers, "analyze", "Analyze capture", analyze)
     analyze_parser.add_argument(
         "capture_file", metavar="CAPTURE_FILE", help="Path to a .capture file"
     )
@@ -54,12 +71,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--timespan",
         type=str,
         default="-",
-        help="Timespan in milliseconds e.g. 0-5000",
+        help=TIMESPAN_HELP,
     )
-    analyze_parser.set_defaults(func=analyze)
+    analyze_parser.add_argument(
+        "-e",
+        "--explain",
+        action="store_true",
+        help="Explain how to read the report, alongside the report itself"
+        " (text format only)",
+    )
 
-    histogram_parser = subparsers.add_parser(
-        "delta-histogram", help="Generate histogram from capture"
+    histogram_parser = _add_subcommand(
+        subparsers,
+        "delta-histogram",
+        "Generate histogram from capture",
+        delta_histogram,
     )
     histogram_parser.add_argument(
         "capture_file", metavar="CAPTURE_FILE", help="Path to a .capture file"
@@ -74,9 +100,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--timespan",
         type=str,
         default="-",
-        help="Timespan in milliseconds e.g. 0-5000",
+        help=TIMESPAN_HELP,
     )
-    histogram_parser.set_defaults(func=delta_histogram)
 
     return parser
 
@@ -90,6 +115,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     args = parser.parse_args(argv)
     try:
         args.func(args)
+    except UsageError as error:
+        args.command_parser.error(str(error))
     except BrokenPipeError:
         devnull = os.open(os.devnull, os.O_WRONLY)
         os.dup2(devnull, sys.stdout.fileno())

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py
@@ -1,21 +1,30 @@
 import argparse
+import bisect
 import logging
 import re
-import statistics
 import collections
 import json
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from ..parser import parse
+from . import explanations
+from ..cycles import PHASES, calculate_frame_cycles
 from ..utils import (
+    UsageError,
+    check_timespan_holds_data,
+    mark_begin,
+    median_vblank_interval,
+    msec_to_sec,
     nsec_to_msec,
     nsec_to_sec,
-    msec_to_sec,
     parse_timespan_argument,
-    trim_sysprof_data_to_timespan,
+    merged_spans,
+    display_refreshes,
+    intervals_between_marks,
+    sample_statistics,
+    sysprof_data_with_marks_by_name,
+    trim_marks_by_name_to_timespan,
 )
-
-RELEVANT_PERCENTILES = [25, 50, 75, 99]
 
 # Columns of the statistics tables, as (label, statistics key, percentile) triples.
 # The percentile is None for statistics that are not percentiles. The median is taken
@@ -31,6 +40,15 @@ STATISTICS_COLUMNS: List[Tuple[str, str, Optional[int]]] = [
     ("P99", "percentiles", 99),
     ("max", "max", None),
 ]
+
+# Derived from the columns, so the percentiles computed and the ones printed cannot
+# drift apart. The 50th is not a column - the median column prints the exact value -
+# but stays for the JSON report, whose consumers already read it.
+PERCENTILE_SHOWN_AS_MEDIAN = 50
+RELEVANT_PERCENTILES = sorted(
+    {percentile for _, _, percentile in STATISTICS_COLUMNS if percentile is not None}
+    | {PERCENTILE_SHOWN_AS_MEDIAN}
+)
 
 MARKS_RELEVANT_FOR_STATISTICS = [
     "EventLoopRun",
@@ -56,6 +74,22 @@ MARKS_RELEVANT_FOR_STATISTICS = [
 # PaintTile messages look like "Skia/CPU threaded, dirty region 768x512+256+56",
 # where the geometry is "<x>x<y>+<width>+<height>".
 DIRTY_REGION_RE = re.compile(r"(\d+)x(\d+)\+(\d+)\+(\d+)")
+REASONS_RE = re.compile(r"^reasons:([^|\n]*)")
+TASKS_RE = re.compile(r"^tasks:\s*(\d+)")
+SUBTREES_RE = re.compile(r"^subtrees:\s*(\d+)")
+TILES_RE = re.compile(r"^dirty tiles:\s*(\d+)")
+
+
+def _frame_rendering_reason(message: str) -> str:
+    """Why a frame was composited, as the DidRenderFrame message tells it."""
+    match = REASONS_RE.match(message.strip())
+    return (match.group(1).strip() if match is not None else "") or "_none"
+
+
+def _counted(message: str, pattern: "re.Pattern[str]") -> Optional[int]:
+    """The number the pattern names in a mark message, None where it does not."""
+    match = pattern.match(message.strip())
+    return int(match.group(1)) if match is not None else None
 
 
 def _dirty_region_pixels(message: str) -> Optional[int]:
@@ -71,15 +105,15 @@ STATISTICAL_DATA_EXTRACTORS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]
     },
     "EventLoopRun": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
     | {
-        "tasks": int(data["message"].split()[1]),
+        "tasks": _counted(data["message"], TASKS_RE),
     },
     "PerformSubtreesLayout": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
     | {
-        "subtrees": int(data["message"].split()[1]) if data["message"] != "" else None,
+        "subtrees": _counted(data["message"], SUBTREES_RE),
     },
     "UpdateTiles": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
     | {
-        "tiles": int(data["message"].split()[2]) if data["message"] != "" else None,
+        "tiles": _counted(data["message"], TILES_RE),
     },
     "PaintTile": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
     | {
@@ -89,105 +123,102 @@ STATISTICAL_DATA_EXTRACTORS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]
 
 
 def analyze(args: argparse.Namespace) -> None:
+    if args.explain and args.format != "text":
+        raise UsageError("--explain only applies to the text format")
     timespan_begin, timespan_end = parse_timespan_argument(args.timespan)
     parsed_data = parse(args.capture_file, marks=True, counters=False)
-    trimmed_data = trim_sysprof_data_to_timespan(
-        parsed_data, timespan_begin, timespan_end
-    )
-    data = _sysprof_data_to_high_level_representation(trimmed_data)
+    capture_begin, capture_end = parsed_data["document"]["timespan"]
+    check_timespan_holds_data(capture_begin, capture_end, timespan_begin, timespan_end)
+    untrimmed_data = sysprof_data_with_marks_by_name(parsed_data)
+    data = trim_marks_by_name_to_timespan(untrimmed_data, timespan_begin, timespan_end)
     logging.info("Preparing report...")
-    report = _prepare_report(data, timespan_begin, timespan_end)
+    # Frame cycles are built from the untrimmed capture and only then cut down to
+    # the timespan: trimming drops the marks that cross a timespan boundary, and a
+    # cycle at that boundary needs them.
+    report = _prepare_report(data, untrimmed_data)
 
     logging.info("Rendering report...")
     if args.format == "text":
-        _render_text_report(report)
+        _render_text_report(report, args.explain)
     elif args.format == "json":
         print(json.dumps(report))
     else:
         raise NotImplementedError
 
 
-def _sysprof_data_to_high_level_representation(
-    sysprof_data: Dict[str, Any],
-) -> Dict[str, Any]:
-    high_level_representation: Dict[str, Any] = {
-        "document": sysprof_data["document"],
-        "all_marks": sysprof_data["marks"],
-        "marks": {},
-    }
-    high_level_representation["document"]["timespan"] = {
-        "begin": sysprof_data["document"]["timespan"][0],
-        "end": sysprof_data["document"]["timespan"][1],
-    }
-    for mark in sysprof_data["marks"]:
-        high_level_representation["marks"].setdefault(mark["name"], []).append(mark)
-    for mark_name in high_level_representation["marks"]:
-        high_level_representation["marks"][mark_name].sort(key=lambda m: m["end_time"])
-    return high_level_representation
+def _calculate_statistics(values: Sequence[Union[int, float]]) -> Dict[str, Any]:
+    return sample_statistics(values, RELEVANT_PERCENTILES)
 
 
 def _prepare_report(
     sysprof_data: Dict[str, Any],
-    timespan_begin: Optional[int],
-    timespan_end: Optional[int],
+    untrimmed_sysprof_data: Dict[str, Any],
 ) -> Dict[str, Any]:
-    # TODO: Frame time.
     # TODO: Dropped frames.
     # TODO: Interaction latency.
     # TODO: System metrics.
-    report = {
-        "document": sysprof_data["document"],
-        "statistics": {},
-        "rendering": _prepare_rendering_report(sysprof_data),
+    timespan_begin = sysprof_data["document"]["timespan"]["begin"]
+    timespan_end = sysprof_data["document"]["timespan"]["end"]
+    document = dict(sysprof_data["document"])
+    document["timespan"] = {
+        "begin": nsec_to_msec(timespan_begin),
+        "end": nsec_to_msec(timespan_end),
     }
-
-    statistics_input_data = _calculate_statistics_input_data(
+    mark_statistics = _calculate_statistics_input_data(
         MARKS_RELEVANT_FOR_STATISTICS, sysprof_data
     )
-    statistics = statistics_input_data
-    for mark_name in statistics:
-        for input_name in statistics[mark_name]:
-            statistics[mark_name][input_name] = _calculate_statistics(
-                statistics[mark_name][input_name]
+    for mark_name in mark_statistics:
+        for input_name in mark_statistics[mark_name]:
+            mark_statistics[mark_name][input_name] = _calculate_statistics(
+                mark_statistics[mark_name][input_name]
             )
-    report["statistics"].update(statistics)
-    report["document"]["timespan"]["begin"] = nsec_to_msec(
-        report["document"]["timespan"]["begin"]
-    )
-    report["document"]["timespan"]["end"] = nsec_to_msec(
-        report["document"]["timespan"]["end"]
-    )
+    report = {
+        "document": document,
+        "statistics": mark_statistics,
+        "rendering": _prepare_rendering_report(
+            sysprof_data, display_refreshes(sysprof_data)
+        ),
+        "frame_cycle": _prepare_frame_cycle_report(
+            untrimmed_sysprof_data,
+            timespan_begin,
+            timespan_end,
+            # From the whole capture, not from the window: a narrow window holds
+            # too few vblanks, and the cycles come from the whole capture too.
+            median_vblank_interval(
+                display_refreshes(untrimmed_sysprof_data)
+            ),
+        ),
+    }
 
     return report
 
 
-def _prepare_rendering_report(sysprof_data: Dict[str, Any]) -> Dict[str, Any]:
+def _prepare_rendering_report(
+    sysprof_data: Dict[str, Any], vblanks: Sequence[Dict[str, Any]]
+) -> Dict[str, Any]:
     document_duration = nsec_to_sec(
         sysprof_data["document"]["timespan"]["end"]
         - sysprof_data["document"]["timespan"]["begin"]
     )
-    vblanks = sysprof_data["marks"].get("DisplayLinkUpdate", [])
-    vblanks_per_rendering_update = _calculate_vblanks_per_rendering_update(sysprof_data)
+    intervals = intervals_between_marks(vblanks)
+    vblanks_per_rendering_update = _calculate_vblanks_per_rendering_update(
+        vblanks, sysprof_data["marks"].get("LayerTreeHostRenderingUpdate", [])
+    )
     did_render_frames = sysprof_data["marks"].get("DidRenderFrame", [])
     report = {
         "vblanks": len(vblanks),
-        "vblank_interval_statistics": _calculate_statistics(
-            [
-                nsec_to_msec(vblanks[i]["end_time"] - vblanks[i - 1]["end_time"])
-                for i in range(1, len(vblanks))
-            ]
-        ),
+        "vblank_interval_statistics": _calculate_statistics(intervals),
         "frames_rendered": len(did_render_frames),
         "theoretical_fps": (
-            len(did_render_frames) / document_duration if document_duration != 0 else 0
+            len(did_render_frames) / document_duration
+            if document_duration > 0
+            else None
         ),
-        "frame_rendering_reasons": dict(
-            collections.Counter(
-                [mark["message"].split(":")[1].strip() for mark in did_render_frames]
-            )
+        "frame_rendering_reasons": collections.Counter(
+            [_frame_rendering_reason(mark["message"]) for mark in did_render_frames]
         ),
         "frame_compositions_per_vblank_statistics": _calculate_statistics(
-            _calculate_frame_compositions_per_vblank(sysprof_data)
+            _calculate_frame_compositions_per_vblank(vblanks, did_render_frames)
         ),
         "vblanks_per_rendering_update": {
             "n_greater_than_1": len(
@@ -199,62 +230,121 @@ def _prepare_rendering_report(sysprof_data: Dict[str, Any]) -> Dict[str, Any]:
     return report
 
 
-def _calculate_frame_compositions_per_vblank(sysprof_data: Dict[str, Any]) -> List[int]:
-    vblanks = sysprof_data["marks"].get("DisplayLinkUpdate", [])
-    if len(vblanks) == 0:
+def _covered_duration(cycles: Sequence[Dict[str, Any]]) -> float:
+    """How much of the timeline the cycles span, in milliseconds.
+
+    Their spans are merged rather than summed, since the cycles of two processes
+    rendering at once overlap and would otherwise cover more time than there is.
+    """
+    return nsec_to_msec(
+        sum(
+            end - begin
+            for begin, end in merged_spans(
+                (cycle["begin_nsec"], cycle["end_nsec"]) for cycle in cycles
+            )
+        )
+    )
+
+
+def _cycle_in_vblank_intervals(
+    cycles: int,
+    median_duration: float,
+    vblank_interval: Optional[float],
+) -> Tuple[Optional[float], Optional[str]]:
+    if not cycles:
+        return None, "no_cycles"
+    if vblank_interval is None:
+        return None, "no_vblank_interval"
+    if not vblank_interval:
+        return None, "zero_vblank_interval"
+    if not median_duration:
+        return None, "zero_length_cycle"
+    return median_duration / vblank_interval, None
+
+
+def _prepare_frame_cycle_report(
+    sysprof_data: Dict[str, Any],
+    timespan_begin: int,
+    timespan_end: int,
+    vblank_interval: Optional[float],
+) -> Dict[str, Any]:
+    cycles = calculate_frame_cycles(sysprof_data, timespan_begin, timespan_end)
+    durations = [cycle["duration"] for cycle in cycles]
+    resolved = [cycle for cycle in cycles if cycle["phases"] is not None]
+    # The phase statistics cover the resolved cycles only, so the duration they are
+    # shares of has to cover the same ones. Taken from all cycles instead, the four
+    # shares do not sum to 100%.
+    resolved_durations = [cycle["duration"] for cycle in resolved]
+
+    duration_statistics = _calculate_statistics(durations)
+    median_duration = duration_statistics.get("median", 0.0)
+    analyzed_duration = nsec_to_msec(timespan_end - timespan_begin)
+    overrunning = [cycle for cycle in resolved if cycle["composition_overrun"] > 0]
+    intervals_per_cycle, unknown_reason = _cycle_in_vblank_intervals(
+        len(cycles), median_duration, vblank_interval
+    )
+    return {
+        "cycles": len(cycles),
+        "processes": len({cycle["pid"] for cycle in cycles}),
+        "duration_statistics": duration_statistics,
+        "implied_fps": 1 / msec_to_sec(median_duration) if median_duration else None,
+        "coverage": (
+            _covered_duration(cycles) / analyzed_duration
+            if analyzed_duration > 0
+            else None
+        ),
+        "capture_vblank_interval": vblank_interval,
+        "vblank_intervals_per_cycle": intervals_per_cycle,
+        "vblank_intervals_per_cycle_unknown": unknown_reason,
+        "phase_statistics": {
+            phase: _calculate_statistics([cycle["phases"][phase] for cycle in resolved])
+            for phase in PHASES
+        },
+        "resolved_duration_statistics": _calculate_statistics(resolved_durations),
+        "overrunning_composition_statistics": _calculate_statistics(
+            [cycle["composition_overrun"] for cycle in overrunning]
+        ),
+    }
+
+
+def _calculate_frame_compositions_per_vblank(
+    vblanks: Sequence[Dict[str, Any]], compositing_finishes: Sequence[Dict[str, Any]]
+) -> List[int]:
+    """Compositions finished within each interval between two consecutive vblanks."""
+    if len(vblanks) < 2:
         return []
-    compositing_finishes = sysprof_data["marks"].get("DidRenderFrame", [])
-    frame_compositions_per_vblank = [0]
-    vblanks_iterator = 0
+    vblank_ends = [vblank["end_time"] for vblank in vblanks]
+    compositions_per_interval = [0] * (len(vblanks) - 1)
     for compositing_finish in compositing_finishes:
-        while (
-            vblanks_iterator < len(vblanks)
-            and vblanks[vblanks_iterator]["end_time"] <= compositing_finish["end_time"]
-        ):
-            vblanks_iterator += 1
-            if vblanks_iterator < len(vblanks):
-                frame_compositions_per_vblank.append(0)
-        if vblanks_iterator == 0:
+        # Each interval runs from one refresh to the next, the later one included,
+        # so a composition ending exactly on a refresh belongs to the interval that
+        # ends there.
+        interval = bisect.bisect_left(vblank_ends, compositing_finish["end_time"]) - 1
+        if not 0 <= interval < len(compositions_per_interval):
+            # Composited before the first vblank of the timespan or after the last
+            # one, so there is no interval between two refreshes it belongs to.
             continue
-        frame_compositions_per_vblank[vblanks_iterator - 1] += 1
+        compositions_per_interval[interval] += 1
+    return compositions_per_interval
 
-    return frame_compositions_per_vblank
 
-
-def _calculate_vblanks_per_rendering_update(sysprof_data: Dict[str, Any]) -> List[int]:
-    vblanks = sysprof_data["marks"].get("DisplayLinkUpdate", [])
-    if len(vblanks) == 0:
+def _calculate_vblanks_per_rendering_update(
+    vblanks: Sequence[Dict[str, Any]], rendering_updates: Sequence[Dict[str, Any]]
+) -> List[int]:
+    """How many display refreshes each rendering update spanned."""
+    if not vblanks:
         return []
-    rendering_updates = sysprof_data["marks"]["LayerTreeHostRenderingUpdate"]
-    vblanks_iterator = 0
-    vblanks_per_rendering_update = []
+    vblank_ends = [vblank["end_time"] for vblank in vblanks]
+    counts = []
     for rendering_update in rendering_updates:
-        rendering_update_begin = (
-            rendering_update["end_time"] - rendering_update["duration"]
-        )
-        while (
-            vblanks_iterator < len(vblanks)
-            and vblanks[vblanks_iterator]["end_time"] <= rendering_update_begin
-        ):
-            vblanks_iterator += 1
-        if (
-            vblanks_iterator >= len(vblanks)
-            or vblanks[vblanks_iterator]["end_time"] <= rendering_update_begin
-        ):
-            break
-        if vblanks_iterator == 0:
+        begin, end = mark_begin(rendering_update), rendering_update["end_time"]
+        if end < vblank_ends[0] or begin > vblank_ends[-1]:
+            # Outside the refreshes the timespan holds, so they say nothing about
+            # this update, rather than saying it spanned none of them.
             continue
-        vblanks_during_rendering_update = 0
-        while (
-            vblanks_iterator < len(vblanks)
-            and vblanks[vblanks_iterator]["end_time"] <= rendering_update["end_time"]
-        ):
-            vblanks_iterator += 1
-            vblanks_during_rendering_update += 1
-        vblanks_per_rendering_update.append(
-            1 + max(vblanks_during_rendering_update - 1, 0)
-        )
-    return vblanks_per_rendering_update
+        first = bisect.bisect_right(vblank_ends, begin)
+        counts.append(max(bisect.bisect_right(vblank_ends, end) - first, 1))
+    return counts
 
 
 def _calculate_statistics_input_data(
@@ -279,45 +369,14 @@ def _calculate_statistics_input_data(
     return statistics_input_data
 
 
-def _calculate_statistics(values: Sequence[Union[int, float]]) -> Dict[str, Any]:
-    if values == []:
-        return {}
-    result: Dict[str, Any] = {
-        "n": len(values),
-        "min": min(values),
-        "max": max(values),
-        "mean": statistics.mean(values),
-        "stddev": statistics.stdev(values) if len(values) > 1 else 0,
-        "median": statistics.median(values),
-    }
-    if len(values) > 1:
-        result["percentiles"] = {
-            k: v
-            for k, v in dict(
-                zip(range(1, 100), statistics.quantiles(values, n=100))
-            ).items()
-            if k in RELEVANT_PERCENTILES
-        }
-    return result
-
-
-def _render_text_report(report: Dict[str, Any]) -> None:
+def _render_text_report(report: Dict[str, Any], explain: bool = False) -> None:
     print(
         "Timespan: {:.4f} - {:.4f} [s]".format(
-            abs(msec_to_sec(report["document"]["timespan"]["begin"])),
-            abs(msec_to_sec(report["document"]["timespan"]["end"])),
+            msec_to_sec(report["document"]["timespan"]["begin"]),
+            msec_to_sec(report["document"]["timespan"]["end"]),
         )
     )
-    print(
-        "Duration: {:.4f} [s]".format(
-            abs(
-                msec_to_sec(
-                    report["document"]["timespan"]["end"]
-                    - report["document"]["timespan"]["begin"]
-                )
-            )
-        )
-    )
+    print("Duration: {:.4f} [s]".format(_analyzed_duration_sec(report)))
 
     print()
     print("Rendering:")
@@ -333,15 +392,13 @@ def _render_text_report(report: Dict[str, Any]) -> None:
         )
     )
     vblanks_per_rendering_update_statistics = _statistics_to_strings(
-        report["rendering"]["vblanks_per_rendering_update"]["statistics"]
+        report["rendering"]["vblanks_per_rendering_update"]["statistics"], "{:.4g}"
     )
     print("- vblanks per LayerTreeHostRenderingUpdate: ", end="")
     print(
-        "(min: {}, median: {}, P75: {}, P99: {}, max: {})".format(
+        "(min: {}, {}, max: {})".format(
             vblanks_per_rendering_update_statistics["min"],
-            vblanks_per_rendering_update_statistics["median"],
-            vblanks_per_rendering_update_statistics["percentiles"][75],
-            vblanks_per_rendering_update_statistics["percentiles"][99],
+            ", ".join(_percentile_strings(vblanks_per_rendering_update_statistics)),
             vblanks_per_rendering_update_statistics["max"],
         )
     )
@@ -351,24 +408,40 @@ def _render_text_report(report: Dict[str, Any]) -> None:
         )
     )
     print(f"- frames rendered: {report['rendering']['frames_rendered']}")
-    print(f"- theoretical FPS: {report['rendering']['theoretical_fps']:.2f}")
+    theoretical_fps = report["rendering"]["theoretical_fps"]
+    print(
+        "- theoretical FPS: {}".format(
+            "{:.2f}".format(theoretical_fps) if theoretical_fps is not None else "-"
+        )
+    )
     print("- frame rendering reasons:")
     for reason in sorted(report["rendering"]["frame_rendering_reasons"].keys()):
         print(
             "  - {}: {}".format(
-                reason, report["rendering"]["frame_rendering_reasons"][reason]
+                explanations.UNNAMED_FRAME_RENDERING_REASONS.get(reason, reason),
+                report["rendering"]["frame_rendering_reasons"][reason],
             )
         )
     frame_compositions_per_vblank_statistics = _statistics_to_strings(
-        report["rendering"]["frame_compositions_per_vblank_statistics"]
+        report["rendering"]["frame_compositions_per_vblank_statistics"], "{:.4g}"
     )
     print(
-        "- frame compositions per vblank: (min: {}, median: {}, max: {})".format(
+        "- frame compositions per vblank:"
+        " (min: {}, mean: {}, median: {}, max: {})".format(
             frame_compositions_per_vblank_statistics["min"],
+            frame_compositions_per_vblank_statistics["mean"],
             frame_compositions_per_vblank_statistics["median"],
             frame_compositions_per_vblank_statistics["max"],
         )
     )
+    if explain:
+        print()
+        print(_theoretical_fps_explanation(report))
+
+    _render_frame_cycle_numbers(report["frame_cycle"])
+    if explain:
+        print()
+        print(explanations.FRAME_CYCLE)
 
     print()
     print("Statistics (durations):")
@@ -397,17 +470,9 @@ def _render_text_report(report: Dict[str, Any]) -> None:
             report,
         )
     )
-    print()
-    print(
-        "  StyleRecalc is an umbrella mark: it nests RenderTreeBuild,\n"
-        "  PerformSubtreesLayout and CompositingUpdate, so its duration is not\n"
-        "  style resolution alone. Subtract the nested marks to get that.\n"
-        "  CompositingUpdate runs twice per rendering update, once inside\n"
-        "  StyleRecalc and once after it, and the second one is much shorter, so\n"
-        "  its percentiles are bimodal rather than centered on a typical value.\n"
-        "  PaintTile runs on the painting threads, so summing it across a frame\n"
-        "  yields aggregate work rather than elapsed time."
-    )
+    if explain:
+        print()
+        print(explanations.MARK_STATISTICS)
 
     print()
     print("Statistics (other):")
@@ -422,6 +487,170 @@ def _render_text_report(report: Dict[str, Any]) -> None:
             report,
         )
     )
+
+
+def _analyzed_duration_sec(report: Dict[str, Any]) -> float:
+    """How long the analyzed timespan is, in seconds."""
+    return msec_to_sec(
+        report["document"]["timespan"]["end"] - report["document"]["timespan"]["begin"]
+    )
+
+
+def _theoretical_fps_explanation(report: Dict[str, Any]) -> str:
+    rendering = report["rendering"]
+    if rendering["theoretical_fps"] is None:
+        return explanations.UNKNOWN_THEORETICAL_FPS.format(
+            frames=rendering["frames_rendered"],
+            refresh_rate=_refresh_rate_explanation(report),
+        )
+    return explanations.THEORETICAL_FPS.format(
+        frames=rendering["frames_rendered"],
+        duration=_analyzed_duration_sec(report),
+        fps="{:.2f}".format(rendering["theoretical_fps"]),
+        refresh_rate=_refresh_rate_explanation(report),
+    )
+
+
+def _refresh_rate_explanation(report: Dict[str, Any]) -> str:
+    rendering = report["rendering"]
+    interval = rendering["vblank_interval_statistics"].get("median")
+    vblanks = rendering["vblanks"]
+    if interval:
+        refresh_rate = explanations.REFRESH_RATE.format(
+            rate=1 / msec_to_sec(interval), interval=interval
+        )
+    elif interval is None:
+        refresh_rate = explanations.REFRESH_RATE_WITHOUT_INTERVAL.format(
+            vblanks=vblanks, plural="" if vblanks == 1 else "s"
+        )
+    else:
+        refresh_rate = explanations.REFRESH_RATE_ZERO_INTERVAL.format(vblanks=vblanks)
+    return refresh_rate
+
+
+def _percentile_strings(strings: Dict[str, Any]) -> List[str]:
+    """The percentiles of a statistic, and its median among them, in order.
+
+    Takes the strings _statistics_to_strings() built, not the statistic itself.
+    """
+    return [
+        (
+            "median: {}".format(strings["median"])
+            if percentile == PERCENTILE_SHOWN_AS_MEDIAN
+            else "P{}: {}".format(percentile, strings["percentiles"][percentile])
+        )
+        for percentile in RELEVANT_PERCENTILES
+    ]
+
+
+def _analyzed_cycles(frame_cycle: Dict[str, Any]) -> int:
+    """How many cycles the phase statistics were taken from."""
+    return frame_cycle["resolved_duration_statistics"].get("n", 0)
+
+
+def _render_frame_cycle_numbers(frame_cycle: Dict[str, Any]) -> None:
+    print()
+    print("Frame cycle:")
+    print(f"- cycles: {frame_cycle['cycles']}")
+    if frame_cycle["processes"] > 1:
+        print(
+            "- rendered by {} processes, whose frames the medians below"
+            " describe together".format(frame_cycle["processes"])
+        )
+
+    if frame_cycle["cycles"] == 0:
+        print(
+            "- no cycles here: no two consecutive LayerTreeHostRenderingUpdate"
+            " marks of one process begin within the analyzed timespan"
+        )
+        return
+
+    duration_statistics = _statistics_to_strings(frame_cycle["duration_statistics"])
+    print(
+        "- cycle duration: (min: {}, {}, max: {}) [ms]".format(
+            duration_statistics["min"],
+            ", ".join(_percentile_strings(duration_statistics)),
+            duration_statistics["max"],
+        )
+    )
+    implied_fps = frame_cycle["implied_fps"]
+    print(
+        "- implied FPS (1000 / median cycle): {}".format(
+            "{:.2f}".format(implied_fps) if implied_fps is not None else "-"
+        )
+    )
+    coverage = frame_cycle["coverage"]
+    print(
+        "- cycles cover {} of the analyzed duration".format(
+            "{:.1f}%".format(coverage * 100) if coverage is not None else "-"
+        )
+    )
+    if frame_cycle["vblank_intervals_per_cycle"] is None:
+        print(
+            "- median cycle in vblank intervals: - ({})".format(
+                explanations.UNKNOWN_VBLANK_INTERVALS_PER_CYCLE[
+                    frame_cycle["vblank_intervals_per_cycle_unknown"]
+                ]
+            )
+        )
+    else:
+        print(
+            "- median cycle in vblank intervals: {:.2f}"
+            " ({:.4f} ms per vblank, from the whole capture)".format(
+                frame_cycle["vblank_intervals_per_cycle"],
+                frame_cycle["capture_vblank_interval"],
+            )
+        )
+
+    # Shares of the median duration of the analyzed cycles, not of all of them,
+    # since the phase medians cover the analyzed ones only.
+    median_duration = frame_cycle["resolved_duration_statistics"].get("median", 0)
+    analyzed = "{} of {} cycles analyzed".format(
+        _analyzed_cycles(frame_cycle), frame_cycle["cycles"]
+    )
+    # Each phase is its own median, and medians do not add up, so the shares below
+    # need not total 100%.
+    if median_duration:
+        analyzed += ", median analyzed cycle {:.4f} ms".format(median_duration)
+    print(f"- phases (median, {analyzed}):")
+    shares_shown = False
+    for phase in PHASES:
+        label = phase.replace("_", " ")
+        phase_statistics = frame_cycle["phase_statistics"][phase]
+        if not phase_statistics:
+            print(f"  - {label}: -")
+            continue
+        share = "-"
+        if median_duration:
+            share = "{:.1f}%".format(phase_statistics["median"] / median_duration * 100)
+            shares_shown = True
+        print(
+            "  - {}: {:.4f} ms ({} of the cycle)".format(
+                label, phase_statistics["median"], share
+            )
+        )
+    if shares_shown:
+        print(
+            "  (each phase is a median of its own,"
+            " so the shares need not total 100%)"
+        )
+    overrun_statistics = frame_cycle["overrunning_composition_statistics"]
+    if not _analyzed_cycles(frame_cycle):
+        print("- composition overrunning the cycle: -")
+    elif overrun_statistics:
+        print(
+            "- composition overrunning the cycle: in {} of {} analyzed cycles,"
+            " by {:.4f} ms median".format(
+                overrun_statistics["n"],
+                _analyzed_cycles(frame_cycle),
+                overrun_statistics["median"],
+            )
+        )
+    else:
+        print(
+            "- composition overrunning the cycle: in none of {} analyzed"
+            " cycles".format(_analyzed_cycles(frame_cycle))
+        )
 
 
 def _render_statistics_rows_to_stdout(statistics_rows: List[List[str]]) -> None:
@@ -460,28 +689,34 @@ def _prepare_statistics_row(
     ]
 
 
-def _statistics_to_strings(statistics: Dict[str, Any]) -> Dict[str, Any]:
+def _statistics_to_strings(
+    statistic: Dict[str, Any], number: str = "{:.4f}"
+) -> Dict[str, Any]:
+    """The numbers of a statistic as strings, `-` where it holds none."""
+
     def format_statistic(
         data: Dict[str, Any],
         key: str,
         default: str = "-",
-        subkey: Optional[int] = None,
+        subkey: Optional[str] = None,
     ) -> str:
         if key not in data:
             return default
-        number = data[key]
-        if subkey is not None and subkey in number:
-            number = data[key][subkey]
+        value = data[key]
+        if subkey is not None:
+            if subkey not in value:
+                return default
+            value = value[subkey]
         if key == "n":
-            return str(number)
-        return "{:.4f}".format(number)
+            return str(value)
+        return number.format(value)
 
     return {
-        key: format_statistic(statistics, key, "0" if key == "n" else "-")
+        key: format_statistic(statistic, key, "0" if key == "n" else "-")
         for key in ["n", "min", "max", "mean", "stddev", "median"]
     } | {
         "percentiles": {
-            percentile: format_statistic(statistics, "percentiles", "-", percentile)
+            percentile: format_statistic(statistic, "percentiles", "-", str(percentile))
             for percentile in RELEVANT_PERCENTILES
         }
     }

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/explanations.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/explanations.py
@@ -1,0 +1,110 @@
+"""The paragraphs `analyze --explain` prints, kept apart from the analysis itself.
+
+The long form of what the report means. The README keeps the same caveats short.
+"""
+
+THEORETICAL_FPS = """\
+  Theoretical FPS is the number of DidRenderFrame marks, one per
+  composition, divided by the analyzed duration:
+  {frames} / {duration:.4f} s = {fps}. It is not clamped to the refresh
+  rate, and it counts every process, so two renderers compositing once
+  per refresh read as two.
+{refresh_rate}
+  Matching it means completing one frame per vblank interval. The frame
+  cycle below shows where a frame's time goes."""
+
+UNKNOWN_THEORETICAL_FPS = """\
+  Theoretical FPS is the number of DidRenderFrame marks, one per
+  composition, divided by the analyzed duration. It is unknown here: the
+  analyzed timespan has no length to divide the {frames} of them by.
+{refresh_rate}"""
+
+REFRESH_RATE = """\
+  That rate is {rate:.2f} Hz here, from the median vblank interval of
+  {interval:.4f} ms."""
+
+REFRESH_RATE_WITHOUT_INTERVAL = """\
+  That rate is unknown here: the display link refreshed {vblanks} time{plural},
+  too few for an interval between two refreshes."""
+
+REFRESH_RATE_ZERO_INTERVAL = """\
+  That rate is unknown here: the median interval between two of the {vblanks}
+  refreshes is zero."""
+
+FRAME_CYCLE = """\
+  A frame cycle starts when a LayerTreeHostRenderingUpdate begins and
+  ends when the next one begins, so consecutive cycles tile a rendering
+  period without gaps and the frame rate within it is 1 / cycle
+  duration. The phases are:
+    - rendering update: the LayerTreeHostRenderingUpdate mark itself,
+      i.e. requestAnimationFrame callbacks, style recalc, layout and the
+      compositing update.
+    - compositing: the time after the rendering update spent in
+      RenderLayerTree, FlushCompositingState, PaintToGLContext or
+      WaitForCompositionCompletion. They are merged as spans rather than
+      added up, since they nest and a cycle can composite twice with a
+      wait in between. On GTK and WPE the wait for the GPU and the buffer
+      handover after it both happen inside RenderLayerTree, so getting the
+      frame out is counted here too.
+    - waiting for compositing: what is left of the cycle once the other
+      phases are taken off it, mostly spent waiting for the painting
+      threads to finish their tiles.
+    - idle: from the end of compositing until the next rendering update
+      begins.
+  Each phase is its own median over the cycles it could be read from, so
+  the shares need not total 100%.
+  The loop is vblank-driven, but it does not wait for a refresh it has
+  already missed: a cycle that runs past its vblank deadline schedules
+  the next rendering update as soon as compositing is far enough along
+  rather than at the following refresh, so a cycle longer than one vblank
+  interval means frames cannot be presented on every vblank. Compositing
+  that began in one cycle can then still be running when the next
+  rendering update opens the following one, and since the phases add up
+  to the cycle exactly, that part of it past the cycle end is reported on
+  its own as composition overrunning the cycle rather than as a fifth
+  phase.
+  Implied FPS is the rate of the median cycle, while theoretical FPS
+  averages over the whole analyzed duration, so the two differ by the
+  time no cycle spans, which coverage reports, plus the time the cycles
+  spent idle. A capture that renders for a stretch and then sits still,
+  rather than rendering evenly throughout, keeps a high coverage, since
+  the pause is itself one long cycle, and a high idle share along with
+  it.
+  A cycle reaching past either end of the analyzed timespan is left out
+  of it. Between two rendering periods the engine idles, and that gap is
+  reported as one long, nearly all-idle cycle rather than dropped.
+  A cycle only ever runs between two rendering updates of one process.
+  Where more than one rendered, their cycles are reported together and
+  the count above says so. The refreshes come from the UI process and
+  name no display, so a capture of two displays refreshing at once halves
+  the interval between them and doubles the rate derived from it."""
+
+
+MARK_STATISTICS = """\
+  StyleRecalc is an umbrella mark: RenderTreeBuild, the CompositingUpdate
+  that follows a style change, and layout where style resolution
+  interleaves it all run inside it, so its duration is not style
+  resolution alone. Subtract the nested marks to get that.
+  CompositingUpdate is emitted after a style change, after layout and on
+  scrolling, and those runs are of very different lengths, so its
+  percentiles mix them rather than centering on a typical value.
+  PaintTile runs on the painting threads, so summing it across a frame
+  yields aggregate work rather than elapsed time.
+  Percentiles are interpolated between the samples, so they lie between
+  the minimum and the maximum, and read - below two samples."""
+
+
+# What the report says of a frame whose message named no reason for compositing it,
+# keyed by the token _frame_rendering_reason() buckets it under.
+UNNAMED_FRAME_RENDERING_REASONS = {
+    "_none": "none given",
+}
+
+# What the report says of a median cycle it cannot be given in vblank intervals,
+# keyed by the token _cycle_in_vblank_intervals() reports it with.
+UNKNOWN_VBLANK_INTERVALS_PER_CYCLE = {
+    "no_cycles": "there are no cycles",
+    "no_vblank_interval": "no vblank interval known",
+    "zero_vblank_interval": "the vblank interval is zero",
+    "zero_length_cycle": "the median cycle is of zero length",
+}

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/cycles/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/cycles/__init__.py
@@ -1,0 +1,258 @@
+"""Frame cycle reconstruction for the `analyze` command.
+
+What a cycle is, what its phases mean and how to read the numbers taken from them
+is what `analyze --explain` prints, from webkitsysprof.analyze.explanations, which
+is where that is written down rather than here.
+"""
+
+import bisect
+import itertools
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..utils import mark_begin, marks_by_process, merged_spans, nsec_to_msec
+
+# Compositing of a cycle is the time any of these marks was running within it,
+# whether the mark began there or in an earlier cycle it overran. All four are read,
+# and as time rather than by name, because which of them a cycle carries varies:
+# renderLayerTree() opens its trace scope before the checks that can return early, so
+# a cycle can hold a RenderLayerTree mark with no flush or paint inside it. Their
+# spans are merged, so listing a mark that RenderLayerTree already encloses adds no
+# time of its own.
+COMPOSITING_MARKS = [
+    "RenderLayerTree",
+    "FlushCompositingState",
+    "PaintToGLContext",
+    "WaitForCompositionCompletion",
+]
+PHASES = [
+    "rendering_update",
+    "waiting_for_compositing",
+    "compositing",
+    "idle",
+]
+RENDERING_UPDATE, WAITING, COMPOSITING, IDLE = PHASES
+
+
+class _MarkIndex:
+    """Marks of a single name, ordered by begin time for lookup within a cycle."""
+
+    def __init__(self, marks: Sequence[Dict[str, Any]]) -> None:
+        self._marks = sorted(marks, key=mark_begin)
+        self._begins = [mark_begin(mark) for mark in self._marks]
+        # The latest end among the first i marks. Every mark still running at a
+        # given time covers that time onwards, so their union is one span reaching
+        # to the latest of their ends, and that is all this has to answer.
+        self._ends_until: List[int] = list(
+            itertools.accumulate((mark["end_time"] for mark in self._marks), max)
+        )
+
+    def spans_within(self, begin: int, end: int) -> List[Tuple[int, int]]:
+        """The [begin, end) spans of time a mark of this name was running.
+
+        Unmerged and in begin order. What began before the window and had not ended
+        by then counts, since a composition of an earlier cycle is what a cycle
+        waiting on the compositor is running, and all of those together reach from
+        the start of the window to the latest of their ends.
+        """
+        first = bisect.bisect_left(self._begins, begin)
+        spans = []
+        still_running = self._ends_until[first - 1] if first else None
+        if still_running is not None and still_running > begin:
+            spans.append((begin, min(still_running, end)))
+        for index in range(first, len(self._marks)):
+            if self._begins[index] >= end:
+                break
+            spans.append(
+                (self._begins[index], min(self._marks[index]["end_time"], end))
+            )
+        return spans
+
+    def last_end_of_marks_beginning_within(self, begin: int, end: int) -> Optional[int]:
+        """End of the last mark beginning within [begin, end), None if there is none.
+
+        The last end, not the first: marks nest, so the first one to end is not the
+        one compositing finished with. Indexing by end time instead has the mirror
+        problem, of returning a short mark of the next cycle when an enclosing mark
+        overruns this one.
+        """
+        first = bisect.bisect_left(self._begins, begin)
+        last = bisect.bisect_left(self._begins, end)
+        if first >= last:
+            return None
+        return max(self._marks[index]["end_time"] for index in range(first, last))
+
+
+def _marks_beginning_within(
+    marks: Sequence[Dict[str, Any]],
+    begin: Optional[int],
+    end: Optional[int],
+    including_end: bool = False,
+) -> List[Dict[str, Any]]:
+    """The marks that begin within the window, which are the only ones read."""
+
+    def within(mark: Dict[str, Any]) -> bool:
+        if begin is not None and mark_begin(mark) < begin:
+            return False
+        if end is None:
+            return True
+        return mark_begin(mark) <= end if including_end else mark_begin(mark) < end
+
+    return [mark for mark in marks if within(mark)]
+
+
+def _compositing_indices_by_process(
+    sysprof_data: Dict[str, Any],
+    timespan_begin: Optional[int],
+    timespan_end: Optional[int],
+) -> Dict[int, List[_MarkIndex]]:
+    """The compositing marks of the capture, grouped by process and by name."""
+    by_pid: Dict[int, Dict[str, List[Dict[str, Any]]]] = {}
+    for mark_name in COMPOSITING_MARKS:
+        marks = [
+            mark
+            for mark in _marks_beginning_within(
+                sysprof_data["marks"].get(mark_name, []), None, timespan_end
+            )
+            if timespan_begin is None or mark["end_time"] >= timespan_begin
+        ]
+        for pid, process_marks in marks_by_process(marks).items():
+            by_pid.setdefault(pid, {})[mark_name] = process_marks
+    return {
+        pid: [_MarkIndex(marks.get(mark_name, [])) for mark_name in COMPOSITING_MARKS]
+        for pid, marks in by_pid.items()
+    }
+
+
+def _compositing_spans(
+    indices: Sequence[_MarkIndex], begin: int, end: int
+) -> List[Tuple[int, int]]:
+    """The spans of [begin, end) that were spent compositing, merged and in order.
+
+    Merged rather than taken as one span from the first mark to the last, because a
+    cycle can composite twice: the tail of a composition it inherited and then one
+    of its own, with the wait for the painting threads in between. Reading that as
+    one span would report the wait as compositing.
+    """
+    return merged_spans(
+        span for index in indices for span in index.spans_within(begin, end)
+    )
+
+
+def _own_compositing_end(
+    indices: Sequence[_MarkIndex], cycle_begin: int, cycle_end: int
+) -> Optional[int]:
+    """When the composition of this cycle was over, None where it has none.
+
+    Only the marks that began within the cycle count, so this is the cycle's own
+    composition rather than one it inherited. It may end after the cycle does: when
+    compositing overruns, the next rendering update is dispatched from within the
+    composition wait. It is usually the RenderLayerTree mark compositing began with,
+    since that encloses the others and runs on through the wait for the GPU to
+    finish the frame, which costs frame time as well.
+    """
+    ends = [
+        index.last_end_of_marks_beginning_within(cycle_begin, cycle_end)
+        for index in indices
+    ]
+    ended = [end for end in ends if end is not None]
+    return max(ended) if ended else None
+
+
+def calculate_frame_cycles(
+    sysprof_data: Dict[str, Any],
+    timespan_begin: Optional[int] = None,
+    timespan_end: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Split the timeline into frame cycles and break each cycle into its phases.
+
+    Each cycle carries its boundaries in nanoseconds, its duration and phases in
+    milliseconds, and the process it belongs to. The phases sum to the cycle
+    duration exactly, so compositing running past the cycle is reported beside them
+    as `composition_overrun` rather than as a fifth phase. A cycle nothing
+    composited in has both set to None, so callers can count it without letting it
+    skew the per-phase statistics.
+
+    A cycle runs between two rendering updates of one process, which the marks name.
+    `timespan_begin`/`timespan_end` keep the cycles
+    lying entirely within that window, in nanoseconds, the way trimming keeps the
+    marks lying entirely within it. Filtering here rather than trimming the marks
+    first keeps the compositing marks of a cycle at the window edge, which trimming
+    drops for reaching past it. `analyze --explain` reads all of this out.
+    """
+    # A cycle ends where the next update begins, and the whole cycle has to fit in
+    # the window, so an update beginning on the very edge still bounds one.
+    all_updates = _marks_beginning_within(
+        sysprof_data["marks"].get("LayerTreeHostRenderingUpdate", []),
+        timespan_begin,
+        timespan_end,
+        including_end=True,
+    )
+    compositing = _compositing_indices_by_process(
+        sysprof_data, timespan_begin, timespan_end
+    )
+    cycles: List[Dict[str, Any]] = []
+    for pid, updates in marks_by_process(all_updates).items():
+        cycles += _cycles_of_one_process(
+            pid, sorted(updates, key=mark_begin), compositing.get(pid, [])
+        )
+    return sorted(cycles, key=lambda cycle: cycle["begin_nsec"])
+
+
+def _cycles_of_one_process(
+    pid: int, updates: Sequence[Dict[str, Any]], indices: Sequence[_MarkIndex]
+) -> List[Dict[str, Any]]:
+    """The cycles between the given rendering updates, all of one process.
+
+    `indices` holds that same process's compositing marks, one index per name.
+    """
+    cycles: List[Dict[str, Any]] = []
+    for update, next_update in zip(updates, itertools.islice(updates, 1, None)):
+        cycle_begin = mark_begin(update)
+        cycle_end = mark_begin(next_update)
+        cycle: Dict[str, Any] = {
+            "pid": pid,
+            "begin_nsec": cycle_begin,
+            "end_nsec": cycle_end,
+            "duration": nsec_to_msec(cycle_end - cycle_begin),
+            "phases": None,
+            "composition_overrun": None,
+        }
+        cycles.append(cycle)
+
+        # LayerTreeHost::updateRendering() asserts it is not re-entered, so an
+        # update cannot outlast its own cycle. The phases cover the cycle, so one
+        # that does anyway is cut off rather than trusted.
+        update_end = min(update["end_time"], cycle_end)
+        # What was traced as compositing within the cycle, whether it began there
+        # or in an earlier one. A composition running entirely beside the rendering
+        # update still says the cycle composited, so it is what decides that, while
+        # the phases below cover the time after the update.
+        within = _compositing_spans(indices, cycle_begin, cycle_end)
+        if not within:
+            # Nothing about compositing can be said of this cycle.
+            continue
+        spans = [
+            (max(span_begin, update_end), span_end)
+            for span_begin, span_end in within
+            if span_end > update_end
+        ]
+        own_end = _own_compositing_end(indices, cycle_begin, cycle_end)
+
+        compositing = sum(span_end - span_begin for span_begin, span_end in spans)
+        # Idle runs from the last thing traced until the next update begins, and
+        # what is neither the update, compositing nor idle was spent waiting.
+        idle = cycle_end - (spans[-1][1] if spans else update_end)
+        cycle["phases"] = {
+            RENDERING_UPDATE: nsec_to_msec(update_end - cycle_begin),
+            WAITING: nsec_to_msec(cycle_end - update_end - compositing - idle),
+            COMPOSITING: nsec_to_msec(compositing),
+            IDLE: nsec_to_msec(idle),
+        }
+        # How far the compositing this cycle began ran past its end. A composition
+        # of an earlier cycle running through this one is that cycle's, not this
+        # one's, so what began here is what counts.
+        cycle["composition_overrun"] = (
+            nsec_to_msec(max(own_end - cycle_end, 0)) if own_end is not None else 0.0
+        )
+
+    return cycles

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/dump/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/dump/__init__.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict, List
 
 from ..parser import parse
+from ..utils import mark_begin, mark_pid
 
 
 def dump(args: argparse.Namespace) -> None:
@@ -12,7 +13,7 @@ def dump(args: argparse.Namespace) -> None:
         headers = ["category", "name", "description", "time", "offset", "value"]
         rows = _counters_to_rows(data["counters"])
     else:
-        headers = ["group", "name", "message", "time", "duration", "end_time"]
+        headers = ["group", "pid", "name", "message", "time", "duration", "end_time"]
         rows = _marks_to_rows(data["marks"])
 
     if args.format == "json":
@@ -25,9 +26,10 @@ def _marks_to_rows(marks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return [
         {
             "group": mark["group"],
+            "pid": mark_pid(mark),
             "name": mark["name"],
             "message": mark["message"],
-            "time": mark["end_time"] - mark["duration"],
+            "time": mark_begin(mark),
             "duration": mark["duration"],
             "end_time": mark["end_time"],
         }

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/histogram/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/histogram/__init__.py
@@ -1,24 +1,31 @@
 import argparse
 import math
-import statistics
 from typing import Any, Dict, List
 
 from ..parser import parse
 from ..utils import (
     MSEC_PER_SEC,
-    nsec_to_msec,
+    check_timespan_holds_data,
+    intervals_between_marks,
+    marks_by_process,
+    marks_in_time_order,
+    percentiles,
+    sample_statistics,
     parse_timespan_argument,
-    trim_sysprof_data_to_timespan,
+    sysprof_data_with_marks_by_name,
+    trim_marks_by_name_to_timespan,
 )
 
 
 def delta_histogram(args: argparse.Namespace) -> None:
     timespan_begin, timespan_end = parse_timespan_argument(args.timespan)
     parsed_data = parse(args.capture_file, marks=True, counters=False)
-    trimmed_data = trim_sysprof_data_to_timespan(
-        parsed_data, timespan_begin, timespan_end
+    capture_begin, capture_end = parsed_data["document"]["timespan"]
+    check_timespan_holds_data(capture_begin, capture_end, timespan_begin, timespan_end)
+    trimmed_data = trim_marks_by_name_to_timespan(
+        sysprof_data_with_marks_by_name(parsed_data), timespan_begin, timespan_end
     )
-    deltas_ms = _calculate_delta_times_ms(trimmed_data["marks"], args.mark_type)
+    deltas_ms = _delta_times_ms(trimmed_data, args.mark_type)
 
     if not deltas_ms:
         print(f"No data available for mark: {args.mark_type}")
@@ -27,27 +34,25 @@ def delta_histogram(args: argparse.Namespace) -> None:
     _plot_delta_time_distribution(args.mark_type, deltas_ms)
 
 
-def _calculate_delta_times_ms(
-    marks: List[Dict[str, Any]], mark_name: str
-) -> List[float]:
-    end_times = sorted(mark["end_time"] for mark in marks if mark["name"] == mark_name)
-    if len(end_times) < 2:
-        return []
+def _delta_times_ms(sysprof_data: Dict[str, Any], mark_name: str) -> List[float]:
+    """Times between consecutive marks of that name, in milliseconds."""
     return [
-        nsec_to_msec(end_times[i] - end_times[i - 1]) for i in range(1, len(end_times))
+        delta
+        for marks in marks_by_process(
+            marks_in_time_order(sysprof_data, mark_name)
+        ).values()
+        for delta in intervals_between_marks(marks)
     ]
 
 
 def _calculate_optimal_bins(deltas_ms: List[float]) -> int:
     # Freedman-Diaconis rule, falling back to Sturges' rule for a tiny IQR.
-    if len(deltas_ms) < 2:
+    low, high = 25, 75
+    quartiles = percentiles(deltas_ms, [low, high], method="exclusive")
+    if not quartiles:
+        # Too few deltas for a quartile, so there is no spread to bin by.
         return 10
-
-    q25, q75 = (
-        statistics.quantiles(deltas_ms, n=4)[0],
-        statistics.quantiles(deltas_ms, n=4)[2],
-    )
-    iqr = q75 - q25
+    iqr = quartiles[str(high)] - quartiles[str(low)]
 
     if iqr > 0:
         n = len(deltas_ms)
@@ -62,17 +67,20 @@ def _calculate_optimal_bins(deltas_ms: List[float]) -> int:
 def _plot_delta_time_distribution(mark_name: str, deltas_ms: List[float]) -> None:
     import matplotlib.pyplot as plt
 
-    mean_val = statistics.mean(deltas_ms)
-    median_val = statistics.median(deltas_ms)
-    min_val = min(deltas_ms)
-    max_val = max(deltas_ms)
-    std_val = statistics.stdev(deltas_ms) if len(deltas_ms) > 1 else 0.0
+    stats = sample_statistics(deltas_ms)
+    mean_val = stats["mean"]
+    median_val = stats["median"]
+    min_val = stats["min"]
+    max_val = stats["max"]
+    std_val = stats["stddev"]
     n_bins = _calculate_optimal_bins(deltas_ms)
 
+    # Marks sharing a timestamp are no time apart, and no frequency either.
+    frequency = f"{MSEC_PER_SEC / mean_val:.1f} Hz" if mean_val else "-"
     stats_text = (
         f"Sample Size: {len(deltas_ms):,}\n"
         f"Std Dev: {std_val:.2f} ms\n"
-        f"Frequency: {MSEC_PER_SEC / mean_val:.1f} Hz"
+        f"Frequency: {frequency}"
     )
 
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(16, 12), gridspec_kw={"hspace": 0.15})

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/parser/direct_parser.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/parser/direct_parser.py
@@ -112,6 +112,10 @@ def _index_frames(data: mmap.mmap) -> List[Tuple[int, int, int, int]]:
 def _parse_mark(
     data: mmap.mmap, offset: int, length: int, duration: int, end_time: int
 ) -> Dict[str, Any]:
+    # The frame header is len, cpu, pid, time, so the process that emitted the mark
+    # is four bytes in. The group names its kind, e.g. "WebKit (Web)", which two
+    # processes of one kind share.
+    (pid,) = struct.unpack_from("<i", data, offset + 4)
     group = _read_cstring(data, offset + 32, 24) or ""
     name = _read_cstring(data, offset + 56, 40) or ""
     message = _read_cstring(data, offset + 96, length - 96) or ""
@@ -121,6 +125,7 @@ def _parse_mark(
         "duration": duration,
         "end_time": end_time,
         "group": group,
+        "pid": pid,
     }
 
 

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/summary/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/summary/__init__.py
@@ -20,8 +20,8 @@ def _print_document_summary(capture_file: str, document: Dict[str, Any]) -> None
     print(f"Subtitle: {document['subtitle']}")
     print(
         "Timespan: {:.4f} - {:.4f} [s]".format(
-            abs(nsec_to_sec(document["timespan"][0])),
-            abs(nsec_to_sec(document["timespan"][1])),
+            nsec_to_sec(document["timespan"][0]),
+            nsec_to_sec(document["timespan"][1]),
         )
     )
     print()

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/frame_cycles_unittest.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/frame_cycles_unittest.py
@@ -1,0 +1,709 @@
+"""Frame cycle reconstruction on synthetic captures.
+
+The sample capture only covers cycles that all resolve. These build the awkward
+cases by hand.
+"""
+
+import unittest
+
+from .helpers import SysprofTestCase, approx, mark, sysprof_data
+
+from webkitsysprof import analyze
+from webkitsysprof.cycles import calculate_frame_cycles
+from webkitsysprof.utils import (
+    display_refreshes,
+    median_vblank_interval,
+    msec_to_nsec,
+)
+
+
+def frame_cycle_report(data, begin_msec=0, end_msec=1000, vblank_interval=None):
+    return analyze._prepare_frame_cycle_report(
+        data, msec_to_nsec(begin_msec), msec_to_nsec(end_msec), vblank_interval
+    )
+
+
+class FrameCyclesTest(SysprofTestCase):
+    def test_phases_partition_every_resolved_cycle(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+                mark("RenderLayerTree", 22, 30),
+                mark("PaintToGLContext", 25, 29),
+                mark("LayerTreeHostRenderingUpdate", 32, 36),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        self.assertEqual(len(cycles), 2)
+        for cycle in cycles:
+            self.assertIsNotNone(cycle["phases"])
+            self.assertEqual(sum(cycle["phases"].values()), approx(cycle["duration"]))
+
+    def test_composition_ending_after_the_cycle_is_reported_as_an_overrun(self):
+        # RenderLayerTree runs on past PaintToGLContext to wait for the GPU to finish
+        # the frame, and the next rendering update starts during that wait.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 30),
+                mark("PaintToGLContext", 10, 13),
+                mark("WaitForCompositionCompletion", 13, 30),
+                mark("LayerTreeHostRenderingUpdate", 20, 25),
+            ]
+        )
+
+        cycle = calculate_frame_cycles(data)[0]
+        self.assertIsNotNone(cycle["phases"])
+        # Compositing covers that wait up to the cycle end, the rest counts as an
+        # overrun rather than being dropped or booked as idle.
+        self.assertEqual(cycle["phases"]["compositing"], approx(13.0))
+        self.assertEqual(cycle["phases"]["idle"], approx(0.0))
+        self.assertEqual(cycle["composition_overrun"], approx(10.0))
+        self.assertEqual(sum(cycle["phases"].values()), approx(cycle["duration"]))
+
+    def test_a_cycle_after_an_overrunning_composition_still_resolves(self):
+        # The first cycle composites past the start of the second. Picking the end mark
+        # in begin order hands that long one to the second cycle too, which used to drop
+        # exactly the slow frames worth looking at.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 56),
+                mark("PaintToGLContext", 10, 50),
+                mark("LayerTreeHostRenderingUpdate", 18, 20),
+                mark("RenderLayerTree", 22, 23),
+                mark("PaintToGLContext", 22, 23),
+                mark("LayerTreeHostRenderingUpdate", 30, 35),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        self.assertEqual(
+            [cycle["phases"] is not None for cycle in cycles], [True, True]
+        )
+        # The composition begun at 6 ms is still running through the second cycle, so
+        # that cycle is compositing from the end of its update to its own end.
+        self.assertEqual(cycles[1]["phases"]["compositing"], approx(10.0))
+        self.assertEqual(cycles[1]["phases"]["idle"], approx(0.0))
+        # Each cycle reports how far its own composition ran past it, so the long one
+        # counts for the cycle it began in and the short one for the next.
+        self.assertEqual(cycles[0]["composition_overrun"], approx(38.0))
+        self.assertEqual(cycles[1]["composition_overrun"], approx(0.0))
+
+    def test_cycles_without_compositing_marks_are_counted_but_not_analyzed(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+                mark("LayerTreeHostRenderingUpdate", 24, 28),
+                mark("RenderLayerTree", 30, 36),
+                mark("PaintToGLContext", 32, 35),
+                mark("LayerTreeHostRenderingUpdate", 40, 44),
+            ]
+        )
+
+        report = frame_cycle_report(data)
+        self.assertEqual(report["cycles"], 3)
+        self.assertEqual(report["resolved_duration_statistics"]["n"], 2)
+        # The phase statistics cover the two cycles that composited, not all three.
+        self.assertEqual(report["resolved_duration_statistics"]["n"], 2)
+        self.assertEqual(report["duration_statistics"]["n"], 3)
+
+    def test_the_gap_between_two_rendering_periods_is_reported_as_a_long_cycle(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+                mark("RenderLayerTree", 22, 30),
+                mark("PaintToGLContext", 25, 29),
+                mark("LayerTreeHostRenderingUpdate", 500, 505),
+                mark("RenderLayerTree", 507, 514),
+                mark("PaintToGLContext", 510, 513),
+                mark("LayerTreeHostRenderingUpdate", 516, 520),
+            ]
+        )
+
+        report = frame_cycle_report(data)
+        # Dropping the 470 ms of idle time between the two bursts would hide it. The
+        # median is what the frames took, and the idle spell is the maximum and the
+        # idle phase, where it can be read as what it is.
+        self.assertEqual(report["cycles"], 3)
+        self.assertEqual(report["duration_statistics"]["median"], approx(16.0))
+        self.assertEqual(report["duration_statistics"]["max"], approx(484.0))
+        self.assertEqual(report["phase_statistics"]["idle"]["max"], approx(470.0))
+
+    def test_the_compositing_mark_name_is_resolved_per_cycle(self):
+        # renderLayerTree() opens its trace scope before the checks that can return
+        # early, so the first cycle holds a RenderLayerTree with nothing inside it.
+        # The marks the second cycle carries must not decide for the first.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+                mark("RenderLayerTree", 22, 30),
+                mark("FlushCompositingState", 23, 25),
+                mark("PaintToGLContext", 25, 29),
+                mark("LayerTreeHostRenderingUpdate", 32, 36),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        self.assertEqual(
+            [cycle["phases"] is not None for cycle in cycles], [True, True]
+        )
+        self.assertEqual(cycles[0]["phases"]["compositing"], approx(7.0))
+        self.assertEqual(cycles[1]["phases"]["compositing"], approx(8.0))
+
+    def test_compositing_is_over_when_the_last_compositing_mark_is(self):
+        # A second RenderLayerTree after PaintToGLContext. Consulting only the first
+        # mark name that matches would book its 29 ms as idle.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 10),
+                mark("PaintToGLContext", 7, 8),
+                mark("RenderLayerTree", 11, 40),
+                mark("LayerTreeHostRenderingUpdate", 50, 55),
+            ]
+        )
+
+        phases = calculate_frame_cycles(data)[0]["phases"]
+        # 6 to 10 and 11 to 40, so the millisecond between the two is a wait rather
+        # than compositing.
+        self.assertEqual(phases["compositing"], approx(33.0))
+        self.assertEqual(phases["waiting_for_compositing"], approx(2.0))
+        self.assertEqual(phases["idle"], approx(10.0))
+
+    def test_compositing_overlapping_the_rendering_update_still_counts(self):
+        # RenderLayerTree starts on the compositing thread 1 ms before the rendering
+        # update mark ends. Skipping it would measure the cycle off PaintToGLContext.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 10),
+                mark("RenderLayerTree", 9, 20),
+                mark("PaintToGLContext", 12, 18),
+                mark("LayerTreeHostRenderingUpdate", 30, 35),
+            ]
+        )
+
+        phases = calculate_frame_cycles(data)[0]["phases"]
+        self.assertEqual(phases["rendering_update"], approx(10.0))
+        self.assertEqual(phases["waiting_for_compositing"], approx(0.0))
+        self.assertEqual(phases["compositing"], approx(10.0))
+        self.assertEqual(phases["idle"], approx(10.0))
+
+    def test_a_cycle_reaching_past_the_timespan_is_left_out_of_it(self):
+        # Like a mark crossing the boundary, which trimming drops: a frame half
+        # outside the window must not contribute a whole frame's timing to it.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 190),
+                mark("PaintToGLContext", 10, 180),
+                mark("LayerTreeHostRenderingUpdate", 200, 205),
+            ],
+            end_msec=10,
+        )
+
+        report = frame_cycle_report(data, end_msec=10)
+        self.assertEqual(report["cycles"], 0)
+        self.assertEqual(report["coverage"], approx(0.0))
+
+    def test_a_capture_without_compositing_marks_keeps_its_cycles(self):
+        # Rendering updates that composited nothing, so no cycle can be split into
+        # phases. The cycles themselves are still measured and reported.
+        marks = [
+            mark("LayerTreeHostRenderingUpdate", i * 50, i * 50 + 8) for i in range(10)
+        ]
+        marks += [
+            mark("DisplayLinkUpdate", i * 16.67, i * 16.67 + 0.1) for i in range(60)
+        ]
+
+        report = frame_cycle_report(sysprof_data(marks))
+        self.assertEqual(report["cycles"], 9)
+        self.assertEqual(report["resolved_duration_statistics"], {})
+        self.assertEqual(report["duration_statistics"]["median"], approx(50.0))
+
+    def test_coverage_is_the_share_of_the_window_the_analyzed_cycles_took(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 90),
+                mark("PaintToGLContext", 10, 88),
+                mark("LayerTreeHostRenderingUpdate", 100, 105),
+                mark("RenderLayerTree", 107, 190),
+                mark("PaintToGLContext", 110, 188),
+                mark("LayerTreeHostRenderingUpdate", 200, 205),
+            ]
+        )
+
+        report = frame_cycle_report(data, begin_msec=100, end_msec=300)
+        # Only the second cycle lies within the window, and it fills half of it.
+        self.assertEqual(report["cycles"], 1)
+        self.assertEqual(report["coverage"], approx(0.5))
+
+    def test_a_single_cycle_reports_no_percentiles_rather_than_failing(self):
+        # statistics.quantiles() raises below two data points before Python 3.13.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+            ]
+        )
+
+        report = frame_cycle_report(data)
+        self.assertEqual(report["cycles"], 1)
+        self.assertEqual(report["duration_statistics"]["percentiles"], {})
+        self.assertEqual(report["phase_statistics"]["compositing"]["percentiles"], {})
+
+    def test_no_cycles_at_all(self):
+        report = frame_cycle_report(
+            sysprof_data([mark("LayerTreeHostRenderingUpdate", 0, 5)])
+        )
+        self.assertEqual(report["cycles"], 0)
+        self.assertEqual(report["resolved_duration_statistics"], {})
+        self.assertEqual(report["duration_statistics"], {})
+        # No cycle is no rate, and reporting 0 would read as an infinitely slow one.
+        self.assertIsNone(report["implied_fps"])
+        self.assertIsNone(report["vblank_intervals_per_cycle"])
+
+    def test_cycles_per_vblank_interval_is_unknown_without_vblank_marks(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 16, 20),
+            ]
+        )
+
+        self.assertIsNone(
+            median_vblank_interval(display_refreshes(data))
+        )
+        # Reporting 0 here would read as "the cycle fits in zero vblank intervals".
+        self.assertIsNone(frame_cycle_report(data)["vblank_intervals_per_cycle"])
+
+    def test_cycles_are_restricted_to_the_ones_lying_within_the_timespan(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 7, 14),
+                mark("PaintToGLContext", 10, 13),
+                mark("LayerTreeHostRenderingUpdate", 100, 105),
+                mark("RenderLayerTree", 107, 114),
+                mark("PaintToGLContext", 110, 113),
+                mark("LayerTreeHostRenderingUpdate", 200, 205),
+            ]
+        )
+
+        self.assertEqual(len(calculate_frame_cycles(data)), 2)
+        # 50 ms falls inside the first cycle, so that cycle belongs to neither side.
+        self.assertEqual(len(calculate_frame_cycles(data, msec_to_nsec(50), None)), 1)
+        self.assertEqual(len(calculate_frame_cycles(data, None, msec_to_nsec(50))), 0)
+        self.assertEqual(len(calculate_frame_cycles(data, None, msec_to_nsec(100))), 1)
+        self.assertEqual(
+            calculate_frame_cycles(data, msec_to_nsec(50), None)[0]["begin_nsec"],
+            msec_to_nsec(100),
+        )
+
+    def test_compositing_running_inside_the_rendering_update_still_resolves(self):
+        # The compositing thread finished while the rendering update mark was still
+        # open. There is no compositing phase to report, but the cycle is measured.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 100),
+                mark("RenderLayerTree", 10, 50),
+                mark("LayerTreeHostRenderingUpdate", 200, 205),
+            ]
+        )
+
+        cycle = calculate_frame_cycles(data)[0]
+        self.assertEqual(
+            cycle["phases"],
+            {
+                "rendering_update": approx(100.0),
+                "waiting_for_compositing": approx(0.0),
+                "compositing": approx(0.0),
+                "idle": approx(100.0),
+            },
+        )
+
+    def test_a_cycle_never_runs_between_two_processes(self):
+        # Two web processes rendering at once, which a system-wide capture holds. A
+        # cycle spanning both would be a frame of neither.
+        marks = []
+        for i in range(3):
+            marks += [
+                mark("LayerTreeHostRenderingUpdate", i * 20, i * 20 + 5, pid=1),
+                mark("RenderLayerTree", i * 20 + 6, i * 20 + 12, pid=1),
+                mark("LayerTreeHostRenderingUpdate", i * 20 + 10, i * 20 + 15, pid=2),
+                mark("RenderLayerTree", i * 20 + 16, i * 20 + 19, pid=2),
+            ]
+
+        cycles = calculate_frame_cycles(sysprof_data(marks))
+        self.assertEqual(len(cycles), 4)
+        self.assertEqual(
+            [cycle["duration"] for cycle in cycles], [approx(20.0) for _ in cycles]
+        )
+        self.assertEqual(sorted({cycle["pid"] for cycle in cycles}), [1, 2])
+        # Compositing of one process never lands in the other one's phases.
+        for cycle in cycles:
+            self.assertEqual(
+                cycle["phases"]["compositing"],
+                approx(6.0 if cycle["pid"] == 1 else 3.0),
+            )
+
+    def test_a_cycle_spent_entirely_on_an_earlier_composition_is_analyzed(self):
+        # Compositing that overruns covers the whole of the next cycle, so that cycle
+        # holds no compositing mark of its own. Dropping it would leave the phase
+        # medians describing the fast frames only.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 120),
+                mark("LayerTreeHostRenderingUpdate", 50, 55),
+                mark("LayerTreeHostRenderingUpdate", 100, 105),
+                mark("RenderLayerTree", 106, 115),
+                mark("LayerTreeHostRenderingUpdate", 150, 155),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        self.assertEqual(
+            cycles[1]["phases"],
+            {
+                "rendering_update": approx(5.0),
+                "waiting_for_compositing": approx(0.0),
+                "compositing": approx(45.0),
+                "idle": approx(0.0),
+            },
+        )
+        # The composition overran by 70 ms past the cycle it began in, and is counted
+        # there rather than once more in every cycle it runs through.
+        self.assertEqual(cycles[0]["composition_overrun"], approx(70.0))
+        self.assertEqual(cycles[1]["composition_overrun"], approx(0.0))
+
+    def test_coverage_merges_the_cycles_of_two_processes(self):
+        marks = []
+        for i in range(10):
+            for pid in (1, 2):
+                marks += [
+                    mark("LayerTreeHostRenderingUpdate", i * 100, i * 100 + 5, pid=pid),
+                    mark("RenderLayerTree", i * 100 + 6, i * 100 + 50, pid=pid),
+                ]
+
+        report = frame_cycle_report(sysprof_data(marks))
+        # Both processes render throughout, so together they cover the 900 ms their
+        # cycles span, not the 1800 ms of summing them up.
+        self.assertEqual(report["cycles"], 18)
+        self.assertEqual(report["coverage"], approx(0.9))
+
+    def test_a_composition_begun_before_the_window_is_still_seen_in_it(self):
+        # The stall began at 6 ms, before the window, and holds up the cycle inside it.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 120),
+                mark("LayerTreeHostRenderingUpdate", 50, 55),
+                mark("LayerTreeHostRenderingUpdate", 100, 105),
+                mark("RenderLayerTree", 106, 115),
+                mark("LayerTreeHostRenderingUpdate", 150, 155),
+            ]
+        )
+
+        windowed = calculate_frame_cycles(data, msec_to_nsec(40), None)
+        self.assertEqual(
+            [cycle["phases"] is not None for cycle in windowed], [True, True]
+        )
+        self.assertEqual(windowed[0]["phases"]["compositing"], approx(45.0))
+
+    def test_a_stall_is_seen_past_a_shorter_mark_of_the_same_name(self):
+        # One process can emit two marks of one name that overlap, a long composition
+        # with a shorter one inside it, and the shorter one must not hide the stall.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 2),
+                mark("RenderLayerTree", 2, 200),
+                mark("RenderLayerTree", 10, 15),
+                mark("LayerTreeHostRenderingUpdate", 20, 22),
+                mark("LayerTreeHostRenderingUpdate", 40, 42),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        self.assertEqual(
+            [cycle["phases"] is not None for cycle in cycles], [True, True]
+        )
+        self.assertEqual(cycles[1]["phases"]["compositing"], approx(18.0))
+
+    def test_a_capture_of_negative_length_reports_no_rate(self):
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 10),
+                mark("LayerTreeHostRenderingUpdate", 20, 25),
+            ]
+        )
+
+        report = analyze._prepare_frame_cycle_report(data, 0, msec_to_nsec(-5), 16.67)
+        # A window of less than no length is no duration to be a share of.
+        self.assertIsNone(report["coverage"])
+
+    def test_no_cycles_says_so_rather_than_blaming_a_zero_median(self):
+        report = frame_cycle_report(
+            sysprof_data([mark("LayerTreeHostRenderingUpdate", 10, 15)]),
+            vblank_interval=16.67,
+        )
+        self.assertEqual(report["cycles"], 0)
+        # A token, so that rewording the report cannot break a JSON consumer.
+        self.assertEqual(report["vblank_intervals_per_cycle_unknown"], "no_cycles")
+        self.assertTrue(
+            analyze.explanations.UNKNOWN_VBLANK_INTERVALS_PER_CYCLE["no_cycles"]
+        )
+
+    def test_every_overrunning_composition_of_a_stall_is_counted(self):
+        # Six 16 ms cycles, each compositing 9 ms past its own end. Counting only the
+        # first would report a sustained stall as a single slow frame.
+        marks = []
+        for i in range(6):
+            marks += [
+                mark("LayerTreeHostRenderingUpdate", i * 16, i * 16 + 3),
+                mark("RenderLayerTree", i * 16 + 5, i * 16 + 25),
+            ]
+
+        cycles = calculate_frame_cycles(sysprof_data(marks))
+        self.assertEqual(
+            [cycle["composition_overrun"] for cycle in cycles],
+            [approx(9.0) for _ in cycles],
+        )
+
+    def test_a_cycle_running_a_sliver_of_an_inherited_composition_is_measured(self):
+        # The composition of the first cycle ends a microsecond after the second one's
+        # rendering update does, so the second ran a sliver of it.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 2),
+                mark("RenderLayerTree", 3, 12.001),
+                mark("LayerTreeHostRenderingUpdate", 10, 12),
+                mark("LayerTreeHostRenderingUpdate", 30, 32),
+            ]
+        )
+
+        phases = calculate_frame_cycles(data)[1]["phases"]
+        self.assertEqual(phases["compositing"], approx(0.001))
+        self.assertEqual(phases["idle"], approx(17.999))
+
+    def test_a_cycle_running_only_an_inherited_composition_is_measured(self):
+        # The composition began before the cycle and ran through the first half of its
+        # rendering update. Nothing began within the cycle, but something composited
+        # in it, so it is measured like a cycle whose own composition did the same.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 10, 100),
+                mark("LayerTreeHostRenderingUpdate", 50, 150),
+                mark("LayerTreeHostRenderingUpdate", 250, 255),
+            ]
+        )
+
+        phases = calculate_frame_cycles(data)[1]["phases"]
+        self.assertEqual(phases["rendering_update"], approx(100.0))
+        self.assertEqual(phases["compositing"], approx(0.0))
+        self.assertEqual(phases["idle"], approx(100.0))
+
+    def test_a_cycle_composited_beside_its_update_only_is_measured_as_zero(self):
+        # The same capture with the composition ending a microsecond earlier: the
+        # second cycle ran it only beside its own rendering update, so it composited
+        # for no time of its own. A microsecond of the phase separates the two cases,
+        # rather than one of them being measured and the other not.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 0, 2),
+                mark("RenderLayerTree", 3, 11.999),
+                mark("LayerTreeHostRenderingUpdate", 10, 12),
+                mark("LayerTreeHostRenderingUpdate", 30, 32),
+            ]
+        )
+
+        phases = calculate_frame_cycles(data)[1]["phases"]
+        self.assertEqual(phases["compositing"], approx(0.0))
+        self.assertEqual(phases["idle"], approx(18.0))
+
+    def test_a_mark_ending_before_the_capture_keeps_its_own_end(self):
+        # The parser shifts timestamps, so a mark that began before the capture ends
+        # at a negative time. Reporting it as ending at 0 would make it look like it
+        # was still running when the capture started.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", -20, -18),
+                mark("RenderLayerTree", -19, -17),
+                mark("LayerTreeHostRenderingUpdate", 0, 5),
+                mark("RenderLayerTree", 6, 12),
+                mark("LayerTreeHostRenderingUpdate", 20, 25),
+            ]
+        )
+
+        cycles = calculate_frame_cycles(data)
+        # The first cycle ends before the second begins, so the second waits for its
+        # own composition rather than inheriting one that was over long before.
+        self.assertEqual(cycles[1]["phases"]["waiting_for_compositing"], approx(1.0))
+
+    def test_a_gap_between_two_compositions_is_a_wait_not_compositing(self):
+        for inherited_end in [12.001, 11.999]:
+            with self.subTest(inherited_end=inherited_end):
+                # The cycle 10 -> 40 runs the tail of the composition it
+                # inherited, waits, and then composites again. Reading that as
+                # one span from the first mark to the last would report the wait
+                # as compositing, and a microsecond either side of the update
+                # would move 18 ms between the two phases.
+                data = sysprof_data(
+                    [
+                        mark("LayerTreeHostRenderingUpdate", 0, 2),
+                        mark("RenderLayerTree", 3, inherited_end),
+                        mark("LayerTreeHostRenderingUpdate", 10, 12),
+                        mark("RenderLayerTree", 30, 38),
+                        mark("LayerTreeHostRenderingUpdate", 40, 42),
+                    ]
+                )
+
+                phases = calculate_frame_cycles(data)[1]["phases"]
+                self.assertEqual(
+                    phases["waiting_for_compositing"], approx(18.0, abs=0.002)
+                )
+                self.assertEqual(phases["compositing"], approx(8.0, abs=0.002))
+                self.assertEqual(phases["idle"], approx(2.0))
+                self.assertEqual(sum(phases.values()), approx(30.0))
+
+    def test_two_renderers_of_one_kind_are_told_apart_by_their_process(self):
+        # Two web processes rendering every 16 ms, 8 ms apart, both naming themselves
+        # "WebKit (Web)". Read by kind they would pair into 8 ms cycles and twice the
+        # frame rate of either.
+        marks = []
+        for i in range(4):
+            marks += [
+                mark("LayerTreeHostRenderingUpdate", i * 16, i * 16 + 2, pid=1),
+                mark("RenderLayerTree", i * 16 + 2, i * 16 + 9, pid=1),
+                mark("LayerTreeHostRenderingUpdate", i * 16 + 8, i * 16 + 10, pid=2),
+                mark("RenderLayerTree", i * 16 + 10, i * 16 + 15, pid=2),
+            ]
+
+        report = frame_cycle_report(sysprof_data(marks, end_msec=200))
+        self.assertEqual(report["processes"], 2)
+        self.assertEqual(report["duration_statistics"]["median"], approx(16.0))
+        self.assertEqual(report["implied_fps"], approx(62.5))
+
+    def test_two_updates_at_one_instant_belong_to_two_processes(self):
+        # One process cannot open two updates at once, so a pair beginning together is
+        # two of them, and neither has a second update to close a cycle with.
+        data = sysprof_data(
+            [
+                mark("LayerTreeHostRenderingUpdate", 10, 12, pid=1),
+                mark("LayerTreeHostRenderingUpdate", 10, 13, pid=2),
+            ]
+        )
+
+        self.assertEqual(calculate_frame_cycles(data), [])
+
+    def test_a_report_without_a_rate_prints_no_rate(self):
+        # implied_fps is None wherever there is no median cycle to take it from, and
+        # the renderer must print that rather than formatting a number that is not one.
+        frame_cycle = {
+            "cycles": 1,
+            "processes": 1,
+            "duration_statistics": {"n": 1, "min": 0, "max": 0, "median": 0, "mean": 0},
+            "resolved_duration_statistics": {},
+            "phase_statistics": {phase: {} for phase in analyze.PHASES},
+            "overrunning_composition_statistics": {},
+            "implied_fps": None,
+            "coverage": None,
+            "capture_vblank_interval": 16.67,
+            "vblank_intervals_per_cycle": None,
+            "vblank_intervals_per_cycle_unknown": "zero_length_cycle",
+        }
+
+        analyze._render_frame_cycle_numbers(frame_cycle)
+
+        stdout = self.stdout()
+        self.assertIn("implied FPS (1000 / median cycle): -", stdout)
+        self.assertIn("cycles cover - of the analyzed duration", stdout)
+
+    def test_a_steady_slow_capture_keeps_its_cycles(self):
+        # 20 FPS, so every cycle idles for 42 of its 50 ms. That is the rhythm of this
+        # capture, not the engine running out of work.
+        marks = []
+        for i in range(20):
+            marks += [
+                mark("LayerTreeHostRenderingUpdate", i * 50, i * 50 + 3),
+                mark("RenderLayerTree", i * 50 + 3, i * 50 + 8),
+            ]
+
+        report = frame_cycle_report(sysprof_data(marks), vblank_interval=16.67)
+        self.assertEqual(report["cycles"], 19)
+        self.assertEqual(report["implied_fps"], approx(20.0))
+        self.assertEqual(report["phase_statistics"]["idle"]["median"], approx(42.0))
+
+    def test_the_composition_overrun_median_describes_the_overrunning_cycles(self):
+        marks = []
+        for i in range(10):
+            begin = i * 100
+            # Two of the ten compositions run past the start of the next cycle.
+            compositing_end = begin + 150 if i in (3, 7) else begin + 50
+            marks += [
+                mark("LayerTreeHostRenderingUpdate", begin, begin + 10),
+                mark("RenderLayerTree", begin + 20, compositing_end),
+            ]
+        marks.append(mark("LayerTreeHostRenderingUpdate", 1000, 1010))
+
+        report = frame_cycle_report(sysprof_data(marks, end_msec=2000))
+        self.assertEqual(report["overrunning_composition_statistics"]["n"], 2)
+        # The eight cycles that did not overrun must not median the number down to 0.
+        self.assertEqual(
+            report["overrunning_composition_statistics"]["median"], approx(50.0)
+        )
+
+    def test_an_unknown_refresh_rate_is_not_reported_as_zero(self):
+        report = {
+            "document": {"timespan": {"begin": 0.0, "end": 1000.0}},
+            "rendering": {
+                "frames_rendered": 10,
+                "theoretical_fps": 10.0,
+                "vblanks": 1,
+                "vblank_interval_statistics": {},
+            },
+        }
+
+        explanation = analyze._theoretical_fps_explanation(report)
+        # One mark is not none, and it is no reason to claim a 0 Hz display either.
+        self.assertIn("refreshed 1 time,", explanation)
+        self.assertNotIn("0.00 Hz", explanation)
+
+    def test_a_zero_median_vblank_interval_is_not_reported_as_shared_timestamps(self):
+        report = {
+            "document": {"timespan": {"begin": 0.0, "end": 1000.0}},
+            "rendering": {
+                "frames_rendered": 10,
+                "theoretical_fps": 10.0,
+                "vblanks": 4,
+                # Two of the four share a timestamp, which is enough for a zero median
+                # without the marks being the same instant.
+                "vblank_interval_statistics": {"median": 0.0},
+            },
+        }
+
+        explanation = analyze._theoretical_fps_explanation(report)
+        self.assertIn("the median interval between two of the 4", explanation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/helpers.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/helpers.py
@@ -1,0 +1,76 @@
+"""What the tests build captures from, and read what a command printed with.
+
+A synthetic mark is shaped like what the parser produces: it carries no begin
+time, so everything derives one from `end_time` and `duration`, and it names the
+process that emitted it by pid as well as by kind.
+"""
+
+import builtins
+import unittest
+
+from webkitcorepy import OutputCapture
+
+from webkitsysprof.utils import msec_to_nsec
+
+
+def mark(name, begin_msec, end_msec, group="WebKit (Web)", pid=1):
+    return {
+        "group": group,
+        "pid": pid,
+        "name": name,
+        "message": "",
+        "duration": msec_to_nsec(end_msec - begin_msec),
+        "end_time": msec_to_nsec(end_msec),
+    }
+
+
+def sysprof_data(marks, begin_msec=0, end_msec=1000):
+    marks_by_name = {}
+    for a_mark in marks:
+        marks_by_name.setdefault(a_mark["name"], []).append(a_mark)
+    return {
+        "document": {
+            "timespan": {
+                "begin": msec_to_nsec(begin_msec),
+                "end": msec_to_nsec(end_msec),
+            }
+        },
+        "marks": marks_by_name,
+    }
+
+
+class approx:
+    """A number equal to another within a tolerance, relative unless `abs` says so.
+
+    Durations are divided and summed before they are compared, so comparing them
+    exactly would test the rounding of binary floating point rather than the
+    analysis. Works inside a list or a dict too, since a float compared against one
+    of these defers to it.
+    """
+
+    def __init__(self, value, rel=1e-6, abs=None):
+        self.value = value
+        self.tolerance = abs if abs is not None else rel * max(builtins.abs(value), 1.0)
+
+    def __eq__(self, other):
+        return builtins.abs(other - self.value) <= self.tolerance
+
+    def __repr__(self):
+        return f"~{self.value!r}"
+
+
+class SysprofTestCase(unittest.TestCase):
+    """A test reading back what the command under it printed.
+
+    OutputCapture keeps stdout and the root logger to itself, so that a command
+    configuring logging does not outlive the test that ran it.
+    """
+
+    def setUp(self):
+        capture = OutputCapture()
+        capture.__enter__()
+        self.addCleanup(capture.__exit__, None, None, None)
+        self._capture = capture
+
+    def stdout(self):
+        return self._capture.stdout.getvalue()

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/subcommands_unittest.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/subcommands_unittest.py
@@ -1,26 +1,30 @@
 import argparse
 import json
-import unittest
 from pathlib import Path
 
-from webkitcorepy import OutputCapture
+import unittest
 
-from webkitsysprof import summary, dump, analyze
+from .helpers import SysprofTestCase, approx, mark, sysprof_data
+
+from webkitsysprof import summary, dump, analyze, histogram
+from webkitsysprof.__main__ import main
+from webkitsysprof.utils import (
+    UsageError,
+    display_refreshes,
+    check_timespan_holds_data,
+    msec_to_nsec,
+    trim_marks_by_name_to_timespan,
+)
 
 SAMPLE_CAPTURE_FILE = str(Path(__file__).parent / "assets" / "sample.syscap")
 
 
-def _capture_stdout(func, args):
-    with OutputCapture() as captured:
-        func(args)
-    return captured.stdout.getvalue()
-
-
-class SubcommandsTest(unittest.TestCase):
+class SubcommandsTest(SysprofTestCase):
     def test_summary(self):
         args = argparse.Namespace(capture_file=SAMPLE_CAPTURE_FILE)
-        stdout = _capture_stdout(summary.summary, args)
+        summary.summary(args)
 
+        stdout = self.stdout()
         self.assertIn(f"File: {SAMPLE_CAPTURE_FILE}", stdout)
         self.assertIn("Marks: 669", stdout)
         self.assertIn("Counters: 53", stdout)
@@ -29,105 +33,631 @@ class SubcommandsTest(unittest.TestCase):
         args = argparse.Namespace(
             capture_file=SAMPLE_CAPTURE_FILE, marks=True, counters=False, format="csv"
         )
-        stdout = _capture_stdout(dump.dump, args)
+        dump.dump(args)
 
-        stdout_lines = stdout.split("\n")
+        stdout_lines = self.stdout().split("\n")
         self.assertEqual(len(stdout_lines), 669 + 1 + 1)
 
     def test_dump_counters_csv(self):
         args = argparse.Namespace(
             capture_file=SAMPLE_CAPTURE_FILE, marks=False, counters=True, format="csv"
         )
-        stdout = _capture_stdout(dump.dump, args)
+        dump.dump(args)
 
-        stdout_lines = stdout.split("\n")
+        stdout_lines = self.stdout().split("\n")
         self.assertEqual(len(stdout_lines), 540 + 1 + 1)
 
     def test_dump_marks_json(self):
         args = argparse.Namespace(
             capture_file=SAMPLE_CAPTURE_FILE, marks=True, counters=False, format="json"
         )
-        stdout = _capture_stdout(dump.dump, args)
+        dump.dump(args)
 
-        marks = json.loads(stdout)
+        marks = json.loads(self.stdout())
         self.assertEqual(len(marks), 669)
         self.assertEqual(
             set(marks[0].keys()),
-            {"group", "name", "message", "time", "duration", "end_time"},
+            {
+                "group",
+                "pid",
+                "name",
+                "message",
+                "time",
+                "duration",
+                "end_time",
+            },
         )
 
     def test_dump_counters_json(self):
         args = argparse.Namespace(
             capture_file=SAMPLE_CAPTURE_FILE, marks=False, counters=True, format="json"
         )
-        stdout = _capture_stdout(dump.dump, args)
+        dump.dump(args)
 
-        counter_values = json.loads(stdout)
+        counter_values = json.loads(self.stdout())
         self.assertEqual(len(counter_values), 540)
         self.assertEqual(
             set(counter_values[0].keys()),
-            {"category", "name", "description", "time", "offset", "value"},
+            {
+                "category",
+                "name",
+                "description",
+                "time",
+                "offset",
+                "value",
+            },
         )
 
     def test_analyze_text(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="-"
+            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="-", explain=False
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
+        stdout = self.stdout()
         self.assertIn("Timespan: 0.0000 - 4.4673 [s]", stdout)
         self.assertIn("vblanks: 35", stdout)
+        self.assertIn("Frame cycle:", stdout)
+        self.assertIn("- cycles: 2", stdout)
+        # The explanations are opt-in, so the report itself stays diffable.
+        self.assertNotIn(
+            "Theoretical FPS is the number of DidRenderFrame marks", stdout
+        )
+        self.assertNotIn(
+            "A frame cycle starts when a LayerTreeHostRenderingUpdate", stdout
+        )
+
+    def test_analyze_text_with_explanations(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="-", explain=True
+        )
+        analyze.analyze(args)
+
+        stdout = self.stdout()
+        self.assertIn("Theoretical FPS is the number of DidRenderFrame marks", stdout)
+        self.assertIn(
+            "A frame cycle starts when a LayerTreeHostRenderingUpdate begins", stdout
+        )
+        self.assertIn("StyleRecalc is an umbrella mark", stdout)
+
+    def test_analyze_json_percentiles_stay_within_the_data_range(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
+        )
+        analyze.analyze(args)
+
+        report = json.loads(self.stdout())
+        all_statistics = (
+            [
+                statistics
+                for mark in report["statistics"].values()
+                for statistics in mark.values()
+            ]
+            + [
+                report["frame_cycle"]["duration_statistics"],
+                report["frame_cycle"]["resolved_duration_statistics"],
+                # The ones the text report prints percentiles of inline.
+                report["rendering"]["vblank_interval_statistics"],
+                report["rendering"]["vblanks_per_rendering_update"]["statistics"],
+                report["rendering"]["frame_compositions_per_vblank_statistics"],
+            ]
+            + list(report["frame_cycle"]["phase_statistics"].values())
+        )
+
+        # Extrapolating past the samples used to yield a P25 below the minimum, a P99
+        # above the maximum and negative durations.
+        for statistics in all_statistics:
+            for percentile in statistics.get("percentiles", {}).values():
+                self.assertTrue(statistics["min"] <= percentile <= statistics["max"])
 
     def test_analyze_json(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-"
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
+        stdout = self.stdout()
         report = json.loads(stdout)
         self.assertEqual(int(report["document"]["timespan"]["begin"]), 0)
         self.assertEqual(int(report["document"]["timespan"]["end"]), 4467)
         self.assertEqual(report["rendering"]["vblanks"], 35)
+        self.assertEqual(report["frame_cycle"]["cycles"], 2)
+        self.assertEqual(report["frame_cycle"]["resolved_duration_statistics"]["n"], 2)
+        self.assertEqual(
+            set(report["frame_cycle"]["phase_statistics"]),
+            {
+                "rendering_update",
+                "waiting_for_compositing",
+                "compositing",
+                "idle",
+            },
+        )
+
+    def test_analyze_json_frame_cycle_phases_add_up_to_cycle_duration(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
+        )
+        analyze.analyze(args)
+
+        frame_cycle = json.loads(self.stdout())["frame_cycle"]
+        phases_mean = sum(
+            statistics["mean"]
+            for statistics in frame_cycle["phase_statistics"].values()
+        )
+        # Against the cycles the phases came from, not all of them: the two differ as
+        # soon as one cycle cannot be split into phases.
+        self.assertEqual(
+            phases_mean,
+            approx(frame_cycle["resolved_duration_statistics"]["mean"], rel=1e-6),
+        )
 
     def test_analyze_json_statistics_cover_all_relevant_marks(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-"
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
-        statistics = json.loads(stdout)["statistics"]
+        statistics = json.loads(self.stdout())["statistics"]
         self.assertEqual(set(statistics), set(analyze.MARKS_RELEVANT_FOR_STATISTICS))
         self.assertEqual(statistics["CompositingUpdate"]["duration"]["n"], 7)
         self.assertEqual(statistics["RenderTreeBuild"]["duration"]["n"], 3)
-        # Tile geometry depends on the rendering backend, so only check that
-        # the dirty area was extracted from every PaintTile message.
+        # Tile geometry depends on the rendering backend, so only check that the
+        # dirty area was extracted from every PaintTile message.
         self.assertEqual(statistics["PaintTile"]["dirty_pixels"]["n"], 80)
         self.assertGreater(statistics["PaintTile"]["dirty_pixels"]["min"], 0)
 
+    def test_analyze_with_a_timespan_holding_vblanks_but_no_rendering_update(self):
+        # The window has vblanks, so the no-vblanks early return does not save it, and
+        # trimming drops the first rendering update for reaching past the window end.
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="text",
+            timespan="0-370",
+            explain=False,
+        )
+        analyze.analyze(args)
+
+        stdout = self.stdout()
+        self.assertIn("- cycles: 0", stdout)
+        self.assertIn("no two consecutive LayerTreeHostRenderingUpdate marks", stdout)
+
+    def test_analyze_json_leaves_out_a_cycle_reaching_past_the_timespan(self):
+        # The only cycle of this window begins at 371.6 ms and ends at 524.2 ms, so it
+        # is no frame of the window and must not be timed as one.
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="json",
+            timespan="0-400",
+            explain=False,
+        )
+        analyze.analyze(args)
+
+        frame_cycle = json.loads(self.stdout())["frame_cycle"]
+        self.assertEqual(frame_cycle["cycles"], 0)
+        self.assertEqual(frame_cycle["coverage"], approx(0.0))
+
+    def test_analyze_resolves_a_cycle_whose_compositing_marks_trimming_drops(self):
+        # The cycle 524.2 -> 560.8 ms lies within this window, but composites in
+        # RenderLayerTree 549.8 -> 571.1, which reaches past the window end and is
+        # trimmed away. Reconstructing from the untrimmed capture keeps it.
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="json",
+            timespan="370-561",
+            explain=False,
+        )
+        analyze.analyze(args)
+
+        frame_cycle = json.loads(self.stdout())["frame_cycle"]
+        self.assertEqual(frame_cycle["cycles"], 2)
+        self.assertEqual(frame_cycle["resolved_duration_statistics"]["n"], 2)
+        # Without that mark the composition looks as if it ended with PaintToGLContext
+        # at 560.6 ms, just inside its cycle, so the overrun would go unnoticed.
+        self.assertEqual(frame_cycle["overrunning_composition_statistics"]["n"], 2)
+
+    def test_explain_is_rejected_for_the_json_format_by_the_module_api(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=True
+        )
+        with self.assertRaises(UsageError):
+            analyze.analyze(args)
+
+    def test_analyze_rejects_a_timespan_it_cannot_honour(self):
+        # Silently analyzing the whole capture, or a window the argument never asked
+        # for, reads as a result for the requested window.
+        for timespan in [
+            "abc",
+            "0-1e3",
+            "1-2-3",
+            "5000-",
+            "5000-6000",
+            "",
+            # Of no length, so it encloses nothing to analyze.
+            "0-0",
+            "500-500",
+        ]:
+            with self.subTest(timespan=timespan):
+                args = argparse.Namespace(
+                    capture_file=SAMPLE_CAPTURE_FILE,
+                    format="text",
+                    timespan=timespan,
+                    explain=False,
+                )
+                with self.assertRaises(UsageError):
+                    analyze.analyze(args)
+
+                with self.assertRaises(SystemExit):
+                    main(["analyze", "-t", timespan, SAMPLE_CAPTURE_FILE])
+
+    def test_analyze_clamps_a_timespan_reaching_past_the_capture(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="json",
+            timespan="0-100000",
+            explain=False,
+        )
+        analyze.analyze(args)
+
+        report = json.loads(self.stdout())
+        # The rates divide by the analyzed duration, so a window stretching past the
+        # capture would water every one of them down.
+        self.assertEqual(int(report["document"]["timespan"]["end"]), 4467)
+        self.assertEqual(
+            report["rendering"]["theoretical_fps"], approx(0.448, abs=0.001)
+        )
+
+    def test_vblanks_per_rendering_update_does_not_depend_on_the_mark_order(self):
+        # The walk needs the updates in begin order, which the grouping does not grant.
+        parsed = analyze.parse(SAMPLE_CAPTURE_FILE, marks=True, counters=False)
+        data = analyze.sysprof_data_with_marks_by_name(parsed)
+        in_parse_order = analyze._prepare_rendering_report(
+            data, display_refreshes(data)
+        )
+
+        for marks in data["marks"].values():
+            marks.reverse()
+        self.assertEqual(
+            analyze._prepare_rendering_report(
+                data, display_refreshes(data)
+            )["vblanks_per_rendering_update"],
+            in_parse_order["vblanks_per_rendering_update"],
+        )
+        self.assertEqual(
+            analyze._prepare_rendering_report(
+                data, display_refreshes(data)
+            )["vblank_interval_statistics"],
+            in_parse_order["vblank_interval_statistics"],
+        )
+
+    def test_a_capture_of_no_length_reports_no_rate(self):
+        # A window of no length is rejected, but a capture of no length is the
+        # capture's own doing and still has to be reported on.
+        data = sysprof_data(
+            [mark("DidRenderFrame", 0, 0)], begin_msec=0, end_msec=0
+        )
+
+        report = analyze._prepare_report(data, data)
+
+        frame_cycle = report["frame_cycle"]
+        # No cycle and no duration to divide, rather than a cycle of zero length that
+        # fits in zero vblank intervals and covers 0% of nothing.
+        self.assertEqual(frame_cycle["cycles"], 0)
+        self.assertIsNone(frame_cycle["implied_fps"])
+        self.assertIsNone(frame_cycle["vblank_intervals_per_cycle"])
+        self.assertIsNone(frame_cycle["coverage"])
+        # No duration to divide frames by either.
+        self.assertIsNone(report["rendering"]["theoretical_fps"])
+
+    def test_delta_histogram_deltas_come_from_the_requested_mark(self):
+        parsed = histogram.parse(SAMPLE_CAPTURE_FILE, marks=True, counters=False)
+        data = histogram.sysprof_data_with_marks_by_name(parsed)
+
+        deltas = histogram.intervals_between_marks(
+            histogram.marks_in_time_order(data, "DisplayLinkUpdate")
+        )
+        self.assertEqual(len(deltas), 34)
+        self.assertGreater(min(deltas), 0)
+        self.assertEqual(
+            histogram.intervals_between_marks(
+                histogram.marks_in_time_order(data, "NoSuchMark")
+            ),
+            [],
+        )
+        self.assertTrue(10 <= histogram._calculate_optimal_bins(deltas) <= 100)
+
+    def test_delta_histogram_honours_the_timespan(self):
+        parsed = histogram.parse(SAMPLE_CAPTURE_FILE, marks=True, counters=False)
+        data = histogram.trim_marks_by_name_to_timespan(
+            histogram.sysprof_data_with_marks_by_name(parsed), None, msec_to_nsec(500)
+        )
+
+        self.assertEqual(len(data["marks"]["DisplayLinkUpdate"]), 10)
+        self.assertEqual(
+            len(
+                histogram.intervals_between_marks(
+                    histogram.marks_in_time_order(data, "DisplayLinkUpdate")
+                )
+            ),
+            9,
+        )
+
+    def test_analyze_json_counts_every_vblank_interval_of_the_timespan(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
+        )
+        analyze.analyze(args)
+
+        rendering = json.loads(self.stdout())["rendering"]
+        # 35 vblanks are 34 intervals, and the ones after the last composition are
+        # samples too. Counting only up to it used to report 15 and a mean twice as
+        # high as the capture actually composited.
+        self.assertEqual(rendering["vblanks"], 35)
+        self.assertEqual(rendering["frame_compositions_per_vblank_statistics"]["n"], 34)
+        self.assertEqual(
+            rendering["frame_compositions_per_vblank_statistics"]["mean"],
+            approx(2 / 34),
+        )
+
+    def test_frame_compositions_outside_the_vblank_range_are_left_out(self):
+        vblanks = [mark("DisplayLinkUpdate", msec, msec) for msec in (0, 16, 32)]
+        compositions = [
+            mark("DidRenderFrame", msec, msec) for msec in (5, 40, 45, 50, 55)
+        ]
+
+        # The four compositions after the last vblank belong to no interval between
+        # two refreshes. Booking them into the last one made up a burst that the
+        # capture never had.
+        self.assertEqual(
+            analyze._calculate_frame_compositions_per_vblank(vblanks, compositions),
+            [
+                1,
+                0,
+            ],
+        )
+
+    def test_frame_rendering_reasons_bucket_a_frame_that_named_none(self):
+        def did_render_frame(message, msec=0):
+            return {
+                "name": "DidRenderFrame",
+                "message": message,
+                "duration": 0,
+                "end_time": msec_to_nsec(msec),
+            }
+
+        data = {
+            "document": {"timespan": {"begin": 0, "end": msec_to_nsec(1000)}},
+            "marks": {
+                "DidRenderFrame": [
+                    did_render_frame("reasons: Scrolling"),
+                    did_render_frame("reasons: Scrolling, AsyncScrolling", 1),
+                    did_render_frame("reasons: ", 2),
+                    did_render_frame("reasons: ", 3),
+                ]
+            },
+        }
+
+        # The reasons of a frame are one bucket, however many it names, and the
+        # frames that named none share one of their own.
+        self.assertEqual(
+            analyze._prepare_rendering_report(data, display_refreshes(data))[
+                "frame_rendering_reasons"
+            ],
+            {"Scrolling": 1, "Scrolling, AsyncScrolling": 1, "_none": 2},
+        )
+
+    def test_explain_reaches_the_report_through_the_command_line(self):
+        # Through main(), so that renaming the flag or its dest cannot quietly stop the
+        # explanations from being printed.
+        main(["analyze", "-e", SAMPLE_CAPTURE_FILE])
+
+        stdout = self.stdout()
+        self.assertIn(
+            "A frame cycle starts when a LayerTreeHostRenderingUpdate begins", stdout
+        )
+        self.assertIn("StyleRecalc is an umbrella mark", stdout)
+
+    def test_a_capture_of_its_own_broken_timespan_is_no_usage_error(self):
+        # No -t was passed, so nothing the user typed can be at fault.
+        data = {"document": {"timespan": {"begin": 0, "end": -5}}, "marks": {}}
+        self.assertEqual(
+            trim_marks_by_name_to_timespan(data, None, None)["document"]["timespan"][
+                "end"
+            ],
+            -5,
+        )
+
+    def test_statistics_are_matched_by_wording_rather_than_word_position(self):
+        extract = analyze.STATISTICAL_DATA_EXTRACTORS["UpdateTiles"]
+
+        self.assertEqual(
+            extract({"message": "dirty tiles: 40", "duration": 0})["tiles"], 40
+        )
+        # A mark that carries no message at all leaves the statistic out, rather
+        # than reporting a number read from somewhere else.
+        self.assertIsNone(extract({"message": "", "duration": 0})["tiles"])
+
+    def test_explaining_an_empty_frame_cycle_section_still_explains_it(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="text",
+            timespan="0-370",
+            explain=True,
+        )
+        analyze.analyze(args)
+
+        stdout = self.stdout()
+        self.assertIn("- cycles: 0", stdout)
+        # An empty section is what raises the question the explanation answers.
+        self.assertIn(
+            "A frame cycle starts when a LayerTreeHostRenderingUpdate begins", stdout
+        )
+
+    def test_a_broken_capture_is_no_usage_error_even_with_a_timespan(self):
+        # -t 0- asks for exactly the capture's own range, so nothing the user typed
+        # can be at fault when that range runs backwards or is of no length.
+        check_timespan_holds_data(0, msec_to_nsec(-5), 0, None)
+        check_timespan_holds_data(0, msec_to_nsec(-5), None, None)
+        check_timespan_holds_data(0, 0, 0, msec_to_nsec(5))
+
+    def test_a_window_meeting_the_capture_at_one_point_is_rejected(self):
+        capture = (msec_to_nsec(100), msec_to_nsec(200))
+        # Clamped to the capture, either of these encloses a single instant, which
+        # is no duration to divide by and no range for a mark to fall inside.
+        with self.assertRaises(UsageError):
+            check_timespan_holds_data(*capture, msec_to_nsec(200), None)
+        with self.assertRaises(UsageError):
+            check_timespan_holds_data(*capture, None, msec_to_nsec(100))
+        # One millisecond of overlap is still a window.
+        check_timespan_holds_data(*capture, msec_to_nsec(199), None)
+        check_timespan_holds_data(*capture, None, msec_to_nsec(101))
+
+    def test_json_percentiles_keep_the_fiftieth(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-", explain=False
+        )
+        analyze.analyze(args)
+
+        percentiles = json.loads(self.stdout())["statistics"]["StyleRecalc"][
+            "duration"
+        ]["percentiles"]
+        # Read by consumers since before the frame cycle section existed.
+        self.assertEqual(sorted(percentiles), ["25", "50", "75", "99"])
+
+    def test_delta_histogram_keeps_the_processes_apart(self):
+        # Two processes rendering at 16 ms, offset by 8 ms from one another.
+        marks = []
+        for i in range(5):
+            marks.append(
+                mark("LayerTreeHostRenderingUpdate", i * 16, i * 16 + 2, pid=1)
+            )
+            marks.append(
+                mark("LayerTreeHostRenderingUpdate", i * 16 + 8, i * 16 + 10, pid=2)
+            )
+        data = sysprof_data(marks, end_msec=100)
+
+        # Merged, the deltas would read 8 ms and the histogram would peak at half the
+        # frame interval of either process.
+        deltas = histogram._delta_times_ms(data, "LayerTreeHostRenderingUpdate")
+        self.assertEqual(deltas, [approx(16.0)] * 8)
+
+    def test_composition_overrun_says_nothing_where_nothing_was_analyzed(self):
+        frame_cycle = {
+            "cycles": 9,
+            "processes": 1,
+            "duration_statistics": {"n": 9, "min": 1, "max": 1, "median": 1, "mean": 1},
+            "resolved_duration_statistics": {},
+            "phase_statistics": {phase: {} for phase in analyze.PHASES},
+            "overrunning_composition_statistics": {},
+            "implied_fps": 1.0,
+            "coverage": 0.5,
+            "capture_vblank_interval": 16.0,
+            "vblank_intervals_per_cycle": 1.0,
+            "vblank_intervals_per_cycle_unknown": None,
+        }
+
+        analyze._render_frame_cycle_numbers(frame_cycle)
+
+        stdout = self.stdout()
+        # "in none of 0 analyzed cycles" would read as a measurement never made.
+        self.assertIn("- composition overrunning the cycle: -", stdout)
+        # The note explains shares, and every phase here reads as -.
+        self.assertNotIn("need not total 100%", stdout)
+
+    def test_an_update_ending_on_the_first_refresh_spans_it(self):
+        vblanks = [mark("DisplayLinkUpdate", msec, msec) for msec in (100, 116, 132)]
+        update = [mark("LayerTreeHostRenderingUpdate", 90, 100)]
+
+        # It ran up to that refresh, so it spanned one, and both ends of the range
+        # are read the same way.
+        self.assertEqual(
+            analyze._calculate_vblanks_per_rendering_update(vblanks, update), [1]
+        )
+
+    def test_refreshes_that_composited_nothing_are_samples_of_nothing(self):
+        vblanks = [
+            mark("DisplayLinkUpdate", i * 16, i * 16, "WebKit (UI)", pid=1)
+            for i in range(60)
+        ]
+        data = sysprof_data(vblanks, end_msec=1000)
+
+        rendering = analyze._prepare_rendering_report(data, vblanks)
+
+        # A capture that composited nothing is not a capture without refreshes: every
+        # interval held no composition, which is 59 samples of zero.
+        statistics = rendering["frame_compositions_per_vblank_statistics"]
+        self.assertEqual(statistics["n"], 59)
+        self.assertEqual(statistics["max"], 0)
+
+    def test_dump_csv_carries_every_column_of_a_row(self):
+        args = argparse.Namespace(
+            capture_file=SAMPLE_CAPTURE_FILE, marks=True, counters=False, format="csv"
+        )
+        dump.dump(args)
+
+        header = self.stdout().splitlines()[0]
+        self.assertEqual(header, "group;pid;name;message;time;duration;end_time")
+
+    def test_a_window_without_refreshes_keeps_the_capture_interval(self):
+        # The link stops before the window begins. Its interval is a property of the
+        # display, so the cycles of the window are still measured in it.
+        marks = [
+            mark("DisplayLinkUpdate", i * 16, i * 16, "WebKit (UI)", pid=1)
+            for i in range(30)
+        ]
+        marks += [
+            mark("LayerTreeHostRenderingUpdate", 600 + i * 20, 600 + i * 20 + 5, pid=2)
+            for i in range(10)
+        ]
+        parsed = {"document": {"timespan": [0, msec_to_nsec(1000)]}, "marks": marks}
+        untrimmed = analyze.sysprof_data_with_marks_by_name(parsed)
+        window = analyze.trim_marks_by_name_to_timespan(
+            untrimmed, msec_to_nsec(600), msec_to_nsec(800)
+        )
+
+        report = analyze._prepare_report(window, untrimmed)
+
+        self.assertEqual(report["rendering"]["vblanks"], 0)
+        self.assertEqual(report["frame_cycle"]["capture_vblank_interval"], approx(16.0))
+        self.assertEqual(
+            report["frame_cycle"]["vblank_intervals_per_cycle"], approx(20 / 16)
+        )
+
     def test_analyze_with_custom_timespan(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="0-0"
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="text",
+            timespan="0-370",
+            explain=False,
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
-        self.assertIn("Timespan: 0.0000 - 0.0000 [s]", stdout)
-        self.assertIn("vblanks: 0", stdout)
+        stdout = self.stdout()
+        self.assertIn("Timespan: 0.0000 - 0.3700 [s]", stdout)
+        self.assertIn("vblanks: 2", stdout)
 
     def test_analyze_with_custom_timespan_begin(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="500-"
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="text",
+            timespan="500-",
+            explain=False,
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
+        stdout = self.stdout()
         self.assertIn("Timespan: 0.5000 - 4.4673 [s]", stdout)
         self.assertIn("vblanks: 25", stdout)
 
     def test_analyze_with_custom_timespan_end(self):
         args = argparse.Namespace(
-            capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="-500"
+            capture_file=SAMPLE_CAPTURE_FILE,
+            format="text",
+            timespan="-500",
+            explain=False,
         )
-        stdout = _capture_stdout(analyze.analyze, args)
+        analyze.analyze(args)
 
+        stdout = self.stdout()
         self.assertIn("Timespan: 0.0000 - 0.5000 [s]", stdout)
         self.assertIn("vblanks: 10", stdout)
 

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/utils_unittest.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/tests/utils_unittest.py
@@ -1,0 +1,92 @@
+"""The helpers webkitsysprof.utils holds, which every command reads marks with."""
+
+import unittest
+
+from .helpers import SysprofTestCase, approx, mark, sysprof_data
+
+from webkitsysprof.utils import (
+    UsageError,
+    marks_in_time_order,
+    merged_spans,
+    msec_to_nsec,
+    parse_timespan_argument,
+    percentiles,
+    sysprof_data_with_marks_by_name,
+    intervals_between_marks,
+    median_vblank_interval,
+    display_refreshes,
+)
+
+
+class UtilsTest(SysprofTestCase):
+    def test_spans_are_merged_where_they_overlap_or_touch(self):
+        self.assertEqual(
+            merged_spans([(0, 5), (3, 8), (8, 9), (20, 25)]), [(0, 9), (20, 25)]
+        )
+        # An empty span is no span at all, rather than one of no length in between.
+        self.assertEqual(merged_spans([(5, 5), (10, 12)]), [(10, 12)])
+        self.assertEqual(merged_spans([]), [])
+
+    def test_a_timespan_bound_is_digits_and_nothing_else(self):
+        # int() would take every one of these and analyze a window nobody asked for.
+        for timespan in [
+            "  5",
+            "+5",
+            "0-1_000",
+            "5\n",
+            "500-100",
+            # Of no length, so it encloses nothing between its bounds.
+            "0-0",
+            "500-500",
+            "abc",
+            "0-1e3",
+            "1-2-3",
+            "",
+        ]:
+            with self.subTest(timespan=timespan), self.assertRaises(UsageError):
+                parse_timespan_argument(timespan)
+
+    def test_percentiles_outside_the_range_of_the_quantiles_are_rejected(self):
+        # Percentile 0 used to index the list from the back and report P99 as P0.
+        for percentile in [0, 100, -1]:
+            with self.subTest(percentile=percentile), self.assertRaises(ValueError):
+                percentiles([1.0, 2.0, 3.0], [percentile])
+
+    def test_a_bare_bound_is_the_begin_of_the_timespan(self):
+        self.assertEqual(parse_timespan_argument("500"), (msec_to_nsec(500), None))
+
+    def test_vblank_intervals_do_not_depend_on_the_order_of_the_marks(self):
+        data = sysprof_data(
+            [
+                mark("DisplayLinkUpdate", 32, 33),
+                mark("DisplayLinkUpdate", 0, 1),
+                mark("DisplayLinkUpdate", 16, 17),
+            ]
+        )
+
+        self.assertEqual(
+            intervals_between_marks(marks_in_time_order(data, "DisplayLinkUpdate")),
+            [
+                approx(16.0),
+                approx(16.0),
+            ],
+        )
+        self.assertEqual(
+            median_vblank_interval(display_refreshes(data)),
+            approx(16.0),
+        )
+
+    def test_reshaping_the_same_parsed_data_twice_yields_the_same_result(self):
+        parsed_data = {
+            "document": {"timespan": [0, msec_to_nsec(1000)]},
+            "marks": [mark("LayerTreeHostRenderingUpdate", 0, 5)],
+        }
+
+        first = sysprof_data_with_marks_by_name(parsed_data)
+        second = sysprof_data_with_marks_by_name(parsed_data)
+        self.assertEqual(first["document"]["timespan"], second["document"]["timespan"])
+        self.assertEqual(parsed_data["document"]["timespan"], [0, msec_to_nsec(1000)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/utils/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/utils/__init__.py
@@ -1,4 +1,18 @@
-from typing import Any, Dict, Optional, Tuple, Union
+import collections
+import logging
+import re
+import statistics
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 NSEC_PER_MSEC = 1_000_000
 NSEC_PER_SEC = 1_000_000_000
@@ -21,20 +35,56 @@ def msec_to_nsec(msec: int) -> int:
     return msec * NSEC_PER_MSEC
 
 
-def parse_timespan_argument(arg: str) -> Tuple[Optional[int], Optional[int]]:
-    timespan_begin, timespan_end = None, None
-    values = arg.split("-")
+# A timespan bound is a plain number of milliseconds, nothing int() would also take.
+# Ended with \Z rather than $, which would let a trailing newline through.
+MILLISECONDS_RE = re.compile(r"^\d+\Z")
 
-    if len(values) > 0:
-        try:
-            timespan_begin = int(values[0])
-        except ValueError:
-            pass
-    if len(values) > 1:
-        try:
-            timespan_end = int(values[1])
-        except ValueError:
-            pass
+
+class UsageError(ValueError):
+    """The user asked for something the tool cannot do, e.g. a backwards timespan.
+
+    Told apart from the other ValueErrors so that the command line can report it as
+    a usage error while a broken capture still raises where it broke.
+    """
+
+
+def mark_begin(mark: Dict[str, Any]) -> int:
+    """Marks carry an end time and a duration, so a begin time has to be derived."""
+    return int(mark["end_time"] - mark["duration"])
+
+
+def parse_timespan_argument(arg: str) -> Tuple[Optional[int], Optional[int]]:
+    """Parse "<begin>-<end>" in milliseconds, either side of which may be empty.
+
+    A single bound without a dash is the begin, e.g. "500" is "from 500 ms on".
+    """
+
+    def parse_bound(value: str) -> Optional[int]:
+        if value == "":
+            return None
+        # Digits and nothing else: int() would take " 5", "+5" and "1_000" too, and
+        # a timespan the tool reads as something other than what was typed is what
+        # rejecting a malformed one is meant to prevent.
+        if not MILLISECONDS_RE.match(value):
+            raise UsageError(f"timespan bound is no number of milliseconds: {value}")
+        return int(value)
+
+    if arg == "":
+        raise UsageError("timespan is empty")
+    values = arg.split("-")
+    if len(values) > 2:
+        raise UsageError(f'timespan is no "<begin>-<end>" in milliseconds: {arg}')
+    timespan_begin = parse_bound(values[0])
+    timespan_end = parse_bound(values[1]) if len(values) == 2 else None
+
+    if timespan_begin is not None and timespan_end is not None:
+        if timespan_begin > timespan_end:
+            raise UsageError(f"timespan begins after it ends: {arg}")
+        # A window of no length encloses no data and is no duration to divide by,
+        # so every rate taken over it is unknown. Rejected rather than reported as
+        # a row of zeroes, which reads as a measurement that was made.
+        if timespan_begin == timespan_end:
+            raise UsageError(f"timespan is of no length: {arg}")
 
     return (
         msec_to_nsec(timespan_begin) if timespan_begin is not None else None,
@@ -42,24 +92,212 @@ def parse_timespan_argument(arg: str) -> Tuple[Optional[int], Optional[int]]:
     )
 
 
-def trim_sysprof_data_to_timespan(
+def sysprof_data_with_marks_by_name(sysprof_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Reshape parsed data so that marks are grouped by name.
+
+    The groups keep the order the marks were parsed in, so the callers that walk
+    them in time order sort them the way they need. The input is left untouched.
+    """
+    document = dict(sysprof_data["document"])
+    document["timespan"] = {
+        "begin": sysprof_data["document"]["timespan"][0],
+        "end": sysprof_data["document"]["timespan"][1],
+    }
+    marks_by_name: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    for mark in sysprof_data["marks"]:
+        marks_by_name[mark["name"]].append(mark)
+    # Handed out as a plain dict, so that a name the capture never held is a
+    # KeyError for the callers that subscript it rather than an empty list.
+    return {"document": document, "marks": dict(marks_by_name)}
+
+
+def check_timespan_holds_data(
+    capture_begin: int,
+    capture_end: int,
+    timespan_begin: Optional[int],
+    timespan_end: Optional[int],
+) -> None:
+    """Reject a timespan the caller asked for that the capture cannot answer."""
+    if capture_begin >= capture_end:
+        # The capture holds no range for a window to miss, so there is nothing the
+        # caller could have asked for that would be right, and blaming the window
+        # for what the capture lacks would point at the wrong thing. Say so, so
+        # that the empty report below carries its reason with it.
+        logging.warning(
+            "The capture spans no time (begins at %d, ends at %d), so the report "
+            "has no rate to give.",
+            capture_begin,
+            capture_end,
+        )
+        return
+    if timespan_begin is not None and timespan_begin >= capture_end:
+        raise UsageError(
+            "timespan begins at or after the capture ends, so it holds no data"
+        )
+    if timespan_end is not None and timespan_end <= capture_begin:
+        raise UsageError(
+            "timespan ends at or before the capture begins, so it holds no data"
+        )
+
+
+def trim_marks_by_name_to_timespan(
     sysprof_data: Dict[str, Any],
     timespan_begin: Optional[int],
     timespan_end: Optional[int],
 ) -> Dict[str, Any]:
-    trimmed_document = sysprof_data["document"]
+    """Narrow data grouped by sysprof_data_with_marks_by_name() to a timespan.
 
+    Marks that cross a boundary are dropped, since only part of them happened
+    within the window. The input is left untouched, so its callers keep the
+    untrimmed data, which the frame cycles need.
+    """
+    # Narrowed even where no bound was given, since the capture holds marks that
+    # begin before its own timespan does, and the frame cycles are cut to that
+    # timespan either way.
+    timespan = dict(sysprof_data["document"]["timespan"])
+    # Clamped to the capture, so that a window reaching past it does not stretch
+    # the analyzed duration that every rate is divided by.
     if timespan_begin is not None:
-        trimmed_document["timespan"][0] = timespan_begin
+        timespan["begin"] = max(timespan_begin, timespan["begin"])
     if timespan_end is not None:
-        trimmed_document["timespan"][1] = timespan_end
+        timespan["end"] = min(timespan_end, timespan["end"])
 
     def mark_in_timespan(mark: Dict[str, Any]) -> bool:
         return (
-            (mark["end_time"] - mark["duration"]) >= trimmed_document["timespan"][0]
-        ) and mark["end_time"] <= trimmed_document["timespan"][1]
+            mark_begin(mark) >= timespan["begin"]
+            and mark["end_time"] <= timespan["end"]
+        )
 
+    trimmed_document = dict(sysprof_data["document"])
+    trimmed_document["timespan"] = timespan
     return {
         "document": trimmed_document,
-        "marks": [mark for mark in sysprof_data["marks"] if mark_in_timespan(mark)],
+        "marks": {
+            mark_name: [mark for mark in marks if mark_in_timespan(mark)]
+            for mark_name, marks in sysprof_data["marks"].items()
+        },
     }
+
+
+def merged_spans(spans: Iterable[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    """The [begin, end) spans merged where they overlap or touch, in order.
+
+    Empty spans are dropped, so that a mark clipped to nothing does not become a
+    span of no length between two real ones.
+    """
+    merged: List[Tuple[int, int]] = []
+    for begin, end in sorted(spans):
+        if end <= begin:
+            continue
+        if merged and begin <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((begin, end))
+    return merged
+
+
+def sample_statistics(
+    values: Sequence[Union[int, float]], wanted: Sequence[int] = ()
+) -> Dict[str, Any]:
+    if not values:
+        return {}
+    return {
+        "n": len(values),
+        "min": min(values),
+        "max": max(values),
+        "mean": statistics.mean(values),
+        "stddev": statistics.stdev(values) if len(values) > 1 else 0,
+        # Both of these sort what they are given, so handing them a sorted sequence
+        # would add a sort rather than save the two they do.
+        "median": statistics.median(values),
+        "percentiles": percentiles(values, wanted),
+    }
+
+
+def percentiles(
+    values: Sequence[Union[int, float]],
+    wanted: Sequence[int],
+    method: Literal["inclusive", "exclusive"] = "inclusive",
+) -> Dict[str, float]:
+    """Percentiles interpolated between the data points, empty below two of them.
+
+    Keyed by the percentile as a string, the shape json.dumps() turns an int key
+    into anyway, so that a report read back from JSON is the report written.
+
+    The inclusive method stays between the smallest and the largest sample, while
+    the exclusive one extrapolates past them: on few samples it reports a P25 below
+    the minimum, a P99 above the maximum and negative durations. Reporting the
+    samples wants the former, estimating the spread of what they were drawn from
+    wants the latter. Both need two data points, and below that quantiles() raises
+    before Python 3.13.
+    """
+    for percentile in wanted:
+        if not 1 <= percentile <= 99:
+            raise ValueError(f"no percentile between 1 and 99: {percentile}")
+    # Before the sort quantiles() does, which nothing would read.
+    if not wanted:
+        return {}
+    if len(values) < 2:
+        return {}
+    quantiles: List[float] = statistics.quantiles(values, n=100, method=method)
+    return {str(percentile): quantiles[percentile - 1] for percentile in wanted}
+
+
+def mark_pid(mark: Dict[str, Any]) -> int:
+    """The process a mark was emitted by, as the capture records it."""
+    return int(mark.get("pid", 0))
+
+
+def marks_by_process(
+    marks: Sequence[Dict[str, Any]],
+) -> Dict[int, List[Dict[str, Any]]]:
+    """The marks grouped by the process they came from, in process order."""
+    by_pid: Dict[int, List[Dict[str, Any]]] = collections.defaultdict(list)
+    for mark in marks:
+        by_pid[mark_pid(mark)].append(mark)
+    return dict(sorted(by_pid.items()))
+
+
+def marks_in_time_order(
+    sysprof_data: Dict[str, Any], mark_name: str
+) -> List[Dict[str, Any]]:
+    """The marks of that name, ordered by when they ended.
+
+    The grouping keeps the marks in parse order, so every walk that depends on
+    time order sorts them here.
+    """
+    return sorted(
+        sysprof_data["marks"].get(mark_name, []), key=lambda mark: mark["end_time"]
+    )
+
+
+def intervals_between_marks(marks: Sequence[Dict[str, Any]]) -> List[float]:
+    """Times between the ends of consecutive marks, in milliseconds.
+
+    Takes the marks in time order, as marks_in_time_order() returns them.
+    """
+    return [
+        nsec_to_msec(marks[i]["end_time"] - marks[i - 1]["end_time"])
+        for i in range(1, len(marks))
+    ]
+
+
+def display_refreshes(sysprof_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """The DisplayLinkUpdate marks of the capture, in time order.
+
+    All of them: the display links all live in the UI process, one per display, so
+    the marks of a capture are the refreshes of one process either way. Two displays
+    driven at once are merged, which no mark tells apart, and so is a link that
+    stopped and started again: the gap it leaves counts as one very long interval
+    between two refreshes.
+    """
+    return marks_in_time_order(sysprof_data, "DisplayLinkUpdate")
+
+
+def median_vblank_interval(refreshes: Sequence[Dict[str, Any]]) -> Optional[float]:
+    """Median time between display refreshes in milliseconds, None if unknown.
+
+    Takes the refreshes as display_refreshes() returns them.
+    """
+    intervals = intervals_between_marks(refreshes)
+    return statistics.median(intervals) if intervals else None


### PR DESCRIPTION
#### 5c1c95db5e0ea336071ae634567cda9aaa80c181
<pre>
[webkit-sysprof] Add a frame cycle breakdown to analyze
<a href="https://bugs.webkit.org/show_bug.cgi?id=322589">https://bugs.webkit.org/show_bug.cgi?id=322589</a>

Reviewed by Carlos Garcia Campos.

webkit-sysprof analyze reports &apos;theoretical FPS&apos;, the number of frames the
engine produced over the analyzed duration. That says nothing about how long
one frame took, nor where its time went.

Add a &apos;frame cycle&apos; reconstruction: a cycle runs from one
LayerTreeHostRenderingUpdate of a process to the next, so the frame rate is
1 / cycle duration, and it splits into the rendering update, waiting for
compositing, compositing and idle. The report gives the phase medians, how
much of the analyzed duration the cycles cover, and the implied FPS while
rendering, so a rate falling short can be told from a phase.

Also add --explain, off by default, which prints what the report does and does
not measure, and reject a timespan of no length rather than reporting zeroes
for it.

* Tools/Scripts/webkit-sysprof/README.md:
* Tools/Scripts/webkit-sysprof/pyproject.toml:
* Tools/Scripts/webkit-sysprof/webkitsysprof/__main__.py:
(_add_subcommand):
(build_parser):
(main):
* Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py:
(_frame_rendering_reason):
(_counted):
(analyze):
(_calculate_statistics):
(_prepare_report):
(_prepare_rendering_report):
(_covered_duration):
(_cycle_in_vblank_intervals):
(_prepare_frame_cycle_report):
(_calculate_frame_compositions_per_vblank):
(_calculate_vblanks_per_rendering_update):
(_render_text_report):
(_analyzed_duration_sec):
(_theoretical_fps_explanation):
(_refresh_rate_explanation):
(_percentile_strings):
(_analyzed_cycles):
(_render_frame_cycle_numbers):
(_statistics_to_strings):
(format_statistic):
(_sysprof_data_to_high_level_representation): Deleted.
(_statistics_to_strings.format_statistic): Deleted.
* Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/explanations.py: Added.
* Tools/Scripts/webkit-sysprof/webkitsysprof/cycles/__init__.py: Added.
(_MarkIndex):
(_MarkIndex.__init__):
(_MarkIndex.spans_within):
(_MarkIndex.last_end_of_marks_beginning_within):
(_marks_beginning_within):
(within):
(_compositing_indices_by_process):
(_compositing_spans):
(_own_compositing_end):
(calculate_frame_cycles):
(_cycles_of_one_process):
* Tools/Scripts/webkit-sysprof/webkitsysprof/dump/__init__.py:
(dump):
(_marks_to_rows):
* Tools/Scripts/webkit-sysprof/webkitsysprof/histogram/__init__.py:
(delta_histogram):
(_delta_times_ms):
(_calculate_optimal_bins):
(_plot_delta_time_distribution):
(_calculate_delta_times_ms): Deleted.
* Tools/Scripts/webkit-sysprof/webkitsysprof/parser/direct_parser.py:
* Tools/Scripts/webkit-sysprof/webkitsysprof/summary/__init__.py:
(_print_document_summary):
* Tools/Scripts/webkit-sysprof/webkitsysprof/tests/frame_cycles_unittest.py: Added.
(frame_cycle_report):
(FrameCyclesTest):
(FrameCyclesTest.test_phases_partition_every_resolved_cycle):
(FrameCyclesTest.test_composition_ending_after_the_cycle_is_reported_as_an_overrun):
(FrameCyclesTest.test_a_cycle_after_an_overrunning_composition_still_resolves):
(FrameCyclesTest.test_cycles_without_compositing_marks_are_counted_but_not_analyzed):
(FrameCyclesTest.test_the_gap_between_two_rendering_periods_is_reported_as_a_long_cycle):
(FrameCyclesTest.test_the_compositing_mark_name_is_resolved_per_cycle):
(FrameCyclesTest.test_compositing_is_over_when_the_last_compositing_mark_is):
(FrameCyclesTest.test_compositing_overlapping_the_rendering_update_still_counts):
(FrameCyclesTest.test_a_cycle_reaching_past_the_timespan_is_left_out_of_it):
(FrameCyclesTest.test_a_capture_without_compositing_marks_keeps_its_cycles):
(FrameCyclesTest.test_coverage_is_the_share_of_the_window_the_analyzed_cycles_took):
(FrameCyclesTest.test_a_single_cycle_reports_no_percentiles_rather_than_failing):
(FrameCyclesTest.test_no_cycles_at_all):
(FrameCyclesTest.test_cycles_per_vblank_interval_is_unknown_without_vblank_marks):
(FrameCyclesTest.test_cycles_are_restricted_to_the_ones_lying_within_the_timespan):
(FrameCyclesTest.test_compositing_running_inside_the_rendering_update_still_resolves):
(FrameCyclesTest.test_a_cycle_never_runs_between_two_processes):
(FrameCyclesTest.test_a_cycle_spent_entirely_on_an_earlier_composition_is_analyzed):
(FrameCyclesTest.test_coverage_merges_the_cycles_of_two_processes):
(FrameCyclesTest.test_a_composition_begun_before_the_window_is_still_seen_in_it):
(FrameCyclesTest.test_a_stall_is_seen_past_a_shorter_mark_of_the_same_name):
(FrameCyclesTest.test_a_capture_of_negative_length_reports_no_rate):
(FrameCyclesTest.test_no_cycles_says_so_rather_than_blaming_a_zero_median):
(FrameCyclesTest.test_every_overrunning_composition_of_a_stall_is_counted):
(FrameCyclesTest.test_a_cycle_running_a_sliver_of_an_inherited_composition_is_measured):
(FrameCyclesTest.test_a_cycle_running_only_an_inherited_composition_is_measured):
(FrameCyclesTest.test_a_cycle_composited_beside_its_update_only_is_measured_as_zero):
(FrameCyclesTest.test_a_mark_ending_before_the_capture_keeps_its_own_end):
(FrameCyclesTest.test_a_gap_between_two_compositions_is_a_wait_not_compositing):
(FrameCyclesTest.test_two_renderers_of_one_kind_are_told_apart_by_their_process):
(FrameCyclesTest.test_two_updates_at_one_instant_belong_to_two_processes):
(FrameCyclesTest.test_a_report_without_a_rate_prints_no_rate):
(FrameCyclesTest.test_a_steady_slow_capture_keeps_its_cycles):
(FrameCyclesTest.test_the_composition_overrun_median_describes_the_overrunning_cycles):
(FrameCyclesTest.test_an_unknown_refresh_rate_is_not_reported_as_zero):
(FrameCyclesTest.test_a_zero_median_vblank_interval_is_not_reported_as_shared_timestamps):
* Tools/Scripts/webkit-sysprof/webkitsysprof/tests/helpers.py: Added.
(mark):
(sysprof_data):
(approx):
(approx.__init__):
(approx.__eq__):
(approx.__repr__):
(SysprofTestCase):
(SysprofTestCase.setUp):
(SysprofTestCase.stdout):
* Tools/Scripts/webkit-sysprof/webkitsysprof/tests/subcommands_unittest.py:
(SubcommandsTest):
(SubcommandsTest.test_summary):
(SubcommandsTest.test_dump_marks_csv):
(SubcommandsTest.test_dump_counters_csv):
(SubcommandsTest.test_dump_marks_json):
(SubcommandsTest.test_dump_counters_json):
(SubcommandsTest.test_analyze_text):
(SubcommandsTest.test_analyze_text_with_explanations):
(SubcommandsTest.test_analyze_json_percentiles_stay_within_the_data_range):
(SubcommandsTest.test_analyze_json):
(SubcommandsTest.test_analyze_json_frame_cycle_phases_add_up_to_cycle_duration):
(SubcommandsTest.test_analyze_json_statistics_cover_all_relevant_marks):
(SubcommandsTest.test_analyze_with_a_timespan_holding_vblanks_but_no_rendering_update):
(SubcommandsTest.test_analyze_json_leaves_out_a_cycle_reaching_past_the_timespan):
(SubcommandsTest.test_analyze_resolves_a_cycle_whose_compositing_marks_trimming_drops):
(SubcommandsTest.test_explain_is_rejected_for_the_json_format_by_the_module_api):
(SubcommandsTest.test_analyze_rejects_a_timespan_it_cannot_honour):
(SubcommandsTest.test_analyze_clamps_a_timespan_reaching_past_the_capture):
(SubcommandsTest.test_vblanks_per_rendering_update_does_not_depend_on_the_mark_order):
(SubcommandsTest.test_a_capture_of_no_length_reports_no_rate):
(SubcommandsTest.test_delta_histogram_deltas_come_from_the_requested_mark):
(SubcommandsTest.test_delta_histogram_honours_the_timespan):
(SubcommandsTest.test_analyze_json_counts_every_vblank_interval_of_the_timespan):
(SubcommandsTest.test_frame_compositions_outside_the_vblank_range_are_left_out):
(SubcommandsTest.test_frame_rendering_reasons_bucket_a_frame_that_named_none):
(SubcommandsTest.test_frame_rendering_reasons_bucket_a_frame_that_named_none.did_render_frame):
(SubcommandsTest.test_explain_reaches_the_report_through_the_command_line):
(SubcommandsTest.test_a_capture_of_its_own_broken_timespan_is_no_usage_error):
(SubcommandsTest.test_statistics_are_matched_by_wording_rather_than_word_position):
(SubcommandsTest.test_explaining_an_empty_frame_cycle_section_still_explains_it):
(SubcommandsTest.test_a_broken_capture_is_no_usage_error_even_with_a_timespan):
(SubcommandsTest.test_a_window_meeting_the_capture_at_one_point_is_rejected):
(SubcommandsTest.test_json_percentiles_keep_the_fiftieth):
(SubcommandsTest.test_delta_histogram_keeps_the_processes_apart):
(SubcommandsTest.test_composition_overrun_says_nothing_where_nothing_was_analyzed):
(SubcommandsTest.test_an_update_ending_on_the_first_refresh_spans_it):
(SubcommandsTest.test_refreshes_that_composited_nothing_are_samples_of_nothing):
(SubcommandsTest.test_dump_csv_carries_every_column_of_a_row):
(SubcommandsTest.test_a_window_without_refreshes_keeps_the_capture_interval):
(SubcommandsTest.test_analyze_with_custom_timespan):
(SubcommandsTest.test_analyze_with_custom_timespan_begin):
(SubcommandsTest.test_analyze_with_custom_timespan_end):
(_capture_stdout): Deleted.
* Tools/Scripts/webkit-sysprof/webkitsysprof/tests/utils_unittest.py: Added.
(UtilsTest):
(UtilsTest.test_spans_are_merged_where_they_overlap_or_touch):
(UtilsTest.test_a_timespan_bound_is_digits_and_nothing_else):
(UtilsTest.test_percentiles_outside_the_range_of_the_quantiles_are_rejected):
(UtilsTest.test_a_bare_bound_is_the_begin_of_the_timespan):
(UtilsTest.test_vblank_intervals_do_not_depend_on_the_order_of_the_marks):
(UtilsTest.test_reshaping_the_same_parsed_data_twice_yields_the_same_result):
* Tools/Scripts/webkit-sysprof/webkitsysprof/utils/__init__.py:
(msec_to_nsec):
(UsageError):
(mark_begin):
(parse_timespan_argument):
(parse_timespan_argument.parse_bound):
(sysprof_data_with_marks_by_name):
(check_timespan_holds_data):
(trim_marks_by_name_to_timespan):
(mark_in_timespan):
(merged_spans):
(sample_statistics):
(percentiles):
(mark_pid):
(marks_by_process):
(marks_in_time_order):
(intervals_between_marks):
(display_refreshes):
(median_vblank_interval):
(trim_sysprof_data_to_timespan): Deleted.

Canonical link: <a href="https://commits.webkit.org/320029@main">https://commits.webkit.org/320029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e756e7b8f4bc7edb5a499fa9ee9e2e1fc812817

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99253 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123336 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182424 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43573 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43203 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4488 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56689 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57394 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152080 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46635 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125812 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18214 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->