### PR TITLE
[TextureMapper] Move BitmapTexture and BitmapTexturePool from texmap to egl directory

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2771,6 +2771,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/displaylists/DisplayListRecorder.h
     platform/graphics/displaylists/DisplayListRecorderImpl.h
 
+    platform/graphics/egl/BitmapTexture.h
+    platform/graphics/egl/BitmapTexturePool.h
     platform/graphics/egl/GLContext.h
     platform/graphics/egl/GLContextWrapper.h
     platform/graphics/egl/GLDisplay.h

--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -38,6 +38,8 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/PlatformDisplay.cpp
 
+    platform/graphics/egl/BitmapTexture.cpp
+    platform/graphics/egl/BitmapTexturePool.cpp
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp
     platform/graphics/egl/GLContextWrapper.cpp

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -57,6 +57,8 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/angle/PlatformDisplayANGLE.cpp
 
+    platform/graphics/egl/BitmapTexture.cpp
+    platform/graphics/egl/BitmapTexturePool.cpp
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextWrapper.cpp
     platform/graphics/egl/GLDisplay.cpp

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -67,6 +67,8 @@ platform/graphics/PlatformDisplay.cpp @no-unify
 
 platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
+platform/graphics/egl/BitmapTexture.cpp @no-unify
+platform/graphics/egl/BitmapTexturePool.cpp @no-unify
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/GLDisplay.cpp @no-unify

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -76,6 +76,8 @@ platform/graphics/glib/SystemFontDatabaseGLib.cpp
 platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp @no-unify
 platform/graphics/android/PlatformDisplayAndroid.cpp @no-unify
 
+platform/graphics/egl/BitmapTexture.cpp @no-unify
+platform/graphics/egl/BitmapTexturePool.cpp @no-unify
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -58,7 +58,7 @@ platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp
 platform/graphics/skia/PlatformDisplaySkia.cpp @no-unify
 platform/graphics/skia/ShareableBitmapSkia.cpp
-platform/graphics/skia/SkiaBackingStore.cpp
+platform/graphics/skia/SkiaBackingStore.cpp @no-unify
 platform/graphics/skia/SkiaCompositingLayer.cpp
 platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
 platform/graphics/skia/SkiaCompositingLayerFilters.cpp
@@ -76,6 +76,6 @@ platform/graphics/skia/SkiaReplayCanvas.cpp
 platform/graphics/skia/SkiaSerializedImageBuffer.cpp
 platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
 platform/graphics/skia/SkiaTextureAtlasPacker.cpp
-platform/graphics/skia/SkiaUtilities.cpp
+platform/graphics/skia/SkiaUtilities.cpp @no-unify
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -3,8 +3,6 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
 )
 
 list(APPEND WebCore_SOURCES
-    platform/graphics/texmap/BitmapTexture.cpp
-    platform/graphics/texmap/BitmapTexturePool.cpp
     platform/graphics/texmap/ClipPath.cpp
     platform/graphics/texmap/ClipStack.cpp
     platform/graphics/texmap/FloatPlane3D.cpp
@@ -24,8 +22,6 @@ list(APPEND WebCore_SOURCES
 )
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
-    platform/graphics/texmap/BitmapTexture.h
-    platform/graphics/texmap/BitmapTexturePool.h
     platform/graphics/texmap/ClipPath.h
     platform/graphics/texmap/ClipStack.h
     platform/graphics/texmap/FloatPlane3D.h

--- a/Source/WebCore/platform/graphics/egl/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexture.cpp
@@ -1,28 +1,26 @@
 /*
- Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
- Copyright (C) 2012, 2025 Igalia S.L.
- Copyright (C) 2012 Adobe Systems Incorporated
-
- This library is free software; you can redistribute it and/or
- modify it under the terms of the GNU Library General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later version.
-
- This library is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Library General Public License for more details.
-
- You should have received a copy of the GNU Library General Public License
- along with this library; see the file COPYING.LIB.  If not, write to
- the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- Boston, MA 02110-1301, USA.
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ * Copyright (C) 2012, 2025, 2026 Igalia S.L.
+ * Copyright (C) 2012 Adobe Systems Incorporated
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
  */
 
 #include "config.h"
 #include "BitmapTexture.h"
-
-#if USE(TEXTURE_MAPPER)
 
 #include "GLContext.h"
 #include "GraphicsContext.h"
@@ -30,9 +28,7 @@
 #include "ImageBuffer.h"
 #include "NativeImage.h"
 #include "PlatformDisplay.h"
-#include "TextureMapper.h"
 #include "TextureMapperFlags.h"
-#include "TextureMapperShaderProgram.h"
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -53,6 +49,29 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win port
 #include <skia/core/SkPixmap.h>
 #include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#ifndef GL_BGRA
+#define GL_BGRA 0x80E1
+#endif
+
+#ifndef GL_UNPACK_ROW_LENGTH
+#define GL_UNPACK_ROW_LENGTH 0x0CF2
+#endif
+
+#ifndef GL_UNPACK_SKIP_ROWS
+#define GL_UNPACK_SKIP_ROWS 0x0CF3
+#endif
+
+#ifndef GL_UNPACK_SKIP_PIXELS
+#define GL_UNPACK_SKIP_PIXELS 0x0CF4
+#endif
 #endif
 
 #if OS(DARWIN)
@@ -85,12 +104,12 @@ void BitmapTexture::determineRenderTargetAndBinding()
     m_renderTarget = GL_TEXTURE_2D;
 }
 
-GLenum BitmapTexture::textureFormat() const
+unsigned BitmapTexture::textureFormat() const
 {
     return m_flags.contains(Flags::UseBGRALayout) ? GL_BGRA : GL_RGBA;
 }
 
-GLenum depthBufferFormat()
+static GLenum depthBufferFormat()
 {
     auto* glContext = GLContext::current();
     if (glContext->version() >= 300 || glContext->glExtensions().OES_packed_depth_stencil)
@@ -594,5 +613,3 @@ sk_sp<SkSurface> BitmapTexture::createSkiaSurface(GrDirectContext* grContext, Gr
 #endif
 
 } // namespace WebCore
-
-#endif // USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/egl/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexture.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2014, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
 #include "IntRect.h"
 #include "IntSize.h"
 #include "PixelFormat.h"
-#include "TextureMapperGLHeaders.h"
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -57,7 +56,6 @@ namespace WebCore {
 
 class GraphicsLayer;
 class NativeImage;
-class TextureMapper;
 enum class TextureMapperFlags : uint16_t;
 
 class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
@@ -111,7 +109,7 @@ public:
 
     ClipStack& clipStack() LIFETIME_BOUND { return m_clipStack; }
 
-    void copyFromExternalTexture(GLuint sourceTextureID, const IntRect& targetRect, const IntSize& sourceOffset);
+    void copyFromExternalTexture(unsigned sourceTextureID, const IntRect& targetRect, const IntSize& sourceOffset);
 
     OptionSet<TextureMapperFlags> colorConvertFlags() const;
 
@@ -138,7 +136,7 @@ private:
 
     void determineRenderTargetAndBinding();
 
-    GLenum textureFormat() const;
+    unsigned textureFormat() const;
     void createTexture();
     void allocateTexture();
 #if USE(GBM)
@@ -147,12 +145,12 @@ private:
 
     OptionSet<Flags> m_flags;
     IntSize m_size;
-    GLuint m_id { 0 };
-    GLenum m_renderTarget { GL_TEXTURE_2D };
-    GLenum m_binding { GL_TEXTURE_BINDING_2D };
-    GLuint m_fbo { 0 };
-    GLuint m_depthBufferObject { 0 };
-    GLuint m_stencilBufferObject { 0 };
+    unsigned m_id { 0 };
+    unsigned m_renderTarget { 0 };
+    unsigned m_binding { 0 };
+    unsigned m_fbo { 0 };
+    unsigned m_depthBufferObject { 0 };
+    unsigned m_stencilBufferObject { 0 };
     bool m_stencilBound { false };
     bool m_shouldClear { true };
     ClipStack m_clipStack;

--- a/Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "BitmapTexturePool.h"
 
-#if USE(TEXTURE_MAPPER)
 #include "GLContext.h"
 #include "GLContextWrapper.h"
 #include "PlatformDisplay.h"
@@ -216,5 +215,3 @@ void BitmapTexturePool::exitLimitExceededModeIfNeeded()
 }
 
 } // namespace WebCore
-
-#endif // USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/egl/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexturePool.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#if USE(TEXTURE_MAPPER)
-
 #include "BitmapTexture.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
@@ -95,5 +93,3 @@ private:
 };
 
 } // namespace WebCore
-
-#endif // USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -43,6 +43,13 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaBackingStore);

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -50,6 +50,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <epoxy/gl.h>
 #else
 #include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
 #endif
 
 namespace WebCore {


### PR DESCRIPTION
#### 6e990fd032628cad2be06bfb42db44f738a3e004
<pre>
[TextureMapper] Move BitmapTexture and BitmapTexturePool from texmap to egl directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=322590">https://bugs.webkit.org/show_bug.cgi?id=322590</a>

Reviewed by Nikolas Zimmermann.

They are actually classes to handle EGL textures, nothing specific to
texture mapper.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/egl/BitmapTexture.cpp: Renamed from Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp.
(WebCore::BitmapTexture::determineRenderTargetAndBinding):
(WebCore::BitmapTexture::textureFormat const):
(WebCore::depthBufferFormat):
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::createTexture):
(WebCore::BitmapTexture::allocateTexture):
(WebCore::BitmapTexture::sizeInBytes const):
(WebCore::BitmapTexture::allocatedSize const):
(WebCore::BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer):
(WebCore::BitmapTexture::swapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::updateContents):
(WebCore::BitmapTexture::initializeStencil):
(WebCore::BitmapTexture::initializeDepthBuffer):
(WebCore::BitmapTexture::clearIfNeeded):
(WebCore::BitmapTexture::createFboIfNeeded):
(WebCore::BitmapTexture::bindAsSurface):
(WebCore::BitmapTexture::~BitmapTexture):
(WebCore::BitmapTexture::copyFromExternalTexture):
(WebCore::BitmapTexture::colorConvertFlags const):
(WebCore::BitmapTexture::createSkiaBackendTexture const):
(WebCore::BitmapTexture::createSkiaSurface const):
* Source/WebCore/platform/graphics/egl/BitmapTexture.h: Renamed from Source/WebCore/platform/graphics/texmap/BitmapTexture.h.
* Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp: Renamed from Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp.
(WebCore::BitmapTexturePool::singleton):
(WebCore::BitmapTexturePool::BitmapTexturePool):
(WebCore::BitmapTexturePool::acquireTexture):
(WebCore::BitmapTexturePool::createTextureForImage):
(WebCore::BitmapTexturePool::scheduleReleaseUnusedTextures):
(WebCore::BitmapTexturePool::releaseUnusedTexturesTimerFired):
(WebCore::BitmapTexturePool::enterLimitExceededModeIfNeeded):
(WebCore::BitmapTexturePool::exitLimitExceededModeIfNeeded):
* Source/WebCore/platform/graphics/egl/BitmapTexturePool.h: Renamed from Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h.
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/319938@main">https://commits.webkit.org/319938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3dc67789e93fb13486b8bcf98115f78f6627c5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183075 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142899 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43557 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43189 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4466 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56667 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152367 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57372 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152062 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46622 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129641 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125790 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55880 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->