### PR TITLE
REGRESSION: streaming fetch() body is withheld until the next network chunk when the reader is busy

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/stashed-chunk.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/stashed-chunk.py
@@ -1,0 +1,13 @@
+import time
+
+def main(request, response):
+    response.headers.set(b"Content-Type", b"application/octet-stream")
+    response.headers.set(b"Cache-Control", b"no-store")
+    response.write_status_headers()
+
+    response.writer.write_content(b"A" * 4096)
+    time.sleep(0.1)
+    response.writer.write_content(b"B" * 4096)
+    time.sleep(0.1)
+    response.writer.write_content(b"C" * 4096)
+    time.sleep(5)

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Response body: chunks stashed while the source is not pulling are delivered on the next pull
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Fetch: chunks stashed before pull() must still be delivered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const CHUNK_SIZE = 4096;
+const EXPECTED_TOTAL = 3 * CHUNK_SIZE;
+
+promise_test(async t => {
+    const response = await fetch("../resources/stashed-chunk.py");
+    const reader = response.body.getReader();
+
+    const first = await reader.read();
+    assert_false(first.done, "first read should return data");
+
+    // Give the remaining server chunks time to reach the response body while no read() is pending.
+    await new Promise(resolve => t.step_timeout(resolve, 500));
+
+    // Read chunks up to EXPECTED_TOTAL, server sends it in 0.2s, we expect lower than 1.5s.
+    const buffer = new Uint8Array(EXPECTED_TOTAL);
+    buffer.set(first.value, 0);
+    let received = first.value.byteLength;
+    const deadlineMs = 1500;
+    const deadline = performance.now() + deadlineMs;
+
+    while (received < EXPECTED_TOTAL) {
+        const remaining = deadline - performance.now();
+        if (remaining <= 0)
+            assert_unreached(`only ${received}/${EXPECTED_TOTAL} bytes delivered within ${deadlineMs}ms — a chunk appears stranded in the stash`);
+
+        const result = await Promise.race([
+            reader.read(),
+            new Promise((_, reject) => t.step_timeout(() => reject(new Error("read deadline exceeded")), remaining))
+        ]);
+        assert_false(result.done, `stream ended after ${received}/${EXPECTED_TOTAL} bytes`);
+        buffer.set(result.value, received);
+        received += result.value.byteLength;
+    }
+
+    assert_equals(received, EXPECTED_TOTAL, "should have received exactly the bytes the server wrote");
+
+    const A = "A".charCodeAt(0);
+    const B = "B".charCodeAt(0);
+    const C = "C".charCodeAt(0);
+    for (let i = 0; i < CHUNK_SIZE; ++i)
+        assert_equals(buffer[i], A, `byte ${i} should be 'A'`);
+    for (let i = CHUNK_SIZE; i < 2 * CHUNK_SIZE; ++i)
+        assert_equals(buffer[i], B, `byte ${i} should be 'B'`);
+    for (let i = 2 * CHUNK_SIZE; i < EXPECTED_TOTAL; ++i)
+        assert_equals(buffer[i], C, `byte ${i} should be 'C'`);
+}, "Response body: chunks stashed while the source is not pulling are delivered on the next pull");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -67,8 +67,11 @@ Ref<DOMPromise> FetchBodySource::pull(JSDOMGlobalObject& globalObject, ReadableB
     auto [promise, deferred] = createPromiseAndWrapper(globalObject);
     if (RefPtr consumer = m_formDataConsumer)
         consumer->resume(WTF::move(deferred));
-    else
+    else {
         m_pullPromise = WTF::move(deferred);
+        if (RefPtr bodyOwner = m_bodyOwner.get())
+            bodyOwner->feedStream();
+    }
     return promise;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -607,7 +607,9 @@ void FetchResponse::cancelStream()
 
 void FetchResponse::feedStream()
 {
-    ASSERT(m_readableStreamSource);
+    if (!m_readableStreamSource)
+        return;
+
     bool shouldCloseStream = !m_loader;
 
     CheckedRef consumer = body().consumer();


### PR DESCRIPTION
#### 718031552ba1f92ec2e38be89387408077d3f7ba
<pre>
REGRESSION: streaming fetch() body is withheld until the next network chunk when the reader is busy
<a href="https://rdar.apple.com/185883588">rdar://185883588</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322545">https://bugs.webkit.org/show_bug.cgi?id=322545</a>

Reviewed by Alex Christensen.

When the stream is pulling the FetchBodySource, we check whether the FetchResponse has already received some data.
If so, we enqueue the data on the readable stream. This is implemented via FetchResponse::feedStream().

Test: imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk.html

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/stashed-chunk.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-body-stashed-chunk.html: Added.
* Source/WebCore/Modules/fetch/FetchBodySource.cpp:
(WebCore::FetchBodySource::pull):

Canonical link: <a href="https://commits.webkit.org/319981@main">https://commits.webkit.org/319981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e70cfd0ae23d0fef9abf88146cc935de7f3eed40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193500 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147571 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fd1d618-3ad4-4f1b-8a69-91bea0b45e63) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1243359-3f2f-4415-9f2d-174a76f6d327) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123481 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/977a2e08-24d5-40c6-99ba-303cc03742ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45488 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43739 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43348 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4675 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195441 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40901 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152242 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46796 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129867 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18360 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55525 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->