### PR TITLE
window.open() with noopener should not always return null

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6628,12 +6628,6 @@ imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-r
 
 webkit.org/b/258192 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h264_avc [ Pass Failure ]
 
-# These tests are timing out since their import.
-imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?indexed [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_self [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_parent [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_top [ Skip ]
-
 # Needs non-zero line gap in 'Arial'
 fast/text/text-box-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-box-edge-no-half-leading-with-line-height-simple.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/w3c-import.log
@@ -38,6 +38,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-indexed-properties.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-defaults.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-invalid-url.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noreferrer.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-popup-behavior.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS window.open() with noopener targeting an existing named iframe does not set its opener
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>window.open() with "noopener" targeting an existing navigable does not set its opener</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+/**
+ * The name lookup in "the rules for choosing a navigable" happens regardless of
+ * noopener, so window.open() can pick an existing navigable even when noopener
+ * is set. When it does, the window open steps must not set that navigable's
+ * opener, which for a nested navigable such as an iframe means it has to stay
+ * null.
+ */
+async_test(function(t) {
+  var iframe = document.createElement("iframe");
+  iframe.name = "window-open-noopener-existing-iframe";
+  t.add_cleanup(function() { iframe.remove(); });
+
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentWindow.opener, null,
+                  "A nested navigable has no opener to begin with");
+
+    iframe.onload = t.step_func_done(function() {
+      assert_equals(iframe.contentWindow.location.pathname, "/common/blank.html",
+                    "Should have navigated the existing iframe");
+      assert_equals(iframe.contentWindow.opener, null,
+                    "Should not have set the opener of the existing iframe");
+    });
+
+    assert_equals(window.open("/common/blank.html", iframe.name, "noopener"), null,
+                  "window.open() with noopener returns null");
+  });
+
+  document.body.append(iframe);
+}, "window.open() with noopener targeting an existing named iframe does not set its opener");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html
@@ -10,6 +10,7 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<div id=log></div>
 <script>
 var testData = [
   { testDescription: "window.open() with 'noopener' should reuse existing target",
@@ -108,20 +109,30 @@ function indexedTests() {
 }
 
 /**
- * Loop over the special targets that ignore noopener and check that doing a
- * window.open() with those targets correctly reuses the existing window.
+ * Check that a window.open() with one of the special targets that ignore
+ * noopener correctly reuses the existing window. The call is made from a
+ * same-origin iframe, so that _self names a different window than _parent and
+ * _top do. The URL is the empty string, so nothing is navigated and this only
+ * tests which window gets chosen.
  */
 function specialTargetTest(target) {
-  if (["_self", "_parent", "_top"].includes(target)) {
-    var t = async_test("noopener window.open targeting " + target);
-    t.openedWindow = window.open(`javascript:var w2 = window.open("", "${target}", "noopener"); this.checkValues(w2); this.close(); void(0);`);
-    assert_equals(t.openedWindow.opener, window);
-    t.openedWindow.checkValues = t.step_func_done(function(win) {
-      assert_equals(win, this.openedWindow);
-    });
-  } else {
+  if (!["_self", "_parent", "_top"].includes(target)) {
     throw 'testError: special target must be one of: _self, _parent, _top'
   }
+  async_test(function(t) {
+    var iframe = document.createElement("iframe");
+    t.add_cleanup(function() { iframe.remove(); });
+
+    window.reportOpenedWindow = t.step_func_done(function(win) {
+      assert_equals(win, target == "_self" ? iframe.contentWindow : window,
+                    "Should have reused the existing window");
+    });
+
+    iframe.srcdoc = `<script>
+      parent.reportOpenedWindow(window.open("", "${target}", "noopener"));
+    <\/script>`;
+    document.body.append(iframe);
+  }, "noopener window.open targeting " + target);
 }
 
 /**

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__parent-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN noopener window.open targeting _parent
+PASS noopener window.open targeting _parent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__self-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__self-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN noopener window.open targeting _self
+PASS noopener window.open targeting _self
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener__top-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN noopener window.open targeting _top
+PASS noopener window.open targeting _top
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -5085,7 +5085,8 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
                 if (RefPtr page = frame->page(); page && isInVisibleAndActivePage(openerFrame))
                     page->chrome().focus();
             }
-            frame->updateOpener(openerFrame);
+            if (!features.wantsNoOpener())
+                frame->updateOpener(openerFrame);
             return { frame, CreatedNewPage::No };
         }
     }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2914,6 +2914,9 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!newFrame)
         return RefPtr<Frame> { nullptr };
 
+    ASSERT(!isParentTargetFrameName(frameName) && !isTopTargetFrameName(frameName));
+    bool shouldReturnNull = noopener && (created == CreatedNewPage::Yes || !isSelfTargetFrameName(frameName));
+
     // https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable
     // Consume user activation when a new browsing context is created.
     if (created == CreatedNewPage::Yes)
@@ -2935,7 +2938,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
 
     RefPtr window = newFrame->window();
     if (window && window->isInsecureScriptAccess(activeWindow, completedURL))
-        return noopener ? RefPtr<Frame> { nullptr } : newFrame;
+        return shouldReturnNull ? RefPtr<Frame> { nullptr } : newFrame;
 
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
     if (prepareDialogFunction && localNewFrame)
@@ -2956,7 +2959,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!newFrame->page())
         return RefPtr<Frame> { nullptr };
 
-    return noopener ? RefPtr<Frame> { nullptr } : newFrame;
+    return shouldReturnNull ? RefPtr<Frame> { nullptr } : newFrame;
 }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 075a8d041b63a6ae6a4cc690e2f96dd635914df9
<pre>
window.open() with noopener should not always return null
<a href="https://bugs.webkit.org/show_bug.cgi?id=322591">https://bugs.webkit.org/show_bug.cgi?id=322591</a>

Reviewed by Chris Dumez.

The name lookup in &quot;the rules for choosing a navigable&quot; ignores noopener, so
window.open() can reuse an existing navigable when noopener is set. Two things
were wrong when it did: the reused navigable got its opener set to the caller,
and _self returned null instead of that navigable. _parent and _top were already
correct, as open() resolves them without reaching createWindow().

Spec changes: <a href="https://github.com/whatwg/html/pull/12845">https://github.com/whatwg/html/pull/12845</a>

Tests: imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
       imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html

Tests upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62213">https://github.com/web-platform-tests/wpt/pull/62213</a>

Canonical link: <a href="https://commits.webkit.org/319932@main">https://commits.webkit.org/319932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66bfe39564991e9ef94ac40dee7a396e328324d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af347dea-e9fe-4eb2-8508-28a0859d2d10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142880 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbf17154-8c81-4ed4-9634-bcee68649cdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123307 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c524db49-6621-4ebc-8b03-40978e6a3f29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43541 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43172 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4445 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195212 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152044 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46606 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129620 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55859 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18183 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55230 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->