### PR TITLE
Exiting Viewer Mode mutates the process-wide caption menu item singletons instead of restoring the caption display mode

### DIFF
--- a/LayoutTests/media/viewer-mode-restore-caption-menu-selection-expected.txt
+++ b/LayoutTests/media/viewer-mode-restore-caption-menu-selection-expected.txt
@@ -1,0 +1,24 @@
+
+RUN(internals.settings.setShouldDisplayTrackKind("Captions", true))
+RUN(internals.setCaptionDisplayMode("ForcedOnly"))
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+RUN(host = internals.controlsHostForMediaElement(video))
+EXPECTED (video.textTracks[0].mode == 'disabled') OK
+EXPECTED (internals.captionDisplayMode == 'forcedonly') OK
+EVENT(fullscreenchange)
+EXPECTED (host.inWindowFullscreen == 'true') OK
+RUN(trackTitle = host.displayNameForTrack(video.textTracks[0]))
+EXPECTED (selectMediaControlsMenuItem(trackTitle) == 'true') OK
+EXPECTED (video.textTracks[0].mode == 'showing') OK
+EXPECTED (internals.captionDisplayMode == 'alwayson') OK
+RUN(document.webkitCancelFullScreen())
+EVENT(fullscreenchange)
+EXPECTED (host.inWindowFullscreen == 'false') OK
+RUN(host.presentationModeChanged())
+EXPECTED (video.textTracks[0].mode == 'disabled') OK
+EXPECTED (internals.captionDisplayMode == 'forcedonly') OK
+EXPECTED (host.captionMenuOffItem.mode == 'disabled') OK
+EXPECTED (host.captionMenuAutomaticItem.mode == 'disabled') OK
+END OF TEST
+

--- a/LayoutTests/media/viewer-mode-restore-caption-menu-selection.html
+++ b/LayoutTests/media/viewer-mode-restore-caption-menu-selection.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>viewer-mode-restore-caption-menu-selection</title>
+	<script src=video-test.js></script>
+	<script src=media-file.js></script>
+	<script>
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	});
+
+	function findMenuItem(items, title)
+	{
+		for (let item of items) {
+			if (item.title == title && item.enabled)
+				return item;
+			let found = findMenuItem(item.children, title);
+			if (found)
+				return found;
+		}
+		return null;
+	}
+
+	function selectMediaControlsMenuItem(title)
+	{
+		document.addEventListener('contextmenu', event => {
+			event.preventDefault();
+			host.showMediaControlsContextMenu(video, { includeSubtitles: true }, () => { });
+		}, { capture: true, once: true });
+
+		let item = findMenuItem(eventSender.contextClick(), title);
+		if (!item)
+			return false;
+		item.click();
+		return true;
+	}
+
+	async function runTest()
+	{
+		findMediaElement();
+
+		run('internals.settings.setShouldDisplayTrackKind("Captions", true)');
+		run('internals.setCaptionDisplayMode("ForcedOnly")');
+		run('video.src = findMediaFile("video", "content/test")');
+		await waitFor(video, 'canplay');
+
+		run('host = internals.controlsHostForMediaElement(video)');
+		testExpected('video.textTracks[0].mode', 'disabled');
+		testExpected('internals.captionDisplayMode', 'forcedonly');
+
+		let enteredViewerMode = waitFor(document, 'fullscreenchange');
+		runWithKeyDown(() => internals.enterViewerMode(video));
+		await enteredViewerMode;
+		await testExpectedEventually('host.inWindowFullscreen', true, '==', 500);
+
+		run('trackTitle = host.displayNameForTrack(video.textTracks[0])');
+		testExpected('selectMediaControlsMenuItem(trackTitle)', true);
+		await testExpectedEventually('video.textTracks[0].mode', 'showing', '==', 500);
+		testExpected('internals.captionDisplayMode', 'alwayson');
+
+		let exitedViewerMode = waitFor(document, 'fullscreenchange');
+		run('document.webkitCancelFullScreen()');
+		await exitedViewerMode;
+		await testExpectedEventually('host.inWindowFullscreen', false, '==', 500);
+		run('host.presentationModeChanged()');
+
+		testExpected('video.textTracks[0].mode', 'disabled');
+		testExpected('internals.captionDisplayMode', 'forcedonly');
+		testExpected('host.captionMenuOffItem.mode', 'disabled');
+		testExpected('host.captionMenuAutomaticItem.mode', 'disabled');
+	}
+	</script>
+</head>
+<body>
+	<video controls width=320 height=240>
+		<track kind="captions" srclang="en" src="content/lorem-ipsum.vtt">
+	</video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -1031,11 +1031,12 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
     if (inWindowFullscreen())
         return;
 
-    RefPtr previouslySelectedTextTrack = m_previouslySelectedTextTrack;
+    RefPtr previouslySelectedTextTrack = std::exchange(m_previouslySelectedTextTrack, nullptr);
     if (!previouslySelectedTextTrack)
         return;
 
-    RefPtr textTracks = m_mediaElement->textTracks();
+    Ref mediaElement = m_mediaElement.get();
+    RefPtr textTracks = mediaElement->textTracks();
     for (unsigned i = 0; textTracks && i < textTracks->length(); ++i) {
         RefPtr textTrack = textTracks->item(i);
         ASSERT(textTrack);
@@ -1045,8 +1046,8 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
         if (previouslySelectedTextTrack != textTrack)
             textTrack->setMode(TextTrack::Mode::Disabled);
     }
-    previouslySelectedTextTrack->setMode(TextTrack::Mode::Showing);
-    m_previouslySelectedTextTrack = nullptr;
+
+    mediaElement->setSelectedTextTrack(previouslySelectedTextTrack.get());
 }
 
 #if ENABLE(MEDIA_SESSION)


### PR DESCRIPTION
#### 19512e685d63ba61052499a84a514461a0fa75b3
<pre>
Exiting Viewer Mode mutates the process-wide caption menu item singletons instead of restoring the caption display mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=322594">https://bugs.webkit.org/show_bug.cgi?id=322594</a>
<a href="https://rdar.apple.com/185890736">rdar://185890736</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/281109@main">281109@main</a> remembers the text track selected from the media controls context menu
in Viewer Mode and restores it on the way out, including the &quot;off&quot; and &quot;auto&quot; menu
items. But the restore applies the saved selection with a bare setMode(Showing),
and those two items are not tracks: they are captionMenuOffItemSingleton() and
captionMenuAutomaticItemSingleton(), NeverDestroyed statics shared by every
document in the process. Nothing sets them back to Disabled — the disable loop
above walks the element&apos;s own textTracks(), which never contains them — so one
trip through Viewer Mode leaves a singleton Showing for the life of the
WebProcess. Since sortedTrackListForMenu() inserts both at indices 0 and 1 of the
menu list and consumers read mode() over that list unfiltered, every later media
element computes allTracksDisabled as false and checks the wrong caption menu row.

Setting mode also fails to restore anything. The menu selection went through
HTMLMediaElement::setSelectedTextTrack(), which writes the page-group level
setCaptionDisplayMode(), so exiting Viewer Mode left the user&apos;s caption display
mode flipped to AlwaysOn.

Route the restore through setSelectedTextTrack(), which maps the singletons back
to a caption display mode instead of mutating them. Keep the disable loop, since
that function&apos;s Automatic branch only writes the display mode and would otherwise
leave the Viewer Mode track showing. Clear m_previouslySelectedTextTrack first so
a reentrant presentationModeChanged() cannot restore twice.

Test: media/viewer-mode-restore-caption-menu-selection.html

* LayoutTests/media/viewer-mode-restore-caption-menu-selection-expected.txt: Added.
* LayoutTests/media/viewer-mode-restore-caption-menu-selection.html: Added.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19512e685d63ba61052499a84a514461a0fa75b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8387cb88-687d-4691-a88d-091a78a0896b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56724 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142891 "Found 1 new test failure: media/viewer-mode-restore-caption-menu-selection.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99235 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e29c0a5-de71-4543-97d8-fb2c18de9e50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186021 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46614 "Found 1 new test failure: media/viewer-mode-restore-caption-menu-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123318 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cc31ecd-c6ab-4c16-b5ff-5d35bf286dea) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45306 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43551 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43186 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4457 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195224 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163151 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152359 "Found 1 new test failure: media/viewer-mode-restore-caption-menu-selection.html (failure)") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57363 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152055 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46615 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129632 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55871 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18197 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->