### PR TITLE
Cherry-pick 319867@main (9fa946d9a72f). https://bugs.webkit.org/show_bug.cgi?id=322290

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -31,6 +31,7 @@
 #include "JSRetainPtr.h"
 #include "JSTypedArray.h"
 #include "LiteralParser.h"
+#include "MarkedVector.h"
 #include "OpaqueJSString.h"
 #include "TypedArrayType.h"
 #include <array>
@@ -873,16 +874,16 @@ char** jsc_value_object_enumerate_properties(JSCValue* value)
     return result.leakSpan().data();
 }
 
-static JSValueRef jsObjectCall(JSGlobalContextRef jsContext, JSObjectRef function, JSC::JSCCallbackFunction::Type functionType, JSObjectRef thisObject, const Vector<JSValueRef>& arguments, JSValueRef* exception)
+static JSValueRef jsObjectCall(JSGlobalContextRef jsContext, JSObjectRef function, JSC::JSCCallbackFunction::Type functionType, JSObjectRef thisObject, std::span<const JSValueRef> arguments, JSValueRef* exception)
 {
     switch (functionType) {
     case JSC::JSCCallbackFunction::Type::Constructor:
-        return JSObjectCallAsConstructor(jsContext, function, arguments.size(), arguments.span().data(), exception);
+        return JSObjectCallAsConstructor(jsContext, function, arguments.size(), arguments.data(), exception);
     case JSC::JSCCallbackFunction::Type::Method:
         ASSERT(thisObject);
         [[fallthrough]];
     case JSC::JSCCallbackFunction::Type::Function:
-        return JSObjectCallAsFunction(jsContext, function, thisObject, arguments.size(), arguments.span().data(), exception);
+        return JSObjectCallAsFunction(jsContext, function, thisObject, arguments.size(), arguments.data(), exception);
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -895,7 +896,7 @@ static GRefPtr<JSCValue> jscValueCallFunction(JSCValue* value, JSObjectRef funct
     JSC::JSLockHolder locker(globalObject);
 
     JSValueRef exception = nullptr;
-    Vector<JSValueRef> arguments;
+    JSC::MarkedVector<JSValueRef> arguments;
     GType parameterType = firstParameterType;
     while (parameterType != G_TYPE_NONE) {
         GValue parameter;
@@ -918,7 +919,7 @@ static GRefPtr<JSCValue> jscValueCallFunction(JSCValue* value, JSObjectRef funct
         parameterType = va_arg(args, GType);
     }
 
-    auto result = jsObjectCall(jsContext, function, functionType, thisObject, arguments, &exception);
+    auto result = jsObjectCall(jsContext, function, functionType, thisObject, arguments.span(), &exception);
     if (jscContextHandleExceptionIfNeeded(priv->context.get(), exception))
         return adoptGRef(jsc_value_new_undefined(priv->context.get()));
 
@@ -1017,7 +1018,7 @@ JSCValue* jsc_value_object_invoke_methodv(JSCValue* value, const char* name, uns
         return jscValueGetJSValue(parametersSpan[i]);
     });
 
-    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Method, object, arguments, &exception);
+    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Method, object, arguments.span(), &exception);
     if (jscContextHandleExceptionIfNeeded(priv->context.get(), exception))
         return jsc_value_new_undefined(priv->context.get());
 
@@ -1368,7 +1369,7 @@ JSCValue* jsc_value_function_callv(JSCValue* value, unsigned parametersCount, JS
         return jscValueGetJSValue(parametersSpan[i]);
     });
 
-    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Function, nullptr, arguments, &exception);
+    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Function, nullptr, arguments.span(), &exception);
     if (jscContextHandleExceptionIfNeeded(priv->context.get(), exception))
         return jsc_value_new_undefined(priv->context.get());
 
@@ -1452,7 +1453,7 @@ JSCValue* jsc_value_constructor_callv(JSCValue* value, unsigned parametersCount,
         return jscValueGetJSValue(parametersSpan[i]);
     });
 
-    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Constructor, nullptr, arguments, &exception);
+    auto result = jsObjectCall(jsContext, function, JSC::JSCCallbackFunction::Type::Constructor, nullptr, arguments.span(), &exception);
     if (jscContextHandleExceptionIfNeeded(priv->context.get(), exception))
         return jsc_value_new_undefined(priv->context.get());
 

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
@@ -25,6 +25,7 @@
 #undef JSC_COMPILATION
 
 #include <JavaScriptCore/JSContextRef.h>
+#include <array>
 #include <jsc/jsc.h>
 #include <wtf/HashSet.h>
 #include <wtf/Threading.h>
@@ -4819,6 +4820,47 @@ static void testJSCJSON()
     }
 }
 
+static constexpr unsigned varargsParameterCount = 16;
+static constexpr unsigned varargsParameterLength = 512 * 1024;
+
+// Each parameter is large enough that converting the next one triggers a collection, when the earlier ones are only referenced from the argument list.
+static void testJSCFunctionCallParameterLifetime()
+{
+    LeakChecker checker;
+    GRefPtr<JSCContext> context = adoptGRef(jsc_context_new());
+    checker.watch(context.get());
+    ExceptionHandler exceptionHandler(context.get());
+
+    GUniquePtr<char> script(g_strdup_printf(
+        "(function() {\n"
+        "    for (var i = 0; i < arguments.length; i++) {\n"
+        "        if (arguments[i] !== String.fromCharCode(65 + i).repeat(%u))\n"
+        "            return 'parameter ' + i + ' did not survive';\n"
+        "    }\n"
+        "    return 'ok';\n"
+        "})", varargsParameterLength));
+    GRefPtr<JSCValue> function = adoptGRef(jsc_context_evaluate(context.get(), script.get(), -1));
+    checker.watch(function.get());
+    g_assert_true(jsc_value_is_function(function.get()));
+
+    std::array<GUniquePtr<char>, varargsParameterCount> parameters;
+    for (unsigned i = 0; i < varargsParameterCount; ++i)
+        parameters[i].reset(g_strnfill(varargsParameterLength, static_cast<char>('A' + i)));
+
+#define STRING_PARAMETER(index) G_TYPE_STRING, parameters[index].get()
+    GRefPtr<JSCValue> result = adoptGRef(jsc_value_function_call(function.get(),
+        STRING_PARAMETER(0), STRING_PARAMETER(1), STRING_PARAMETER(2), STRING_PARAMETER(3),
+        STRING_PARAMETER(4), STRING_PARAMETER(5), STRING_PARAMETER(6), STRING_PARAMETER(7),
+        STRING_PARAMETER(8), STRING_PARAMETER(9), STRING_PARAMETER(10), STRING_PARAMETER(11),
+        STRING_PARAMETER(12), STRING_PARAMETER(13), STRING_PARAMETER(14), STRING_PARAMETER(15),
+        G_TYPE_NONE));
+#undef STRING_PARAMETER
+
+    checker.watch(result.get());
+    GUniquePtr<char> resultString(jsc_value_to_string(result.get()));
+    g_assert_cmpstr(resultString.get(), ==, "ok");
+}
+
 int main(int argc, char** argv)
 {
     g_test_init(&argc, &argv, nullptr);
@@ -4846,6 +4888,7 @@ int main(int argc, char** argv)
     g_test_add_func("/jsc/autocleanups", testsJSCAutocleanups);
 #endif
     g_test_add_func("/jsc/json", testJSCJSON);
+    g_test_add_func("/jsc/function-call-parameter-lifetime", testJSCFunctionCallParameterLifetime);
 
     return g_test_run();
 }


### PR DESCRIPTION
#### 6e96bab351adb25d43a837dbac602063e7b974de
<pre>
Cherry-pick 319867@main (9fa946d9a72f). <a href="https://bugs.webkit.org/show_bug.cgi?id=322290">https://bugs.webkit.org/show_bug.cgi?id=322290</a>

    Clean up jsObjectCall style
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322290">https://bugs.webkit.org/show_bug.cgi?id=322290</a>

    Reviewed by Claudio Saavedra.

    This was bugging me while I was looking at it, little drive-by cleanup.

    Canonical link: <a href="https://commits.webkit.org/319867@main">https://commits.webkit.org/319867@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.151@webkitglib/2.54">https://commits.webkit.org/317695.151@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9883a025ee0330b1e763c6890869c5396087c1ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183069 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56992 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193286 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147357 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184931 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58334 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56727 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147357 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186024 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58334 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123320 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58334 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56727 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5290 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58334 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4460 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/44339 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49639 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56727 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195227 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56661 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152361 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57366 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152057 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27782 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57366 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129635 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125775 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55874 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50809 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55245 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55482 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55312 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->