### PR TITLE
[block-in-inline] An orthogonal block level box in an inline box makes its container as wide as the box instead of as its content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A block level box on a line contributes its block size to an orthogonal container's inline size
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta name="assert" content="This ensures that a block level box on a line whose writing mode is orthogonal to the line's contributes its block size to the container's inline size, the same as it does as a block sibling.">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#orthogonal-flows" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.container {
+    writing-mode: sideways-lr;
+    width: 300px;
+    background-color: silver;
+}
+.orthogonal {
+    writing-mode: horizontal-tb;
+    width: 200px;
+    height: 20px;
+    background-color: green;
+}
+</style>
+
+<div class="container" id="nested"><span><div class="orthogonal"></div></span></div>
+<div class="container" id="sibling"><div class="orthogonal"></div></div>
+
+<script>
+function inlineSizeOf(id) {
+    // The containers are sideways-lr, so their inline size is their height.
+    return document.getElementById(id).clientHeight;
+}
+
+test(() => {
+    assert_equals(inlineSizeOf("nested"), inlineSizeOf("sibling"));
+    assert_equals(inlineSizeOf("nested"), 20, "the box's 20px block size, not its 200px inline size");
+}, "A block level box on a line contributes its block size to an orthogonal container's inline size");
+</script>

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -278,10 +278,22 @@ LayoutUnit formattingContextRootLogicalWidthForType(const Layout::ElementBox& bo
     ASSERT(box.establishesFormattingContext() || box.isBlockLevelBox());
 
     CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    auto isOrthogonalBlockLevelBox = [&] {
+        if (!box.isBlockLevelBox())
+            return false;
+        CheckedPtr containingBlock = renderer->containingBlock();
+        return containingBlock && containingBlock->writingMode().isOrthogonal(renderer->writingMode());
+    };
+
     switch (logicalWidthType) {
     case LogicalWidthType::MaxContentContribution:
+        if (isOrthogonalBlockLevelBox())
+            return renderer->computeIntrinsicLogicalHeight();
         return renderer->maxContentLogicalWidthContribution();
     case LogicalWidthType::MinContentContribution:
+        if (isOrthogonalBlockLevelBox())
+            return renderer->computeIntrinsicLogicalHeight();
         return renderer->minContentLogicalWidthContribution();
     case LogicalWidthType::MaxContent:
     case LogicalWidthType::MinContent: {


### PR DESCRIPTION
#### 613b3c7720c2e6c88b661def85af22d987313b74
<pre>
[block-in-inline] An orthogonal block level box in an inline box makes its container as wide as the box instead of as its content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322595">https://bugs.webkit.org/show_bug.cgi?id=322595</a>
&lt;<a href="https://rdar.apple.com/problem/185890940">rdar://problem/185890940</a>&gt;

Reviewed by Antti Koivisto.

The line asks the render tree what a block level box on it costs along the line&apos;s inline axis, and got the
box&apos;s own inline size back. When the box&apos;s writing mode is orthogonal to the line&apos;s, that is the wrong axis.
Read the box&apos;s intrinsic block size for that case, which is what block layout reads for an orthogonal block
child in the block level branch of RenderBlockFlow::computeInlinePreferredLogicalWidths.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-inline-size-001.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::formattingContextRootLogicalWidthForType):

Canonical link: <a href="https://commits.webkit.org/319897@main">https://commits.webkit.org/319897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c4db6b2e823bfd6a16531f41e3d8368f144694

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147360 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f90603d0-fbd9-43b5-b88f-7ac52bff9c85) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/934044bf-1cdb-43df-a7aa-d8f4a2bd199f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6102740-209d-48c4-b13c-6fb01c085753) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45309 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43555 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43184 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4463 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152058 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46620 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129638 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125778 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55877 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18195 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->