### PR TITLE
[block-in-inline] An orthogonal block level box in an inline box is misplaced

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001-expected.txt
@@ -1,0 +1,6 @@
+first
+second
+third
+
+PASS A block level box on a line in an orthogonal writing mode starts after the line it follows on its container's block axis
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="assert" content="This ensures that a block level box on a line whose writing mode is orthogonal to its container's starts after the line it follows, on the container's block axis.">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#orthogonal-flows" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#container {
+    writing-mode: sideways-lr;
+    font-size: 40px;
+    line-height: 20px;
+    background-color: silver;
+}
+#target {
+    writing-mode: horizontal-tb;
+    background-color: green;
+}
+</style>
+
+<div id="container">first<span><div id="target">second</div></span>third</div>
+
+<script>
+test(() => {
+    var container = document.getElementById("container");
+    var target = document.getElementById("target");
+    // The container is sideways-lr, so its block axis runs from its left edge rightwards. The line before the box
+    // takes the line height, which is 20px whatever the font's own metrics are.
+    var blockAxisOffset = target.getBoundingClientRect().left - container.getBoundingClientRect().left;
+    assert_equals(blockAxisOffset, 20, "the line before the box takes 20px of the container's block axis");
+}, "A block level box on a line in an orthogonal writing mode starts after the line it follows on its container's block axis");
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4215,7 +4215,7 @@ bool RenderBlockFlow::layoutSimpleBlockContentInInline(MarginInfo& marginInfo)
                 return false;
             }
 
-            auto borderBoxLogicalTop = blockRenderer->logicalTop();
+            auto borderBoxLogicalTop = logicalTopForChild(*blockRenderer);
             auto marginBoxLogicalTop = borderBoxLogicalTop;
 
             if (!marginInfo.canCollapseWithMarginBefore()) {
@@ -4236,7 +4236,7 @@ bool RenderBlockFlow::layoutSimpleBlockContentInInline(MarginInfo& marginInfo)
             };
             if (shouldFallbackToNormalInlineLayout())
                 return false;
-            blockRenderer->setLogicalTop(borderBoxLogicalTop);
+            setLogicalTopForChild(*blockRenderer, borderBoxLogicalTop);
         }
         return true;
     };


### PR DESCRIPTION
#### 4102848ed39add0d8fef73db2f3f781773a8ab93
<pre>
[block-in-inline] An orthogonal block level box in an inline box is misplaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=322597">https://bugs.webkit.org/show_bug.cgi?id=322597</a>
&lt;<a href="https://rdar.apple.com/problem/185895981">rdar://problem/185895981</a>&gt;

Reviewed by Sam Weinig and Antti Koivisto.

RenderBlockFlow::layoutSimpleBlockContentInInline lays a block level box on a line out again where it already
is. It read the position back with RenderBox::logicalTop(), which is on the box&apos;s own block axis, and handed it
to layoutBlockChildFromInlineLayout, which writes it on the container&apos;s. Orthogonal writing modes make those
two different axes, so the box landed at its inline offset along the container&apos;s block axis: 55px into a
container whose only line before it takes 20px, sitting on that line rather than after it.

Read and write the position through the container&apos;s own accessors, which is what put the box there in the first
place.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-block-in-inline-block-axis-position-001.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutSimpleBlockContentInInline):

Canonical link: <a href="https://commits.webkit.org/319895@main">https://commits.webkit.org/319895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf1579250ae4ef4430548100f2d5bff69f0407fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147369 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17376775-623e-4f98-baef-3164f6bacaa2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4264db4e-13c7-4f18-be50-6b564cf87561) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123329 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86623423-dc2a-4aba-a438-35595acdfc93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45320 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43195 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4472 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195240 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152377 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40831 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57378 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152072 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46628 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129647 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55886 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18206 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->