### PR TITLE
Unify naming of zoom applying/unapplying functions

### DIFF
--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -96,7 +96,7 @@ struct WidthFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto width = Style::adjustForAbsoluteZoom(renderer.contentBoxWidth(), renderer);
+        auto width = Style::unapplyingZoom<int>(renderer.contentBoxWidth(), renderer);
         return evaluateLengthFeature(feature, width, conversionData);
     }
 };
@@ -111,7 +111,7 @@ struct HeightFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto height = Style::adjustForAbsoluteZoom(renderer.contentBoxHeight(), renderer);
+        auto height = Style::unapplyingZoom<int>(renderer.contentBoxHeight(), renderer);
         return evaluateLengthFeature(feature, height, conversionData);
     }
 };
@@ -126,7 +126,7 @@ struct InlineSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto logicalWidth = Style::adjustForAbsoluteZoom(renderer.contentBoxLogicalWidth(), renderer);
+        auto logicalWidth = Style::unapplyingZoom<int>(renderer.contentBoxLogicalWidth(), renderer);
         return evaluateLengthFeature(feature, logicalWidth, conversionData);
     }
 };
@@ -141,7 +141,7 @@ struct BlockSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto logicalHeight = Style::adjustForAbsoluteZoom(renderer.contentBoxLogicalHeight(), renderer);
+        auto logicalHeight = Style::unapplyingZoom<int>(renderer.contentBoxLogicalHeight(), renderer);
         return evaluateLengthFeature(feature, logicalHeight, conversionData);
     }
 };

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -429,7 +429,7 @@ static const LengthSchema& heightFeatureSchema()
         [](auto& context) {
             auto height = protect(context.document->view())->layoutHeight();
             if (CheckedPtr renderView = context.document->renderView())
-                height = Style::adjustForAbsoluteZoom(height, *renderView);
+                height = Style::unapplyingZoom<int>(height, *renderView);
             return height;
         }
     };
@@ -729,7 +729,7 @@ static const LengthSchema& widthFeatureSchema()
         [](auto& context) {
             auto width = protect(context.document->view())->layoutWidth();
             if (CheckedPtr renderView = context.document->renderView())
-                width = Style::adjustForAbsoluteZoom(width, *renderView);
+                width = Style::unapplyingZoom<int>(width, *renderView);
             return width;
         }
     };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -535,12 +535,12 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
 
             auto contentBoxSize = entry->contentBoxSize().at(0);
             if (box->style().logicalContainIntrinsicWidth().hasAuto()) {
-                auto adjustedWidth = LayoutUnit { Style::applyZoom(contentBoxSize->inlineSize(), box->style()) };
+                auto adjustedWidth = LayoutUnit { Style::applyingZoom<float>(contentBoxSize->inlineSize(), box->style()) };
                 target->setLastRememberedLogicalWidth(adjustedWidth);
             }
 
             if (box->style().logicalContainIntrinsicHeight().hasAuto()) {
-                auto adjustedHeight = LayoutUnit { Style::applyZoom(contentBoxSize->blockSize(), box->style()) };
+                auto adjustedHeight = LayoutUnit { Style::applyingZoom<float>(contentBoxSize->blockSize(), box->style()) };
                 target->setLastRememberedLogicalHeight(adjustedHeight);
             }
         }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1447,8 +1447,8 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
         return;
 
     auto scrollToOptions = normalizeNonFiniteCoordinatesOrFallBackTo(options,
-        Style::adjustForAbsoluteZoom(renderer->scrollLeft(), *renderer),
-        Style::adjustForAbsoluteZoom(renderer->scrollTop(), *renderer)
+        Style::unapplyingZoom<int>(renderer->scrollLeft(), *renderer),
+        Style::unapplyingZoom<int>(renderer->scrollTop(), *renderer)
     );
     IntPoint scrollPosition(
         clampTo<int>(scrollToOptions.left.value() * renderer->style().usedZoom()),
@@ -1590,7 +1590,7 @@ int Element::offsetWidth()
     protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
     if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetWidth = LayoutUnit { roundToInt(renderer->offsetWidth()) };
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(offsetWidth, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(offsetWidth, *renderer).toDouble());
     }
     return 0;
 }
@@ -1600,7 +1600,7 @@ int Element::offsetHeight()
     protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
     if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetHeight = LayoutUnit { roundToInt(renderer->offsetHeight()) };
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(offsetHeight, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(offsetHeight, *renderer).toDouble());
     }
     return 0;
 }
@@ -1631,7 +1631,7 @@ int Element::clientLeft()
 
     if (CheckedPtr renderer = renderBox()) {
         auto clientLeft = LayoutUnit { roundToInt(renderer->borderLeft()) };
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientLeft, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(clientLeft, *renderer).toDouble());
     }
     return 0;
 }
@@ -1642,7 +1642,7 @@ int Element::clientTop()
 
     if (CheckedPtr renderer = renderBox()) {
         auto clientTop = LayoutUnit { roundToInt(renderer->borderTop()) };
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientTop, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(clientTop, *renderer).toDouble());
     }
     return 0;
 }
@@ -1661,7 +1661,7 @@ int Element::clientWidth()
     // When in quirks mode, clientWidth for the body element should return the width of the containing frame.
     bool inQuirksMode = document->inQuirksMode();
     if ((!inQuirksMode && document->documentElement() == this) || (inQuirksMode && isHTMLElement() && document->bodyOrFrameset() == this))
-        return Style::adjustForAbsoluteZoom(protect(renderView->frameView())->layoutWidth(), renderView);
+        return Style::unapplyingZoom<int>(protect(renderView->frameView())->layoutWidth(), renderView);
     
     if (CheckedPtr renderer = renderBox()) {
         auto clientWidth = LayoutUnit { roundToInt(renderer->paddingBoxWidth()) };
@@ -1680,7 +1680,7 @@ int Element::clientWidth()
                 clientWidth += renderer->paddingLeft() + renderer->paddingRight();
             clientWidth += renderer->borderLeft() + renderer->borderRight();
         }
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientWidth, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(clientWidth, *renderer).toDouble());
     }
     return 0;
 }
@@ -1698,7 +1698,7 @@ int Element::clientHeight()
     // When in quirks mode, clientHeight for the body element should return the height of the containing frame.
     bool inQuirksMode = document->inQuirksMode();
     if ((!inQuirksMode && document->documentElement() == this) || (inQuirksMode && isHTMLElement() && document->bodyOrFrameset() == this))
-        return Style::adjustForAbsoluteZoom(protect(renderView->frameView())->layoutHeight(), renderView);
+        return Style::unapplyingZoom<int>(protect(renderView->frameView())->layoutHeight(), renderView);
 
     if (CheckedPtr renderer = renderBox()) {
         auto clientHeight = LayoutUnit { roundToInt(renderer->paddingBoxHeight()) };
@@ -1717,7 +1717,7 @@ int Element::clientHeight()
                 clientHeight += renderer->paddingTop() + renderer->paddingBottom();
             clientHeight += renderer->borderTop() + renderer->borderBottom();
         }
-        return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientHeight, *renderer).toDouble());
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(clientHeight, *renderer).toDouble());
     }
     return 0;
 }
@@ -1757,7 +1757,7 @@ int Element::scrollLeft()
     }
 
     if (CheckedPtr renderer = renderBox())
-        return Style::adjustForAbsoluteZoom(renderer->scrollLeft(), *renderer);
+        return Style::unapplyingZoom<int>(renderer->scrollLeft(), *renderer);
     return 0;
 }
 
@@ -1773,7 +1773,7 @@ int Element::scrollTop()
     }
 
     if (CheckedPtr renderer = renderBox())
-        return Style::adjustForAbsoluteZoom(renderer->scrollTop(), *renderer);
+        return Style::unapplyingZoom<int>(renderer->scrollTop(), *renderer);
     return 0;
 }
 
@@ -1847,7 +1847,7 @@ int Element::scrollWidth()
     }
 
     if (CheckedPtr renderer = renderBox())
-        return Style::adjustForAbsoluteZoom(renderer->scrollWidth(), *renderer);
+        return Style::unapplyingZoom<int>(renderer->scrollWidth(), *renderer);
     return 0;
 }
 
@@ -1865,7 +1865,7 @@ int Element::scrollHeight()
     }
 
     if (CheckedPtr renderer = renderBox())
-        return Style::adjustForAbsoluteZoom(renderer->scrollHeight(), *renderer);
+        return Style::unapplyingZoom<int>(renderer->scrollHeight(), *renderer);
     return 0;
 }
 

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -565,8 +565,8 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
             FloatSize sizeBeforeTransform;
             if (CheckedPtr renderer = textContainer->renderBoxModelObject()) {
                 sizeBeforeTransform = {
-                    Style::adjustLayoutUnitForAbsoluteZoom(renderer->offsetWidth(), *renderer).toFloat(),
-                    Style::adjustLayoutUnitForAbsoluteZoom(renderer->offsetHeight(), *renderer).toFloat(),
+                    Style::unapplyingZoom<LayoutUnit>(renderer->offsetWidth(), *renderer).toFloat(),
+                    Style::unapplyingZoom<LayoutUnit>(renderer->offsetHeight(), *renderer).toFloat(),
                 };
             }
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -992,7 +992,7 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
     // Factor out the zoom from the nearest common ancestor of the captured element and the view transition
     // pseudo tree (the document element), so that it doesn't get applied a second time when rendering the
     // snapshots.
-    LayoutSize cssSize = Style::adjustLayoutSizeForAbsoluteZoom(output.size, documentElementRenderer->style());
+    auto cssSize = Style::unapplyingZoom<LayoutSize>(output.size, documentElementRenderer->style());
     protect(output.properties)->setProperty(CSSPropertyWidth, CSSPrimitiveValue::create(cssSize.width(), CSSUnitType::Px));
     protect(output.properties)->setProperty(CSSPropertyHeight, CSSPrimitiveValue::create(cssSize.height(), CSSUnitType::Px));
 }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -677,7 +677,7 @@ unsigned HTMLImageElement::width()
     if (!box)
         return 0;
     LayoutRect contentRect = box->contentBoxRect();
-    return Style::adjustLayoutUnitForAbsoluteZoom(contentRect.width(), *box).round();
+    return Style::unapplyingZoom<LayoutUnit>(contentRect.width(), *box).round();
 }
 
 unsigned HTMLImageElement::height()
@@ -700,7 +700,7 @@ unsigned HTMLImageElement::height()
     if (!box)
         return 0;
     LayoutRect contentRect = box->contentBoxRect();
-    return Style::adjustLayoutUnitForAbsoluteZoom(contentRect.height(), *box).round();
+    return Style::unapplyingZoom<LayoutUnit>(contentRect.height(), *box).round();
 }
 
 unsigned HTMLImageElement::naturalWidth() const

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -179,7 +179,7 @@ unsigned ImageInputType::height() const
 
     CheckedPtr renderer = element->renderer();
     if (renderer)
-        return Style::adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxHeight(), *renderer);
+        return Style::unapplyingZoom<int>(downcast<RenderBox>(*renderer).contentBoxHeight(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
     if (auto optionalHeight = parseHTMLNonNegativeInteger(element->attributeWithoutSynchronization(heightAttr)))
@@ -202,7 +202,7 @@ unsigned ImageInputType::width() const
 
     CheckedPtr renderer = element->renderer();
     if (renderer)
-        return Style::adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxWidth(), *renderer);
+        return Style::unapplyingZoom<int>(downcast<RenderBox>(*renderer).contentBoxWidth(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
     if (auto optionalWidth = parseHTMLNonNegativeInteger(element->attributeWithoutSynchronization(widthAttr)))

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1195,8 +1195,8 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
     String elementHeight;
     if (is<RenderBoxModelObject>(renderer)) {
         CheckedPtr modelObject = downcast<RenderBoxModelObject>(renderer.get());
-        elementWidth = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetWidth()), *modelObject));
-        elementHeight = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetHeight()), *modelObject));
+        elementWidth = String::number(Style::unapplyingZoom<int>(roundToInt(modelObject->offsetWidth()), *modelObject));
+        elementHeight = String::number(Style::unapplyingZoom<int>(roundToInt(modelObject->offsetHeight()), *modelObject));
     } else {
         RefPtr containingView = node.document().frame()->view();
         IntRect boundingBox = snappedIntRect(containingView->contentsToRootView(renderer->absoluteBoundingBoxRect()));

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -81,9 +81,9 @@ auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
             if (box->isSkippedContent())
                 return std::nullopt;
             return { {
-                Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxSize(), *box),
-                Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxLogicalSize(), *box),
-                Style::adjustLayoutSizeForAbsoluteZoom(box->logicalSize(), *box)
+                Style::unapplyingZoom<LayoutSize>(box->contentBoxSize(), *box),
+                Style::unapplyingZoom<LayoutSize>(box->contentBoxLogicalSize(), *box),
+                Style::unapplyingZoom<LayoutSize>(box->logicalSize(), *box)
             } };
         }
     }

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -114,7 +114,7 @@ RefPtr<CSSValue> Extractor::getFontSizeCSSValuePreferringKeyword() const
     if (auto sizeIdentifier = style->fontDescription().keywordSizeAsIdentifier())
         return CSSKeywordValue::create(sizeIdentifier);
 
-    return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(style->fontDescription().computedSize(), *style), CSSUnitType::Px);
+    return CSSPrimitiveValue::create(unapplyingZoom<float>(style->fontDescription().computedSize(), *style), CSSUnitType::Px);
 }
 
 bool Extractor::useFixedFontDefaultSize() const

--- a/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,6 @@
 
 namespace WebCore {
 
-class LayoutSize;
-class LayoutUnit;
 class RenderElement;
 
 namespace Style {
@@ -45,18 +43,19 @@ struct ZoomFactor {
     constexpr bool operator==(const ZoomFactor&) const = default;
 };
 
-// Map from values with zoom applied to web-exposed values, which are zoom-independent.
-inline int adjustForAbsoluteZoom(int, const ComputedStyle&);
-inline int adjustForAbsoluteZoom(int, const RenderElement&);
-inline float adjustFloatForAbsoluteZoom(float, const ComputedStyle&);
-inline float adjustFloatForAbsoluteZoom(float, const RenderElement&);
-inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit, const ComputedStyle&);
-inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit, const RenderElement&);
-inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize, const ComputedStyle&);
-inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize, const RenderElement&);
+// Map from values with zoom applied to values which are zoom-independent.
+template<typename T>
+T unapplyingZoom(T, const ComputedStyle&);
 
-// Map from zoom-independent style values to with zoom applied.
-inline float applyZoom(float, const ComputedStyle&);
+template<typename T>
+T unapplyingZoom(T, const RenderElement&);
+
+// Map from values which are zoom-independent to values with zoom applied.
+template<typename T>
+T applyingZoom(T, const ComputedStyle&);
+
+template<typename T>
+T applyingZoom(T, const RenderElement&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/viewport/StyleZoomPrimitivesInlines.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomPrimitivesInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,65 +29,50 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Rounding.h"
 #include "StyleZoomPrimitives.h"
+#include <concepts>
 
 namespace WebCore {
 namespace Style {
 
-inline int adjustForAbsoluteZoom(int value, const ComputedStyle& style)
-{
-    double zoomFactor = style.usedZoom();
-    if (zoomFactor == 1)
-        return value;
-    // Needed because resolveAsLength<int> truncates (rather than rounds) when scaling up.
-    if (zoomFactor > 1) {
-        if (value < 0)
-            value--;
-        else
-            value++;
-    }
-
-    return roundForImpreciseConversion<int>(value / zoomFactor);
-}
-
-inline int adjustForAbsoluteZoom(int value, const RenderElement& renderer)
-{
-    return adjustForAbsoluteZoom(value, renderer.style());
-}
-
-inline float adjustFloatForAbsoluteZoom(float value, const ComputedStyle& style)
-{
-    return value / style.usedZoom();
-}
-
-inline float adjustFloatForAbsoluteZoom(float value, const RenderElement& renderer)
-{
-    return adjustFloatForAbsoluteZoom(value, renderer.style());
-}
-
-inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit value, const ComputedStyle& style)
-{
-    return LayoutUnit(value / style.usedZoom());
-}
-
-inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit value, const RenderElement& renderer)
-{
-    return adjustLayoutUnitForAbsoluteZoom(value, renderer.style());
-}
-
-inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize size, const ComputedStyle& style)
+template<typename T>
+T unapplyingZoom(T value, const ComputedStyle& style)
 {
     auto zoom = style.usedZoom();
-    return { size.width() / zoom, size.height() / zoom };
+
+    if constexpr (std::integral<T>) {
+        if (zoom == 1)
+            return value;
+        // Needed to match historical `CSSPrimitiveValue::resolveAsLength<int>` behavior which truncated (rather than rounding) when scaling up.
+        if (zoom > 1) {
+            if (value < 0)
+                value--;
+            else
+                value++;
+        }
+        return roundForImpreciseConversion<int>(value / zoom);
+    } else if constexpr (std::floating_point<T> || std::same_as<T, LayoutUnit>) {
+        return T(value / zoom);
+    } else if constexpr (std::same_as<T, LayoutSize>) {
+        return T(value.width() / zoom, value.height() / zoom);
+    }
 }
 
-inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize size, const RenderElement& renderer)
+template<typename T>
+T unapplyingZoom(T value, const RenderElement& renderer)
 {
-    return adjustLayoutSizeForAbsoluteZoom(size, renderer.style());
+    return Style::unapplyingZoom<T>(value, renderer.style());
 }
 
-inline float applyZoom(float value, const ComputedStyle& style)
+template<typename T>
+inline T applyingZoom(T value, const ComputedStyle& style)
 {
     return value * style.usedZoom();
+}
+
+template<typename T>
+inline T applyingZoom(T value, const RenderElement& renderer)
+{
+    return Style::applyingZoom<T>(value, renderer.style());
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 084154b27a5c5184b5cb401c9b6916d71a4d120d
<pre>
Unify naming of zoom applying/unapplying functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=322599">https://bugs.webkit.org/show_bug.cgi?id=322599</a>

Reviewed by Darin Adler and Taher Ali.

Unify naming of zoom applying/unapplying functions to:
  - applyingZoom&lt;T&gt;(...)
  - unapplyingZoom&lt;T&gt;(...)

Making the type required makes it more clear at call sites
what conversions are happening. The previous behavior of
truncating to int when using the base function was unclear.

* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ImageOverlay.cpp:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/html/ImageInputType.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/page/ResizeObservation.cpp:
* Source/WebCore/style/StyleExtractor.cpp:
* Source/WebCore/style/values/viewport/StyleZoomPrimitives.h:
* Source/WebCore/style/values/viewport/StyleZoomPrimitivesInlines.h:

Canonical link: <a href="https://commits.webkit.org/320078@main">https://commits.webkit.org/320078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/084c4549e8887a4e568db7ca1a61c5346c7cd258

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183365 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143132 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99393 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45582 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43814 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43428 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4760 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56959 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152634 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57663 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152317 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46870 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129942 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126241 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56171 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18438 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->