### PR TITLE
[block-in-inline] A relatively positioned block level box on a line reports scrollable overflow as wide as the line

### DIFF
--- a/LayoutTests/fast/repaint/transform-absolute-in-positioned-container-expected.txt
+++ b/LayoutTests/fast/repaint/transform-absolute-in-positioned-container-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 992x585
-  RenderView at (0,0) size 800x585
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
 layer at (0,0) size 800x296
   RenderBlock {HTML} at (0,0) size 800x296
     RenderBody {BODY} at (8,16) size 784x272
@@ -13,7 +13,7 @@ layer at (0,0) size 800x296
           text run at (362,0) width 298: ". The rotated box should be correctly redrawn."
       RenderBlock (anonymous) at (0,34) size 784x238
         RenderText {#text} at (0,0) size 0x0
-layer at (18,110) size 784x278
+layer at (18,110) size 784x278 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderInline (relative positioned) {SPAN} at (0,-20) size 784x278 [bgcolor=#DDDDDD]
     RenderText {#text} at (20,0) size 64x18
       text run at (20,0) width 64: "Container"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt
@@ -1,0 +1,5 @@
+text
+text
+
+PASS A relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as a block sibling
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta name="assert" content="This ensures that a relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as it does as a block sibling.">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.container { width: 100px; height: 50px; font: 16px/18px monospace; }
+.shifted { width: 10px; height: 10px; position: relative; left: 20px; background-color: green; }
+</style>
+
+<div class="container" id="nested">text<span><div class="shifted"></div></span></div>
+<div class="container" id="sibling">text<div class="shifted"></div></div>
+
+<script>
+test(() => {
+    assert_equals(document.getElementById("nested").scrollWidth, document.getElementById("sibling").scrollWidth);
+}, "A relatively positioned block level box nested in an inline box contributes the same scrollable overflow in the inline direction as a block sibling");
+</script>

--- a/LayoutTests/platform/glib/fast/encoding/utf-16-big-endian-expected.txt
+++ b/LayoutTests/platform/glib/fast/encoding/utf-16-big-endian-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 797x1122
-  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x1122
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 785x1122
   RenderBlock {HTML} at (0,0) size 785x1122
     RenderBody {BODY} at (8,8) size 769x1101 [bgcolor=#EEEEEE]
@@ -391,7 +391,7 @@ layer at (23,8) size 600x39
       text run at (73,146) width 106: "DEBI STANGEL, "
       text run at (178,146) width 119: "119 GLEN COURT, "
       text run at (296,146) width 139: "DANVILLE CA Z/94526"
-layer at (23,8) size 769x73
+layer at (23,8) size 769x73 backgroundClip at (0,0) size 785x1122 clip at (0,0) size 785x1122
   RenderInline (relative positioned) {SPAN} at (0,205) size 769x73
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,197) size 20x21

--- a/LayoutTests/platform/glib/fast/encoding/utf-16-little-endian-expected.txt
+++ b/LayoutTests/platform/glib/fast/encoding/utf-16-little-endian-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 797x1122
-  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x1122
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 785x1122
   RenderBlock {HTML} at (0,0) size 785x1122
     RenderBody {BODY} at (8,8) size 769x1101 [bgcolor=#EEEEEE]
@@ -391,7 +391,7 @@ layer at (23,8) size 600x39
       text run at (73,146) width 106: "DEBI STANGEL, "
       text run at (178,146) width 119: "119 GLEN COURT, "
       text run at (296,146) width 139: "DANVILLE CA Z/94526"
-layer at (23,8) size 769x73
+layer at (23,8) size 769x73 backgroundClip at (0,0) size 785x1122 clip at (0,0) size 785x1122
   RenderInline (relative positioned) {SPAN} at (0,205) size 769x73
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,197) size 20x21

--- a/LayoutTests/platform/glib/fast/repaint/transform-absolute-in-positioned-container-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/transform-absolute-in-positioned-container-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 992x585
-  RenderView at (0,0) size 800x585
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
 layer at (0,0) size 800x296
   RenderBlock {HTML} at (0,0) size 800x296
     RenderBody {BODY} at (8,16) size 784x272
@@ -13,7 +13,7 @@ layer at (0,0) size 800x296
           text run at (356,0) width 293: ". The rotated box should be correctly redrawn."
       RenderBlock (anonymous) at (0,34) size 784x238
         RenderText {#text} at (0,0) size 0x0
-layer at (18,110) size 784x278
+layer at (18,110) size 784x278 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderInline (relative positioned) {SPAN} at (0,-20) size 784x278 [bgcolor=#DDDDDD]
     RenderText {#text} at (20,0) size 62x18
       text run at (20,0) width 62: "Container"

--- a/LayoutTests/platform/mac/fast/encoding/utf-16-big-endian-expected.txt
+++ b/LayoutTests/platform/mac/fast/encoding/utf-16-big-endian-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 797x1122
-  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x1122
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 785x1122
   RenderBlock {HTML} at (0,0) size 785x1122
     RenderBody {BODY} at (8,8) size 769x1101 [bgcolor=#EEEEEE]
@@ -391,7 +391,7 @@ layer at (23,8) size 597x39
       text run at (72,146) width 105: "DEBI STANGEL, "
       text run at (176,146) width 119: "119 GLEN COURT, "
       text run at (294,146) width 139: "DANVILLE CA Z/94526"
-layer at (23,8) size 769x73
+layer at (23,8) size 769x73 backgroundClip at (0,0) size 785x1122 clip at (0,0) size 785x1122
   RenderInline (relative positioned) {SPAN} at (0,205) size 769x73
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,197) size 20x21

--- a/LayoutTests/platform/mac/fast/encoding/utf-16-little-endian-expected.txt
+++ b/LayoutTests/platform/mac/fast/encoding/utf-16-little-endian-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 797x1122
-  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x1122
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 785x1122
   RenderBlock {HTML} at (0,0) size 785x1122
     RenderBody {BODY} at (8,8) size 769x1101 [bgcolor=#EEEEEE]
@@ -391,7 +391,7 @@ layer at (23,8) size 597x39
       text run at (72,146) width 105: "DEBI STANGEL, "
       text run at (176,146) width 119: "119 GLEN COURT, "
       text run at (294,146) width 139: "DANVILLE CA Z/94526"
-layer at (23,8) size 769x73
+layer at (23,8) size 769x73 backgroundClip at (0,0) size 785x1122 clip at (0,0) size 785x1122
   RenderInline (relative positioned) {SPAN} at (0,205) size 769x73
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,197) size 20x21

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -150,10 +150,10 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
 
     for (size_t lineIndex = startIndex; lineIndex < lines.size(); ++lineIndex) {
         auto& line = lines[lineIndex];
-        auto lineScrollableOverflowRect = line.scrollableOverflow();
+        auto lineScrollableOverflowRect = line.hasBlockLevelBox() ? FloatRect { } : line.scrollableOverflow();
         auto adjustOverflowLogicalWidthWithBlockFlowQuirk = [&] {
             if (line.hasBlockLevelBox()) {
-                // A block box contributes its own through layoutOverflowRectForPropagation(), which uses the margin the box ended up with. See InlineDisplayLineBuilder::collectEnclosingLineGeometry.
+                // A block box contributes its own through layoutOverflowRectForPropagation(), which uses the margin the box ended up with.
                 return;
             }
             auto scrollableOverflowLogicalWidth = isHorizontalWritingMode ? lineScrollableOverflowRect.width() : lineScrollableOverflowRect.height();
@@ -177,8 +177,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             inlineContent.setHasPaintedInlineLevelBoxes();
 
         auto firstBoxIndex = boxIndex;
-        // A block level box on a line contributes its own ink overflow below, and only when it is not self painting.
-        auto lineInkOverflowRect = line.hasBlockLevelBox() ? FloatRect { } : lineScrollableOverflowRect;
+        auto lineInkOverflowRect = lineScrollableOverflowRect;
         // Collect overflow from boxes.
         // Note while we compute ink overflow for all type of boxes including atomic inline level boxes (e.g. <iframe> <img>) as part of constructing
         // display boxes (see InlineDisplayContentBuilder) RenderBlockFlow expects visual overflow.
@@ -211,9 +210,6 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
                     childInkOverflow.move(box.left(), box.top());
                     lineInkOverflowRect.unite(childInkOverflow);
                 }
-
-                if (box.isBlockLevelBox() && renderer->isInFlowPositioned())
-                    lineScrollableOverflowRect.move(renderer->offsetForInFlowPosition());
 
                 if (!renderer->hasControlClip()) {
                     auto childScrollableOverflow = renderer->layoutOverflowRectForPropagation(renderer->parent()->writingMode());


### PR DESCRIPTION
#### 00f2675ea704e8fe868d2d6b9de581bdca82d709
<pre>
[block-in-inline] A relatively positioned block level box on a line reports scrollable overflow as wide as the line
<a href="https://bugs.webkit.org/show_bug.cgi?id=322539">https://bugs.webkit.org/show_bug.cgi?id=322539</a>
&lt;<a href="https://rdar.apple.com/problem/185835450">rdar://problem/185835450</a>&gt;

Reviewed by Antti Koivisto.

A block level box gets a line of its own, and that line box is as wide as the container&apos;s content box.
Ink overflow already leaves that rect out and lets the box contribute its own, since the box is what the line
holds. Let&apos;s apply it to scrollable overflow too.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-relative-positioned-block-in-inline-002.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):
* LayoutTests/fast/repaint/transform-absolute-in-positioned-container-expected.txt:
* LayoutTests/platform/glib/fast/encoding/utf-16-big-endian-expected.txt:
* LayoutTests/platform/glib/fast/encoding/utf-16-little-endian-expected.txt:
* LayoutTests/platform/glib/fast/repaint/transform-absolute-in-positioned-container-expected.txt:
* LayoutTests/platform/mac/fast/encoding/utf-16-big-endian-expected.txt:
* LayoutTests/platform/mac/fast/encoding/utf-16-little-endian-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319899@main">https://commits.webkit.org/319899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c849636bc09b3f93104ba2c37e72747e5ffa1bad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142916 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38e22ca5-39f4-456d-9853-c7721eac85cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123343 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d649e590-af55-4ef4-a28b-5eb9ac3c3426) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45335 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43212 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4497 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195265 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40839 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57403 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152089 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46646 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129673 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125821 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55911 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55282 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->