### PR TITLE
[AppKit Gestures] Magnification can snap the scroll position unexpectedly

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -298,6 +298,13 @@ static RetainPtr<CABasicAnimation> transientPositionAnimation(const FloatPoint& 
     return fillFowardsAnimationWithKeyPathAndValue(@"position", [NSValue valueWithPoint:position]);
 }
 
+static RetainPtr<CABasicAnimation> additiveTransientPositionAnimation(const FloatSize& offset)
+{
+    RetainPtr animation = fillFowardsAnimationWithKeyPathAndValue(@"position", [NSValue valueWithPoint:toFloatPoint(offset)]);
+    [animation setAdditive:YES];
+    return animation;
+}
+
 void RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer()
 {
     ASSERT(m_transientZoomScale);
@@ -319,7 +326,10 @@ void RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer()
     auto clipLayerPosition = FloatPoint { [clipLayer position] };
     auto clipLayerZoomOrigin = clipLayerPosition + *m_transientZoomOriginInVisibleRect;
     auto transientClipLayerFrame = scaledRectAtOrigin([clipLayer frame], scaleForClipLayerAdjustment, clipLayerZoomOrigin);
-    auto transientScrolledContentsPosition = FloatPoint { [scrolledContentsLayer position] } + (clipLayerPosition - transientClipLayerFrame.location());
+    // Instead of deriving a position relative to the scrolled contents layer,
+    // we use this as an additive offset. Otherwise, transient zoom and scrolling
+    // try to stomp over the same property in every frame.
+    auto scrolledContentsCorrection = clipLayerPosition - transientClipLayerFrame.location();
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     auto animationWithScale = transientZoomTransformOverrideAnimation(transform);
@@ -330,7 +340,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer()
     [clipLayer addAnimation:transientPositionAnimation(transientClipLayerFrame.location()).get() forKey:transientClipPositionAnimationKey];
     [clipLayer addAnimation:transientSizeAnimation(transientClipLayerFrame.size()).get() forKey:transientClipSizeAnimationKey];
     [scrolledContentsLayer removeAnimationForKey:transientScrolledContentsPositionAnimationKey];
-    [scrolledContentsLayer addAnimation:transientPositionAnimation(transientScrolledContentsPosition).get() forKey:transientScrolledContentsPositionAnimationKey];
+    [scrolledContentsLayer addAnimation:additiveTransientPositionAnimation(scrolledContentsCorrection).get() forKey:transientScrolledContentsPositionAnimationKey];
     END_BLOCK_OBJC_EXCEPTIONS
 
 #if ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -205,6 +205,9 @@ void ViewGestureController::didEndGesture()
 
     m_activeGestureType = ViewGestureType::None;
     m_currentGestureID = 0;
+#if !PLATFORM(IOS_FAMILY)
+    m_magnificationGestureInputSource = std::nullopt;
+#endif
 
     if (RefPtr page = m_webPageProxy.get())
         page->didEndViewGesture();
@@ -792,7 +795,15 @@ FloatPoint ViewGestureController::scaledMagnificationOrigin(FloatPoint origin, d
     scaledMagnificationOrigin.moveBy(m_visibleContentRect.location());
     float magnificationOriginScale = 1 - (scale / m_initialMagnification);
     scaledMagnificationOrigin.scale(magnificationOriginScale);
-    scaledMagnificationOrigin.move(origin - m_initialMagnificationOrigin);
+
+    // Trackpad magnification (InputSource::UserDriven) should not have a moving origin
+    // during transient zoom. However, in configurations where that is possible, we do
+    // not want to double account for the potential scroll from the magnification origin
+    // moving around, which should already have been accounted for since we produced
+    // representative wheel events.
+    if (m_magnificationGestureInputSource != WebEventInputSource::Automation)
+        scaledMagnificationOrigin.move(origin - m_initialMagnificationOrigin);
+
     return scaledMagnificationOrigin;
 }
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "NativeWebWheelEvent.h"
 #include "SameDocumentNavigationType.h"
+#include "WebEvent.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/BoxExtents.h>
 #include <WebCore/Color.h>
@@ -165,7 +166,7 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    void handleMagnificationGesture(double scale, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
+    void handleMagnificationGesture(double scale, WebEventPhase, WebCore::FloatPoint originInViewCoordinates, WebEventInputSource = WebEventInputSource::UserDriven);
     void handleSmartMagnificationGesture(WebCore::FloatPoint gestureLocationInViewCoordinates);
 
     void setCustomSwipeViews(Vector<RetainPtr<NSView>> views) { m_customSwipeViews = WTF::move(views); }
@@ -423,6 +424,7 @@ private:
 
     double m_initialMagnification { 1 };
     WebCore::FloatPoint m_initialMagnificationOrigin;
+    std::optional<WebEventInputSource> m_magnificationGestureInputSource;
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1483,6 +1483,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool canScrollVertically = [_panGestureRecognizer _canPanVertically] && !(pinnedState.top() && pinnedState.bottom());
     gestureDelta = WebCore::FloatSize { _directionalScrollLockTracker->update(gestureDelta, canScrollHorizontally, canScrollVertically, prefersUnlockedScroll, [gesture timestamp]) };
 
+    // FIXME: Fold this into WKDirectionalScrollLockTracker as a hard clamp  applied _after_ directional lock heuristics.
+    if (!canScrollVertically)
+        gestureDelta.setHeight(0);
+    if (!canScrollHorizontally)
+        gestureDelta.setWidth(0);
+
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice = false;
@@ -1706,14 +1712,14 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (gestureController->hasActiveMagnificationGesture()) {
-        gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { });
+        gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { }, WebKit::WebEventInputSource::Automation);
         return;
     }
 
     if (webEvent)
         page->handleGestureEvent(*webEvent);
 #else
-    gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { });
+    gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { }, WebKit::WebEventInputSource::Automation);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -128,11 +128,13 @@ double ViewGestureController::resistanceForDelta(double deltaScale, double curre
     return resistance;
 }
 
-void ViewGestureController::handleMagnificationGesture(double scale, WebEventPhase phase, FloatPoint origin)
+void ViewGestureController::handleMagnificationGesture(double scale, WebEventPhase phase, FloatPoint origin, WebEventInputSource inputSource)
 {
     RefPtr page = m_webPageProxy.get();
     if (!page)
         return;
+
+    m_magnificationGestureInputSource = inputSource;
 
     auto obscuredContentInsets = page->obscuredContentInsets();
     origin.move(-obscuredContentInsets.left(), -obscuredContentInsets.top());

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1041,7 +1041,7 @@ private:
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
     bool inputMethodUsesCorrectKeyEventOrder();
 
-    void applyNativeMagnification(float magnification, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
+    void applyNativeMagnification(float magnification, WebEventPhase, WebCore::FloatPoint originInViewCoordinates, WebEventInputSource = WebEventInputSource::UserDriven);
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5854,14 +5854,16 @@ void WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *event)
 
 void WebViewImpl::magnificationGestureEventWasNotHandledByWebCoreFromViewOnly(NSEventPhase phase, CGFloat magnification, NSPoint locationInWindow)
 {
-    applyNativeMagnification(magnification, WebEventFactory::phaseForNativeEventPhase(phase), [m_view.get() convertPoint:locationInWindow fromView:nil]);
+    applyNativeMagnification(magnification, WebEventFactory::phaseForNativeEventPhase(phase), [m_view.get() convertPoint:locationInWindow fromView:nil], WebEventInputSource::Automation);
 }
 
-void WebViewImpl::applyNativeMagnification(float magnification, WebEventPhase phase, FloatPoint originInViewCoordinates)
+void WebViewImpl::applyNativeMagnification(float magnification, WebEventPhase phase, FloatPoint originInViewCoordinates, WebEventInputSource inputSource)
 {
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (m_allowsMagnification && m_gestureController)
-        m_gestureController->handleMagnificationGesture(magnification, phase, originInViewCoordinates);
+        m_gestureController->handleMagnificationGesture(magnification, phase, originInViewCoordinates, inputSource);
+#else
+    UNUSED_PARAM(inputSource);
 #endif
 }
 


### PR DESCRIPTION
#### 153ae030bbdec163692f4b2826096674c01ed360
<pre>
[AppKit Gestures] Magnification can snap the scroll position unexpectedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=322602">https://bugs.webkit.org/show_bug.cgi?id=322602</a>
<a href="https://rdar.apple.com/185721724">rdar://185721724</a>

Reviewed by Tim Horton.

Our gesture recognizer driven magnification can drive two independent
subsystems  at once: the pan GR synthesizes wheel events that produce
scrolling, while the magnification GR drives a transient zoom. When
driven through NSResponder magnification, these are not supposed to
overlap. Three separate problems (and how we solve them) fall out of that:

1. Transient zoom compensates for growing the main frame clip layer by
   shifting the scrolled contents layer back, and prescribes a new
   position derived from the layer&apos;s current one. If there is a
   simultaneous scroll, then the scrolling tree rewrites that position
   every frame, too, and these mechanisms start fighting each other.
   We can instead let the scrolling tree continue being the only writer
   of that data if we derive an additive compensation rather than an
   absolute position in RLTDrawingAreaProxyMac::applyTransientZoomToLayer.
   This is a no-op for configurations where the scrolling tree does not
   actually touch the scrolled content layer position during a
   magnification gesture.

2. scaledMagnificationOrigin() is derived from the magnification gesture&apos;s
   origin, so we can end up double accounting when the origin changes
   (due to a scroll). This made sense in the past since we did not have
   a configuration that allowed scrolls during a transient zoom, but now
   it only makes sense for NSResponder magnification. As such, we limit
   this behavior change behind the gesture input source.

3. -sendWheelEventForGesture: computed the scrollability along each axis
   and handed that over to the directional scroll lock tracker. However,
   certain gestures can bypass this scrollability check (those that
   &quot;prefer unlocked scrolls&quot;). This produced unwanted sideways jitter -&gt;
   rubberband stretch rather than a scroll. We should instead let the
   directional scroll tracker do its internal updating with the provided
   scrollability values, and then enforce a hard clamp separately. I
   left a FIXME to try to incorporate this witihn the tracker itself,
   but this shape minimizes the risk (since we also use this for
   momentum calulcations).

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::additiveTransientPositionAnimation):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::didEndGesture):
(WebKit::ViewGestureController::scaledMagnificationOrigin):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController sendWheelEventForGesture:]):
(-[WKAppKitGestureController magnificationGestureRecognized:]):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGesture):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::magnifyWithEvent):
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly):
(WebKit::WebViewImpl::magnificationGestureEventWasNotHandledByWebCoreFromViewOnly):
(WebKit::WebViewImpl::applyNativeMagnification):

Canonical link: <a href="https://commits.webkit.org/319888@main">https://commits.webkit.org/319888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50d316426ae7aabcbed9f69ae354be2c73349fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0c90e1a-6b71-41dc-990f-175acc62f551) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/beec5939-2b14-4855-956c-3518c4bd4fc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46646 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a421254c-93c1-4d76-ad38-792b1bed6a85) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45338 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43214 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4501 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56702 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57407 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152093 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46651 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125827 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55915 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55286 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->