### PR TITLE
BroadcastChannel cross-origin spoof

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -40,6 +40,19 @@ namespace WebKit {
 #define MESSAGE_CHECK(assertion, connection) MESSAGE_CHECK_BASE(assertion, connection)
 #define MESSAGE_CHECK_COMPLETION(assertion, connection, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, completion)
 
+// Via the "allowsFirstPartyForCookies" check, we know which domains a given IPC::Connection should have access to.
+bool NetworkBroadcastChannelRegistry::isOriginAllowedForConnection(IPC::Connection& connection, const WebCore::ClientOrigin& origin) const
+{
+    RefPtr webProcessConnection = m_networkProcess->webProcessConnection(connection);
+    if (!webProcessConnection)
+        return false;
+
+    WebCore::RegistrableDomain registrableDomain { origin.topOrigin };
+    auto allowCookieAccess = m_networkProcess->allowsFirstPartyForCookies(webProcessConnection->webProcessIdentifier(), registrableDomain);
+
+    return allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow;
+}
+
 static bool isValidClientOrigin(const WebCore::ClientOrigin& clientOrigin)
 {
     return !clientOrigin.topOrigin.isNull() && !clientOrigin.clientOrigin.isNull();
@@ -63,6 +76,7 @@ void NetworkBroadcastChannelRegistry::registerChannel(IPC::Connection& connectio
 {
     MESSAGE_CHECK(isValidClientOrigin(origin), connection);
     MESSAGE_CHECK(!name.isNull(), connection);
+    MESSAGE_CHECK(isOriginAllowedForConnection(connection, origin), connection);
 
     auto& channelsForOrigin = m_broadcastChannels.ensure(origin, [] { return NameToConnectionIdentifiersMap { }; }).iterator->value;
     auto& connectionIdentifiersForName = channelsForOrigin.ensure(name, [] { return Vector<IPC::Connection::UniqueID> { }; }).iterator->value;
@@ -74,6 +88,7 @@ void NetworkBroadcastChannelRegistry::unregisterChannel(IPC::Connection& connect
 {
     MESSAGE_CHECK(isValidClientOrigin(origin), connection);
     MESSAGE_CHECK(!name.isNull(), connection);
+    MESSAGE_CHECK(isOriginAllowedForConnection(connection, origin), connection);
 
     auto channelsForOriginIterator = m_broadcastChannels.find(origin);
     ASSERT(channelsForOriginIterator != m_broadcastChannels.end());
@@ -92,6 +107,7 @@ void NetworkBroadcastChannelRegistry::postMessage(IPC::Connection& connection, c
 {
     MESSAGE_CHECK_COMPLETION(isValidClientOrigin(origin), connection, completionHandler());
     MESSAGE_CHECK_COMPLETION(!name.isNull(), connection, completionHandler());
+    MESSAGE_CHECK_COMPLETION(isOriginAllowedForConnection(connection, origin), connection, completionHandler());
 
     auto channelsForOriginIterator = m_broadcastChannels.find(origin);
     ASSERT(channelsForOriginIterator != m_broadcastChannels.end());

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
@@ -59,6 +59,8 @@ public:
 private:
     explicit NetworkBroadcastChannelRegistry(NetworkProcess&);
 
+    bool isOriginAllowedForConnection(IPC::Connection&, const WebCore::ClientOrigin&) const;
+
     const Ref<NetworkProcess> m_networkProcess;
     using NameToConnectionIdentifiersMap = HashMap<String, Vector<IPC::Connection::UniqueID>>;
     HashMap<WebCore::ClientOrigin, NameToConnectionIdentifiersMap> m_broadcastChannels;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
@@ -34,12 +34,14 @@
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/Utilities.h"
 #import <WebKit/WKErrorPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessageHandler.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKDataTask.h>
 #import <WebKit/_WKDataTaskDelegate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <mach/mach_init.h>
 #import <mach/mach_port.h>
@@ -971,3 +973,131 @@ TEST(NetworkProcess, URLSchemeHandlerWasPrivateRelayed)
 
     EXPECT_EQ(NO, [webView _wasPrivateRelayed]);
 }
+
+#if ENABLE(IPC_TESTING_API)
+
+static bool attackerReceivedMessage = false;
+static bool attackerReady = false;
+static RetainPtr<NSString> interceptedMessageName;
+
+@interface BroadcastChannelSpoofMessageHandler : NSObject <WKScriptMessageHandler>
+@end
+
+@implementation BroadcastChannelSpoofMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    NSString *body = [message body];
+    if ([body isEqualToString:@"ready"])
+        attackerReady = true;
+    else if ([body hasPrefix:@"INTERCEPTED:"]) {
+        interceptedMessageName = body;
+        attackerReceivedMessage = true;
+    }
+}
+@end
+
+static RetainPtr<WKWebViewConfiguration> createConfigurationWithIPCTestingAPI()
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+    return configuration;
+}
+
+static constexpr auto attackerHTML = R"IPCRESOURCE(
+<!DOCTYPE html><html><body>
+<script src='/coreipc.js'></script>
+<script>
+if (!window.IPC)
+    webkit.messageHandlers.test.postMessage('ready');
+else {
+    CoreIPC.Networking.NetworkBroadcastChannelRegistry.RegisterChannel(0, {
+        origin: {
+            topOrigin: {
+                data: {
+                    variantType: 'WebCore::SecurityOriginData::Tuple',
+                    variant: { protocol: 'http', host: 'victim.example', port: { } }
+                }
+            },
+            clientOrigin: {
+                data: {
+                    variantType: 'WebCore::SecurityOriginData::Tuple',
+                    variant: { protocol: 'http', host: 'victim.example', port: { } }
+                }
+            }
+        },
+        name: 'secret'
+    });
+
+    IPC.addIncomingMessageListener('Networking', (msg) => {
+        const postMsgName = IPC.messages.WebBroadcastChannelRegistry_PostMessageToRemote?.name;
+        if (postMsgName && msg.name === postMsgName)
+            webkit.messageHandlers.test.postMessage('INTERCEPTED:' + msg.name);
+    });
+
+    webkit.messageHandlers.test.postMessage('ready');
+}
+</script></body></html>"
+)IPCRESOURCE"_s;
+
+TEST(NetworkProcess, BroadcastChannelOriginSpoof)
+{
+    using namespace TestWebKitAPI;
+
+    attackerReceivedMessage = false;
+    attackerReady = false;
+    interceptedMessageName = nil;
+
+    // For the types involved in this attack, we need coreipc.js
+    NSURL *coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    if (!coreIPCURL)
+        coreIPCURL = [NSBundle.mainBundle URLForResource:@"coreipc" withExtension:@"js"];
+    ASSERT_TRUE(coreIPCURL);
+    NSString *coreIPCJS = [NSString stringWithContentsOfURL:coreIPCURL encoding:NSUTF8StringEncoding error:nil];
+
+    HTTPServer server({
+        { "/attacker.html"_s, { attackerHTML } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, String(coreIPCJS) } },
+    });
+
+    auto configuration = createConfigurationWithIPCTestingAPI();
+
+    auto messageHandler = adoptNS([[BroadcastChannelSpoofMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"test"];
+
+    // The attacking page registers its connection to listen for broadcast channel messages
+    // that it otherwise should not receive.
+    auto attackerView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [attackerView loadRequest:server.request("/attacker.html"_s)];
+    Util::run(&attackerReady);
+
+    auto attackerPID = [attackerView _webProcessIdentifier];
+    EXPECT_NE(attackerPID, 0);
+
+    auto victimView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    NSString *victimHTML = @"<script>let bc = new BroadcastChannel('secret');</script>";
+    [victimView synchronouslyLoadHTMLString:victimHTML baseURL:[NSURL URLWithString:@"http://victim.example/"]];
+
+    auto victimPID = [victimView _webProcessIdentifier];
+    EXPECT_NE(victimPID, 0);
+    EXPECT_NE(attackerPID, victimPID);
+
+    bool finishedRunningScript = false;
+    [victimView evaluateJavaScript:@"bc.postMessage('sensitive-data')" completionHandler:[&](id, NSError *error) {
+        EXPECT_TRUE(!error);
+        finishedRunningScript = true;
+    }];
+    Util::run(&finishedRunningScript);
+
+    // Wait for the attacker to receive the intercepted message.
+    // If it doesn't happen within a second, it probably never will.
+    Util::runFor(&attackerReceivedMessage, 1_s);
+
+    EXPECT_FALSE([interceptedMessageName hasPrefix:@"INTERCEPTED:"]);
+}
+
+#endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### e88c8b010e7f325019231b36d6031c41462c5ee8
<pre>
BroadcastChannel cross-origin spoof
<a href="https://rdar.apple.com/172230453">rdar://172230453</a>

Reviewed by Charlie Wolfe.

A compromised web content process can send a malicious message to the Networking process
to register for broadcast channel messages it should not have access to.

This adds message checks to validate that the IPC::Connection these messages are
coming from has access to the top security origin claimed.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/BroadcastChannelOriginSpoof.mm

* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::isOriginAllowedForConnection const):
(WebKit::NetworkBroadcastChannelRegistry::registerChannel):
(WebKit::NetworkBroadcastChannelRegistry::unregisterChannel):
(WebKit::NetworkBroadcastChannelRegistry::postMessage):
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowsFirstPartyForCookies): Remove an unnecessary ASSERT that prevents
  this from being tested in the debug configuration.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(-[BroadcastChannelSpoofMessageHandler userContentController:didReceiveScriptMessage:]):
((NetworkProcess, BroadcastChannelOriginSpoof)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:

Originally-landed-as: 305413.560@safari-7624-branch (e1706a288fb5). <a href="https://rdar.apple.com/185459196">rdar://185459196</a>
Canonical link: <a href="https://commits.webkit.org/319914@main">https://commits.webkit.org/319914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fa16b303e3272fb432e2edd8f3ed32886f801f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183123 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43594 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43225 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4514 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56715 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40850 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57420 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46659 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129690 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125841 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55928 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18236 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->