### PR TITLE
[JSC][Wasm] Implement the compact import section proposal

### DIFF
--- a/JSTests/wasm/js-api/compact-import-section-disabled.js
+++ b/JSTests/wasm/js-api/compact-import-section-disabled.js
@@ -1,0 +1,47 @@
+//@ requireOptions("--useWasmCompactImportSection=false")
+import * as assert from "../assert.js";
+
+function leb(n)
+{
+    const bytes = [];
+    do {
+        let byte = n & 0x7f;
+        n >>>= 7;
+        if (n)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (n);
+    return bytes;
+}
+
+function name(string)
+{
+    const bytes = [];
+    for (let i = 0; i < string.length; ++i)
+        bytes.push(string.charCodeAt(i));
+    return [...leb(bytes.length), ...bytes];
+}
+
+function section(id, payload)
+{
+    return [id, ...leb(payload.length), ...payload];
+}
+
+function compactTwoFunctions()
+{
+    const type = section(1, [1, 0x60, 0, 1, 0x7f]);
+    const imports = section(2, [
+        1,
+        ...name("env"),
+        0x00,
+        0x7e,
+        0x00,
+        0x00,
+        2,
+        ...name("a"),
+        ...name("b"),
+    ]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, ...type, ...imports]);
+}
+
+assert.throws(() => new WebAssembly.Module(compactTwoFunctions()), WebAssembly.CompileError, "kind");

--- a/JSTests/wasm/js-api/compact-import-section.js
+++ b/JSTests/wasm/js-api/compact-import-section.js
@@ -1,0 +1,281 @@
+//@ requireOptions("--useWasmCompactImportSection=true")
+import * as assert from "../assert.js";
+
+function leb(n)
+{
+    const bytes = [];
+    do {
+        let byte = n & 0x7f;
+        n >>>= 7;
+        if (n)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (n);
+    return bytes;
+}
+
+function name(string)
+{
+    const bytes = [];
+    for (let i = 0; i < string.length; ++i)
+        bytes.push(string.charCodeAt(i));
+    return [...leb(bytes.length), ...bytes];
+}
+
+function section(id, payload)
+{
+    return [id, ...leb(payload.length), ...payload];
+}
+
+function moduleBytes(...sections)
+{
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, ...sections.flat()]);
+}
+
+const typeVoidToI32 = section(1, [1, 0x60, 0, 1, 0x7f]);
+const typeI32ToVoid = section(1, [1, 0x60, 1, 0x7f, 0]);
+
+{
+    const bytes = moduleBytes(
+        typeVoidToI32,
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7e,
+            0x00,
+            0x00,
+            2,
+            ...name("a"),
+            ...name("b"),
+        ]),
+        section(7, [
+            2,
+            ...name("a"), 0x00, 0x00,
+            ...name("b"), 0x00, 0x01,
+        ]),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    assert.eq(imports.length, 2);
+    assert.eq(imports[0].module, "env");
+    assert.eq(imports[0].name, "a");
+    assert.eq(imports[0].kind, "function");
+    assert.eq(imports[1].module, "env");
+    assert.eq(imports[1].name, "b");
+    assert.eq(imports[1].kind, "function");
+
+    const instance = new WebAssembly.Instance(module, { env: { a: () => 1, b: () => 2 } });
+    assert.eq(instance.exports.a(), 1);
+    assert.eq(instance.exports.b(), 2);
+}
+
+{
+    const bytes = moduleBytes(
+        typeVoidToI32,
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7f,
+            2,
+            ...name("a"), 0x00, 0x00,
+            ...name("b"), 0x00, 0x00,
+        ]),
+        section(7, [
+            2,
+            ...name("a"), 0x00, 0x00,
+            ...name("b"), 0x00, 0x01,
+        ]),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    assert.eq(imports.length, 2);
+    assert.eq(imports[0].name, "a");
+    assert.eq(imports[1].name, "b");
+    const instance = new WebAssembly.Instance(module, { env: { a: () => 3, b: () => 4 } });
+    assert.eq(instance.exports.a(), 3);
+    assert.eq(instance.exports.b(), 4);
+}
+
+{
+    const bytes = moduleBytes(
+        typeVoidToI32,
+        section(2, [
+            2,
+            ...name("env"),
+            0x00,
+            0x7e,
+            0x00,
+            0x00,
+            2,
+            ...name("a"),
+            ...name("b"),
+            ...name("other"),
+            ...name("c"),
+            0x00,
+            0x00,
+        ]),
+        section(7, [
+            3,
+            ...name("a"), 0x00, 0x00,
+            ...name("b"), 0x00, 0x01,
+            ...name("c"), 0x00, 0x02,
+        ]),
+    );
+    const imports = WebAssembly.Module.imports(new WebAssembly.Module(bytes));
+    assert.eq(imports.length, 3);
+    assert.eq(imports[0].module, "env");
+    assert.eq(imports[0].name, "a");
+    assert.eq(imports[1].name, "b");
+    assert.eq(imports[2].module, "other");
+    assert.eq(imports[2].name, "c");
+}
+
+{
+    const bytes = moduleBytes(
+        typeVoidToI32,
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x00,
+            0x00,
+        ]),
+        section(7, [
+            1,
+            ...name("empty"), 0x00, 0x00,
+        ]),
+    );
+    const imports = WebAssembly.Module.imports(new WebAssembly.Module(bytes));
+    assert.eq(imports.length, 1);
+    assert.eq(imports[0].module, "env");
+    assert.eq(imports[0].name, "");
+    assert.eq(imports[0].kind, "function");
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes), { env: { "": () => 5 } });
+    assert.eq(instance.exports.empty(), 5);
+}
+
+{
+    const bytes = moduleBytes(
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7e,
+            0x03,
+            0x7f, 0x00,
+            2,
+            ...name("g0"),
+            ...name("g1"),
+        ]),
+        section(7, [
+            2,
+            ...name("g0"), 0x03, 0x00,
+            ...name("g1"), 0x03, 0x01,
+        ]),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    assert.eq(imports.length, 2);
+    assert.eq(imports[0].kind, "global");
+    assert.eq(imports[1].kind, "global");
+    const instance = new WebAssembly.Instance(module, {
+        env: {
+            g0: new WebAssembly.Global({ value: "i32" }, 8),
+            g1: new WebAssembly.Global({ value: "i32" }, 9),
+        },
+    });
+    assert.eq(instance.exports.g0.value, 8);
+    assert.eq(instance.exports.g1.value, 9);
+}
+
+{
+    const bytes = moduleBytes(
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7e,
+            0x01,
+            0x70, 0x00, 0x01,
+            2,
+            ...name("t0"),
+            ...name("t1"),
+        ]),
+        section(7, [
+            2,
+            ...name("t0"), 0x01, 0x00,
+            ...name("t1"), 0x01, 0x01,
+        ]),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    assert.eq(imports.length, 2);
+    assert.eq(imports[0].kind, "table");
+    assert.eq(imports[1].kind, "table");
+    const instance = new WebAssembly.Instance(module, {
+        env: {
+            t0: new WebAssembly.Table({ element: "funcref", initial: 1 }),
+            t1: new WebAssembly.Table({ element: "funcref", initial: 1 }),
+        },
+    });
+    assert.eq(instance.exports.t0.length, 1);
+    assert.eq(instance.exports.t1.length, 1);
+}
+
+{
+    const bytes = moduleBytes(
+        typeI32ToVoid,
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7f,
+            2,
+            ...name("f"), 0x00, 0x00,
+            ...name("m"), 0x02, 0x00, 0x01,
+        ]),
+        section(7, [
+            2,
+            ...name("f"), 0x00, 0x00,
+            ...name("m"), 0x02, 0x00,
+        ]),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    assert.eq(imports.length, 2);
+    assert.eq(imports[0].kind, "function");
+    assert.eq(imports[1].kind, "memory");
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const instance = new WebAssembly.Instance(module, { env: { f: () => { }, m: memory } });
+    assert.eq(instance.exports.m.buffer.byteLength, 65536);
+}
+
+{
+    const bytes = moduleBytes(
+        typeVoidToI32,
+        section(2, [
+            1,
+            ...name("env"),
+            0x00,
+            0x7f,
+            0,
+        ]),
+    );
+    assert.eq(WebAssembly.Module.imports(new WebAssembly.Module(bytes)).length, 0);
+}
+
+assert.throws(() => new WebAssembly.Module(moduleBytes(
+    typeVoidToI32,
+    section(2, [
+        1,
+        ...name("env"),
+        ...name("not-empty"),
+        0x7e,
+        0x00,
+        0x00,
+        1,
+        ...name("a"),
+    ]),
+)), WebAssembly.CompileError, "kind");

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -615,6 +615,9 @@ static_assert(static_cast<int>(ExternalKind::Memory)   == 2, "Wasm needs Memory 
 static_assert(static_cast<int>(ExternalKind::Global)   == 3, "Wasm needs Global to have the value 3");
 static_assert(static_cast<int>(ExternalKind::Exception)   == 4, "Wasm needs Exception to have the value 4");
 
+static constexpr uint8_t compactImportEncodingItemsWithTypes = 0x7F;
+static constexpr uint8_t compactImportEncodingItemsWithSharedType = 0x7E;
+
 inline ASCIILiteral makeString(ExternalKind kind)
 {
     switch (kind) {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSCJSValueInlines.h"
+#include "Options.h"
 #include "WasmBranchHintsSectionParser.h"
 #include "WasmConstExprGenerator.h"
 #include "WasmMemoryInformation.h"
@@ -140,6 +141,85 @@ auto SectionParser::parseType() -> PartialResult
     return { };
 }
 
+auto SectionParser::parseImportType(uint32_t importNumber, const Name& module, const Name& field, ExternalKind kind, ParsedImportType& parsed) -> PartialResult
+{
+    parsed.kind = kind;
+    switch (kind) {
+    case ExternalKind::Function: {
+        uint32_t functionTypeIndex;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(functionTypeIndex), "can't get "_s, importNumber, "th Import's function signature in module '"_s, module, "' field '"_s, field, "'"_s);
+        WASM_PARSER_FAIL_IF(functionTypeIndex >= m_info->typeCount(), "invalid function signature for "_s, importNumber, "th Import, "_s, functionTypeIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, module, "' field '"_s, field, "'"_s);
+        parsed.typeIndex = TypeSignatureIndex(functionTypeIndex);
+        const auto& importRTT = m_info->rtt(parsed.typeIndex);
+        WASM_PARSER_FAIL_IF(importRTT.kind() != RTTKind::Function, importNumber, "th Function type "_s, functionTypeIndex, " doesn't have a function signature"_s);
+        break;
+    }
+    case ExternalKind::Table:
+        WASM_FAIL_IF_HELPER_FAILS(parseTableType(true, parsed.table));
+        break;
+    case ExternalKind::Memory:
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryType(true, parsed.memory));
+        break;
+    case ExternalKind::Global:
+        WASM_FAIL_IF_HELPER_FAILS(parseGlobalType(parsed.global));
+        // Only mutable globals need floating bindings.
+        if (parsed.global.mutability == Mutability::Mutable)
+            parsed.global.bindingMode = GlobalInformation::BindingMode::Portable;
+        break;
+    case ExternalKind::Exception: {
+        uint8_t tagType;
+        WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get "_s, importNumber, "th Import exception's tag type"_s);
+        WASM_PARSER_FAIL_IF(tagType, importNumber, "th Import exception has tag type "_s, tagType, " but the only supported tag type is 0"_s);
+
+        uint32_t exceptionSignatureIndex;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionSignatureIndex), "can't get "_s, importNumber, "th Import's exception signature in module '"_s, module, "' field '"_s, field, "'"_s);
+        WASM_PARSER_FAIL_IF(exceptionSignatureIndex >= m_info->typeCount(), "invalid exception signature for "_s, importNumber, "th Import, "_s, exceptionSignatureIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, module, "' field '"_s, field, "'"_s);
+        parsed.typeIndex = TypeSignatureIndex(exceptionSignatureIndex);
+        const auto& expandedRTT = m_info->rtt(parsed.typeIndex);
+        WASM_PARSER_FAIL_IF(expandedRTT.kind() != RTTKind::Function, importNumber, "th Exception type "_s, exceptionSignatureIndex, " doesn't have a function signature"_s);
+        WASM_PARSER_FAIL_IF(!expandedRTT.returnsVoid(), importNumber, "th Exception type cannot have a non-void return type "_s, exceptionSignatureIndex);
+        break;
+    }
+    }
+    return { };
+}
+
+auto SectionParser::appendImportType(const ParsedImportType& parsed, unsigned& kindIndex) -> PartialResult
+{
+    switch (parsed.kind) {
+    case ExternalKind::Function:
+        kindIndex = m_info->importFunctionTypeSignatureIndices.size();
+        WASM_ALLOCATOR_FAIL_IF(!m_info->importFunctionTypeSignatureIndices.tryAppend(parsed.typeIndex), "can't allocate enough memory for import function signatures"_s);
+        break;
+    case ExternalKind::Table:
+        kindIndex = m_info->tables.size();
+        WASM_FAIL_IF_HELPER_FAILS(appendTable(parsed.table));
+        break;
+    case ExternalKind::Memory:
+        kindIndex = m_info->memories.size();
+        WASM_FAIL_IF_HELPER_FAILS(appendMemory(parsed.memory));
+        break;
+    case ExternalKind::Global:
+        kindIndex = m_info->globals.size();
+        WASM_ALLOCATOR_FAIL_IF(!m_info->globals.tryAppend(parsed.global), "can't allocate enough memory for globals"_s);
+        break;
+    case ExternalKind::Exception:
+        kindIndex = m_info->importExceptionTypeSignatureIndices.size();
+        WASM_ALLOCATOR_FAIL_IF(!m_info->importExceptionTypeSignatureIndices.tryAppend(parsed.typeIndex), "can't allocate enough memory for import exception signatures"_s);
+        break;
+    }
+    return { };
+}
+
+auto SectionParser::addImport(Name&& module, Name&& field, const ParsedImportType& parsed) -> PartialResult
+{
+    WASM_PARSER_FAIL_IF(m_info->imports.size() >= maxImports, "Import section's count is too big "_s, m_info->imports.size() + 1, " maximum "_s, maxImports);
+    unsigned kindIndex = 0;
+    WASM_FAIL_IF_HELPER_FAILS(appendImportType(parsed, kindIndex));
+    WASM_ALLOCATOR_FAIL_IF(!m_info->imports.tryAppend({ WTF::move(module), WTF::move(field), parsed.kind, kindIndex }), "can't allocate enough memory for imports"_s);
+    return { };
+}
+
 auto SectionParser::parseImport() -> PartialResult
 {
     uint32_t importCount;
@@ -149,83 +229,65 @@ auto SectionParser::parseImport() -> PartialResult
     RELEASE_ASSERT(!m_info->imports.capacity());
     RELEASE_ASSERT(!m_info->importFunctionTypeSignatureIndices.capacity());
     RELEASE_ASSERT(!m_info->importExceptionTypeSignatureIndices.capacity());
-    WASM_ALLOCATOR_FAIL_IF(!m_info->globals.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " globals"_s); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_ALLOCATOR_FAIL_IF(!m_info->imports.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " imports"_s); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_ALLOCATOR_FAIL_IF(!m_info->importFunctionTypeSignatureIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import function signatures"_s); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_ALLOCATOR_FAIL_IF(!m_info->importExceptionTypeSignatureIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import exception signatures"_s); // FIXME this over-allocates when we fix the FIXMEs below.
+    WASM_ALLOCATOR_FAIL_IF(!m_info->globals.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " globals"_s);
+    WASM_ALLOCATOR_FAIL_IF(!m_info->imports.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " imports"_s);
+    WASM_ALLOCATOR_FAIL_IF(!m_info->importFunctionTypeSignatureIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import function signatures"_s);
+    WASM_ALLOCATOR_FAIL_IF(!m_info->importExceptionTypeSignatureIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import exception signatures"_s);
+
+    auto parseField = [&](uint32_t importNumber, const Name& module, Name& field) -> PartialResult {
+        uint32_t fieldLen;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get "_s, importNumber, "th Import's field name length in module '"_s, module, "'"_s);
+        WASM_ALLOCATOR_FAIL_IF(!consumeUTF8String(field, fieldLen), "can't get "_s, importNumber, "th Import's field name of length "_s, fieldLen, " in module '"_s, module, "'"_s);
+        return { };
+    };
 
     for (uint32_t importNumber = 0; importNumber < importCount; ++importNumber) {
         uint32_t moduleLen;
-        uint32_t fieldLen;
         Name moduleString;
         Name fieldString;
-        ExternalKind kind;
-        unsigned kindIndex { 0 };
 
         WASM_PARSER_FAIL_IF(!parseVarUInt32(moduleLen), "can't get "_s, importNumber, "th Import's module name length"_s);
         WASM_ALLOCATOR_FAIL_IF(!consumeUTF8String(moduleString, moduleLen), "can't get "_s, importNumber, "th Import's module name of length "_s, moduleLen);
+        WASM_FAIL_IF_HELPER_FAILS(parseField(importNumber, moduleString, fieldString));
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get "_s, importNumber, "th Import's field name length in module '"_s, moduleString, "'"_s);
-        WASM_ALLOCATOR_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get "_s, importNumber, "th Import's field name of length "_s, moduleLen, " in module '"_s, moduleString, "'"_s);
+        uint8_t rawKind;
+        WASM_PARSER_FAIL_IF(!parseUInt8(rawKind), "can't get "_s, importNumber, "th Import's kind in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
 
-        WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get "_s, importNumber, "th Import's kind in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
-        switch (kind) {
-        case ExternalKind::Function: {
-            uint32_t functionTypeIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionTypeIndex), "can't get "_s, importNumber, "th Import's function signature in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
-            WASM_PARSER_FAIL_IF(functionTypeIndex >= m_info->typeCount(), "invalid function signature for "_s, importNumber, "th Import, "_s, functionTypeIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
-            kindIndex = m_info->importFunctionTypeSignatureIndices.size();
-            auto index = TypeSignatureIndex(functionTypeIndex);
-            const auto& importRTT = m_info->rtt(index);
-            WASM_PARSER_FAIL_IF(importRTT.kind() != RTTKind::Function, importNumber, "th Function type "_s, functionTypeIndex, " doesn't have a function signature"_s);
-            m_info->importFunctionTypeSignatureIndices.append(index);
-            break;
-        }
-        case ExternalKind::Table: {
-            bool isImport = true;
-            kindIndex = m_info->tables.size();
-            PartialResult result = parseTableHelper(isImport);
-            if (!result) [[unlikely]]
-                return makeUnexpected(WTF::move(result.error()));
-            break;
-        }
-        case ExternalKind::Memory: {
-            bool isImport = true;
-            kindIndex = m_info->memories.size();
-            PartialResult result = parseMemoryHelper(isImport);
-            if (!result) [[unlikely]]
-                return makeUnexpected(WTF::move(result.error()));
-            break;
-        }
-        case ExternalKind::Global: {
-            GlobalInformation global;
-            WASM_FAIL_IF_HELPER_FAILS(parseGlobalType(global));
-            // Only mutable globals need floating bindings.
-            if (global.mutability == Mutability::Mutable)
-                global.bindingMode = GlobalInformation::BindingMode::Portable;
-            kindIndex = m_info->globals.size();
-            m_info->globals.append(WTF::move(global));
-            break;
-        }
-        case ExternalKind::Exception: {
-            uint8_t tagType;
-            WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get "_s, importNumber, "th Import exception's tag type"_s);
-            WASM_PARSER_FAIL_IF(tagType, importNumber, "th Import exception has tag type "_s, tagType, " but the only supported tag type is 0"_s);
-
-            uint32_t exceptionSignatureIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionSignatureIndex), "can't get "_s, importNumber, "th Import's exception signature in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
-            WASM_PARSER_FAIL_IF(exceptionSignatureIndex >= m_info->typeCount(), "invalid exception signature for "_s, importNumber, "th Import, "_s, exceptionSignatureIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
-            kindIndex = m_info->importExceptionTypeSignatureIndices.size();
-            auto index = TypeSignatureIndex(exceptionSignatureIndex);
-            const auto& expandedRTT = m_info->rtt(index);
-            WASM_PARSER_FAIL_IF(expandedRTT.kind() != RTTKind::Function, importNumber, "th Exception type "_s, exceptionSignatureIndex, " doesn't have a function signature"_s);
-            WASM_PARSER_FAIL_IF(!expandedRTT.returnsVoid(), importNumber, "th Exception type cannot have a non-void return type "_s, exceptionSignatureIndex);
-            m_info->importExceptionTypeSignatureIndices.append(index);
-            break;
-        }
+        if (Options::useWasmCompactImportSection() && fieldString.isEmpty()) {
+            if (rawKind == compactImportEncodingItemsWithTypes) {
+                uint32_t itemCount;
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(itemCount), "can't get "_s, importNumber, "th Import group's compact item count"_s);
+                for (uint32_t i = 0; i < itemCount; ++i) {
+                    Name itemField;
+                    WASM_FAIL_IF_HELPER_FAILS(parseField(importNumber, moduleString, itemField));
+                    ExternalKind kind;
+                    WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get "_s, importNumber, "th Import group's "_s, i, "th kind in module '"_s, moduleString, "' field '"_s, itemField, "'"_s);
+                    ParsedImportType parsed;
+                    WASM_FAIL_IF_HELPER_FAILS(parseImportType(importNumber, moduleString, itemField, kind, parsed));
+                    WASM_FAIL_IF_HELPER_FAILS(addImport(Name { moduleString }, WTF::move(itemField), parsed));
+                }
+                continue;
+            }
+            if (rawKind == compactImportEncodingItemsWithSharedType) {
+                ExternalKind kind;
+                WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get "_s, importNumber, "th Import group's kind in module '"_s, moduleString, "'"_s);
+                ParsedImportType parsed;
+                WASM_FAIL_IF_HELPER_FAILS(parseImportType(importNumber, moduleString, fieldString, kind, parsed));
+                uint32_t itemCount;
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(itemCount), "can't get "_s, importNumber, "th Import group's compact item count"_s);
+                for (uint32_t i = 0; i < itemCount; ++i) {
+                    Name itemField;
+                    WASM_FAIL_IF_HELPER_FAILS(parseField(importNumber, moduleString, itemField));
+                    WASM_FAIL_IF_HELPER_FAILS(addImport(Name { moduleString }, WTF::move(itemField), parsed));
+                }
+                continue;
+            }
         }
 
-        m_info->imports.append({ WTF::move(moduleString), WTF::move(fieldString), kind, kindIndex });
+        WASM_PARSER_FAIL_IF(!isValidExternalKind(rawKind), "can't get "_s, importNumber, "th Import's kind in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
+        ParsedImportType parsed;
+        WASM_FAIL_IF_HELPER_FAILS(parseImportType(importNumber, moduleString, fieldString, static_cast<ExternalKind>(rawKind), parsed));
+        WASM_FAIL_IF_HELPER_FAILS(addImport(WTF::move(moduleString), WTF::move(fieldString), parsed));
     }
 
     m_info->firstInternalGlobal = m_info->globals.size();
@@ -313,10 +375,8 @@ auto SectionParser::parseResizableLimits(uint64_t& initial, std::optional<uint64
     return { };
 }
 
-auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
+auto SectionParser::parseTableType(bool isImport, TableInformation& table) -> PartialResult
 {
-    WASM_PARSER_FAIL_IF(m_info->tableCount() >= maxTables, "Table count of "_s, m_info->tableCount(), " is too big, maximum "_s, maxTables);
-
     Type type;
     bool hasInitExpr = false;
     TableInformation::InitializationType tableInitType = TableInformation::Default;
@@ -368,9 +428,23 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     }
 
     TableElementType tableType = isSubtype(type, funcrefType()) ? TableElementType::Funcref : TableElementType::Externref;
-    m_info->tables.append(TableInformation(initial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber, isTable64));
+    table = TableInformation(initial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber, isTable64);
 
     return { };
+}
+
+auto SectionParser::appendTable(const TableInformation& table) -> PartialResult
+{
+    WASM_PARSER_FAIL_IF(m_info->tableCount() >= maxTables, "Table count of "_s, m_info->tableCount(), " is too big, maximum "_s, maxTables);
+    WASM_ALLOCATOR_FAIL_IF(!m_info->tables.tryAppend(table), "can't allocate enough memory for tables"_s);
+    return { };
+}
+
+auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
+{
+    TableInformation table;
+    WASM_FAIL_IF_HELPER_FAILS(parseTableType(isImport, table));
+    return appendTable(table);
 }
 
 auto SectionParser::parseTable() -> PartialResult
@@ -388,15 +462,8 @@ auto SectionParser::parseTable() -> PartialResult
     return { };
 }
 
-auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
+auto SectionParser::parseMemoryType(bool isImport, MemoryInformation& memory) -> PartialResult
 {
-    // This test is here in order to handle the case of a single imported memory and a single specified memory
-    // in its own section, which is legal iff multimemory is enabled
-    if (!Options::useWasmMultiMemory())
-        WASM_PARSER_FAIL_IF(m_info->memoryCount(), "there can at most be one Memory section for now"_s);
-
-    WASM_PARSER_FAIL_IF(m_info->memoryCount() >= maxMemories, "there can be at most "_s, maxMemories, " memories"_s);
-
     PageCount initialPageCount;
     PageCount maximumPageCount;
     bool isShared { false };
@@ -422,9 +489,25 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
     ASSERT(initialPageCount);
     ASSERT(!maximumPageCount || maximumPageCount >= initialPageCount);
 
-    m_info->memories.append(MemoryInformation(initialPageCount, maximumPageCount, isShared, isImport, isMemory64));
-
+    memory = MemoryInformation(initialPageCount, maximumPageCount, isShared, isImport, isMemory64);
     return { };
+}
+
+auto SectionParser::appendMemory(const MemoryInformation& memory) -> PartialResult
+{
+    // Imported memory plus a defined Memory section is legal only if multi-memory is enabled.
+    if (!Options::useWasmMultiMemory())
+        WASM_PARSER_FAIL_IF(m_info->memoryCount(), "there can at most be one Memory section for now"_s);
+    WASM_PARSER_FAIL_IF(m_info->memoryCount() >= maxMemories, "there can be at most "_s, maxMemories, " memories"_s);
+    WASM_ALLOCATOR_FAIL_IF(!m_info->memories.tryAppend(memory), "can't allocate enough memory for memories"_s);
+    return { };
+}
+
+auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
+{
+    MemoryInformation memory;
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryType(isImport, memory));
+    return appendMemory(memory);
 }
 
 auto SectionParser::parseMemory() -> PartialResult

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "WasmFormat.h"
+#include "WasmMemoryInformation.h"
 #include "WasmOps.h"
 #include "WasmParser.h"
 #include "WasmTypeSectionState.h"
@@ -63,9 +64,24 @@ private:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offset + m_offsetInSource), ": "_s, makeString(args)...));
     }
 
+    struct ParsedImportType {
+        ExternalKind kind { ExternalKind::Function };
+        TypeSignatureIndex typeIndex;
+        TableInformation table;
+        MemoryInformation memory;
+        GlobalInformation global;
+    };
+
     [[nodiscard]] PartialResult parseGlobalType(GlobalInformation&);
+    [[nodiscard]] PartialResult parseMemoryType(bool isImport, MemoryInformation&);
     [[nodiscard]] PartialResult parseMemoryHelper(bool isImport);
+    [[nodiscard]] PartialResult parseTableType(bool isImport, TableInformation&);
     [[nodiscard]] PartialResult parseTableHelper(bool isImport);
+    [[nodiscard]] PartialResult appendTable(const TableInformation&);
+    [[nodiscard]] PartialResult appendMemory(const MemoryInformation&);
+    [[nodiscard]] PartialResult parseImportType(uint32_t importNumber, const Name& module, const Name& field, ExternalKind, ParsedImportType&);
+    [[nodiscard]] PartialResult appendImportType(const ParsedImportType&, unsigned& kindIndex);
+    [[nodiscard]] PartialResult addImport(Name&& module, Name&& field, const ParsedImportType&);
     enum class LimitsType { Memory, Table };
     template <LimitsType T>
     [[nodiscard]] PartialResult parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9943,6 +9943,19 @@ WantsBalancedSetDefersLoadingBehavior:
     WebCore:
       default: false
 
+WasmCompactImportSectionEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly Compact Import Section"
+  humanReadableDescription: "Allow the compact import section encodings from the wasm compact-import-section spec."
+  webcoreBinding: none
+  jscOptionName: useWasmCompactImportSection
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 WasmJSStringBuiltinsEnabled:
   type: bool
   status: stable


### PR DESCRIPTION
#### 3d7f901278d1b5a31a9c388a4bfd824c9320ae07
<pre>
[JSC][Wasm] Implement the compact import section proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=322608">https://bugs.webkit.org/show_bug.cgi?id=322608</a>

Reviewed by NOBODY (OOPS!).

The compact import section proposal adds two encodings so a module
name, and optionally an externtype, is not repeated for every import.
Parse both behind useWasmCompactImportSection, which is off by default.

* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseImportType):
(JSC::Wasm::SectionParser::appendImportType):
(JSC::Wasm::SectionParser::addImport):
(JSC::Wasm::SectionParser::parseImport):
(JSC::Wasm::SectionParser::parseTableType):
(JSC::Wasm::SectionParser::appendTable):
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseMemoryType):
(JSC::Wasm::SectionParser::appendMemory):
(JSC::Wasm::SectionParser::parseMemoryHelper):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* JSTests/wasm/js-api/compact-import-section.js: Added.
* JSTests/wasm/js-api/compact-import-section-disabled.js: Added.
</pre>