### PR TITLE
[EWS] Flaky Detection Fixes

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -585,7 +585,7 @@ class ResultsDBReportMixin(abc.ABC):
             configuration['platform'] = ResultsDatabase.platform_for_query(platform)
         if (style := self.getProperty('configuration', None)) in ('debug', 'release'):
             configuration['style'] = style
-        if (flavor := self.getProperty('flavor', None)) in ('wk1', 'wk2'):
+        if (flavor := self.getProperty('flavor', None)) in ('wk1', 'wk2', 'site-isolation'):
             configuration['flavor'] = flavor
         return configuration
 
@@ -593,7 +593,7 @@ class ResultsDBReportMixin(abc.ABC):
         architecture = self.getProperty('machine_architecture', None) or self.getProperty('architecture', None)
         return {
             **self.results_db_query_configuration(),
-            'version': self.getProperty('os_version', None) or None,
+            'version': self.getProperty('os_version', None) or self.getProperty('webkit_version', None) or None,
             'architecture': architecture if architecture and ' ' not in architecture else None,
             'is_simulator': 'simulator' in (self.getProperty('fullPlatform', '') or ''),
         }
@@ -3941,6 +3941,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
     logfiles = {'json': jsonFileName}
     test_failures_log_name = 'test-failures'
     results_db_log_name = 'results-db'
+    results_db_flavor = 'wk2'
     suite = 'layout-tests'
     ENABLE_GUARD_MALLOC = False
     ENABLE_ADDITIONAL_ARGUMENTS = True
@@ -4015,10 +4016,10 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         self.addLogObserver('json', self.log_observer_json)
         self.setLayoutTestCommand()
 
-        if self.layout_test_driver == 'DumpRenderTree':
-            self.setProperty('flavor', 'wk1')
-        elif self.layout_test_driver == 'WebKitTestRunner':
-            self.setProperty('flavor', 'wk2')
+        # Only the step that starts a run labels the build: every queue reruns with
+        # ReRunWebKitTests, so a wk1 queue would relabel itself wk2 halfway through.
+        if self.results_db_flavor:
+            self.setProperty('flavor', self.results_db_flavor)
 
         if SHOULD_FILTER_LOGS is True:
             self.command = self.shell_command(' '.join(quote(str(c)) for c in self.command) + ' 2>&1 | Tools/Scripts/filter-test-logs layout')
@@ -4280,6 +4281,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
 
 class RunWebKitTestsInStressMode(RunWebKitTests):
     reports_to_results_db = False
+    results_db_flavor = None
     name = 'run-layout-tests-in-stress-mode'
     suffix = 'stress-mode'
     EXIT_AFTER_FAILURES = '10'
@@ -4375,6 +4377,7 @@ class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
 
 class ReRunWebKitTests(RunWebKitTests):
     name = 're-run-layout-tests'
+    results_db_flavor = None
     NUM_FAILURES_TO_DISPLAY = 10
 
     def evaluateCommand(self, cmd):
@@ -4530,6 +4533,7 @@ class ReRunWebKitTests(RunWebKitTests):
 
 class RunWebKitTestsWithoutChange(RunWebKitTests):
     name = 'run-layout-tests-without-change'
+    results_db_flavor = None
 
     @defer.inlineCallbacks
     def run(self):
@@ -4639,15 +4643,8 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
 
 
 class SiteIsolationResultsDBMixin(object):
-    reports_to_results_db = False
-
-    def results_db_query_configuration(self) -> dict:
-        # Use flavor='site-isolation' without a platform filter so that results from
-        # Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests (the closest post-commit queue) are consulted.
-        configuration = super().results_db_query_configuration()
-        configuration['flavor'] = 'site-isolation'
-        configuration.pop('platform', None)
-        return configuration
+    # Precedes ReRunWebKitTests in the MRO so a rerun keeps this flavor instead of inheriting None.
+    results_db_flavor = 'site-isolation'
 
 
 class RunWebKitTestsEWSSiteIsolation(SiteIsolationResultsDBMixin, RunWebKitTests):
@@ -4937,6 +4934,8 @@ class AnalyzeLayoutTestsResults(ResultsDBReportMixin, buildstep.BuildStep, Bugzi
 
 
 class RunWebKit1Tests(RunWebKitTests):
+    results_db_flavor = 'wk1'
+
     @defer.inlineCallbacks
     def run(self):
         self.layout_test_driver = 'DumpRenderTree'

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1964,6 +1964,32 @@ ts","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM o
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         return self.run_step()
 
+    @defer.inlineCallbacks
+    def test_the_run_labels_the_build_wk2(self) -> None:
+        # Nothing else sets `flavor`, and a query missing it is a partial configuration: it reads
+        # wk1 and site-isolation history for the same test alongside this queue's own.
+        self.configureStep()
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertEqual(self.getProperty('flavor'), 'wk2')
+        self.assertEqual(
+            self.get_nth_step(0).results_db_query_configuration(),
+            {'platform': 'mac', 'style': 'release', 'flavor': 'wk2'},
+        )
+
     def test_warnings(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')
@@ -2248,6 +2274,29 @@ ts","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM o
         self.property_failures = 'second_run_failures'
         ReRunWebKitTests.filter_failures_using_results_db = lambda x, failing_tests: ''
 
+    @defer.inlineCallbacks
+    def test_the_rerun_leaves_the_label_the_first_run_set(self) -> None:
+        # Every queue reruns with this class, wk1 queues included, so relabelling here would move a
+        # wk1 build's rows and queries to wk2 halfway through the build.
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('flavor', 'wk1')
+        self.setProperty('first_run_failures', ['test1'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertEqual(self.getProperty('flavor'), 'wk1')
+
     def test_flaky_failures_in_first_run(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')
@@ -2318,6 +2367,28 @@ class TestRunWebKitTestsInStressMode(BuildStepMixinAdditions, unittest.TestCase)
         self.setup_step(RunWebKitTestsInStressMode())
         self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
         self.property_failures = 'first_run_failures'
+
+    @defer.inlineCallbacks
+    def test_stress_mode_does_not_label_the_build(self) -> None:
+        # It runs one test 100 times to provoke a failure, so its rates are not comparable with an
+        # ordinary run's. It reports nothing, and must not label the rows the real run writes.
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release -2 --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --iterations 100 test1 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertIsNone(self.getProperty('flavor'))
 
     def test_success(self):
         self.configureStep()
@@ -2808,11 +2879,31 @@ class TestRunWebKitTestsEWSSiteIsolation(BuildStepMixinAdditions, unittest.TestC
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         return self.run_step()
 
-    def test_results_db_query_configuration_uses_site_isolation_flavor(self):
-        self.setup_step(RunWebKitTestsEWSSiteIsolation())
-        self.setProperty('platform', 'mac-sequoia')
+    @defer.inlineCallbacks
+    def test_the_run_labels_the_build_site_isolation(self) -> None:
+        # The rows this queue writes carry the label, so the query has to ask for it too. An
+        # unlabelled query is a partial configuration, which matches every other flavor instead.
+        self.configureStep()
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
         self.setProperty('configuration', 'release')
-        self.assertEqual(self.get_nth_step(0).results_db_query_configuration(), {'flavor': 'site-isolation', 'style': 'release'})
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertEqual(self.getProperty('flavor'), 'site-isolation')
+        self.assertEqual(
+            self.get_nth_step(0).results_db_query_configuration(),
+            {'platform': 'mac', 'style': 'release', 'flavor': 'site-isolation'},
+        )
 
     def test_failure_schedules_site_isolation_rerun(self):
         self.configureStep()
@@ -2840,10 +2931,28 @@ class TestReRunWebKitTestsEWSSiteIsolation(BuildStepMixinAdditions, unittest.Tes
         self.setup_step(ReRunWebKitTestsEWSSiteIsolation())
         ReRunWebKitTestsEWSSiteIsolation.filter_failures_using_results_db = lambda x, failing_tests: ''
 
-    def test_results_db_query_configuration_uses_site_isolation_flavor(self):
+    @defer.inlineCallbacks
+    def test_the_rerun_keeps_the_site_isolation_label(self) -> None:
+        # ReRunWebKitTests declares no flavor so an ordinary rerun leaves the first run's label
+        # alone; the mixin has to win the MRO here or a site-isolation rerun would go unlabelled.
         self.configureStep()
-        self.setProperty('configuration', 'debug')
-        self.assertEqual(self.get_nth_step(0).results_db_query_configuration(), {'flavor': 'site-isolation', 'style': 'debug'})
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.setProperty('first_run_failures', ['imported/w3c/web-platform-tests/test1.html'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertEqual(self.getProperty('flavor'), 'site-isolation')
 
     def test_failure_schedules_clean_tree_run(self):
         self.configureStep()
@@ -2884,6 +2993,33 @@ class TestRunWebKit1Tests(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         return self.run_step()
+
+    @defer.inlineCallbacks
+    def test_the_run_labels_the_build_wk1(self) -> None:
+        # wk1 and wk2 keep separate history for the same test, so a wk1 queue asking without the
+        # label would be answered largely out of wk2's rows.
+        self.setup_step(RunWebKit1Tests())
+        RunWebKit1Tests.filter_failures_using_results_db = lambda x, failing_tests: ''
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'debug')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --debug -1 --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        yield self.run_step()
+
+        self.assertEqual(self.getProperty('flavor'), 'wk1')
+        self.assertEqual(
+            self.get_nth_step(0).results_db_query_configuration(),
+            {'platform': 'mac', 'style': 'debug', 'flavor': 'wk1'},
+        )
 
     def test_failure(self):
         self.setup_step(RunWebKit1Tests())
@@ -3337,15 +3473,16 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
             {'platform': 'mac', 'style': 'release', 'flavor': 'wk2'},
         )
 
-    def test_site_isolation_queries_across_platforms(self):
-        # There is no mac-sequoia site-isolation post-commit queue, so the query has to reach the
-        # closest one on another platform rather than filter itself down to nothing.
+    def test_site_isolation_queries_keep_their_platform(self) -> None:
+        # mac has its own site-isolation post-commit queue, so dropping the platform here would
+        # fold another platform's history for the same test into the verdict.
         self.setup_step(RunWebKitTestsEWSSiteIsolation())
         self.setProperty('platform', 'mac')
         self.setProperty('configuration', 'release')
+        self.setProperty('flavor', 'site-isolation')
         self.assertEqual(
             self.get_nth_step(0).results_db_query_configuration(),
-            {'style': 'release', 'flavor': 'site-isolation'},
+            {'platform': 'mac', 'style': 'release', 'flavor': 'site-isolation'},
         )
 
     @defer.inlineCallbacks
@@ -3665,6 +3802,15 @@ class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
         step = self.configureStep()
         self.setProperty('platform', 'wpe')
         self.assertEqual(step.results_db_configuration()['platform'], 'WPE')
+
+    def test_a_glib_port_reports_the_webkit_version_it_builds(self) -> None:
+        # GTK and WPE workers leave os_version empty, and version is a required member, so without
+        # this fallback the guard drops every glib report.
+        step = self.configureStep()
+        self.setProperty('platform', 'gtk')
+        self.setProperty('os_version', '')
+        self.setProperty('webkit_version', '2.53')
+        self.assertEqual(step.results_db_configuration()['version'], '2.53')
 
     def test_merges_a_tests_outcomes_across_runs_without_repeating_them(self):
         step = self.configureStep()


### PR DESCRIPTION
#### f391e2248bba0cd065ec18899cbc0f64725a955f
<pre>
[EWS] Flaky Detection Fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322607">https://bugs.webkit.org/show_bug.cgi?id=322607</a>
<a href="https://rdar.apple.com/185912043">rdar://185912043</a>

Reviewed by Aakash Jain.

GTK/WPE need to fall back to `webkit_version` when there is no
`os_version`.

`SiteIsolationResultsDBMixin` suppresses reporting because the site-isolation
queue used to blame a change after a single test run, so there was no
confirmed outcome worth recording. 319404@main gave the queue the same retry
ladder as every other layout-test queue so we should add it to the system.

Layout-test steps derive the results-database flavor from
`layout_test_driver`, but only `RunWebKit1Tests` and
`RunWebKitTestsInStressMode` ever set that attribute, and the stress step
runs only when the change modified layout tests. Replace the derivation
with a `results_db_flavor` class attribute, since the subclass is the
label. `None` means &quot;leave the label the first run set&quot;, which the reruns
need.

* Tools/CISupport/ews-build/steps.py:
(ResultsDBReportMixin.results_db_query_configuration):
(ResultsDBReportMixin.results_db_configuration):
(RunWebKitTests):
(RunWebKitTests.run):
(RunWebKitTestsInStressMode):
(ReRunWebKitTests):
(RunWebKitTestsWithoutChange):
(SiteIsolationResultsDBMixin):
(RunWebKit1Tests):
(SiteIsolationResultsDBMixin.results_db_query_configuration): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(test_the_run_labels_the_build_wk2):
(test_the_rerun_leaves_the_label_the_first_run_set):
(TestRunWebKitTestsInStressMode):
(TestRunWebKitTestsInStressMode.test_stress_mode_does_not_label_the_build):
(TestRunWebKitTestsEWSSiteIsolation):
(TestRunWebKitTestsEWSSiteIsolation.test_the_run_labels_the_build_site_isolation):
(TestReRunWebKitTestsEWSSiteIsolation):
(TestReRunWebKitTestsEWSSiteIsolation.test_the_rerun_keeps_the_site_isolation_label):
(TestRunWebKit1Tests):
(TestRunWebKit1Tests.test_the_run_labels_the_build_wk1):
(TestFilterLayoutTestFailuresUsingResultsDB.test_site_isolation_queries_keep_their_platform):
(TestReportToResultsDB.test_a_glib_port_reports_the_webkit_version_it_builds):
(TestRunWebKitTestsEWSSiteIsolation.test_results_db_query_configuration_uses_site_isolation_flavor): Deleted.
(TestReRunWebKitTestsEWSSiteIsolation.test_results_db_query_configuration_uses_site_isolation_flavor): Deleted.
(TestFilterLayoutTestFailuresUsingResultsDB.test_site_isolation_queries_across_platforms): Deleted.

Canonical link: <a href="https://commits.webkit.org/319902@main">https://commits.webkit.org/319902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c794a0adc7e11f8c0090e0d75a16c174c4d4084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57057 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193352 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56792 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46666 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45357 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4525 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195293 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182538 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40836 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57431 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152111 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46669 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55939 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->