### PR TITLE
[Grid Lanes][Cleanup] Remove GridLanesLayout::m_stackingAxisSpan

### DIFF
--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -267,8 +267,9 @@ GridSpan GridLanesLayout::gridAxisSpanFromArea(const GridArea& gridArea) const
 
 GridArea GridLanesLayout::gridAreaFromGridAxisSpan(const GridSpan& gridAxisSpan) const
 {
+    auto stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
     return m_stackingAxisDirection == Style::GridTrackSizingDirection::Rows
-        ? GridArea { m_stackingAxisSpan, gridAxisSpan }
-        : GridArea { gridAxisSpan, m_stackingAxisSpan };
+        ? GridArea { stackingAxisSpan, gridAxisSpan }
+        : GridArea { gridAxisSpan, stackingAxisSpan };
 }
 } // end namespace WebCore

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -84,7 +84,6 @@ private:
     LayoutUnit m_gridContentSize;
 
     const Style::GridTrackSizingDirection m_stackingAxisDirection;
-    const GridSpan m_stackingAxisSpan = GridSpan::stackingAxisTranslatedDefiniteGridSpan();
 
     unsigned m_autoFlowNextCursor { 0 };
 };


### PR DESCRIPTION
#### 98d64b7362c212ee5f886ea3d065b68e98aa26bc
<pre>
[Grid Lanes][Cleanup] Remove GridLanesLayout::m_stackingAxisSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=322611">https://bugs.webkit.org/show_bug.cgi?id=322611</a>
<a href="https://rdar.apple.com/problem/185914211">rdar://problem/185914211</a>

Reviewed by Brent Fulgham.

m_stackingAxisSpan was not derived from the grid or from anything passed to the
constructor. It was initialized to GridSpan::stackingAxisTranslatedDefiniteGridSpan(),
which always returns GridSpan(0, 1, TranslatedDefinite), so it was a constant being
stored per object rather than state belonging to a placement run.

There is not need to store this as a member since it only had a single
reader.

Canonical link: <a href="https://commits.webkit.org/319907@main">https://commits.webkit.org/319907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a1f2eb5a51354f8ee9f234c8aea88d46b0d3309

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193348 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2290071-88d3-4379-98b3-45087540fa06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45642e33-06cd-4793-ab09-58051a77f5c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ae45a78-b786-4770-ab8d-ca986a31d5aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45354 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43226 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4521 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195289 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56722 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40844 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57427 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152108 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46663 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55935 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18237 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->