### PR TITLE
Honor a non-keyword max-width on an out-of-flow replaced box with an intrinsic ratio

### DIFF
--- a/LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio-expected.txt
+++ b/LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio-expected.txt
@@ -1,0 +1,25 @@
+max-width must clamp the used inline size of an out-of-flow positioned replaced element
+that has an intrinsic ratio but no intrinsic inline size. Expected values were measured in
+another engine on this same markup; the tolerance is 0.5px.
+
+PASS inline svg, left:0 right:0, max-width:220px, auto inline margins is within 0.5 of 219.98 x 188.59
+PASS inline svg, left:0 right:0, max-width:220px is within 0.5 of 219.98 x 188.59
+PASS img of a viewBox-only svg, left:0 right:0, max-width:220px is within 0.5 of 219.98 x 188.59
+PASS inline svg, all four insets 0, max-width:220px is within 0.5 of 219.98 x 188.59
+PASS inline svg, left:50px right:50px, max-width:220px is within 0.5 of 219.98 x 188.59
+PASS inline svg, left:0 right:0, max-width:220px, box-sizing:border-box, padding:10px is within 0.5 of 219.98 x 191.45
+PASS inline svg, left:0 right:0, max-width:50% is within 0.5 of 299.98 x 257.17
+PASS inline svg, position:fixed, left:0 right:0, max-width:220px is within 0.5 of 219.98 x 188.59
+PASS inline svg, left:0 right:0, max-width:220px, zero inline margins is within 0.5 of 219.98 x 188.59
+PASS inline svg, left:0 right:0, max-width:220px, direction:rtl is within 0.5 of 219.98 x 188.59
+PASS control: inline svg, left:0 right:0, no max-width is within 0.5 of 599.98 x 514.36
+PASS control: img of a viewBox-only svg, left:0 right:0, no max-width is within 0.5 of 599.98 x 514.36
+PASS control: inline svg, left:0 right:0, max-width:max-content is within 0.5 of 599.98 x 514.36
+PASS control: inline svg, left:0 right:0, min-width:800px is within 0.5 of 800 x 685.81
+PASS control: inline svg, left:0 right:0, min-width:800px, max-width:220px is within 0.5 of 800 x 685.81
+PASS control: inline svg, left:0 right:0, max-width:220px, writing-mode:vertical-rl is within 0.5 of 220 x 188.59
+PASS control: inline svg, left:0 only, width:100%, max-width:220px is within 0.5 of 220 x 188.59
+PASS control: inline svg, left:0 right:0, width:100%, max-width:220px is within 0.5 of 220 x 188.59
+PASS control: inline svg, left:0 right:0, height:100px, max-width:220px is within 0.5 of 116.64 x 100
+PASS control: inline svg, left:0 right:0, max-height:100px is within 0.5 of 116.64 x 100
+PASS control: inline svg, static, width:100%, max-width:220px is within 0.5 of 220 x 188.59

--- a/LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio.html
+++ b/LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>max-width on an out-of-flow positioned replaced element that has an intrinsic ratio but no intrinsic inline size</title>
+<style>
+#bench { position: absolute; left: -20000px; top: 0; }
+.containingBlock { position: relative; width: 600px; height: 400px; }
+</style>
+</head>
+<body>
+<pre id="results"></pre>
+<script>
+// https://webkit.org/b/322612: the used inline size of an out-of-flow positioned replaced box whose only
+// intrinsic sizing information is an aspect ratio, with width:auto, an indefinite block size and
+// both inline-axis insets set, comes from the constraint equation for block-level non-replaced
+// elements (CSS 2.1 10.3.2). max-width must still clamp that result unless it is an intrinsic
+// sizing keyword, which is treated as its initial value in this configuration.
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+const viewBoxWidth = 136.49992;
+const viewBoxHeight = 117.01795;
+const tolerance = 0.5;
+
+// An SVG resource with a viewBox and no width/height attributes: an intrinsic ratio, no
+// intrinsic dimensions. This is the <img> analogue of the inline <svg> below.
+const ratioOnlySVGURI = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + viewBoxWidth + " " + viewBoxHeight + '">'
+    + '<rect width="100%" height="100%" fill="#f1680d"/></svg>');
+
+function svgWithViewBoxOnly()
+{
+    const target = document.createElementNS(svgNamespace, "svg");
+    target.setAttribute("viewBox", "0 0 " + viewBoxWidth + " " + viewBoxHeight);
+    return target;
+}
+
+function imgOfSVGWithViewBoxOnly()
+{
+    const target = document.createElement("img");
+    target.setAttribute("src", ratioOnlySVGURI);
+    return target;
+}
+
+const tests = [
+    // max-width is a length, a percentage or a calc(): it must clamp the used inline size.
+    { name: "inline svg, left:0 right:0, max-width:220px, auto inline margins",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px;margin-left:auto;margin-right:auto",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, left:0 right:0, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px",
+      width: 219.98, height: 188.59 },
+    { name: "img of a viewBox-only svg, left:0 right:0, max-width:220px",
+      create: imgOfSVGWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, all four insets 0, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;top:0;bottom:0;left:0;right:0;max-width:220px",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, left:50px right:50px, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:50px;right:50px;max-width:220px",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, left:0 right:0, max-width:220px, box-sizing:border-box, padding:10px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px;box-sizing:border-box;padding:10px",
+      width: 219.98, height: 191.45 },
+    { name: "inline svg, left:0 right:0, max-width:50%",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:50%",
+      width: 299.98, height: 257.17 },
+    { name: "inline svg, position:fixed, left:0 right:0, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:fixed;left:0;right:0;max-width:220px",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, left:0 right:0, max-width:220px, zero inline margins",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px;margin-left:0;margin-right:0",
+      width: 219.98, height: 188.59 },
+    { name: "inline svg, left:0 right:0, max-width:220px, direction:rtl",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px;direction:rtl",
+      width: 219.98, height: 188.59 },
+
+    // Controls: none of these may change. The first three are the unclamped stretch itself, which
+    // both engines agree on; max-content is the intrinsic sizing keyword the carve-out is for.
+    { name: "control: inline svg, left:0 right:0, no max-width",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0",
+      width: 599.98, height: 514.36 },
+    { name: "control: img of a viewBox-only svg, left:0 right:0, no max-width",
+      create: imgOfSVGWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0",
+      width: 599.98, height: 514.36 },
+    { name: "control: inline svg, left:0 right:0, max-width:max-content",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:max-content",
+      width: 599.98, height: 514.36 },
+    { name: "control: inline svg, left:0 right:0, min-width:800px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;min-width:800px",
+      width: 800, height: 685.81 },
+    { name: "control: inline svg, left:0 right:0, min-width:800px, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;min-width:800px;max-width:220px",
+      width: 800, height: 685.81 },
+    { name: "control: inline svg, left:0 right:0, max-width:220px, writing-mode:vertical-rl",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-width:220px;writing-mode:vertical-rl",
+      width: 220, height: 188.59 },
+    { name: "control: inline svg, left:0 only, width:100%, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;width:100%;max-width:220px",
+      width: 220, height: 188.59 },
+    { name: "control: inline svg, left:0 right:0, width:100%, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;width:100%;max-width:220px",
+      width: 220, height: 188.59 },
+    { name: "control: inline svg, left:0 right:0, height:100px, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;height:100px;max-width:220px",
+      width: 116.64, height: 100 },
+    { name: "control: inline svg, left:0 right:0, max-height:100px",
+      create: svgWithViewBoxOnly,
+      style: "position:absolute;left:0;right:0;max-height:100px",
+      width: 116.64, height: 100 },
+    { name: "control: inline svg, static, width:100%, max-width:220px",
+      create: svgWithViewBoxOnly,
+      style: "position:static;width:100%;max-width:220px",
+      width: 220, height: 188.59 },
+];
+
+function roundToHundredths(value)
+{
+    return Math.round(value * 100) / 100;
+}
+
+async function measure(bench, test)
+{
+    const containingBlock = document.createElement("div");
+    containingBlock.className = "containingBlock";
+    const target = test.create();
+    target.setAttribute("style", test.style);
+    containingBlock.appendChild(target);
+    bench.appendChild(containingBlock);
+
+    if (target.localName == "img" && !target.complete) {
+        await new Promise(resolve => {
+            target.addEventListener("load", resolve);
+            target.addEventListener("error", resolve);
+        });
+    }
+
+    const rect = target.getBoundingClientRect();
+    containingBlock.remove();
+    return rect;
+}
+
+async function runTests()
+{
+    const lines = [
+        "max-width must clamp the used inline size of an out-of-flow positioned replaced element",
+        "that has an intrinsic ratio but no intrinsic inline size. Expected values were measured in",
+        "another engine on this same markup; the tolerance is " + tolerance + "px.",
+        "",
+    ];
+
+    // The measured elements live in a container that is removed again, so that the text dump
+    // contains nothing but the results below.
+    const bench = document.createElement("div");
+    bench.id = "bench";
+    document.body.appendChild(bench);
+
+    for (const test of tests) {
+        const rect = await measure(bench, test);
+        const expected = test.width + " x " + test.height;
+        if (Math.abs(rect.width - test.width) <= tolerance && Math.abs(rect.height - test.height) <= tolerance)
+            lines.push("PASS " + test.name + " is within " + tolerance + " of " + expected);
+        else
+            lines.push("FAIL " + test.name + " should be within " + tolerance + " of " + expected + ". Was " + roundToHundredths(rect.width) + " x " + roundToHundredths(rect.height) + ".");
+    }
+
+    bench.remove();
+    document.getElementById("results").textContent = lines.join("\n");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+runTests();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt
@@ -41,4 +41,6 @@ PASS minmax replaced IMG 38
 PASS minmax replaced IMG 39
 PASS minmax replaced IMG 40
 PASS minmax replaced IMG 41
+PASS minmax replaced IMG 42
+PASS minmax replaced IMG 43
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax.html
@@ -272,6 +272,20 @@
   data-expected-width="188" data-expected-height="47" data-offset-y="146" data-offset-x="109"
   >
 </div>
+<!-- Same as the previous two tests, but with a max-width that is a definite length
+ rather than an intrinsic keyword. webkit.org/b/322612 -->
+<div class="container">
+  <img class="target" style="left:100px;right:100px;max-width:100px" src="data:image/svg+xml,%3Csvg viewBox='0 0 100 10' xmlns='http://www.w3.org/2000/svg' %3E%3Crect width='100%' height='100%' style='fill:rgb(0,255,0);'/%3E%3C/svg%3E"
+  data-expected-width="138" data-expected-height="42" data-offset-y="151" data-offset-x="109"
+  >
+</div>
+<!-- Same, with the max-width as a percentage, resolved against the containing block's
+ 400px. 25% is 100px, below the width the insets alone would give, so it constrains. -->
+<div class="container">
+  <img class="target" style="left:100px;right:100px;max-width:25%" src="data:image/svg+xml,%3Csvg viewBox='0 0 100 10' xmlns='http://www.w3.org/2000/svg' %3E%3Crect width='100%' height='100%' style='fill:rgb(0,255,0);'/%3E%3C/svg%3E"
+  data-expected-width="138" data-expected-height="42" data-offset-y="151" data-offset-x="109"
+  >
+</div>
 <!-- Viewbox + svg width. Has aspect_ratio and width. Height is scaled -->
 <div class="container">
   <img class="target" src="data:image/svg+xml,%3Csvg viewBox='0 0 100 10' width='100px' xmlns='http://www.w3.org/2000/svg' %3E%3Crect width='100%' height='100%' style='fill:rgb(0,255,0);'/%3E%3C/svg%3E"

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -844,10 +844,11 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(IsComputingIntrinsicSize 
                 // keywords constrain the width.
                 auto& style = this->style();
                 if (isOutOfFlowPositioned() && !style.logicalLeft().isAuto() && !style.logicalRight().isAuto()) {
-                    // Still respect min-width, but ignore max-width if it's an intrinsic keyword.
                     auto& logicalMinWidth = style.logicalMinWidth();
+                    auto& logicalMaxWidth = style.logicalMaxWidth();
                     auto minLogicalWidth = logicalMinWidth.isIntrinsic() ? 0_lu : computeReplacedLogicalWidthUsing(logicalMinWidth);
-                    return std::max(minLogicalWidth, constrainedLogicalWidth);
+                    auto maxLogicalWidth = logicalMaxWidth.isIntrinsic() || logicalMaxWidth.isNone() ? constrainedLogicalWidth : computeReplacedLogicalWidthUsing(logicalMaxWidth);
+                    return std::max(minLogicalWidth, std::min(constrainedLogicalWidth, maxLogicalWidth));
                 }
 
                 return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, IsComputingIntrinsicSize::No);


### PR DESCRIPTION
#### e6ef3220723e0ec983018314278e9f2a8291ecc9
<pre>
Honor a non-keyword max-width on an out-of-flow replaced box with an intrinsic ratio
<a href="https://bugs.webkit.org/show_bug.cgi?id=322612">https://bugs.webkit.org/show_bug.cgi?id=322612</a>
<a href="https://rdar.apple.com/185831651">rdar://185831651</a>

Reviewed by Alan Baradlay and Sammy Gill.

An &lt;svg&gt; whose only intrinsic sizing information is an aspect ratio (e.g, a viewBox with
no width/height attributes), absolutely positioned with left and right both non-auto and
width:auto, was getting stretched to the full width of its containing block, ignoring its
`max-width` property.

computeReplacedLogicalWidth()` has a carve-out for an out-of-flow replaced box with both
inline insets set, with a comment that implies that it was only intended for intrinsic
keywords. It calculated the width from left/right per CSS 2.1 10.3.7 and returns early,
skipping `computeReplacedLogicalWidthRespectingMinMaxWidth()`. But the condition did not
restrict its behavior, discarding all `max-width` cases. `min-width` did not suffer from
this issue because it is applied inside the block.

This patch corrects this issue by applying the `max-width` clamp inside the carve-out,
still ignoring it when it is an intrinsic keyword, so lengths and percentages constrain
the box while the keywords keep the behavior for which the carve-out was added.

A new WPT is included to protect this from regressing.

Tests: fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio.html
       imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax.html

* LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio-expected.txt: Added.
* LayoutTests/fast/replaced/max-width-on-positioned-replaced-with-intrinsic-ratio.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax.html:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeReplacedLogicalWidth const):
Clamp to max-width unless it is an intrinsic keyword or none.

Canonical link: <a href="https://commits.webkit.org/319917@main">https://commits.webkit.org/319917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66abf513faaf415d13f171ba59403aa64e67043

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193372 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0493a256-cae6-4338-8682-2960bb3c7a8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49c77c5d-90de-4375-9df4-0257a578426c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123383 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ed93add-79d2-4d22-97b7-6fbb1f7fe70e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43621 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43249 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4546 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195313 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40852 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57451 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46685 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129721 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55959 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18260 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->