### PR TITLE
[GLIB] Unskip ipc/serialized-type-info.html

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -188,6 +188,9 @@
                         result.push("WKDDActionContext");
                     }
                 }
+            } else {
+                result.push("UnixFileDescriptor");
+                result.push("GTlsCertificateFlags");
             }
         }
         return result.sort();

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5221,7 +5221,6 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.
 imported/w3c/web-platform-tests/workers/Worker-creation-happens-in-parallel.https.html [ Skip ]
 imported/w3c/web-platform-tests/workers/postMessage_block.https.html [ Skip ]
 imported/w3c/web-platform-tests/workers/Worker-postMessage-happens-in-parallel.https.html [ Skip ]
-ipc/serialized-type-info.html [ Skip ]
 ipc/stream-sync-reply-shared-memory.html [ Skip ]
 webkit.org/b/297737 ipc/send-gradient.html [ Skip ]
 webkit.org/b/297737 ipc/send-filter.html [ Skip ]

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -106,7 +106,7 @@ using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight,
 #if OS(ANDROID)
     RefPtr<AHardwareBuffer> hardwareBuffer;
 #else
-    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
     uint32_t fourcc;

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -151,7 +151,7 @@ header: <WebCore/PlatformXR.h>
     bool isSharedTexture;
 #endif
 #if !PLATFORM(COCOA)
-    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
     uint32_t fourcc;
@@ -333,7 +333,7 @@ header: <WebCore/PlatformXR.h>
     PlatformXR::LayerHandle handle;
     bool visible;
     Vector<PlatformXR::DeviceLayer::LayerView> views;
-    WTF::UnixFileDescriptor fenceFD;
+    UnixFileDescriptor fenceFD;
 #if ENABLE(WEBXR_LAYERS)
     bool blendTextureSourceAlpha;
     bool forceMonoPresentation;

--- a/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in
+++ b/Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in
@@ -30,7 +30,7 @@ header: "CoreIPCGUnixFDList.h"
 additional_forward_declaration: typedef struct _GUnixFDList GUnixFDList
 
 [GRefPtrWrapped=GUnixFDList] class WebKit::CoreIPCGUnixFDList {
-    Vector<WTF::UnixFileDescriptor> fileDescriptors();
+    Vector<UnixFileDescriptor> fileDescriptors();
 }
 
 #endif

--- a/Source/WebKit/Shared/glib/DMABufBufferAttributes.serialization.in
+++ b/Source/WebKit/Shared/glib/DMABufBufferAttributes.serialization.in
@@ -26,7 +26,7 @@ header: <WebCore/DMABufBufferAttributes.h>
 [RValue, CustomHeader] class WebCore::DMABufBufferAttributes {
     WebCore::IntSize size;
     WebCore::FourCC fourcc;
-    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<UnixFileDescriptor> fds;
     Vector<uint32_t> offsets;
     Vector<uint32_t> strides;
     uint64_t modifier;


### PR DESCRIPTION
#### ffbf2c925325a2780830d333468cc8d71de71b71
<pre>
[GLIB] Unskip ipc/serialized-type-info.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=322614">https://bugs.webkit.org/show_bug.cgi?id=322614</a>

Reviewed by Carlos Alberto Lopez Perez.

The test reports two types that reach IPC on the ports using Unix domain sockets
and cannot be described.

UnixFileDescriptor is their IPC::Attachment, the role MachSendRight has on Darwin
(Platform/IPC/Attachment.h); attachments are passed out of band by a hand-written
coder and have no members, which is why MachSendRight is already allowlisted. It
was also spelled two ways, and only the unqualified form is registered.

GTlsCertificateFlags is a GIO C flags enum, and the generator only parses enum
class, the same reason WebCore::ContextMenuAction is allowlisted. Describing it
would mean mirroring GIO&apos;s flags in WebKit.

Allowlist both and unskip. GTK and WPE report identical sets, so one line covers
them.

* LayoutTests/ipc/serialized-type-info.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/Shared/WebGL.serialization.in:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/Shared/glib/CoreIPCGUnixFDList.serialization.in:
* Source/WebKit/Shared/glib/DMABufBufferAttributes.serialization.in:

Canonical link: <a href="https://commits.webkit.org/320031@main">https://commits.webkit.org/320031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055d4874c7ddae228e1e9c4f8c73c8d53b07a870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143043 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99339 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123469 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45480 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43728 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43340 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4664 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57568 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152234 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46788 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129864 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56076 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18352 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55447 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->