### PR TITLE
SVGPropertyRegistry should be able to reset each of its properties back to its initial value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
@@ -39,14 +39,14 @@ PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimu
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimuth (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value) assert_equals: initial after expected 2 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value)
 FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 0 but got 42
 FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 0 but got 42
 FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 0 but got 42

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -14631,6 +14631,7 @@
 		726D56E1253AE0430002EF90 /* PlatformImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformImage.h; sourceTree = "<group>"; };
 		727003E5292F2DBB0094C64B /* FilterRenderingMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FilterRenderingMode.h; sourceTree = "<group>"; };
 		7272D336292F767D00F74D99 /* FilterStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FilterStyle.h; sourceTree = "<group>"; };
+		72766158303E129F00D536E5 /* SVGAnimatedPrimitivePropertyAccessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGAnimatedPrimitivePropertyAccessor.h; sourceTree = "<group>"; };
 		727AFED11A2EA6A0000442E8 /* EXTsRGB.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EXTsRGB.cpp; sourceTree = "<group>"; };
 		727AFED21A2EA6A0000442E8 /* EXTsRGB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXTsRGB.h; sourceTree = "<group>"; };
 		727AFED31A2EA6A0000442E8 /* EXTsRGB.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EXTsRGB.idl; sourceTree = "<group>"; };
@@ -24705,6 +24706,7 @@
 			children = (
 				5553592022441A16008F5EC9 /* SVGAnimatedDecoratedProperty.h */,
 				55EE5357223B29F800FBA944 /* SVGAnimatedPrimitiveProperty.h */,
+				72766158303E129F00D536E5 /* SVGAnimatedPrimitivePropertyAccessor.h */,
 				55EE5362223B2A2300FBA944 /* SVGAnimatedProperty.h */,
 				55EE5359223B29FA00FBA944 /* SVGAnimatedPropertyAccessor.h */,
 				55EE5358223B29F900FBA944 /* SVGAnimatedPropertyAccessorImpl.h */,

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -45,9 +45,9 @@ inline SVGFEDropShadowElement::SVGFEDropShadowElement(const QualifiedName& tagNa
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEDropShadowElement::m_in1>();
-        PropertyRegistry::registerProperty<SVGNames::dxAttr, &SVGFEDropShadowElement::m_dx>();
-        PropertyRegistry::registerProperty<SVGNames::dyAttr, &SVGFEDropShadowElement::m_dy>();
-        PropertyRegistry::registerProperty<SVGNames::stdDeviationAttr, &SVGFEDropShadowElement::m_stdDeviationX, &SVGFEDropShadowElement::m_stdDeviationY>();
+        PropertyRegistry::registerProperty<SVGNames::dxAttr, &SVGFEDropShadowElement::m_dx, offsetInitalValue>();
+        PropertyRegistry::registerProperty<SVGNames::dyAttr, &SVGFEDropShadowElement::m_dy, offsetInitalValue>();
+        PropertyRegistry::registerProperty<SVGNames::stdDeviationAttr, &SVGFEDropShadowElement::m_stdDeviationX, &SVGFEDropShadowElement::m_stdDeviationY, stdDeviationInitalValue, stdDeviationInitalValue>();
     }
 }
 
@@ -70,16 +70,23 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
-        }
+        } else
+            propertyRegistry().resetPropertyBaseVal(name);
         break;
     case AttributeNames::inAttr:
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::dxAttr:
-        m_dx->setBaseValInternal(newValue.toFloat());
+        if (auto result = parseNumber(newValue))
+            m_dx->setBaseValInternal(*result);
+        else
+            propertyRegistry().resetPropertyBaseVal(name);
         break;
     case AttributeNames::dyAttr:
-        m_dy->setBaseValInternal(newValue.toFloat());
+        if (auto result = parseNumber(newValue))
+            m_dy->setBaseValInternal(*result);
+        else
+            propertyRegistry().resetPropertyBaseVal(name);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -48,6 +48,9 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
 
+    static constexpr float offsetInitalValue = 2.0f;
+    static constexpr float stdDeviationInitalValue = 2.0f;
+
 private:
     SVGFEDropShadowElement(const QualifiedName&, Document&);
 
@@ -62,10 +65,10 @@ private:
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     const Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    const Ref<SVGAnimatedNumber> m_dx { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_dy { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_stdDeviationX { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_stdDeviationY { SVGAnimatedNumber::create(this, 2) };
+    const Ref<SVGAnimatedNumber> m_dx { SVGAnimatedNumber::create(this, offsetInitalValue) };
+    const Ref<SVGAnimatedNumber> m_dy { SVGAnimatedNumber::create(this, offsetInitalValue) };
+    const Ref<SVGAnimatedNumber> m_stdDeviationX { SVGAnimatedNumber::create(this, stdDeviationInitalValue) };
+    const Ref<SVGAnimatedNumber> m_stdDeviationY { SVGAnimatedNumber::create(this, stdDeviationInitalValue) };
 };
     
 } // namespace WebCore

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,28 +25,39 @@
 
 #pragma once
 
+#include "SVGAnimatedPropertyAccessor.h"
+
 namespace WebCore {
 
-class SVGAnimatedPropertyBase;
-class SVGAttributeAnimator;
+template<typename OwnerType, typename AnimatedPropertyType>
+class SVGAnimatedPrimitivePropertyAccessor : public SVGAnimatedPropertyAccessor<OwnerType, AnimatedPropertyType> {
+    using Base = SVGAnimatedPropertyAccessor<OwnerType, AnimatedPropertyType>;
 
-class SVGPropertyRegistry {
 public:
-    SVGPropertyRegistry() = default;
-    virtual ~SVGPropertyRegistry() = default;
+    using Base::property;
+    using ValueType = AnimatedPropertyType::ValueType;
 
-    virtual void detachAllProperties() const = 0;
-    virtual QualifiedName propertyAttributeName(const SVGProperty&) const = 0;
-    virtual QualifiedName animatedPropertyAttributeName(const SVGAnimatedPropertyBase&) const = 0;
-    virtual void setAnimatedPropertyDirty(const QualifiedName&, SVGAnimatedPropertyBase&) const = 0;
-    virtual std::optional<String> synchronize(const QualifiedName&) const = 0;
-    virtual HashMap<QualifiedName, String> synchronizeAllAttributes() const = 0;
-    virtual void resetPropertyBaseVal(const QualifiedName&) const = 0;
+    SVGAnimatedPrimitivePropertyAccessor(const Ref<AnimatedPropertyType> OwnerType::*property, ValueType initialValue)
+        : Base(property)
+        , m_initialValue(initialValue)
+    {
+    }
 
-    virtual bool isAnimatedPropertyAttribute(const QualifiedName&) const = 0;
-    virtual bool isAnimatedStylePropertyAttribute(const QualifiedName&) const = 0;
-    virtual RefPtr<SVGAttributeAnimator> createAnimator(const QualifiedName&, AnimationMode, CalcMode, bool isAccumulated, bool isAdditive) const = 0;
-    virtual void appendAnimatedInstance(const QualifiedName& attributeName, SVGAttributeAnimator&) const = 0;
+    template<typename AccessorType, const Ref<AnimatedPropertyType> OwnerType::*property, ValueType initialValue>
+    static const SVGMemberAccessor<OwnerType>& singleton()
+    {
+        static NeverDestroyed<AccessorType> propertyAccessor { property, initialValue };
+        return propertyAccessor;
+    }
+
+    void resetBaseVal(const OwnerType& owner) const override
+    {
+        property(owner)->setBaseValInternal(m_initialValue);
+    }
+
+protected:
+    ValueType m_initialValue;
 };
 
-}
+} // namespace WebCore
+

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SVGAnimatedPrimitivePropertyAccessor.h"
 #include "SVGAnimatedPropertyAccessor.h"
 #include "SVGAnimatedPropertyAnimatorImpl.h"
 #include "SVGAnimatedPropertyImpl.h"
@@ -87,14 +88,14 @@ private:
 };
 
 template<typename OwnerType>
-class SVGAnimatedIntegerAccessor final : public SVGAnimatedPropertyAccessor<OwnerType, SVGAnimatedInteger> {
-    using Base = SVGAnimatedPropertyAccessor<OwnerType, SVGAnimatedInteger>;
+class SVGAnimatedIntegerAccessor final : public SVGAnimatedPrimitivePropertyAccessor<OwnerType, SVGAnimatedInteger> {
+    using Base = SVGAnimatedPrimitivePropertyAccessor<OwnerType, SVGAnimatedInteger>;
 
 public:
     using Base::Base;
     using Base::property;
-    template<auto property>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedIntegerAccessor, property>(); }
+    template<auto property, int initialValue>
+    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedIntegerAccessor, property, initialValue>(); }
 
 private:
     RefPtr<SVGAttributeAnimator> createAnimator(OwnerType& owner, const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive) const final
@@ -156,14 +157,14 @@ private:
 };
 
 template<typename OwnerType>
-class SVGAnimatedNumberAccessor final : public SVGAnimatedPropertyAccessor<OwnerType, SVGAnimatedNumber> {
-    using Base = SVGAnimatedPropertyAccessor<OwnerType, SVGAnimatedNumber>;
+class SVGAnimatedNumberAccessor final : public SVGAnimatedPrimitivePropertyAccessor<OwnerType, SVGAnimatedNumber> {
+    using Base = SVGAnimatedPrimitivePropertyAccessor<OwnerType, SVGAnimatedNumber>;
 
 public:
     using Base::Base;
     using Base::property;
-    template<auto property>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedNumberAccessor, property>(); }
+    template<auto property, float initialValue>
+    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedNumberAccessor, property, initialValue>(); }
 
 private:
     RefPtr<SVGAttributeAnimator> createAnimator(OwnerType& owner, const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive) const final

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
@@ -36,17 +36,17 @@ class SVGAnimatedPropertyPairAccessor : public SVGMemberAccessor<OwnerType> {
     using Base = SVGMemberAccessor<OwnerType>;
 
 public:
-    SVGAnimatedPropertyPairAccessor(const Ref<AnimatedPropertyType1> OwnerType::*property1, const Ref<AnimatedPropertyType2> OwnerType::*property2)
-        : m_accessor1(property1)
-        , m_accessor2(property2)
+    SVGAnimatedPropertyPairAccessor(AccessorType1&& accessor1, AccessorType2&& accessor2)
+        : m_accessor1(WTF::move(accessor1))
+        , m_accessor2(WTF::move(accessor2))
     {
     }
 
 protected:
-    template<typename AccessorType, auto property1, auto property2>
-    static SVGMemberAccessor<OwnerType>& singleton()
+    template<typename AccessorType>
+    static SVGMemberAccessor<OwnerType>& singleton(AccessorType1&& accessor1, AccessorType2&& accessor2)
     {
-        static NeverDestroyed<AccessorType> propertyAccessor { property1, property2 };
+        static NeverDestroyed<AccessorType> propertyAccessor { WTF::move(accessor1), WTF::move(accessor2) };
         return propertyAccessor;
     }
 
@@ -57,6 +57,12 @@ protected:
 
     const Ref<AnimatedPropertyType2>& property2(OwnerType& owner) const { return m_accessor2.property(owner); }
     const Ref<AnimatedPropertyType2>& property2(const OwnerType& owner) const { return m_accessor2.property(owner); }
+
+    void resetBaseVal(const OwnerType& owner) const override
+    {
+        m_accessor1.resetBaseVal(owner);
+        m_accessor2.resetBaseVal(owner);
+    }
 
     void detach(const OwnerType& owner) const override
     {

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
@@ -45,8 +45,11 @@ class SVGAnimatedAngleOrientAccessor final : public SVGAnimatedPropertyPairAcces
 
 public:
     using Base::Base;
-    template<auto property1, auto property2>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedAngleOrientAccessor, property1, property2>(); }
+
+    constexpr static const SVGMemberAccessor<OwnerType>& singleton(SVGAnimatedAngleAccessor<OwnerType>&& accessor1, SVGAnimatedOrientTypeAccessor<OwnerType>&& accessor2)
+    {
+        return Base::template singleton<SVGAnimatedAngleOrientAccessor>(WTF::move(accessor1), WTF::move(accessor2));
+    }
 
 private:
     void setDirty(const OwnerType& owner, SVGAnimatedPropertyBase& animatedProperty) const final
@@ -92,8 +95,11 @@ class SVGAnimatedIntegerPairAccessor final : public SVGAnimatedPropertyPairAcces
 
 public:
     using Base::Base;
-    template<auto property1, auto property2>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedIntegerPairAccessor, property1, property2>(); }
+
+    constexpr static const SVGMemberAccessor<OwnerType>& singleton(SVGAnimatedIntegerAccessor<OwnerType>&& accessor1, SVGAnimatedIntegerAccessor<OwnerType>&& accessor2)
+    {
+        return Base::template singleton<SVGAnimatedIntegerPairAccessor>(WTF::move(accessor1), WTF::move(accessor2));
+    }
 
 private:
     std::optional<String> synchronize(const OwnerType& owner) const final
@@ -127,8 +133,11 @@ class SVGAnimatedNumberPairAccessor final : public SVGAnimatedPropertyPairAccess
 
 public:
     using Base::Base;
-    template<auto property1, auto property2>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedNumberPairAccessor, property1, property2>(); }
+
+    constexpr static const SVGMemberAccessor<OwnerType>& singleton(SVGAnimatedNumberAccessor<OwnerType>&& accessor1, SVGAnimatedNumberAccessor<OwnerType>&& accessor2)
+    {
+        return Base::template singleton<SVGAnimatedNumberPairAccessor>(WTF::move(accessor1), WTF::move(accessor2));
+    }
 
 private:
     std::optional<String> synchronize(const OwnerType& owner) const final

--- a/Source/WebCore/svg/properties/SVGMemberAccessor.h
+++ b/Source/WebCore/svg/properties/SVGMemberAccessor.h
@@ -39,6 +39,7 @@ class SVGMemberAccessor {
 public:
     virtual ~SVGMemberAccessor() = default;
 
+    virtual void resetBaseVal(const OwnerType&) const { }
     virtual void detach(const OwnerType&) const { }
     virtual bool isAnimatedProperty() const { return false; }
     virtual bool isAnimatedLength() const { return false; }

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -93,10 +93,10 @@ public:
         registerProperty(attributeName, SVGAnimatedEnumerationAccessor<OwnerType, EnumType>::template singleton<property>());
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property>
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property, int initialValue = 0>
     static void registerProperty()
     {
-        registerProperty(attributeName, SVGAnimatedIntegerAccessor<OwnerType>::template singleton<property>());
+        registerProperty(attributeName, SVGAnimatedIntegerAccessor<OwnerType>::template singleton<property, initialValue>());
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedLength> OwnerType::*property>
@@ -111,10 +111,10 @@ public:
         registerProperty(attributeName, SVGAnimatedLengthListAccessor<OwnerType>::template singleton<property>());
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property>
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property, float initialValue = 0.0f>
     static void registerProperty()
     {
-        registerProperty(attributeName, SVGAnimatedNumberAccessor<OwnerType>::template singleton<property>());
+        registerProperty(attributeName, SVGAnimatedNumberAccessor<OwnerType>::template singleton<property, initialValue>());
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumberList> OwnerType::*property>
@@ -126,7 +126,7 @@ public:
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedAngle> OwnerType::*property1, const Ref<SVGAnimatedOrientType> OwnerType::*property2>
     static void registerProperty()
     {
-        registerProperty(attributeName, SVGAnimatedAngleOrientAccessor<OwnerType>::template singleton<property1, property2>());
+        registerProperty(attributeName, SVGAnimatedAngleOrientAccessor<OwnerType>::singleton(SVGAnimatedAngleAccessor<OwnerType>(property1), SVGAnimatedOrientTypeAccessor<OwnerType>(property2)));
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedPath> OwnerType::*property>
@@ -165,16 +165,16 @@ public:
         registerProperty(attributeName, SVGAnimatedTransformListAccessor<OwnerType>::template singleton<property>());
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property1, const Ref<SVGAnimatedInteger> OwnerType::*property2>
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property1, const Ref<SVGAnimatedInteger> OwnerType::*property2, int initialValue1 = 0, int initialValue2 = 0>
     static void registerProperty()
     {
-        registerProperty(attributeName, SVGAnimatedIntegerPairAccessor<OwnerType>::template singleton<property1, property2>());
+        registerProperty(attributeName, SVGAnimatedIntegerPairAccessor<OwnerType>::singleton(SVGAnimatedIntegerAccessor<OwnerType>(property1, initialValue1), SVGAnimatedIntegerAccessor<OwnerType>(property2, initialValue2)));
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property1, const Ref<SVGAnimatedNumber> OwnerType::*property2>
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property1, const Ref<SVGAnimatedNumber> OwnerType::*property2, float initialValue1 = 0.0f, float initialValue2 = 0.0f>
     static void registerProperty()
     {
-        registerProperty(attributeName, SVGAnimatedNumberPairAccessor<OwnerType>::template singleton<property1, property2>());
+        registerProperty(attributeName, SVGAnimatedNumberPairAccessor<OwnerType>::singleton(SVGAnimatedNumberAccessor<OwnerType>(property1, initialValue1), SVGAnimatedNumberAccessor<OwnerType>(property2, initialValue2)));
     }
 
     // Enumerate all the SVGMemberAccessors recursively. The functor will be called and will
@@ -294,6 +294,13 @@ public:
             return true;
         });
         return map;
+    }
+
+    void resetPropertyBaseVal(const QualifiedName& attributeName) const override
+    {
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            accessor.resetBaseVal(m_owner);
+        });
     }
 
     bool isAnimatedPropertyAttribute(const QualifiedName& attributeName) const override


### PR DESCRIPTION
#### 301096e700d8b6139da1886c1e675e71ba84010e
<pre>
SVGPropertyRegistry should be able to reset each of its properties back to its initial value
<a href="https://bugs.webkit.org/show_bug.cgi?id=322615">https://bugs.webkit.org/show_bug.cgi?id=322615</a>
<a href="https://rdar.apple.com/185919860">rdar://185919860</a>

Reviewed by NOBODY (OOPS!).

When registering a property in SVGPropertyRegistry, the initial value should be
passed and stored in the corresponding accessor.

When parsing the new value for an SVG property fails, attributeChanged() should
ask the SVGPropertyRegistry reset this property to its initial value.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::SVGFEDropShadowElement):
(WebCore::SVGFEDropShadowElement::attributeChanged):
* Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h: Copied from Source/WebCore/svg/properties/SVGPropertyRegistry.h.
(WebCore::SVGAnimatedPrimitivePropertyAccessor::SVGAnimatedPrimitivePropertyAccessor):
(WebCore::SVGAnimatedPrimitivePropertyAccessor::singleton):
* Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h:
(WebCore::SVGAnimatedPropertyPairAccessor::SVGAnimatedPropertyPairAccessor):
(WebCore::SVGAnimatedPropertyPairAccessor::singleton):
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h:
* Source/WebCore/svg/properties/SVGMemberAccessor.h:
(WebCore::SVGMemberAccessor::resetBaseVal const):
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::registerProperty):
* Source/WebCore/svg/properties/SVGPropertyRegistry.h:
* Source/WebCore/svg/SVGFEDropShadowElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/301096e700d8b6139da1886c1e675e71ba84010e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147486 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50b46820-0a59-40c6-9502-7127eb7887af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142988 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99299 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf0031dc-fbc0-4b12-912e-c8fb9ddbb8fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03c0b5fe-f984-4d57-a8c6-4fb384b1f2ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45417 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43662 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43284 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4589 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56789 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152476 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57494 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152172 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46728 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129764 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126073 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56002 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18295 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55611 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->