### PR TITLE
Fix typo in `cache-add.https.any.js` leading to test failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any-expected.txt
@@ -17,7 +17,7 @@ PASS Cache.addAll with an empty array
 PASS Cache.addAll with string URL arguments
 PASS Cache.addAll with Request arguments
 PASS Cache.addAll with a mix of succeeding and failing requests
-FAIL Cache.addAll called with the same Request object specified twice promise_rejects_dom: Cache.addAll should throw InvalidStateError if the same request is added twice. function "function() { throw e; }" threw object "TypeError: Response is not OK" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS Cache.addAll called with the same Request object specified twice
 PASS Cache.addAll should reject when entries differ only by fragment
 PASS Cache.addAll should succeed when entries differ by vary header
 PASS Cache.addAll should reject when entries are duplicate by vary header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.js
@@ -276,7 +276,7 @@ cache_test(function(cache, test) {
   }, 'Cache.addAll with a mix of succeeding and failing requests');
 
 cache_test(function(cache, test) {
-    var request = new Request('../resources/simple.txt');
+    var request = new Request('./resources/simple.txt');
     return promise_rejects_dom(
       test,
       'InvalidStateError',

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.serviceworker-expected.txt
@@ -17,7 +17,7 @@ PASS Cache.addAll with an empty array
 PASS Cache.addAll with string URL arguments
 PASS Cache.addAll with Request arguments
 PASS Cache.addAll with a mix of succeeding and failing requests
-FAIL Cache.addAll called with the same Request object specified twice promise_rejects_dom: Cache.addAll should throw InvalidStateError if the same request is added twice. function "function() { throw e; }" threw object "TypeError: Response is not OK" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS Cache.addAll called with the same Request object specified twice
 PASS Cache.addAll should reject when entries differ only by fragment
 PASS Cache.addAll should succeed when entries differ by vary header
 PASS Cache.addAll should reject when entries are duplicate by vary header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.sharedworker-expected.txt
@@ -17,7 +17,7 @@ PASS Cache.addAll with an empty array
 PASS Cache.addAll with string URL arguments
 PASS Cache.addAll with Request arguments
 PASS Cache.addAll with a mix of succeeding and failing requests
-FAIL Cache.addAll called with the same Request object specified twice promise_rejects_dom: Cache.addAll should throw InvalidStateError if the same request is added twice. function "function() { throw e; }" threw object "TypeError: Response is not OK" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS Cache.addAll called with the same Request object specified twice
 PASS Cache.addAll should reject when entries differ only by fragment
 PASS Cache.addAll should succeed when entries differ by vary header
 PASS Cache.addAll should reject when entries are duplicate by vary header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.worker-expected.txt
@@ -17,7 +17,7 @@ PASS Cache.addAll with an empty array
 PASS Cache.addAll with string URL arguments
 PASS Cache.addAll with Request arguments
 PASS Cache.addAll with a mix of succeeding and failing requests
-FAIL Cache.addAll called with the same Request object specified twice promise_rejects_dom: Cache.addAll should throw InvalidStateError if the same request is added twice. function "function() { throw e; }" threw object "TypeError: Response is not OK" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS Cache.addAll called with the same Request object specified twice
 PASS Cache.addAll should reject when entries differ only by fragment
 PASS Cache.addAll should succeed when entries differ by vary header
 PASS Cache.addAll should reject when entries are duplicate by vary header


### PR DESCRIPTION
#### 9b26f3d4f2750ef3019a629975fb1b1f3d9ec94f
<pre>
Fix typo in `cache-add.https.any.js` leading to test failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=322617">https://bugs.webkit.org/show_bug.cgi?id=322617</a>
<a href="https://rdar.apple.com/185922165">rdar://185922165</a>

Reviewed by NOBODY (OOPS!).

While doing another PR, I noticed this typo so just fixing it, I will
upstream the fix as well.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.js:
(cache_test):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-add.https.any.worker-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b26f3d4f2750ef3019a629975fb1b1f3d9ec94f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193364 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18b5bbfc-db81-42fb-a7b9-f8ddf3488266) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142948 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b125e3e6-f95b-4784-8c9c-43780b393545) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46677 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8ffc7f4-96ab-4daa-bee9-dd449a3e724f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45368 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43240 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4538 "Built successfully") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47877 "Found 1 new test failure: http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195305 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57443 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152125 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46677 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125864 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55951 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->