### PR TITLE
[JSC] Detect CPU core configurations more accurately

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -27,8 +27,11 @@
 #include "CPU.h"
 
 #if (CPU(X86) || CPU(X86_64) || CPU(ARM64)) && OS(DARWIN)
+#include <array>
 #include <mutex>
+#include <optional>
 #include <sys/sysctl.h>
+#include <wtf/text/StringView.h>
 #endif
 
 #if ENABLE(ASSEMBLER)
@@ -106,7 +109,7 @@ int32_t hwPhysicalCPUMax()
 #endif // #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 
 #if CPU(ARM64) && OS(DARWIN)
-static int32_t hwPerfLevelPhysicalCPUMax(const char* name)
+static int32_t sysctlInt32(const char* name)
 {
     int32_t val = 0;
     size_t valSize = sizeof(val);
@@ -116,22 +119,75 @@ static int32_t hwPerfLevelPhysicalCPUMax(const char* name)
     return val;
 }
 
-// The highest performance cores.
-int32_t hwNumberOfP0Cores()
+struct PerfLevelSysctls {
+    const ASCIILiteral physicalCPUMax;
+    const ASCIILiteral name;
+};
+
+static constexpr std::array<PerfLevelSysctls, numberOfCoreCategories> perfLevelSysctls = { {
+    { "hw.perflevel0.physicalcpu_max"_s, "hw.perflevel0.name"_s },
+    { "hw.perflevel1.physicalcpu_max"_s, "hw.perflevel1.name"_s },
+    { "hw.perflevel2.physicalcpu_max"_s, "hw.perflevel2.name"_s },
+} };
+
+static std::optional<CoreCategory> categoryFromPerfLevelName(unsigned level)
 {
-    if (int32_t numberOfCoresOverride = Options::numberOfP0CoresOverrides())
-        return numberOfCoresOverride;
-    return hwPerfLevelPhysicalCPUMax("hw.perflevel0.physicalcpu_max");
+    std::array<char, 32> buffer { };
+    size_t bufferSize = buffer.size();
+    if (sysctlbyname(perfLevelSysctls[level].name, buffer.data(), &bufferSize, nullptr, 0) < 0)
+        return std::nullopt;
+    auto name = StringView::fromLatin1(buffer.data());
+    if (name == "Super"_s)
+        return CoreCategory::Super;
+    if (name == "Performance"_s)
+        return CoreCategory::Performance;
+    if (name == "Efficiency"_s)
+        return CoreCategory::Efficiency;
+    // A chip whose cores are all alike reports one level named "Standard". Nothing slower exists to
+    // contrast those cores with, so they are the performance cores.
+    if (name == "Standard"_s)
+        return CoreCategory::Performance;
+    return std::nullopt;
 }
 
-int32_t hwNumberOfP1Cores()
+// Fallback for a level whose name is missing or unfamiliar. The slowest level always holds the
+// efficiency cores, and only a chip reporting all three levels has Super cores.
+static CoreCategory categoryFromPerfLevelIndex(unsigned level, unsigned lastLevel)
 {
-    return hwPerfLevelPhysicalCPUMax("hw.perflevel1.physicalcpu_max");
+    if (lastLevel && level == lastLevel)
+        return CoreCategory::Efficiency;
+    if (lastLevel > 1 && !level)
+        return CoreCategory::Super;
+    return CoreCategory::Performance;
 }
 
-int32_t hwNumberOfP2Cores()
+int32_t hwNumberOfCores(CoreCategory category)
 {
-    return hwPerfLevelPhysicalCPUMax("hw.perflevel2.physicalcpu_max");
+    static std::once_flag onceFlag;
+    static std::array<int32_t, numberOfCoreCategories> coresPerCategory { };
+    std::call_once(onceFlag, [] {
+        constexpr unsigned maxLevelCount = perfLevelSysctls.size();
+        std::array<int32_t, maxLevelCount> coresPerLevel { };
+        std::array<std::optional<CoreCategory>, maxLevelCount> categoryPerLevel { };
+        unsigned lastLevel = 0;
+        // A level this chip does not have simply fails to answer, so ask about every level rather
+        // than assuming the ones that answer are contiguous.
+        for (unsigned level = 0; level < maxLevelCount; ++level) {
+            int32_t cores = sysctlInt32(perfLevelSysctls[level].physicalCPUMax);
+            if (cores <= 0)
+                continue;
+            coresPerLevel[level] = cores;
+            categoryPerLevel[level] = categoryFromPerfLevelName(level);
+            lastLevel = level;
+        }
+        for (unsigned level = 0; level < maxLevelCount; ++level) {
+            if (coresPerLevel[level] <= 0)
+                continue;
+            CoreCategory levelCategory = categoryPerLevel[level].value_or(categoryFromPerfLevelIndex(level, lastLevel));
+            coresPerCategory[static_cast<unsigned>(levelCategory)] += coresPerLevel[level];
+        }
+    });
+    return coresPerCategory[static_cast<unsigned>(category)];
 }
 #endif // #if CPU(ARM64) && OS(DARWIN)
 

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -159,9 +159,17 @@ ALWAYS_INLINE int32_t hwPhysicalCPUMax() { return kernTCSMAwareNumberOfProcessor
 #endif
 
 #if CPU(ARM64) && OS(DARWIN)
-int32_t hwNumberOfP0Cores();
-int32_t hwNumberOfP1Cores();
-int32_t hwNumberOfP2Cores();
+// Cores are reported as performance levels ordered fastest first, but a level's index does not
+// identify the kind of core it holds: a chip with Super and Performance cores and a chip with
+// Performance and Efficiency cores both report two levels. A category a chip lacks reports zero.
+enum class CoreCategory : uint8_t {
+    Super,
+    Performance,
+    Efficiency,
+};
+static constexpr unsigned numberOfCoreCategories = 3;
+
+int32_t hwNumberOfCores(CoreCategory);
 #endif
 
 constexpr size_t prologueStackPointerDelta()

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -563,6 +563,15 @@ static void scaleJITPolicy()
 static void disableAllSignalHandlerBasedOptions();
 #endif
 
+#if OS(DARWIN) && CPU(ARM64)
+static unsigned numberOfSuperAndPerformanceCores()
+{
+    if (int32_t coresOverride = Options::numberOfSuperAndPerformanceCoresOverride(); coresOverride > 0)
+        return coresOverride;
+    return hwNumberOfCores(CoreCategory::Super) + hwNumberOfCores(CoreCategory::Performance);
+}
+#endif
+
 static void overrideDefaults()
 {
 #if OS(DARWIN)
@@ -587,24 +596,24 @@ static void overrideDefaults()
 #if OS(DARWIN) && CPU(ARM64)
     {
         // Example topologies.
-        //                P0       P1       GC
-        // M1       :      4        4        6
-        // M1 Pro   :      6        2        6
-        // M1 Max   :      8        2        7
-        // M1 Ultra :     16        4        7
-        // M4       :    3-4      4-6      6-7
-        // M4 Pro   :   8-10        4        7
-        // M4 Max   :  10-12        4        7
-        // M5       :    3-4        6        7
-        // M5 Pro   :    5-6    10-12        7
-        // M5 Max   :      6       12        7
-        // A18      :      2        4        4
-        unsigned p0 = hwNumberOfP0Cores();
-        unsigned p1 = hwNumberOfP1Cores();
+        //           Super  Performance  Efficiency   GC
+        // M1            0            4           4    6
+        // M1 Pro        0            6           2    6
+        // M1 Max        0            8           2    7
+        // M1 Ultra      0           16           4    7
+        // M4            0          3-4         4-6  6-7
+        // M4 Pro        0         8-10           4    7
+        // M4 Max        0        10-12           4    7
+        // M5            0          3-4           6    7
+        // M5 Pro      5-6        10-12           0    7
+        // M5 Max        6           12           0    7
+        // A18           0            2           4    4
+        unsigned performanceCores = numberOfSuperAndPerformanceCores();
+        unsigned efficiencyCores = hwNumberOfCores(CoreCategory::Efficiency);
         unsigned gcMarkers = 0;
-        if (p0 < 3)
+        if (performanceCores < 3)
             gcMarkers = std::min<unsigned>(4, kernTCSMAwareNumberOfProcessorCores());
-        else if ((p0 + p1) < 9)
+        else if ((performanceCores + efficiencyCores) < 9)
             gcMarkers = std::min<unsigned>(6, kernTCSMAwareNumberOfProcessorCores());
         else
             gcMarkers = std::min<unsigned>(7, kernTCSMAwareNumberOfProcessorCores());
@@ -624,14 +633,14 @@ static void overrideDefaults()
 #endif
 
 #if PLATFORM(MAC) && CPU(ARM64)
-    // JIT compilation can contribute to thermal load on low P-core count Apple silicon Macs.
-    constexpr int32_t maxP0CoresForThresholdScaling = 2;
-    if (hwNumberOfP0Cores() <= maxP0CoresForThresholdScaling) {
-        Options::thresholdForOptimizeAfterWarmUp() *= Options::dfgThresholdScaleForLowP0Cores();
-        Options::thresholdForOptimizeAfterLongWarmUp() *= Options::dfgThresholdScaleForLowP0Cores();
-        Options::thresholdForOptimizeSoon() *= Options::dfgThresholdScaleForLowP0Cores();
-        Options::thresholdForFTLOptimizeAfterWarmUp() *= Options::ftlThresholdScaleForLowP0Cores();
-        Options::thresholdForFTLOptimizeSoon() *= Options::ftlThresholdScaleForLowP0Cores();
+    // JIT compilation can contribute to thermal load on Apple silicon Macs with few fast cores.
+    constexpr unsigned maxPerformanceCoresForThresholdScaling = 2;
+    if (numberOfSuperAndPerformanceCores() <= maxPerformanceCoresForThresholdScaling) {
+        Options::thresholdForOptimizeAfterWarmUp() *= Options::dfgThresholdScaleForFewPerformanceCores();
+        Options::thresholdForOptimizeAfterLongWarmUp() *= Options::dfgThresholdScaleForFewPerformanceCores();
+        Options::thresholdForOptimizeSoon() *= Options::dfgThresholdScaleForFewPerformanceCores();
+        Options::thresholdForFTLOptimizeAfterWarmUp() *= Options::ftlThresholdScaleForFewPerformanceCores();
+        Options::thresholdForFTLOptimizeSoon() *= Options::ftlThresholdScaleForFewPerformanceCores();
     }
 #endif
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -358,9 +358,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, wasmInliningSmallFunctionThreshold, 50, Normal, "Wasm size threshold for small wasm functions"_s) \
     \
     v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal)."_s) \
-    v(Int32, numberOfP0CoresOverrides, 0, Normal, "If non-zero, overrides the number of P0 (highest-performance) cores reported by hwNumberOfP0Cores(); 0 means use the value reported by the hardware."_s) \
-    v(Double, dfgThresholdScaleForLowP0Cores, 2.0, Normal, "On low P0-core-count Apple silicon Macs, scale the DFG tier-up thresholds (thresholdForOptimize*) by this factor."_s) \
-    v(Double, ftlThresholdScaleForLowP0Cores, 1.5, Normal, "On low P0-core-count Apple silicon Macs, scale the FTL tier-up thresholds (thresholdForFTLOptimize*) by this factor."_s) \
+    v(Int32, numberOfSuperAndPerformanceCoresOverride, 0, Normal, "If non-zero, overrides the number of Super and Performance (i.e. non-Efficiency) cores reported by the hardware; 0 means use the value reported by the hardware."_s) \
+    v(Double, dfgThresholdScaleForFewPerformanceCores, 2.0, Normal, "On Apple silicon Macs with few Super and Performance cores, scale the DFG tier-up thresholds (thresholdForOptimize*) by this factor."_s) \
+    v(Double, ftlThresholdScaleForFewPerformanceCores, 1.5, Normal, "On Apple silicon Macs with few Super and Performance cores, scale the FTL tier-up thresholds (thresholdForFTLOptimize*) by this factor."_s) \
     v(Bool, forceEagerCompilation, false, Normal, nullptr) \
     v(Int32, thresholdForJITAfterWarmUp, 500, Normal, nullptr) \
     v(Int32, thresholdForJITSoon, 100, Normal, nullptr) \


### PR DESCRIPTION
#### d9d2fbd881a5ee2ca3a91e3e3c49709280c4873e
<pre>
[JSC] Detect CPU core configurations more accurately
<a href="https://bugs.webkit.org/show_bug.cgi?id=322619">https://bugs.webkit.org/show_bug.cgi?id=322619</a>
<a href="https://rdar.apple.com/185922475">rdar://185922475</a>

Reviewed by Keith Miller.

After M5, we introduced Super Cores, and we may have three categories,
Super, Performance, and Efficiency. And in M6, we started splitting
Performance into Super and Performance, so it can have these three
categories on one device. But the current code is only detecting P0 and
P1, and they can be mapped differently based on devices. Sometimes P0 is
Super and P1 is Performance. Sometimes, P0 is Performance and P1 is
Efficiency. So just checking P0 and P1 are wrong metrics.

This patch introduces CoreCategory and collecting each core number
accurately.

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::sysctlInt32):
(JSC::categoryFromPerfLevelName):
(JSC::categoryFromPerfLevelIndex):
(JSC::hwNumberOfCores):
(JSC::hwPerfLevelPhysicalCPUMax): Deleted.
(JSC::hwNumberOfP0Cores): Deleted.
(JSC::hwNumberOfP1Cores): Deleted.
(JSC::hwNumberOfP2Cores): Deleted.
* Source/JavaScriptCore/assembler/CPU.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::numberOfSuperAndPerformanceCores):
(JSC::overrideDefaults):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/319928@main">https://commits.webkit.org/319928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06aa69b06668a8a915e76efb49e5af4de906b72d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10c407da-539e-4810-96a4-acb3f31be0b8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142972 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/379f98c9-090b-40f3-bf85-c07e9d346ead) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123399 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43627 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5369 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12188 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43248 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44423 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195312 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56745 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57450 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152134 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46693 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129720 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125871 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55958 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18259 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->