### PR TITLE
[GFC][Integration] Grid content does not contribute to the scrollable overflow area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents-expected.txt
@@ -1,0 +1,8 @@
+
+PASS A grid item wider than its column contributes to the inline scrollable overflow
+PASS A grid item taller than its row contributes to the block scrollable overflow
+PASS A descendant of a grid item contributes to the inline scrollable overflow
+PASS A relatively positioned grid item contributes its offset position
+PASS An absolutely positioned box whose containing block is the grid container contributes to the scrollable overflow
+PASS A fixed positioned box does not contribute to the scrollable overflow
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<title>CSS Overflow: Scrollable overflow from the contents of a grid container</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#grid-model">
+<meta name="assert" content="A grid container whose own overflow is visible propagates the scrollable overflow of its grid items, of their descendants, and of the out-of-flow boxes it is the containing block for, to an ancestor scroller. Fixed positioned boxes do not scroll with the content and so do not contribute.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  .scroller {
+    overflow: scroll;
+    width: 120px;
+    height: 60px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 100px;
+  }
+</style>
+
+<div class="scroller" id="wideItem">
+  <div class="grid">
+    <div style="width: 400px; height: 20px"></div>
+  </div>
+</div>
+
+<div class="scroller" id="tallItem" style="width: 200px; height: 40px">
+  <div class="grid" style="grid-template-rows: 30px">
+    <div style="height: 300px"></div>
+  </div>
+</div>
+
+<div class="scroller" id="wideDescendant">
+  <div class="grid">
+    <div style="height: 20px">
+      <div style="width: 400px; height: 15px"></div>
+    </div>
+  </div>
+</div>
+
+<div class="scroller" id="relativePositionedItem">
+  <div class="grid">
+    <div style="position: relative; left: 200px; width: 50px; height: 20px"></div>
+  </div>
+</div>
+
+<div class="scroller" id="absolutePositionedDescendant">
+  <div class="grid" style="position: relative">
+    <div style="height: 20px">
+      <div style="position: absolute; left: 300px; top: 100px; width: 40px; height: 40px"></div>
+    </div>
+  </div>
+</div>
+
+<div class="scroller" id="fixedPositionedDescendant">
+  <div class="grid" style="position: relative">
+    <div style="height: 20px">
+      <div style="position: fixed; left: 300px; top: 400px; width: 40px; height: 40px"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+test(() => {
+  assert_equals(wideItem.scrollWidth, 400);
+}, "A grid item wider than its column contributes to the inline scrollable overflow");
+
+test(() => {
+  assert_equals(tallItem.scrollHeight, 300);
+}, "A grid item taller than its row contributes to the block scrollable overflow");
+
+test(() => {
+  assert_equals(wideDescendant.scrollWidth, 400);
+}, "A descendant of a grid item contributes to the inline scrollable overflow");
+
+test(() => {
+  assert_equals(relativePositionedItem.scrollWidth, 250);
+}, "A relatively positioned grid item contributes its offset position");
+
+test(() => {
+  assert_equals(absolutePositionedDescendant.scrollWidth, 340);
+}, "An absolutely positioned box whose containing block is the grid container contributes to the scrollable overflow");
+
+test(() => {
+  // Compared against clientWidth because the scroller's client width depends on the
+  // user agent's scrollbar width.
+  assert_equals(fixedPositionedDescendant.scrollWidth, fixedPositionedDescendant.clientWidth);
+}, "A fixed positioned box does not contribute to the scrollable overflow");
+</script>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -244,22 +244,50 @@ void GridLayout::updateOverflow(RenderGrid& renderGrid)
     auto& gridBoxGeometry = layoutState->geometryForBox(gridBox());
     auto contentBoxOffset = LayoutSize { gridBoxGeometry.contentBoxLeft(), gridBoxGeometry.contentBoxTop() };
 
-    auto gridItemsOverflowRect = LayoutRect { };
+    // https://drafts.csswg.org/css-overflow-3/#scrollable
+    auto gridItemsLayoutOverflowRect = LayoutRect { };
+    auto gridItemsVisualOverflowRect = LayoutRect { };
     for (CheckedRef layoutBox : formattingContextBoxes(gridBox())) {
         LayoutRect gridItemBorderBoxRect = Layout::BoxGeometry::borderBoxRect(layoutState->geometryForBox(layoutBox));
         gridItemBorderBoxRect.move(contentBoxOffset);
-        gridItemsOverflowRect.unite(gridItemBorderBoxRect);
+        gridItemsVisualOverflowRect.unite(gridItemBorderBoxRect);
 
         CheckedRef gridItemRenderer = downcast<RenderBox>(*layoutBox->rendererForIntegration());
+
+        // A grid item's content is laid out outside of this formatting context, so the overflow that
+        // its own subtree generates is only available from the renderer. The returned rect already
+        // includes the grid item's border box.
+        auto gridItemLayoutOverflowRect = gridItemRenderer->layoutOverflowRectForPropagation(renderGrid.writingMode());
+        gridItemLayoutOverflowRect.move(gridItemRenderer->locationOffset());
+        gridItemsLayoutOverflowRect.unite(gridItemLayoutOverflowRect);
+
         if (gridItemRenderer->hasVisualOverflow()) {
             auto gridItemVisualOverflowRect = gridItemRenderer->visualOverflowRectForPropagation(renderGrid.writingMode());
             gridItemVisualOverflowRect.move(gridItemRenderer->locationOffset());
-            gridItemsOverflowRect.unite(gridItemVisualOverflowRect);
+            gridItemsVisualOverflowRect.unite(gridItemVisualOverflowRect);
         }
     }
 
-    if (!renderGrid.borderBoxRect().contains(gridItemsOverflowRect))
-        renderGrid.addVisualOverflow(gridItemsOverflowRect);
+    renderGrid.addLayoutOverflow(gridItemsLayoutOverflowRect);
+
+    // Out-of-flow boxes whose containing block is the grid container are laid out by
+    // layoutOutOfFlowBoxes, also outside of this formatting context.
+    auto outOfFlowBoxesLayoutOverflowRect = LayoutRect { };
+    if (auto* outOfFlowDescendants = renderGrid.outOfFlowBoxes()) {
+        for (CheckedRef outOfFlowBox : *outOfFlowDescendants) {
+            // Fixed positioned boxes do not scroll with the content, so they never contribute to the
+            // scrollable overflow area.
+            if (outOfFlowBox->isFixedPositioned())
+                continue;
+            auto outOfFlowBoxLayoutOverflowRect = outOfFlowBox->layoutOverflowRectForPropagation(renderGrid.writingMode());
+            outOfFlowBoxLayoutOverflowRect.move(outOfFlowBox->locationOffset());
+            outOfFlowBoxesLayoutOverflowRect.unite(outOfFlowBoxLayoutOverflowRect);
+        }
+    }
+    renderGrid.addLayoutOverflow(outOfFlowBoxesLayoutOverflowRect);
+
+    if (!renderGrid.borderBoxRect().contains(gridItemsVisualOverflowRect))
+        renderGrid.addVisualOverflow(gridItemsVisualOverflowRect);
 }
 
 void GridLayout::layoutOutOfFlowBoxes(const Layout::UsedTrackSizes& usedTrackSizes)


### PR DESCRIPTION
#### ccdac12e77a9fb9a990d03335aadbe84efcc76c3
<pre>
[GFC][Integration] Grid content does not contribute to the scrollable overflow area
<a href="https://bugs.webkit.org/show_bug.cgi?id=322620">https://bugs.webkit.org/show_bug.cgi?id=322620</a>
<a href="https://rdar.apple.com/problem/185923265">rdar://problem/185923265</a>

Reviewed by Alan Baradlay.

RenderGrid::layoutGrid() returns as soon as layoutUsingGridFormattingContext() succeeds,
which skips the legacy computeInFlowOverflow() and addOverflowFromOutOfFlowBoxes() calls.
GridLayout::updateOverflow() only added visual overflow, so nothing a grid container
contains ever extended its scrollable overflow area. An ancestor scroller would report a
scrollWidth/scrollHeight that ignored the grid&apos;s contents, leaving that content
unreachable.

Accumulate the scrollable overflow area alongside the visual overflow rect and hand it to
addLayoutOverflow(). The grid items and the out-of-flow boxes which the grid container is
the containing block for are collected separately, since they are two distinct sources.

Both use layoutOverflowRectForPropagation(), which already starts from the box&apos;s border
box and accounts for layout containment, the single-axis overflow: clip cases, a grid
item&apos;s margin-end contribution, and the paint geometry of relatively positioned and
transformed boxes. A grid item&apos;s own subtree is laid out outside of the grid formatting
context, so the overflow it generates is only available from the renderer. Fixed
positioned boxes are skipped because they do not scroll with the content.

Test: imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-from-grid-container-contents.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::GridLayout::updateOverflow): Compute the scrollable overflow
area from the grid items and from the out-of-flow boxes the grid container contains, in
addition to the visual overflow rect.

Canonical link: <a href="https://commits.webkit.org/319929@main">https://commits.webkit.org/319929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf92f7296d7fdd7d2b29f10e8275cba74839e5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147483 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff125b36-e776-4be2-b6fc-c2b3f14a982a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142983 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9146948d-48c0-41a9-87fd-04aaba87ab0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123410 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43656 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43276 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4586 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195353 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40861 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57491 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39896 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152169 "Found 1 new API test failure: TestWebKit.WebKit.GeolocationTransitionToLowAccuracy (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46724 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129761 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55999 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18287 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->