### PR TITLE
[Grid Lanes][Cleanup] Grid axis track count member variable is redundant.

### DIFF
--- a/Source/WebCore/rendering/GridLanesLayout.cpp
+++ b/Source/WebCore/rendering/GridLanesLayout.cpp
@@ -35,8 +35,7 @@
 namespace WebCore {
 
 GridLanesLayout::GridLanesLayout(RenderGrid& renderGrid, unsigned gridAxisTracksCount, Style::GridTrackSizingDirection stackingAxisDirection)
-    : m_gridAxisTracksCount(gridAxisTracksCount)
-    , m_runningPositions(gridAxisTracksCount)
+    : m_runningPositions(gridAxisTracksCount)
     , m_renderGrid(renderGrid)
     , m_stackingAxisGridGap(renderGrid.gridGap(stackingAxisDirection))
     , m_stackingAxisDirection(stackingAxisDirection)
@@ -54,7 +53,7 @@ void GridLanesLayout::performGridLanesPlacement(const GridTrackSizingAlgorithm& 
 
 void GridLanesLayout::placeGridLanesItems(const GridTrackSizingAlgorithm& algorithm, ResolvedFitTolerance fitTolerance, Phase layoutPhase)
 {
-    if (!m_gridAxisTracksCount)
+    if (!gridAxisTracksCount())
         return;
 
     auto& grid = m_renderGrid->currentGrid();
@@ -140,7 +139,7 @@ void GridLanesLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm
     setItemContainingBlockToGridArea(algorithm, gridItem);
     gridItem.layoutIfNeeded();
     updateRunningPositions(gridItem, area);
-    m_autoFlowNextCursor = gridAxisSpanFromArea(area).endLine() % m_gridAxisTracksCount;
+    m_autoFlowNextCursor = gridAxisSpanFromArea(area).endLine() % gridAxisTracksCount();
 }
 
 LayoutUnit GridLanesLayout::stackingAxisMarginBoxForItem(const RenderBox& gridItem)
@@ -196,8 +195,8 @@ LayoutUnit GridLanesLayout::maxRunningPositionForSpan(unsigned startLine, unsign
 
 GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item, ResolvedFitTolerance fitTolerance)
 {
-    auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), m_gridAxisTracksCount);
-    auto gridAxisLines = m_gridAxisTracksCount + 1;
+    auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), gridAxisTracksCount());
+    auto gridAxisLines = gridAxisTracksCount() + 1;
 
     if (WTF::holdsAlternative<CSS::Keyword::Infinite>(fitTolerance)) {
         // Infinite tolerance: place items strictly in order without considering track lengths
@@ -205,7 +204,7 @@ GridArea GridLanesLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& ite
         auto startingLine = m_autoFlowNextCursor;
 
         // If the item doesn't fit at the cursor position, wrap to the beginning
-        if (startingLine + itemSpanLength > m_gridAxisTracksCount)
+        if (startingLine + itemSpanLength > gridAxisTracksCount())
             startingLine = 0;
 
         auto gridAxisPosition = GridSpan::translatedDefiniteGridSpan(startingLine, startingLine + itemSpanLength);

--- a/Source/WebCore/rendering/GridLanesLayout.h
+++ b/Source/WebCore/rendering/GridLanesLayout.h
@@ -71,11 +71,11 @@ private:
     LayoutUnit maxRunningPositionForSpan(unsigned startLine, unsigned spanLength) const;
     inline Style::GridTrackSizingDirection NODELETE gridAxisDirection() const;
 
+    unsigned gridAxisTracksCount() const { return static_cast<unsigned>(m_runningPositions.size()); }
+
     bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAxisDirection) const;
     GridArea NODELETE gridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
-
-    const unsigned m_gridAxisTracksCount;
 
     Vector<LayoutUnit> m_runningPositions;
     HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;


### PR DESCRIPTION
#### 53d02d6d6e07ddcd52cccc5b2fb34033db7f68a2
<pre>
[Grid Lanes][Cleanup] Grid axis track count member variable is redundant.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322621">https://bugs.webkit.org/show_bug.cgi?id=322621</a>
<a href="https://rdar.apple.com/problem/185923771">rdar://problem/185923771</a>

Reviewed by Brent Fulgham.

We currently have a member variable to keep track of the number of
tracks in the grid axis as well as a list of the running positions in
the grid. However, there is exactly one running position per track in
the grid axis so the former is redundant since it is captured in the
size of the Vector for the running positions. So we can just drop the
member variable dedicated for the the grid axis tracks count and derive
it from the size of the Vector.

Canonical link: <a href="https://commits.webkit.org/319920@main">https://commits.webkit.org/319920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca90a77886b707445b11d48e9251856d3a21907

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d33d51cb-3d7d-40f6-8a5e-4a9ad416178f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0db11326-bdac-4b83-aee2-12d9e8de52d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123381 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c736bb5d-8f39-42e3-b4ac-72a0f1157dee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45375 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43251 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195314 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56747 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152437 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40853 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57452 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152132 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46689 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129722 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125873 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55960 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->