### PR TITLE
[CMake] Build directory should survive an Xcode/SDK update or location move

### DIFF
--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -8,8 +8,9 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
 
     # Preset values are not replayed on auto-reconfigure; if CMake's "compiler
     # changed" path wipes the cache, these silently revert. Stamp them outside
-    # the cache and refuse to proceed if any go missing.
-    set(WEBKIT_IDENTITY_VARS CMAKE_BUILD_TYPE PORT DEVELOPER_MODE ENABLE_SANITIZERS WEBKIT_SDK_NAME CMAKE_OSX_SYSROOT)
+    # the cache and refuse to proceed if any go missing. Only values CMake
+    # cannot re-derive belong here; the SDK is re-resolved every configure.
+    set(WEBKIT_IDENTITY_VARS CMAKE_BUILD_TYPE PORT DEVELOPER_MODE ENABLE_SANITIZERS WEBKIT_SDK_NAME USE_APPLE_INTERNAL_SDK)
     set(_config_stamp "${CMAKE_BINARY_DIR}/.webkit-config-stamp")
     if (EXISTS "${_config_stamp}")
         file(STRINGS "${_config_stamp}" _stamp_lines)
@@ -17,6 +18,9 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
             if (_line MATCHES "^([^=]+)=(.*)$")
                 set(_var "${CMAKE_MATCH_1}")
                 set(_prev "${CMAKE_MATCH_2}")
+                if (NOT _var IN_LIST WEBKIT_IDENTITY_VARS)
+                    continue ()
+                endif ()
                 if (NOT DEFINED CACHE{${_var}})
                     message(FATAL_ERROR
                         "${_var} is not in the CMake cache, but this build directory was "

--- a/Source/cmake/WebKitXcodeSDK.cmake
+++ b/Source/cmake/WebKitXcodeSDK.cmake
@@ -3,8 +3,11 @@
 # Always pass --sdk to xcrun explicitly -- otherwise, toolchain and SDK
 # are not guaranteed to match.
 
-# Sets CMAKE_OSX_SYSROOT, WEBKIT_SDK_NAME, and WEBKIT_SDK_VERSION in the caller's scope.
+# Sets CMAKE_OSX_SYSROOT and WEBKIT_SDK_VERSION in the caller's scope, and
+# caches WEBKIT_SDK_NAME. The SDK it was asked for is remembered so that the
+# path can be re-resolved on later configures.
 function(WEBKIT_RESOLVE_SDK)
+    set(WEBKIT_SDK_REQUEST "${ARGN}" CACHE INTERNAL "")
     foreach (_sdk IN LISTS ARGN)
         execute_process(COMMAND xcrun --sdk ${_sdk} --show-sdk-path
             OUTPUT_VARIABLE _sdk_path
@@ -19,8 +22,9 @@ function(WEBKIT_RESOLVE_SDK)
 
             message(STATUS "Xcode SDK: ${_sdk_canonical_name} at ${_sdk_path}")
             set(WEBKIT_SDK_VERSION "${_sdk_version}" PARENT_SCOPE)
-            set(WEBKIT_SDK_NAME "${_platform_name}" PARENT_SCOPE)
+            set(WEBKIT_SDK_NAME "${_platform_name}" CACHE INTERNAL "")
             set(CMAKE_OSX_SYSROOT "${_sdk_path}" CACHE PATH "" FORCE)
+            set(WEBKIT_SDK_RESOLVED "${_sdk_path}" CACHE INTERNAL "")
             if (_sdk_path MATCHES "\\.[Ii]nternal.sdk$")
                 set(USE_APPLE_INTERNAL_SDK ON CACHE BOOL "" FORCE)
             else ()
@@ -91,13 +95,24 @@ function(WEBKIT_XCRUN OUTPUT_VAR)
 endfunction()
 
 function(WEBKIT_RESOLVE_TOOL OUTPUT_VAR _tool)
+    # A tool the developer pointed outside the Xcode is not ours to replace.
     if (DEFINED ${OUTPUT_VAR} AND EXISTS "${${OUTPUT_VAR}}")
-        return()
+        set(_stale OFF)
+        if (WEBKIT_OLD_XCODE)
+            string(FIND "${${OUTPUT_VAR}}" "${WEBKIT_OLD_XCODE}/" _found_at)
+            if (_found_at EQUAL 0)
+                set(_stale ON)
+            endif ()
+        endif ()
+        if (NOT _stale)
+            return()
+        endif ()
     endif ()
     WEBKIT_XCRUN(_path -f ${_tool})
     if (NOT EXISTS "${_path}")
         message(SEND_ERROR "Cannot find ${_tool} in the active SDK and "
             "toolchain (${CMAKE_OSX_SYSROOT})")
+        set(WEBKIT_TOOLCHAIN_INCOMPLETE ON PARENT_SCOPE)
     else ()
         set(${OUTPUT_VAR} "${_path}" CACHE STRING "" FORCE)
     endif ()
@@ -108,8 +123,15 @@ endfunction()
 # tools from the SDK.
 # ----------------------------------------------------------------------------
 
-if (CMAKE_OSX_SYSROOT)
-    WEBKIT_RESOLVE_SDK(${CMAKE_OSX_SYSROOT})
+# CMAKE_OSX_SYSROOT is both the request ("macosx.internal;macosx") and, once
+# resolved, the answer, which resolves to itself forever. Recover the request.
+set(_sdk_request "${CMAKE_OSX_SYSROOT}")
+if (_sdk_request STREQUAL "$CACHE{WEBKIT_SDK_RESOLVED}")
+    set(_sdk_request "$CACHE{WEBKIT_SDK_REQUEST}")
+endif ()
+
+if (_sdk_request)
+    WEBKIT_RESOLVE_SDK(${_sdk_request})
 elseif (PORT STREQUAL "Mac" OR PORT STREQUAL "Cocoa" OR PORT STREQUAL "JSCOnly" OR NOT PORT)
     WEBKIT_RESOLVE_SDK(macosx.internal macosx)
 elseif (PORT STREQUAL "IOS" AND CMAKE_IOS_SIMULATOR)
@@ -183,6 +205,19 @@ endif ()
 # use the selected SDK and toolchain.
 set(ENV{SDKROOT} ${CMAKE_OSX_SYSROOT})
 
+# An Xcode can move on every update while the old paths stay resolvable, so an
+# EXISTS check cannot tell a live pin from a stale one. Compare Xcodes instead,
+# taking the previous one from the compiler we pinned last time.
+WEBKIT_XCRUN(_clang -f clang)
+if (NOT EXISTS "${_clang}")
+    message(FATAL_ERROR "xcrun could not find clang in ${CMAKE_OSX_SYSROOT}")
+endif ()
+string(REGEX REPLACE "/Contents/Developer/.*$" "/Contents/Developer" _new_xcode "${_clang}")
+string(REGEX REPLACE "/Contents/Developer/.*$" "/Contents/Developer" _old_xcode "$CACHE{CMAKE_C_COMPILER}")
+if (_old_xcode MATCHES "/Contents/Developer$" AND NOT _old_xcode STREQUAL _new_xcode)
+    set(WEBKIT_OLD_XCODE "${_old_xcode}")
+endif ()
+
 WEBKIT_RESOLVE_TOOL(CMAKE_C_COMPILER "clang")
 WEBKIT_RESOLVE_TOOL(CMAKE_ASM_COMPILER "clang")
 WEBKIT_RESOLVE_TOOL(CMAKE_CXX_COMPILER "clang++")
@@ -195,3 +230,23 @@ WEBKIT_RESOLVE_TOOL(CMAKE_LINKER "ld")
 # language.
 WEBKIT_RESOLVE_TOOL(GPERF_EXECUTABLE "gperf")
 WEBKIT_RESOLVE_TOOL(Mig_EXECUTABLE "mig")
+
+# Acted on only once everything above resolved: build.ninja lists
+# CMakeFiles/${CMAKE_VERSION} among its regeneration inputs, so removing it
+# without reaching generation would leave Ninja unable to recover.
+#
+# CMake wipes the whole cache -- preset values included -- when it notices
+# CMAKE_C_COMPILER moving, so drop its detection results and let it re-detect.
+# CMake never re-validates a populated find_* entry either, so the framework,
+# .tbd and binutil paths into the old Xcode have to go by hand.
+if (WEBKIT_OLD_XCODE AND NOT WEBKIT_TOOLCHAIN_INCOMPLETE)
+    message(STATUS "Xcode moved; dropping paths under ${WEBKIT_OLD_XCODE}")
+    file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/CMakeFiles/${CMAKE_VERSION}")
+    get_cmake_property(_cache_vars CACHE_VARIABLES)
+    foreach (_cache_var IN LISTS _cache_vars)
+        string(FIND "$CACHE{${_cache_var}}" "${WEBKIT_OLD_XCODE}/" _found_at)
+        if (_found_at EQUAL 0)
+            unset(${_cache_var} CACHE)
+        endif ()
+    endforeach ()
+endif ()


### PR DESCRIPTION
#### aa7b83df2895e5fd65275bea2c00c386a6c794ea
<pre>
[CMake] Build directory should survive an Xcode/SDK update or location move
<a href="https://bugs.webkit.org/show_bug.cgi?id=322657">https://bugs.webkit.org/show_bug.cgi?id=322657</a>
<a href="https://rdar.apple.com/185927877">rdar://185927877</a>

Reviewed by NOBODY (OOPS!).

Updating Xcode made every CMake build directory unusable:

    CMAKE_OSX_SYSROOT changed from &apos;&lt;old&gt;&apos; to &apos;&lt;new&gt;&apos;. Delete the build
    directory and reconfigure.

An Xcode can move to a new path on every update, so pinning its path as a
build directory identity turned a routine update into a mandatory rm -rf.
The SDK does not need pinning -- it is re-derived on every configure.
USE_APPLE_INTERNAL_SDK does, since PORT is Cocoa for both Mac and iOS and
WEBKIT_SDK_NAME is macosx for both the public and internal SDKs.

Recovering in place takes three things:

Re-resolve the SDK. CMAKE_OSX_SYSROOT is both the request
(&quot;macosx.internal;macosx&quot;) and, once resolved, the answer, and the resolved
path resolves to itself forever. Remember the request instead.

Re-resolve the toolchain. Old Xcode paths stay resolvable, so an EXISTS
check cannot tell a live pin from a stale one, and the build would quietly
use the previous Xcode&apos;s clang against the new SDK.

Drop what is stale. CMake never re-validates a populated find_* entry, so
the framework, .tbd and binutil paths would keep pointing into the old Xcode
-- compiling against new headers while linking old stubs. Unset those, and
remove CMake&apos;s recorded compiler detection so it re-detects rather than
deleting the whole cache and taking the preset&apos;s values with it
(see <a href="https://commits.webkit.org/313411@main">313411@main</a>).

Ninja still rebuilds, since the compiler and -isysroot paths change. The
point is that reconfiguring works and the result is not silently mixed.

* Source/cmake/WebKitCommon.cmake:
* Source/cmake/WebKitXcodeSDK.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa7b83df2895e5fd65275bea2c00c386a6c794ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147458 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/742c86e8-a483-4675-8edf-ead89b7fa43f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142967 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99287 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2040fbfd-44b0-40eb-8482-902559843410) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123394 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e4d0b73-27ea-46fa-bdde-e28c6dbf530b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45401 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43638 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5364 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12202 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43262 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4561 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44439 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56761 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152451 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152147 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46698 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126070 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55974 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55412 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->