### PR TITLE
MediaSource should remove itself as a Logger observer on destruction

### DIFF
--- a/LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash-expected.txt
+++ b/LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash.html
+++ b/LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.configureLoggingChannel("Media", true);
+
+const workerSource = `
+    for (let i = 0; i < 16; i++)
+        new MediaSource();
+    postMessage("done");
+`;
+const worker = new Worker(URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" })));
+worker.onmessage = () => {
+    worker.terminate();
+    setTimeout(() => {
+        document.createElement("video");
+        if (window.internals)
+            internals.configureLoggingChannel("Media", false);
+        document.body.textContent = "PASS if no crash.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 200);
+};
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -53,6 +53,14 @@ Vector<std::reference_wrapper<Logger::Observer>>& Logger::observers()
     return observers;
 }
 
+void Logger::Observer::assertIsNotRegistered() const
+{
+    Locker locker { observerLock() };
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!observers().containsIf([this](auto& observer) {
+        return &observer.get() == this;
+    }));
+}
+
 Vector<std::reference_wrapper<Logger::MessageHandlerObserver>>& Logger::messageHandlerObservers()
 {
     static NeverDestroyed<Vector<std::reference_wrapper<MessageHandlerObserver>>> observers;

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -138,9 +138,11 @@ public:
 
     class Observer {
     public:
-        virtual ~Observer() = default;
+        virtual ~Observer() { assertIsNotRegistered(); }
         // Can be called on any thread.
         virtual void didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) = 0;
+
+        WTF_EXPORT_PRIVATE void assertIsNotRegistered() const;
     };
 
     class MessageHandlerObserver {

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -224,6 +224,10 @@ MediaSource::~MediaSource()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+#if !RELEASE_LOG_DISABLED
+    m_logger->removeObserver(*this);
+#endif
+
     m_detachable = false;
 
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -155,6 +155,7 @@
 #include "LocalFrameView.h"
 #include "LocalizedStrings.h"
 #include "Location.h"
+#include "LogInitialization.h"
 #include "MallocStatistics.h"
 #include "MediaControlsHost.h"
 #include "MediaDevices.h"
@@ -7256,6 +7257,14 @@ void Internals::setConsoleMessageListener(RefPtr<StringCallback>&& listener)
 
     if (RefPtr page = contextDocument()->page())
         page->setConsoleMessageListenerForTesting(WTF::move(listener));
+}
+
+void Internals::configureLoggingChannel(const String& channelName, bool enabled)
+{
+    if (auto* channel = getLogChannel(channelName)) {
+        channel->state = enabled ? WTFLogChannelState::On : WTFLogChannelState::Off;
+        channel->level = enabled ? WTFLogLevel::Info : WTFLogLevel::Error;
+    }
 }
 
 void Internals::setResponseSizeWithPadding(FetchResponse& response, uint64_t size)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1181,6 +1181,7 @@ public:
     void updateQuotaBasedOnSpaceUsage();
 
     void setConsoleMessageListener(RefPtr<StringCallback>&&);
+    void configureLoggingChannel(const String& channelName, bool enabled);
 
     using HasRegistrationPromise = DOMPromiseDeferred<IDLBoolean>;
     void hasServiceWorkerRegistration(const String& clientURL, HasRegistrationPromise&&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1317,6 +1317,7 @@ enum ContentsFormat {
     undefined updateQuotaBasedOnSpaceUsage();
 
     undefined setConsoleMessageListener(StringCallback? callback);
+    undefined configureLoggingChannel(DOMString channelName, boolean enabled);
 
     readonly attribute boolean supportsAudioSession;
     AudioSessionCategory audioSessionCategory();


### PR DESCRIPTION
#### d3699b58389400a9357d99a530102b809da42d6e
<pre>
MediaSource should remove itself as a Logger observer on destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=318837">https://bugs.webkit.org/show_bug.cgi?id=318837</a>
<a href="https://rdar.apple.com/177356913">rdar://177356913</a>

Reviewed by Eric Carlson.

Logger stores raw references to observers in Logger::observers(), so the observer is responsible
for removing itself from Logger::observers() prior to destruction. Modified MediaSource&apos;s
destructor do call Logger::removeObserver, and modified Logger::Observer&apos;s destructor to
RELEASE_ASSERT that the observer has been removed.

Test: media/media-source/worker/media-source-worker-logger-observer-crash.html

* LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash-expected.txt: Added.
* LayoutTests/media/media-source/worker/media-source-worker-logger-observer-crash.html: Added.
* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::Observer::assertIsNotRegistered const):
* Source/WTF/wtf/Logger.h:
(WTF::Logger::Observer::~Observer):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::~MediaSource):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::configureLoggingChannel):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Originally-landed-as: 305413.1106@safari-7624.5-branch (ed0a2c844690). <a href="https://rdar.apple.com/185368565">rdar://185368565</a>
Canonical link: <a href="https://commits.webkit.org/319926@main">https://commits.webkit.org/319926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b42b83fb737b7a3d05511383a73fab8dcf66164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56835 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142986 "Found 1 new test failure: media/media-source/worker/media-source-worker-logger-observer-crash.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43646 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5383 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12212 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43272 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44447 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195336 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163237 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152460 "Found 1 new test failure: media/media-source/worker/media-source-worker-logger-observer-crash.html (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40860 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152156 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46716 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129744 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55982 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55353 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->