### PR TITLE
corner-shape: curve versus curve case doesn't have support

### DIFF
--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -25,13 +25,17 @@
 #include "config.h"
 #include "BezierUtilities.h"
 
+#include "DoublePoint.h"
 #include "FloatPoint.h"
 #include "FloatRect.h"
 #include "GeometryUtilities.h"
 #include "RectEdges.h"
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 #include <numbers>
+#include <optional>
 #include <utility>
 
 namespace WebCore {
@@ -41,11 +45,90 @@ namespace {
 // Parameters within this of an interval boundary are snapped to it
 constexpr double parameterEpsilon = 1e-7;
 constexpr double nearZeroEpsilon = 1e-12;
-struct BezierIntersection {
-    float positionOnCurve { 0 };
-    float positionOnLine { 0 };
-    FloatPoint point;
-};
+
+// Curve/curve tolerances: geometric ones are fractions of a device pixel, parameter ones unitless.
+// Two edges no further apart than this over a stretch are the same edge.
+constexpr double coincidenceDistanceTolerance = 0.01;
+// Below this the run is a tangency rather than a shared stretch.
+constexpr double coincidenceSpanMinimum = 0.05;
+constexpr unsigned maximumBisectionIterations = 24;
+// Candidates this close in both parameters are the same crossing.
+constexpr double crossingWeldTolerance = 1e-4;
+// So are candidates whose points land this close.
+constexpr double crossingWeldDistance = 0.05;
+// Cross product of the unit tangents below this counts as parallel, i.e. a tangency.
+constexpr double parallelTangentTolerance = 1e-3;
+// A refined crossing is real only if the two points end up this close.
+constexpr double crossingAcceptanceDistance = 0.1;
+// Subdivision stops when a piece's control points fit in a box this size
+constexpr double subdivisionSizeLimit = crossingWeldDistance;
+
+constexpr unsigned maximumSubdivisionDepth = 40;
+constexpr unsigned maximumCandidateCount = 96;
+
+// Samples along a curve are spaced by size on screen, within these bounds on the count.
+constexpr double sampleSpacing = 1.0;
+constexpr unsigned minimumSampleCount = 16;
+constexpr unsigned maximumSampleCount = 48;
+
+constexpr unsigned maximumNewtonIterations = 16;
+constexpr unsigned maximumTangentialProjections = 24;
+constexpr unsigned refinementWalkAllowance = 8;
+
+// Returns the position on the curve at `parameter` in double. `parameter` is the Bézier curve parameter t in [0, 1]
+DoublePoint precisePointAtParameter(const BezierSegment& curve, double parameter)
+{
+    double oneMinusParameter = 1.0 - parameter;
+    double weightStart = oneMinusParameter * oneMinusParameter * oneMinusParameter;
+    double weightControl1 = 3.0 * oneMinusParameter * oneMinusParameter * parameter;
+    double weightControl2 = 3.0 * oneMinusParameter * parameter * parameter;
+    double weightEnd = parameter * parameter * parameter;
+    return {
+        curve.start.x() * weightStart + curve.controlPoint1.x() * weightControl1 + curve.controlPoint2.x() * weightControl2 + curve.end.x() * weightEnd,
+        curve.start.y() * weightStart + curve.controlPoint1.y() * weightControl1 + curve.controlPoint2.y() * weightControl2 + curve.end.y() * weightEnd,
+    };
+}
+
+// Returns the direction of travel at `parameter`, magnitude included in double. The derivative of the Bernstein form, so it weights the legs between control points rather than the points.
+DoubleSize preciseTangentAtParameter(const BezierSegment& curve, double parameter)
+{
+    double oneMinusParameter = 1.0 - parameter;
+    double weightFirstLeg = 3.0 * oneMinusParameter * oneMinusParameter;
+    double weightMiddleLeg = 6.0 * oneMinusParameter * parameter;
+    double weightLastLeg = 3.0 * parameter * parameter;
+    return {
+        weightFirstLeg * (curve.controlPoint1.x() - curve.start.x()) + weightMiddleLeg * (curve.controlPoint2.x() - curve.controlPoint1.x()) + weightLastLeg * (curve.end.x() - curve.controlPoint2.x()),
+        weightFirstLeg * (curve.controlPoint1.y() - curve.start.y()) + weightMiddleLeg * (curve.controlPoint2.y() - curve.controlPoint1.y()) + weightLastLeg * (curve.end.y() - curve.controlPoint2.y()),
+    };
+}
+
+FloatRect controlPointBounds(const BezierSegment& curve)
+{
+    FloatRect bounds { curve.start, FloatSize { } };
+    bounds.extend(curve.controlPoint1);
+    bounds.extend(curve.controlPoint2);
+    bounds.extend(curve.end);
+    return bounds;
+}
+
+// How many samples to walk along this curve
+unsigned sampleCountForCurve(const BezierSegment& curve)
+{
+    auto bounds = controlPointBounds(curve);
+    double extent = std::max(bounds.width(), bounds.height());
+    if (!std::isfinite(extent))
+        return minimumSampleCount;
+    double wanted = std::clamp(std::ceil(extent / sampleSpacing), static_cast<double>(minimumSampleCount), static_cast<double>(maximumSampleCount));
+    return static_cast<unsigned>(wanted);
+}
+
+// Halving a window of this radius down to parameterEpsilon takes this many steps
+unsigned refinementBudget(double windowRadius)
+{
+    if (!(windowRadius > parameterEpsilon))
+        return refinementWalkAllowance;
+    return static_cast<unsigned>(std::ceil(std::log2(windowRadius / parameterEpsilon))) + refinementWalkAllowance;
+}
 
 // Solves cubic equation where roots are the parameters t at which a cubic Bézier curve crosses a line
 Vector<double, 3> solveCubicForParametersInUnitInterval(double cubicCoefficient, double quadraticCoefficient, double linearCoefficient, double constantCoefficient)
@@ -112,7 +195,7 @@ Vector<double, 3> solveCubicForParametersInUnitInterval(double cubicCoefficient,
     return parametersInUnitInterval;
 }
 
-Vector<BezierIntersection> intersectBezierAndLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd)
+Vector<BezierIntersection, 3> intersectBezierAndLineInternal(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd)
 {
     double directionX = lineEnd.x() - lineStart.x();
     double directionY = lineEnd.y() - lineStart.y();
@@ -133,7 +216,7 @@ Vector<BezierIntersection> intersectBezierAndLine(const BezierSegment& curve, co
 
     double lineLengthSquared = directionX * directionX + directionY * directionY;
 
-    Vector<BezierIntersection> intersections;
+    Vector<BezierIntersection, 3> intersections;
     for (double parameter : parameters) {
         auto point = pointOnBezierAtParameter(curve, parameter);
 
@@ -146,11 +229,17 @@ Vector<BezierIntersection> intersectBezierAndLine(const BezierSegment& curve, co
         if (positionOnLine < -parameterEpsilon || positionOnLine > 1.0 + parameterEpsilon)
             continue;
 
-        intersections.append({ float(parameter), float(std::clamp(positionOnLine, 0.0, 1.0)), point });
+        auto tangent = preciseTangentAtParameter(curve, parameter);
+        double tangentLength = tangent.diagonalLength();
+        double lineLength = std::sqrt(lineLengthSquared);
+        bool tangential = tangentLength > nearZeroEpsilon && lineLength > nearZeroEpsilon
+            && std::abs(tangent.width() * directionY - tangent.height() * directionX) / (tangentLength * lineLength) < parallelTangentTolerance;
+
+        intersections.append({ parameter, std::clamp(positionOnLine, 0.0, 1.0), point, tangential });
     }
 
     std::sort(intersections.begin(), intersections.end(), [](const BezierIntersection& lhs, const BezierIntersection& rhs) {
-        return lhs.positionOnCurve < rhs.positionOnCurve;
+        return lhs.parameterOnFirst < rhs.parameterOnFirst;
     });
     return intersections;
 }
@@ -172,7 +261,7 @@ std::pair<BezierSegment, BezierSegment> splitBezier(const BezierSegment& curve, 
 
 Vector<BezierSegment> trimBezierToLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd, bool keepLeftOfLine)
 {
-    auto crossings = intersectBezierAndLine(curve, lineStart, lineEnd);
+    auto crossings = intersectBezierAndLineInternal(curve, lineStart, lineEnd);
 
     // Between successive crossings the pieces alternate sides of the line, so keep those whose midpoint is on the requested side.
     Vector<BezierSegment> kept;
@@ -180,7 +269,7 @@ Vector<BezierSegment> trimBezierToLine(const BezierSegment& curve, const FloatPo
     float consumedParameter = 0.0f;
     for (const auto& crossing : crossings) {
         // Re-map the crossing parameter into the shrinking `remaining` curve's own [0, 1] range.
-        float localParameter = (crossing.positionOnCurve - consumedParameter) / (1.0f - consumedParameter);
+        float localParameter = (static_cast<float>(crossing.parameterOnFirst) - consumedParameter) / (1.0f - consumedParameter);
         localParameter = std::clamp(localParameter, 0.0f, 1.0f);
         auto [piece, rest] = splitBezier(remaining, localParameter);
 
@@ -189,7 +278,7 @@ Vector<BezierSegment> trimBezierToLine(const BezierSegment& curve, const FloatPo
             kept.append(piece);
 
         remaining = rest;
-        consumedParameter = crossing.positionOnCurve;
+        consumedParameter = static_cast<float>(crossing.parameterOnFirst);
     }
     bool tailOnLeft = signedDistanceToLine(pointOnBezierAtParameter(remaining, 0.5), lineStart, lineEnd) > 0;
     if (tailOnLeft == keepLeftOfLine)
@@ -205,21 +294,366 @@ static bool boxesTouchOrOverlap(const FloatRect& first, const FloatRect& second)
         && first.maxY() >= second.y() && first.y() <= second.maxY();
 }
 
+// Restricts a curve to a parameter window: de Casteljau at the window start, then at the end
+// remapped into what remains.
+BezierSegment subCurveForWindow(const BezierSegment& curve, double startParameter, double endParameter)
+{
+    auto afterStart = splitBezier(curve, static_cast<float>(startParameter)).second;
+    double remainingSpan = 1.0 - startParameter;
+    if (remainingSpan <= nearZeroEpsilon)
+        return { curve.end, curve.end, curve.end, curve.end };
+    double localEnd = std::clamp((endParameter - startParameter) / remainingSpan, 0.0, 1.0);
+    return splitBezier(afterStart, static_cast<float>(localEnd)).first;
+}
+
+// Fractions along two segments where their infinite lines meet; false when parallel.
+bool chordCrossingFractions(const FloatPoint& firstStart, const FloatPoint& firstEnd, const FloatPoint& secondStart, const FloatPoint& secondEnd, double& fractionOnFirst, double& fractionOnSecond)
+{
+    double firstDeltaX = firstEnd.x() - firstStart.x();
+    double firstDeltaY = firstEnd.y() - firstStart.y();
+    double secondDeltaX = secondEnd.x() - secondStart.x();
+    double secondDeltaY = secondEnd.y() - secondStart.y();
+
+    double denominator = firstDeltaX * secondDeltaY - firstDeltaY * secondDeltaX;
+    if (std::abs(denominator) < nearZeroEpsilon)
+        return false;
+
+    double offsetX = secondStart.x() - firstStart.x();
+    double offsetY = secondStart.y() - firstStart.y();
+    fractionOnFirst = std::clamp((offsetX * secondDeltaY - offsetY * secondDeltaX) / denominator, 0.0, 1.0);
+    fractionOnSecond = std::clamp((offsetX * firstDeltaY - offsetY * firstDeltaX) / denominator, 0.0, 1.0);
+    return true;
+}
+
+double nearestParameterOnBezier(const BezierSegment& curve, const DoublePoint& target, double& distanceOut)
+{
+    const unsigned sweepSteps = sampleCountForCurve(curve);
+    double bestParameter = 0;
+    double bestDistance = std::numeric_limits<double>::max();
+    for (unsigned step = 0; step <= sweepSteps; ++step) {
+        double parameter = static_cast<double>(step) / sweepSteps;
+        double distance = (precisePointAtParameter(curve, parameter) - target).diagonalLength();
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestParameter = parameter;
+        }
+    }
+
+    double windowRadius = 1.0 / sweepSteps;
+    const unsigned maximumRefinements = refinementBudget(windowRadius);
+    for (unsigned refinement = 0; refinement < maximumRefinements; ++refinement) {
+        double lowerProbe = std::clamp(bestParameter - windowRadius, 0.0, 1.0);
+        double upperProbe = std::clamp(bestParameter + windowRadius, 0.0, 1.0);
+        double lowerDistance = (precisePointAtParameter(curve, lowerProbe) - target).diagonalLength();
+        double upperDistance = (precisePointAtParameter(curve, upperProbe) - target).diagonalLength();
+        if (lowerDistance < bestDistance && lowerDistance <= upperDistance) {
+            bestDistance = lowerDistance;
+            bestParameter = lowerProbe;
+        } else if (upperDistance < bestDistance) {
+            bestDistance = upperDistance;
+            bestParameter = upperProbe;
+        } else
+            windowRadius /= 2;
+        if (windowRadius < parameterEpsilon)
+            break;
+    }
+
+    distanceOut = bestDistance;
+    return bestParameter;
+}
+
+static bool tangentsAreParallel(const DoubleSize& first, const DoubleSize& second)
+{
+    double firstLength = first.diagonalLength();
+    double secondLength = second.diagonalLength();
+    if (firstLength <= nearZeroEpsilon || secondLength <= nearZeroEpsilon)
+        return true;
+    return std::abs(first.width() * second.height() - first.height() * second.width()) / (firstLength * secondLength) < parallelTangentTolerance;
+}
+
+// Returns the longest stretch where the two curves lie on top of each other rather than crossing
+std::optional<BezierCoincidentSpan> longestCoincidentSpan(const BezierSegment& first, const BezierSegment& second)
+{
+    const unsigned sampleCount = sampleCountForCurve(first);
+
+    unsigned runStart = 0;
+    unsigned runLength = 0;
+    unsigned bestRunStart = 0;
+    unsigned bestRunLength = 0;
+    std::array<double, maximumSampleCount + 1> matchedParameters { };
+
+    for (unsigned sample = 0; sample <= sampleCount; ++sample) {
+        double parameterOnFirst = static_cast<double>(sample) / sampleCount;
+        double distance = 0;
+        matchedParameters[sample] = nearestParameterOnBezier(second, precisePointAtParameter(first, parameterOnFirst), distance);
+
+        bool sharesDirection = tangentsAreParallel(preciseTangentAtParameter(first, parameterOnFirst),
+            preciseTangentAtParameter(second, matchedParameters[sample]));
+
+        if (distance <= coincidenceDistanceTolerance && sharesDirection) {
+            if (!runLength)
+                runStart = sample;
+            ++runLength;
+            if (runLength > bestRunLength) {
+                bestRunLength = runLength;
+                bestRunStart = runStart;
+            }
+        } else
+            runLength = 0;
+    }
+
+    if (bestRunLength < 2)
+        return std::nullopt;
+
+    auto coincidentAt = [&](double parameterOnFirst, double& matchedParameter) {
+        double distance = 0;
+        matchedParameter = nearestParameterOnBezier(second, precisePointAtParameter(first, parameterOnFirst), distance);
+        if (distance > coincidenceDistanceTolerance)
+            return false;
+        return tangentsAreParallel(preciseTangentAtParameter(first, parameterOnFirst), preciseTangentAtParameter(second, matchedParameter));
+    };
+
+    auto refinedBoundary = [&](unsigned insideSample, int outsideSample) {
+        double inside = static_cast<double>(insideSample) / sampleCount;
+        if (outsideSample < 0 || static_cast<unsigned>(outsideSample) > sampleCount)
+            return inside;
+
+        double outside = static_cast<double>(outsideSample) / sampleCount;
+        for (unsigned iteration = 0; iteration < maximumBisectionIterations; ++iteration) {
+            double middle = (inside + outside) / 2;
+            double matchedParameter = 0;
+            if (coincidentAt(middle, matchedParameter))
+                inside = middle;
+            else
+                outside = middle;
+        }
+        return inside;
+    };
+
+    unsigned lastSample = bestRunStart + bestRunLength - 1;
+    double firstStart = bestRunStart ? refinedBoundary(bestRunStart, static_cast<int>(bestRunStart) - 1) : 0.0;
+    double firstEnd = lastSample < sampleCount ? refinedBoundary(lastSample, static_cast<int>(lastSample) + 1) : 1.0;
+    if (firstEnd - firstStart < coincidenceSpanMinimum)
+        return std::nullopt;
+
+    double secondStart = matchedParameters[bestRunStart];
+    double secondEnd = matchedParameters[lastSample];
+    coincidentAt(firstStart, secondStart);
+    coincidentAt(firstEnd, secondEnd);
+
+    return BezierCoincidentSpan { firstStart, firstEnd, secondStart, secondEnd, secondEnd < secondStart };
+}
+
+// Resolves a rough candidate pair of parameters into an exact crossing, or rejects it. Returns the crossing with a
+// parameter on each curve, the point where they meet and whether it is a tangency (curves touch without crossing)
+std::optional<BezierIntersection> resolveCrossingCandidate(const BezierSegment& first, const BezierSegment& second, double parameterOnFirst, double parameterOnSecond)
+{
+    for (unsigned iteration = 0; iteration < maximumNewtonIterations; ++iteration) {
+        auto firstPoint = precisePointAtParameter(first, parameterOnFirst);
+        auto secondPoint = precisePointAtParameter(second, parameterOnSecond);
+        auto gap = firstPoint - secondPoint;
+        if (gap.diagonalLength() <= nearZeroEpsilon)
+            break;
+
+        auto firstTangent = preciseTangentAtParameter(first, parameterOnFirst);
+        auto secondTangent = preciseTangentAtParameter(second, parameterOnSecond);
+
+        double determinant = -firstTangent.width() * secondTangent.height() + firstTangent.height() * secondTangent.width();
+        if (std::abs(determinant) < nearZeroEpsilon) {
+            // Tangential: walk each curve onto the other until the pair stops moving.
+            for (unsigned projection = 0; projection < maximumTangentialProjections; ++projection) {
+                double distance = 0;
+                double nextOnSecond = nearestParameterOnBezier(second, precisePointAtParameter(first, parameterOnFirst), distance);
+                double nextOnFirst = nearestParameterOnBezier(first, precisePointAtParameter(second, nextOnSecond), distance);
+                bool settled = std::abs(nextOnFirst - parameterOnFirst) < parameterEpsilon
+                    && std::abs(nextOnSecond - parameterOnSecond) < parameterEpsilon;
+                parameterOnFirst = nextOnFirst;
+                parameterOnSecond = nextOnSecond;
+                if (settled)
+                    break;
+            }
+            break;
+        }
+
+        double deltaFirst = (gap.width() * secondTangent.height() - secondTangent.width() * gap.height()) / determinant;
+        double deltaSecond = (-firstTangent.width() * gap.height() + firstTangent.height() * gap.width()) / determinant;
+
+        double nextParameterOnFirst = std::clamp(parameterOnFirst + deltaFirst, 0.0, 1.0);
+        double nextParameterOnSecond = std::clamp(parameterOnSecond + deltaSecond, 0.0, 1.0);
+        bool converged = std::abs(nextParameterOnFirst - parameterOnFirst) < parameterEpsilon
+            && std::abs(nextParameterOnSecond - parameterOnSecond) < parameterEpsilon;
+        parameterOnFirst = nextParameterOnFirst;
+        parameterOnSecond = nextParameterOnSecond;
+        if (converged)
+            break;
+    }
+
+    auto firstPoint = precisePointAtParameter(first, parameterOnFirst);
+    auto secondPoint = precisePointAtParameter(second, parameterOnSecond);
+    if ((firstPoint - secondPoint).diagonalLength() > crossingAcceptanceDistance)
+        return std::nullopt;
+
+    bool tangential = tangentsAreParallel(preciseTangentAtParameter(first, parameterOnFirst), preciseTangentAtParameter(second, parameterOnSecond));
+
+    FloatPoint meetingPoint {
+        static_cast<float>((firstPoint.x() + secondPoint.x()) / 2),
+        static_cast<float>((firstPoint.y() + secondPoint.y()) / 2),
+    };
+    return BezierIntersection { parameterOnFirst, parameterOnSecond, meetingPoint, tangential };
+}
+
+void collectCrossingCandidates(const BezierSegment& first, double firstStart, double firstEnd, const BezierSegment& second, double secondStart, double secondEnd, unsigned depth, Vector<BezierIntersection, 9>& candidates)
+{
+    if (candidates.size() >= maximumCandidateCount)
+        return;
+
+    auto firstPiece = subCurveForWindow(first, firstStart, firstEnd);
+    auto secondPiece = subCurveForWindow(second, secondStart, secondEnd);
+    auto firstBounds = controlPointBounds(firstPiece);
+    auto secondBounds = controlPointBounds(secondPiece);
+    if (!boxesTouchOrOverlap(firstBounds, secondBounds))
+        return;
+
+    double firstSpan = firstEnd - firstStart;
+    double secondSpan = secondEnd - secondStart;
+
+    auto boundsAreSmallEnough = [](const FloatRect& bounds) {
+        return std::max(bounds.width(), bounds.height()) <= subdivisionSizeLimit;
+    };
+
+    if (depth >= maximumSubdivisionDepth || (boundsAreSmallEnough(firstBounds) && boundsAreSmallEnough(secondBounds))) {
+        double fractionOnFirst = 0.5;
+        double fractionOnSecond = 0.5;
+        chordCrossingFractions(firstPiece.start, firstPiece.end, secondPiece.start, secondPiece.end, fractionOnFirst, fractionOnSecond);
+        candidates.append({ firstStart + firstSpan * fractionOnFirst, secondStart + secondSpan * fractionOnSecond, { }, false });
+        return;
+    }
+
+    if (firstSpan >= secondSpan) {
+        double middle = (firstStart + firstEnd) / 2;
+        collectCrossingCandidates(first, firstStart, middle, second, secondStart, secondEnd, depth + 1, candidates);
+        collectCrossingCandidates(first, middle, firstEnd, second, secondStart, secondEnd, depth + 1, candidates);
+        return;
+    }
+    double middle = (secondStart + secondEnd) / 2;
+    collectCrossingCandidates(first, firstStart, firstEnd, second, secondStart, middle, depth + 1, candidates);
+    collectCrossingCandidates(first, firstStart, firstEnd, second, middle, secondEnd, depth + 1, candidates);
+}
+
 } // namespace
 
-// `parameter` is the Bézier curve parameter t in [0, 1] (the variable of the Bernstein basis
-// below, and of solveCubicForParametersInUnitInterval): t = 0 is curve.start, t = 1 is curve.end.
+// `parameter` is the Bézier curve parameter t in [0, 1] (the variable of the Bernstein basis, and of
+// solveCubicForParametersInUnitInterval): t = 0 is curve.start, t = 1 is curve.end.
 FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter)
 {
-    double oneMinusParameter = 1.0 - parameter;
-    double weightStart = oneMinusParameter * oneMinusParameter * oneMinusParameter;
-    double weightControl1 = 3.0 * oneMinusParameter * oneMinusParameter * parameter;
-    double weightControl2 = 3.0 * oneMinusParameter * parameter * parameter;
-    double weightEnd = parameter * parameter * parameter;
-    return {
-        static_cast<float>(curve.start.x() * weightStart + curve.controlPoint1.x() * weightControl1 + curve.controlPoint2.x() * weightControl2 + curve.end.x() * weightEnd),
-        static_cast<float>(curve.start.y() * weightStart + curve.controlPoint1.y() * weightControl1 + curve.controlPoint2.y() * weightControl2 + curve.end.y() * weightEnd),
+    auto point = precisePointAtParameter(curve, parameter);
+    return { static_cast<float>(point.x()), static_cast<float>(point.y()) };
+}
+
+
+// Direction of travel, magnitude included.
+FloatSize tangentOnBezierAtParameter(const BezierSegment& curve, double parameter)
+{
+    auto tangent = preciseTangentAtParameter(curve, parameter);
+    return { static_cast<float>(tangent.width()), static_cast<float>(tangent.height()) };
+}
+
+Vector<BezierIntersection, 3> intersectBezierAndLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd)
+{
+    return intersectBezierAndLineInternal(curve, lineStart, lineEnd);
+}
+
+// Crossings come back as a parameter pair each; stretches where the curves run along each other come
+// back separately, having no single point to split at.
+BezierIntersections intersectBeziers(const BezierSegment& first, const BezierSegment& second)
+{
+    BezierIntersections result;
+
+    if (!boxesTouchOrOverlap(controlPointBounds(first), controlPointBounds(second)))
+        return result;
+
+    if (auto coincidentSpan = longestCoincidentSpan(first, second))
+        result.coincidences.append(*coincidentSpan);
+
+    Vector<BezierIntersection, 9> candidates;
+
+    auto seedEndpointPair = [&](double parameterOnFirst, double parameterOnSecond) {
+        if ((precisePointAtParameter(first, parameterOnFirst) - precisePointAtParameter(second, parameterOnSecond)).diagonalLength() <= crossingWeldDistance)
+            candidates.append({ parameterOnFirst, parameterOnSecond, { }, false });
     };
+    seedEndpointPair(0, 0);
+    seedEndpointPair(0, 1);
+    seedEndpointPair(1, 0);
+    seedEndpointPair(1, 1);
+
+    collectCrossingCandidates(first, 0, 1, second, 0, 1, 0, candidates);
+
+    for (const auto& candidate : candidates) {
+        auto refined = resolveCrossingCandidate(first, second, candidate.parameterOnFirst, candidate.parameterOnSecond);
+        if (!refined)
+            continue;
+
+        bool insideCoincidence = false;
+        for (const auto& span : result.coincidences) {
+            if (refined->parameterOnFirst >= span.firstStart - crossingWeldTolerance && refined->parameterOnFirst <= span.firstEnd + crossingWeldTolerance) {
+                insideCoincidence = true;
+                break;
+            }
+        }
+        if (insideCoincidence)
+            continue;
+
+        bool alreadyFound = false;
+        for (auto& existing : result.crossings) {
+            bool sameParameters = std::abs(existing.parameterOnFirst - refined->parameterOnFirst) <= crossingWeldTolerance
+                && std::abs(existing.parameterOnSecond - refined->parameterOnSecond) <= crossingWeldTolerance;
+            bool samePoint = std::hypot(existing.point.x() - refined->point.x(), existing.point.y() - refined->point.y()) <= crossingWeldDistance;
+            if (sameParameters || samePoint) {
+                // Tangential only if every candidate that landed here says so.
+                existing.tangential = existing.tangential && refined->tangential;
+                alreadyFound = true;
+                break;
+            }
+        }
+        if (alreadyFound)
+            continue;
+
+        result.crossings.append(*refined);
+        if (result.crossings.size() >= 9)
+            break;
+    }
+
+    std::sort(result.crossings.begin(), result.crossings.end(), [](const BezierIntersection& lhs, const BezierIntersection& rhs) {
+        return lhs.parameterOnFirst < rhs.parameterOnFirst;
+    });
+    return result;
+}
+
+Vector<BezierSegment> splitBezierAtParameters(const BezierSegment& curve, const Vector<double>& parameters)
+{
+    Vector<double> cuts;
+    cuts.reserveInitialCapacity(parameters.size());
+    for (double parameter : parameters) {
+        if (parameter > parameterEpsilon && parameter < 1.0 - parameterEpsilon)
+            cuts.append(parameter);
+    }
+    std::sort(cuts.begin(), cuts.end());
+
+    Vector<BezierSegment> pieces;
+    auto remaining = curve;
+    double consumedParameter = 0;
+    for (double cut : cuts) {
+        if (cut - consumedParameter <= parameterEpsilon)
+            continue;
+        // Remap the cut into the remainder's own [0, 1] range.
+        double localParameter = std::clamp((cut - consumedParameter) / (1.0 - consumedParameter), 0.0, 1.0);
+        auto [piece, rest] = splitBezier(remaining, static_cast<float>(localParameter));
+        pieces.append(piece);
+        remaining = rest;
+        consumedParameter = cut;
+    }
+    pieces.append(remaining);
+    return pieces;
 }
 
 Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect& rect)
@@ -252,6 +686,312 @@ Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRe
         curves = clipped;
     }
     return curves;
+}
+
+namespace {
+
+constexpr double loopStitchTolerance = 0.05; // device pixels
+constexpr double loopPieceMinimumLength = 1e-4;
+// Pieces this close to each other's start leave the same point
+constexpr double loopJunctionTolerance = 1e-3;
+
+double doubledSignedArea(const BezierLoop& loop)
+{
+    double total = 0;
+    for (const auto& curve : loop)
+        total += curve.start.x() * curve.end.y() - curve.end.x() * curve.start.y();
+    return total;
+}
+
+BezierSegment reversedSegment(const BezierSegment& curve)
+{
+    return { curve.end, curve.controlPoint2, curve.controlPoint1, curve.start };
+}
+
+BezierLoop reversedLoop(const BezierLoop& loop)
+{
+    BezierLoop reversed;
+    reversed.reserveInitialCapacity(loop.size());
+    for (size_t index = loop.size(); index-- > 0;)
+        reversed.append(reversedSegment(loop[index]));
+    return reversed;
+}
+
+bool isDegenerateSegment(const BezierSegment& curve)
+{
+    auto span = curve.end - curve.start;
+    if (span.diagonalLength() > loopPieceMinimumLength)
+        return false;
+    return (curve.controlPoint1 - curve.start).diagonalLength() <= loopPieceMinimumLength
+        && (curve.controlPoint2 - curve.start).diagonalLength() <= loopPieceMinimumLength;
+}
+
+// A stretch two loops share rather than cross, as parameters along one segment of one of them.
+struct CoincidentRange {
+    double start { 0 };
+    double end { 0 };
+    bool opposedDirection { false };
+};
+
+struct LoopPiece {
+    BezierSegment curve;
+    size_t segmentIndex { 0 };
+    // Where the piece sits in its original segment, so it can be matched against that segment's shared stretches.
+    double midpointParameter { 0 };
+};
+
+// Splits every segment of `loop` at the parameters collected for it, keeping the traversal order.
+Vector<LoopPiece> splitLoopAtParameters(const BezierLoop& loop, const Vector<Vector<double>>& parametersPerSegment)
+{
+    Vector<LoopPiece> pieces;
+    for (size_t index = 0; index < loop.size(); ++index) {
+        auto parameters = parametersPerSegment[index];
+        std::sort(parameters.begin(), parameters.end());
+
+        Vector<double> boundaries;
+        for (double parameter : parameters) {
+            if (parameter <= parameterEpsilon || parameter >= 1.0 - parameterEpsilon)
+                continue;
+            if (!boundaries.isEmpty() && parameter - boundaries.last() <= parameterEpsilon)
+                continue;
+            boundaries.append(parameter);
+        }
+
+        auto split = splitBezierAtParameters(loop[index], boundaries);
+        ASSERT(split.size() == boundaries.size() + 1);
+
+        double previousParameter = 0;
+        for (size_t pieceIndex = 0; pieceIndex < split.size(); ++pieceIndex) {
+            double nextParameter = pieceIndex < boundaries.size() ? boundaries[pieceIndex] : 1.0;
+            if (!isDegenerateSegment(split[pieceIndex]))
+                pieces.append({ split[pieceIndex], index, (previousParameter + nextParameter) / 2 });
+            previousParameter = nextParameter;
+        }
+    }
+    return pieces;
+}
+
+// Whether a piece lies along a stretch the two loops share, and if so which way the other loop runs there.
+std::optional<bool> sharedStretchIsOpposed(const Vector<CoincidentRange>& ranges, double midpointParameter)
+{
+    for (const auto& range : ranges) {
+        if (midpointParameter >= range.start - parameterEpsilon && midpointParameter <= range.end + parameterEpsilon)
+            return range.opposedDirection;
+    }
+    return std::nullopt;
+}
+
+Vector<BezierLoop> stitchPiecesIntoLoops(Vector<BezierSegment>&& pieces)
+{
+    Vector<bool> used(FillWith { }, pieces.size(), false);
+    Vector<BezierLoop> loops;
+
+    for (size_t startIndex = 0; startIndex < pieces.size(); ++startIndex) {
+        if (used[startIndex])
+            continue;
+
+        BezierLoop loop;
+        loop.append(pieces[startIndex]);
+        used[startIndex] = true;
+
+        while (true) {
+            auto tail = loop.last().end;
+            if ((tail - loop.first().start).diagonalLength() <= loopStitchTolerance)
+                break;
+
+            double nearestDistance = loopStitchTolerance;
+            for (size_t index = 0; index < pieces.size(); ++index) {
+                if (used[index])
+                    continue;
+                nearestDistance = std::min<double>(nearestDistance, (pieces[index].start - tail).diagonalLength());
+            }
+
+            auto arriving = tangentOnBezierAtParameter(loop.last(), 1);
+            std::optional<size_t> nextIndex;
+            double widestTurn = -std::numeric_limits<double>::max();
+            for (size_t index = 0; index < pieces.size(); ++index) {
+                if (used[index])
+                    continue;
+                double distance = (pieces[index].start - tail).diagonalLength();
+                if (distance > nearestDistance + loopJunctionTolerance || distance > loopStitchTolerance)
+                    continue;
+
+                auto leaving = tangentOnBezierAtParameter(pieces[index], 0);
+                double across = arriving.width() * leaving.height() - arriving.height() * leaving.width();
+                double along = arriving.width() * leaving.width() + arriving.height() * leaving.height();
+                double turn = std::atan2(across, along);
+                if (turn > widestTurn) {
+                    widestTurn = turn;
+                    nextIndex = index;
+                }
+            }
+            if (!nextIndex)
+                break;
+
+            auto next = pieces[*nextIndex];
+            auto shift = tail - next.start;
+            next.start = tail;
+            next.controlPoint1 = next.controlPoint1 + shift;
+
+            loop.append(next);
+            used[*nextIndex] = true;
+        }
+
+        if (!loop.isEmpty()) {
+            auto& last = loop.last();
+            auto shift = loop.first().start - last.end;
+            if (shift.diagonalLength() <= loopStitchTolerance) {
+                last.end = loop.first().start;
+                last.controlPoint2 = last.controlPoint2 + shift;
+            }
+        }
+
+        bool closed = (loop.last().end - loop.first().start).diagonalLength() <= loopStitchTolerance;
+        if (closed && loop.size() > 1)
+            loops.append(WTF::move(loop));
+    }
+    return loops;
+}
+
+bool loopContainsPoint(const BezierLoop& loop, const FloatPoint& point)
+{
+    return windingNumberForLoop(loop, point);
+}
+
+} // namespace
+
+int windingNumberForLoop(const BezierLoop& loop, const FloatPoint& point)
+{
+    FloatRect bounds { point, FloatSize { } };
+    for (const auto& curve : loop) {
+        bounds.extend(curve.start);
+        bounds.extend(curve.controlPoint1);
+        bounds.extend(curve.controlPoint2);
+        bounds.extend(curve.end);
+    }
+    FloatPoint rayEnd { bounds.maxX() + 1.0f, point.y() };
+
+    int winding = 0;
+    for (size_t index = 0; index < loop.size(); ++index) {
+        const auto& curve = loop[index];
+        for (const auto& crossing : intersectBezierAndLine(curve, point, rayEnd)) {
+            if (crossing.parameterOnFirst <= parameterEpsilon)
+                continue;
+            if (crossing.parameterOnSecond <= 0.0)
+                continue;
+
+            auto tangent = tangentOnBezierAtParameter(curve, crossing.parameterOnFirst);
+            if (!tangent.height())
+                continue;
+
+            if (crossing.parameterOnFirst >= 1.0 - parameterEpsilon) {
+                auto leaving = tangentOnBezierAtParameter(loop[(index + 1) % loop.size()], 0);
+                if (leaving.height() && (leaving.height() > 0) != (tangent.height() > 0))
+                    continue;
+            }
+
+            if (tangent.height() > 0)
+                ++winding;
+            else
+                --winding;
+        }
+    }
+    return winding;
+}
+
+Vector<BezierLoop> subtractLoopFromLoop(const BezierLoop& region, const BezierLoop& sliver)
+{
+    if (region.isEmpty())
+        return { };
+    if (sliver.isEmpty())
+        return { region };
+
+    if ((doubledSignedArea(region) > 0) != (doubledSignedArea(sliver) > 0))
+        return subtractLoopFromLoop(region, reversedLoop(sliver));
+
+    Vector<Vector<double>> regionParameters(region.size());
+    Vector<Vector<double>> sliverParameters(sliver.size());
+    Vector<Vector<CoincidentRange>> regionShared(region.size());
+    Vector<Vector<CoincidentRange>> sliverShared(sliver.size());
+
+    struct SharedStretch {
+        size_t regionIndex { 0 };
+        size_t sliverIndex { 0 };
+        BezierCoincidentSpan span;
+    };
+    Vector<SharedStretch> sharedStretches;
+
+    bool haveIntersection = false;
+    for (size_t regionIndex = 0; regionIndex < region.size(); ++regionIndex) {
+        for (size_t sliverIndex = 0; sliverIndex < sliver.size(); ++sliverIndex) {
+            auto intersections = intersectBeziers(region[regionIndex], sliver[sliverIndex]);
+            for (const auto& crossing : intersections.crossings) {
+                if (crossing.tangential)
+                    continue;
+                regionParameters[regionIndex].append(crossing.parameterOnFirst);
+                sliverParameters[sliverIndex].append(crossing.parameterOnSecond);
+                haveIntersection = true;
+            }
+            for (const auto& shared : intersections.coincidences) {
+                sharedStretches.append({ regionIndex, sliverIndex, shared });
+                haveIntersection = true;
+            }
+        }
+    }
+
+    auto snappedToCrossing = [](const BezierSegment& curve, double parameter, const Vector<double>& crossings) {
+        auto atParameter = pointOnBezierAtParameter(curve, parameter);
+        for (double crossing : crossings) {
+            if ((pointOnBezierAtParameter(curve, crossing) - atParameter).diagonalLength() <= 2 * coincidenceDistanceTolerance)
+                return crossing;
+        }
+        return parameter;
+    };
+
+    for (const auto& stretch : sharedStretches) {
+        const auto& regionCurve = region[stretch.regionIndex];
+        const auto& sliverCurve = sliver[stretch.sliverIndex];
+
+        double regionStart = snappedToCrossing(regionCurve, stretch.span.firstStart, regionParameters[stretch.regionIndex]);
+        double regionEnd = snappedToCrossing(regionCurve, stretch.span.firstEnd, regionParameters[stretch.regionIndex]);
+        double sliverStart = snappedToCrossing(sliverCurve, stretch.span.secondStart, sliverParameters[stretch.sliverIndex]);
+        double sliverEnd = snappedToCrossing(sliverCurve, stretch.span.secondEnd, sliverParameters[stretch.sliverIndex]);
+
+        regionParameters[stretch.regionIndex].appendVector(Vector<double> { regionStart, regionEnd });
+        sliverParameters[stretch.sliverIndex].appendVector(Vector<double> { sliverStart, sliverEnd });
+        regionShared[stretch.regionIndex].append({ std::min(regionStart, regionEnd), std::max(regionStart, regionEnd), stretch.span.opposedDirection });
+        sliverShared[stretch.sliverIndex].append({ std::min(sliverStart, sliverEnd), std::max(sliverStart, sliverEnd), stretch.span.opposedDirection });
+    }
+
+    if (!haveIntersection) {
+        if (loopContainsPoint(sliver, region.first().start))
+            return { };
+        if (!loopContainsPoint(region, sliver.first().start))
+            return { region };
+        return { region, reversedLoop(sliver) };
+    }
+
+    auto regionPieces = splitLoopAtParameters(region, regionParameters);
+    auto sliverPieces = splitLoopAtParameters(sliver, sliverParameters);
+
+    Vector<BezierSegment> kept;
+    for (const auto& piece : regionPieces) {
+        if (auto opposed = sharedStretchIsOpposed(regionShared[piece.segmentIndex], piece.midpointParameter)) {
+            if (*opposed)
+                kept.append(piece.curve);
+            continue;
+        }
+        if (!loopContainsPoint(sliver, pointOnBezierAtParameter(piece.curve, 0.5)))
+            kept.append(piece.curve);
+    }
+    for (const auto& piece : sliverPieces) {
+        if (sharedStretchIsOpposed(sliverShared[piece.segmentIndex], piece.midpointParameter))
+            continue;
+        if (loopContainsPoint(region, pointOnBezierAtParameter(piece.curve, 0.5)))
+            kept.append(reversedSegment(piece.curve));
+    }
+
+    return stitchPiecesIntoLoops(WTF::move(kept));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FloatSize.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -37,8 +38,44 @@ struct BezierSegment {
     FloatPoint end;
 };
 
+struct BezierIntersection {
+    double parameterOnFirst { 0 };
+    double parameterOnSecond { 0 };
+    FloatPoint point;
+    // Touching without crossing
+    bool tangential { false };
+};
+
+// A range over which two edges lie on top of one another
+struct BezierCoincidentSpan {
+    double firstStart { 0 };
+    double firstEnd { 0 };
+    double secondStart { 0 };
+    double secondEnd { 0 };
+    bool opposedDirection { false };
+};
+
+struct BezierIntersections {
+    // Two cubics cross at most nine times.
+    Vector<BezierIntersection, 9> crossings;
+    Vector<BezierCoincidentSpan, 2> coincidences;
+};
+
+WEBCORE_EXPORT BezierIntersections intersectBeziers(const BezierSegment& first, const BezierSegment& second);
+WEBCORE_EXPORT Vector<BezierIntersection, 3> intersectBezierAndLine(const BezierSegment&, const FloatPoint& lineStart, const FloatPoint& lineEnd);
+WEBCORE_EXPORT Vector<BezierSegment> splitBezierAtParameters(const BezierSegment&, const Vector<double>& parameters);
+
 WEBCORE_EXPORT Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect&);
+
+using BezierLoop = Vector<BezierSegment>;
+
+// Non-zero winding number of `loop` around `point`, for classifying which side of a loop a piece lies on.
+WEBCORE_EXPORT int windingNumberForLoop(const BezierLoop&, const FloatPoint&);
+
+// Returns the loops bounding what is left of `region` once `sliver` is taken out of it, or none if the sliver covered it entirely.
+WEBCORE_EXPORT Vector<BezierLoop> subtractLoopFromLoop(const BezierLoop& region, const BezierLoop& sliver);
 // `parameter` is the Bézier curve parameter t in [0, 1]: 0 is the start point, 1 is the end point (not arc length).
 FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter);
+WEBCORE_EXPORT FloatSize tangentOnBezierAtParameter(const BezierSegment& curve, double parameter);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -407,7 +407,25 @@ static FloatPoint sharpInnerCornerPoint(const FloatRect& innerRect, BoxCorner or
 }
 
 // rect ∩ corner-carve
-static void addTrimmedSuperellipseCorner(Path& path, const ResolvedCorner& corner, const FloatRect& innerRect, bool& started)
+
+// Builds a cubic that is a straight line
+static BezierSegment straightSegment(const FloatPoint& from, const FloatPoint& to)
+{
+    auto delta = to - from;
+    return { from, from + delta * (1.0f / 3.0f), from + delta * (2.0f / 3.0f), to };
+}
+
+static Vector<BezierSegment> trimmedInsetCurves(const ResolvedCorner& corner, const FloatRect& innerRect)
+{
+    Vector<BezierSegment> clippedCurves;
+    for (const auto& bezier : cornerCurveBeziers(corner)) {
+        for (const auto& curve : trimBezierToRect(bezier, innerRect))
+            clippedCurves.append(curve);
+    }
+    return clippedCurves;
+}
+
+static void addTrimmedCurves(Path& path, const Vector<BezierSegment>& curves, const ResolvedCorner& corner, const FloatRect& innerRect, bool& started)
 {
     auto lineOrMoveTo = [&](FloatPoint point) {
         if (!started) {
@@ -417,19 +435,51 @@ static void addTrimmedSuperellipseCorner(Path& path, const ResolvedCorner& corne
             path.addLineTo(point);
     };
 
-    Vector<BezierSegment> clippedCurves;
-    for (const auto& bezier : cornerCurveBeziers(corner)) {
-        for (const auto& curve : trimBezierToRect(bezier, innerRect))
-            clippedCurves.append(curve);
-    }
-
-    if (clippedCurves.isEmpty()) {
+    if (curves.isEmpty()) {
         lineOrMoveTo(sharpInnerCornerPoint(innerRect, corner.adjusted.orientation));
         return;
     }
-    for (const auto& curve : clippedCurves) {
+    for (const auto& curve : curves) {
         lineOrMoveTo(curve.start);
         path.addBezierCurveTo(curve.controlPoint1, curve.controlPoint2, curve.end);
+    }
+}
+
+// Crossings at the shared endpoint of two neighbouring stretches are the join itself, not an overlap.
+constexpr double neighbourJoinParameter = 1e-3;
+
+// Two neighbouring corners on the same edge can reach far enough along it to run through each other. Where
+// they cross, cut both back to the crossing so the contour passes through it once instead of doubling back.
+static void joinOverlappingNeighbours(Vector<BezierSegment>& earlier, Vector<BezierSegment>& later)
+{
+    if (earlier.isEmpty() || later.isEmpty())
+        return;
+
+    for (size_t earlierIndex = earlier.size(); earlierIndex-- > 0;) {
+        for (size_t laterIndex = 0; laterIndex < later.size(); ++laterIndex) {
+            for (const auto& crossing : intersectBeziers(earlier[earlierIndex], later[laterIndex]).crossings) {
+                if (crossing.tangential)
+                    continue;
+                bool atNeighbourJoin = crossing.parameterOnFirst > 1.0 - neighbourJoinParameter
+                    && crossing.parameterOnSecond < neighbourJoinParameter;
+                if (atNeighbourJoin)
+                    continue;
+
+                if (crossing.parameterOnFirst < neighbourJoinParameter || crossing.parameterOnSecond > 1.0 - neighbourJoinParameter)
+                    continue;
+
+                auto earlierPieces = splitBezierAtParameters(earlier[earlierIndex], { crossing.parameterOnFirst });
+                auto laterPieces = splitBezierAtParameters(later[laterIndex], { crossing.parameterOnSecond });
+                if (earlierPieces.isEmpty() || laterPieces.size() < 2)
+                    continue;
+
+                earlier.shrink(earlierIndex + 1);
+                earlier[earlierIndex] = earlierPieces.first();
+                later.removeAt(0, laterIndex);
+                later[0] = laterPieces.last();
+                return;
+            }
+        }
     }
 }
 
@@ -456,9 +506,182 @@ static void addClampedSharpCorner(Path& path, const ResolvedCorner& corner, cons
 
 } // namespace
 
-// https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, ContourStart contourStart)
+static FloatRect boundsOfLoop(const BezierLoop& loop)
 {
+    if (loop.isEmpty())
+        return { };
+
+    FloatRect bounds { loop.first().start, FloatSize { } };
+    for (const auto& curve : loop) {
+        bounds.extend(curve.start);
+        bounds.extend(curve.end);
+    }
+    return bounds;
+}
+
+static BezierLoop rectangleLoop(const FloatRect& rect)
+{
+    return {
+        straightSegment(rect.minXMinYCorner(), rect.maxXMinYCorner()),
+        straightSegment(rect.maxXMinYCorner(), rect.maxXMaxYCorner()),
+        straightSegment(rect.maxXMaxYCorner(), rect.minXMaxYCorner()),
+        straightSegment(rect.minXMaxYCorner(), rect.minXMinYCorner()),
+    };
+}
+
+static FloatSize cornerwardDiagonal(BoxCorner orientation)
+{
+    switch (orientation) {
+    case BoxCorner::TopLeft:     return { -1, -1 };
+    case BoxCorner::TopRight:    return { 1, -1 };
+    case BoxCorner::BottomLeft:  return { -1, 1 };
+    case BoxCorner::BottomRight: return { 1, 1 };
+    }
+    return { };
+}
+
+// A corner's own stretch of the contour, from where it leaves one edge to where it meets the next.
+static BezierLoop cornerCurveSegments(const ResolvedCorner& corner)
+{
+    const auto& adjusted = corner.adjusted;
+    if (isNotch(adjusted)) {
+        return {
+            straightSegment(adjusted.start, adjusted.center),
+            straightSegment(adjusted.center, adjusted.end),
+        };
+    }
+
+    BezierLoop segments;
+    for (const auto& curve : cornerCurveBeziers(corner))
+        segments.append(curve);
+    return segments;
+}
+
+// An outset corner's stretch: in from its miter, around the curve, back out to the other miter
+static BezierLoop outsetCornerSegments(const ResolvedCorner& corner)
+{
+    if (corner.collapsePoint) {
+        return {
+            straightSegment(corner.miterStart, *corner.collapsePoint),
+            straightSegment(*corner.collapsePoint, corner.miterEnd),
+        };
+    }
+
+    BezierLoop segments;
+    if ((corner.adjusted.start - corner.miterStart).diagonalLength() >= limit)
+        segments.append(straightSegment(corner.miterStart, corner.adjusted.start));
+    segments.appendVector(cornerCurveSegments(corner));
+    if ((corner.miterEnd - corner.adjusted.end).diagonalLength() >= limit)
+        segments.append(straightSegment(corner.adjusted.end, corner.miterEnd));
+    return segments;
+}
+
+// Returns the area a corner takes away: its stretch of the contour closed off through an apex placed well
+// outside the target rect, so the wedge covers everything on the far side of the curve.
+static BezierLoop closeWedgeThroughCorner(BezierLoop&& stretch, BoxCorner orientation, const FloatRect& targetRect)
+{
+    if (stretch.isEmpty())
+        return { };
+
+    auto vertex = sharpInnerCornerPoint(targetRect, orientation);
+    float extent = 4 * (targetRect.width() + targetRect.height());
+    auto apex = vertex + cornerwardDiagonal(orientation).scaled(extent);
+
+    auto wedge = WTF::move(stretch);
+    auto first = wedge.first().start;
+    wedge.append(straightSegment(wedge.last().end, apex));
+    wedge.append(straightSegment(apex, first));
+    return wedge;
+}
+
+// Builds the contour by taking each corner's wedge out of the target rect, which resolves the overlap that
+// trimming one curve at a time cannot see. Returns nothing if a wedge could not be subtracted, so the caller trims.
+static std::optional<Vector<BezierLoop>> contourBySubtractingCorners(const RectCorners<ResolvedCorner>& corners, const RectCorners<CornerInput>& cornerRects, const FloatRect& targetRect)
+{
+    if (targetRect.isEmpty())
+        return Vector<BezierLoop> { };
+
+    Vector<BezierLoop> regions;
+    regions.append(rectangleLoop(targetRect));
+
+    for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
+        const auto& corner = corners[key];
+        const auto& input = cornerRects[key];
+        // A square corner reaches its own vertex, so it takes nothing away.
+        if (isEmpty(corner.adjusted) || isSquare(corner.adjusted))
+            continue;
+
+        bool inset = input.startInset >= 0.0 && input.endInset >= 0.0;
+        auto stretch = inset ? cornerCurveSegments(corner) : outsetCornerSegments(corner);
+        if (stretch.isEmpty())
+            return std::nullopt;
+
+        auto wedge = closeWedgeThroughCorner(WTF::move(stretch), corner.adjusted.orientation, targetRect);
+
+        Vector<BezierLoop> remaining;
+        for (const auto& region : regions) {
+            auto loops = subtractLoopFromLoop(region, wedge);
+            if (loops.isEmpty()) {
+                auto insideRegion = boundsOfLoop(region).center();
+                if (!windingNumberForLoop(region, insideRegion) || !windingNumberForLoop(wedge, insideRegion))
+                    return std::nullopt;
+                continue;
+            }
+            remaining.appendVector(WTF::move(loops));
+        }
+
+        if (remaining.isEmpty())
+            return Vector<BezierLoop> { };
+        regions = WTF::move(remaining);
+    }
+    return regions;
+}
+
+static void addLoopsToPath(Path& path, const Vector<BezierLoop>& loops)
+{
+    for (const auto& loop : loops) {
+        if (loop.isEmpty())
+            continue;
+        path.moveTo(loop.first().start);
+        for (const auto& curve : loop)
+            path.addBezierCurveTo(curve.controlPoint1, curve.controlPoint2, curve.end);
+        path.closeSubpath();
+    }
+}
+
+// https://drafts.csswg.org/css-borders-4/#contour-path
+ContourOutcome borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, ContourStart contourStart)
+{
+    static constexpr std::array<BoxCorner, 4> contourOrder { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft };
+
+    RectCorners<ResolvedCorner> corners;
+    for (auto key : contourOrder) {
+        const auto& input = cornerRects[key];
+        corners[key] = resolveCorner(makeCorner(input), input.startInset, input.endInset);
+    }
+
+    if (targetRect) {
+        if (auto loops = contourBySubtractingCorners(corners, cornerRects, *targetRect)) {
+            addLoopsToPath(path, *loops);
+            return ContourOutcome::Built;
+        }
+    }
+
+    // Fallback: trim each corner's curve to the target rect, then cut back the pairs that ran into each other.
+    RectCorners<Vector<BezierSegment>> insetCurves;
+    if (targetRect) {
+        auto takesInsetCurve = [&](BoxCorner key) {
+            const auto& input = cornerRects[key];
+            const auto& adjusted = corners[key].adjusted;
+            return input.startInset >= 0.0 && input.endInset >= 0.0
+                && !isEmpty(adjusted) && std::isfinite(adjusted.curvature);
+        };
+        for (auto key : contourOrder)
+            insetCurves[key] = takesInsetCurve(key) ? trimmedInsetCurves(corners[key], *targetRect) : Vector<BezierSegment> { };
+        for (size_t index = 0; index < contourOrder.size(); ++index)
+            joinOverlappingNeighbours(insetCurves[contourOrder[index]], insetCurves[contourOrder[(index + 1) % contourOrder.size()]]);
+    }
+
     bool started = false;
 
     // offset-path's <coord-box> wants the contour to begin on the top edge instead of at the first corner.
@@ -475,16 +698,16 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
             path.addLineTo(point);
     };
 
-    for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
+    for (auto key : contourOrder) {
         const auto& input = cornerRects[key];
-        auto corner = resolveCorner(makeCorner(input), input.startInset, input.endInset);
+        const auto& corner = corners[key];
         const auto& adjusted = corner.adjusted;
 
         bool insetToTargetRect = targetRect && input.startInset >= 0.0 && input.endInset >= 0.0
             && !isEmpty(adjusted);
         if (insetToTargetRect) {
             if (std::isfinite(adjusted.curvature))
-                addTrimmedSuperellipseCorner(path, corner, *targetRect, started);
+                addTrimmedCurves(path, insetCurves[key], corner, *targetRect, started);
             else
                 addClampedSharpCorner(path, corner, *targetRect, started);
             continue;
@@ -503,6 +726,7 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
         path.addLineTo(corner.miterEnd);
     }
     path.closeSubpath();
+    return path.isEmpty() ? ContourOutcome::NotBuilt : ContourOutcome::Built;
 }
 
 static Vector<FloatPoint> normalizedInnerCornerHull(double curvature)

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -44,8 +44,12 @@ struct CornerInput {
 
 enum class ContourStart : bool { FirstCorner, TopEdge };
 
+// A contour that was subtracted away to nothing is Built (and empty); NotBuilt means no contour could be
+// constructed and the caller should fall back to the plain rounded rect.
+enum class ContourOutcome : bool { Built, NotBuilt };
+
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, ContourStart = ContourStart::FirstCorner);
+ContourOutcome borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, ContourStart = ContourStart::FirstCorner);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
 double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);

--- a/Source/WebCore/platform/graphics/DoubleSize.h
+++ b/Source/WebCore/platform/graphics/DoubleSize.h
@@ -46,6 +46,10 @@ public:
     constexpr double width() const { return m_width; }
     constexpr double height() const { return m_height; }
 
+    double diagonalLength() const
+    {
+        return std::hypot(m_width, m_height);
+    }
 
 #if USE(CG)
     WEBCORE_EXPORT DoubleSize(const CGSize&);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -478,7 +478,7 @@ Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, 
     return pathForOuterRoundedRect(outerSnapped);
 }
 
-static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
+static ContourOutcome addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     auto outerRect = outerSnapped.rect();
     auto innerRect = innerSnapped.rect();
@@ -491,7 +491,7 @@ static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
     RectCorners<CornerInput> cornerRects;
     buildCornerInputs(outerSnapped, cornerCurvatures, leftWidth, topWidth, rightWidth, bottomWidth, cornerRects);
     rebuildOffsetCornersFromReference(cornerRects, offsetReferenceRect, cornerCurvatures, innerRect);
-    borderContourPath(path, cornerRects, &innerRect);
+    return borderContourPath(path, cornerRects, &innerRect);
 }
 
 Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
@@ -505,8 +505,7 @@ Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, 
         if (!path.isEmpty())
             return path;
     }
-    addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference);
-    if (path.isEmpty())
+    if (addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference) == ContourOutcome::NotBuilt)
         return pathForInnerRoundedRect(innerSnapped);
     return path;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
@@ -188,4 +188,323 @@ TEST(BezierUtilities, TrimKeepsLineLyingAlongTopEdge)
     EXPECT_FALSE(result.isEmpty());
 }
 
+TEST(BezierUtilities, IntersectBeziersFindsSingleCrossing)
+{
+    auto rising = lineCurve({ 0, 0 }, { 10, 10 });
+    auto falling = lineCurve({ 0, 10 }, { 10, 0 });
+
+    auto result = intersectBeziers(rising, falling);
+
+    ASSERT_EQ(1u, result.crossings.size());
+    EXPECT_TRUE(result.coincidences.isEmpty());
+    EXPECT_NEAR(0.5, result.crossings[0].parameterOnFirst, 1e-3);
+    EXPECT_NEAR(0.5, result.crossings[0].parameterOnSecond, 1e-3);
+    expectPointNear(result.crossings[0].point, 5, 5);
+    EXPECT_FALSE(result.crossings[0].tangential);
+}
+
+TEST(BezierUtilities, IntersectBeziersFindsNothingWhenApart)
+{
+    auto result = intersectBeziers(lineCurve({ 0, 0 }, { 1, 1 }), lineCurve({ 10, 10 }, { 11, 11 }));
+
+    EXPECT_TRUE(result.crossings.isEmpty());
+    EXPECT_TRUE(result.coincidences.isEmpty());
+}
+
+// A crossing at the end of one curve and the start of the next still has to be reported.
+TEST(BezierUtilities, IntersectBeziersFindsSharedEndpoint)
+{
+    auto along = lineCurve({ 0, 0 }, { 10, 0 });
+    auto up = lineCurve({ 10, 0 }, { 10, 10 });
+
+    auto result = intersectBeziers(along, up);
+
+    ASSERT_EQ(1u, result.crossings.size());
+    EXPECT_NEAR(1.0, result.crossings[0].parameterOnFirst, 1e-3);
+    EXPECT_NEAR(0.0, result.crossings[0].parameterOnSecond, 1e-3);
+    expectPointNear(result.crossings[0].point, 10, 0);
+}
+
+// The vertical controls 1, -1/3, -1/3, 1 are (2t - 1)^2, so this grazes y = 0 at t = 0.5 without
+// crossing, and has to come back tangential.
+TEST(BezierUtilities, IntersectBeziersFlagsTangentialTouch)
+{
+    BezierSegment grazing { { 0, 1 }, { 10.f / 3, -1.f / 3 }, { 20.f / 3, -1.f / 3 }, { 10, 1 } };
+    auto flat = lineCurve({ 0, 0 }, { 10, 0 });
+
+    auto result = intersectBeziers(grazing, flat);
+
+    EXPECT_TRUE(result.coincidences.isEmpty());
+    ASSERT_EQ(1u, result.crossings.size());
+    EXPECT_NEAR(0.5, result.crossings[0].parameterOnFirst, 1e-2);
+    expectPointNear(result.crossings[0].point, 5, 0);
+    EXPECT_TRUE(result.crossings[0].tangential);
+}
+
+// Curves lying on one another overlap along a stretch, as two concave corners on a shared rect edge do,
+// so it is reported as a coincidence rather than a crossing.
+TEST(BezierUtilities, IntersectBeziersReportsCoincidentCurves)
+{
+    auto curve = lineCurve({ 0, 0 }, { 10, 0 });
+
+    auto result = intersectBeziers(curve, curve);
+
+    EXPECT_FALSE(result.coincidences.isEmpty());
+}
+
+// For a curve/line pair the line is the second edge, its parameter a fraction along the segment.
+TEST(BezierUtilities, IntersectBezierAndLineFindsCrossing)
+{
+    auto result = intersectBezierAndLine(lineCurve({ 0, 0 }, { 10, 10 }), { 0, 10 }, { 10, 0 });
+
+    ASSERT_EQ(1u, result.size());
+    EXPECT_NEAR(0.5, result[0].parameterOnFirst, 1e-3);
+    EXPECT_NEAR(0.5, result[0].parameterOnSecond, 1e-3);
+    expectPointNear(result[0].point, 5, 5);
+}
+
+// The pieces have to tile the original: outer endpoints kept, each piece starting where the last ended.
+TEST(BezierUtilities, SplitBezierAtParametersTilesTheCurve)
+{
+    auto curve = lineCurve({ 0, 0 }, { 12, 0 });
+
+    auto pieces = splitBezierAtParameters(curve, { 0.25, 0.75 });
+
+    ASSERT_EQ(3u, pieces.size());
+    expectPointNear(pieces[0].start, 0, 0);
+    expectPointNear(pieces[0].end, 3, 0);
+    expectPointNear(pieces[1].start, 3, 0);
+    expectPointNear(pieces[1].end, 9, 0);
+    expectPointNear(pieces[2].start, 9, 0);
+    expectPointNear(pieces[2].end, 12, 0);
+}
+
+// A cubic that is really a straight line keeps one direction end to end.
+TEST(BezierUtilities, TangentOnBezierAtParameterFollowsTheCurve)
+{
+    auto curve = lineCurve({ 0, 0 }, { 10, 0 });
+
+    for (double parameter : { 0.0, 0.25, 0.5, 1.0 }) {
+        auto tangent = tangentOnBezierAtParameter(curve, parameter);
+        EXPECT_GT(tangent.width(), 0);
+        EXPECT_NEAR(0, tangent.height(), 1e-3);
+    }
+}
+
+static BezierLoop rectangleLoop(const FloatRect& rect)
+{
+    return {
+        lineCurve(rect.minXMinYCorner(), rect.maxXMinYCorner()),
+        lineCurve(rect.maxXMinYCorner(), rect.maxXMaxYCorner()),
+        lineCurve(rect.maxXMaxYCorner(), rect.minXMaxYCorner()),
+        lineCurve(rect.minXMaxYCorner(), rect.minXMinYCorner()),
+    };
+}
+
+// A corner sliver as the contour builder makes them: in along one edge, across, and back out.
+static BezierLoop cornerSliver(const FloatPoint& vertex, const FloatPoint& start, const FloatPoint& end)
+{
+    return { lineCurve(vertex, start), lineCurve(start, end), lineCurve(end, vertex) };
+}
+
+static FloatRect loopBounds(const BezierLoop& loop)
+{
+    FloatRect bounds { loop.first().start, FloatSize { } };
+    for (const auto& curve : loop) {
+        bounds.extend(curve.start);
+        bounds.extend(curve.end);
+    }
+    return bounds;
+}
+
+TEST(BezierUtilities, WindingNumberIsZeroOutsideAndNonZeroInside)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+
+    EXPECT_EQ(0, windingNumberForLoop(square, { -1, 5 }));
+    EXPECT_EQ(0, windingNumberForLoop(square, { 11, 5 }));
+    EXPECT_EQ(0, windingNumberForLoop(square, { 5, -1 }));
+    EXPECT_NE(0, windingNumberForLoop(square, { 5, 5 }));
+    EXPECT_NE(0, windingNumberForLoop(square, { 0.5, 0.5 }));
+}
+
+TEST(BezierUtilities, SubtractingAMissingSliverLeavesTheRegionAlone)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    auto elsewhere = rectangleLoop({ 20, 20, 5, 5 });
+
+    auto result = subtractLoopFromLoop(square, elsewhere);
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(square.size(), result[0].size());
+}
+
+TEST(BezierUtilities, SubtractingACoveringSliverLeavesNothing)
+{
+    auto square = rectangleLoop({ 2, 2, 4, 4 });
+    auto cover = rectangleLoop({ 0, 0, 10, 10 });
+
+    EXPECT_TRUE(subtractLoopFromLoop(square, cover).isEmpty());
+}
+
+// One corner cut off a square: the result keeps the square's other three corners and gains the cut.
+TEST(BezierUtilities, SubtractingOneCornerSliverBevelsThatCorner)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    auto sliver = cornerSliver({ 0, 0 }, { 4, 0 }, { 0, 4 });
+
+    auto result = subtractLoopFromLoop(square, sliver);
+    ASSERT_EQ(1u, result.size());
+
+    auto bounds = loopBounds(result[0]);
+    EXPECT_NEAR(0, bounds.x(), 0.01);
+    EXPECT_NEAR(0, bounds.y(), 0.01);
+    EXPECT_NEAR(10, bounds.maxX(), 0.01);
+    EXPECT_NEAR(10, bounds.maxY(), 0.01);
+
+    // The cut corner is gone and the far corner is untouched.
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 0.5, 0.5 }));
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 9.5, 9.5 }));
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 5, 5 }));
+}
+
+// Two slivers deep enough to overlap: subtracting in sequence has to remove their union, without the
+// contour doubling back. This is the case the local crossing cut could not repair.
+TEST(BezierUtilities, SubtractingOverlappingSliversRemovesTheirUnion)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    auto left = cornerSliver({ 0, 0 }, { 7, 0 }, { 0, 7 });
+    auto right = cornerSliver({ 10, 0 }, { 10, 7 }, { 3, 0 });
+
+    auto afterLeft = subtractLoopFromLoop(square, left);
+    ASSERT_EQ(1u, afterLeft.size());
+    auto result = subtractLoopFromLoop(afterLeft[0], right);
+    ASSERT_EQ(1u, result.size());
+
+    // Both cut corners are gone, and so is the wedge the two slivers share.
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 1, 1 }));
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 9, 1 }));
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 5, 1 }));
+    // The bottom of the square is untouched by either.
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 5, 9 }));
+}
+
+// Subtracting the same sliver twice must not change the result: overlap is idempotent, which is what lets
+// callers subtract each corner without checking the others.
+TEST(BezierUtilities, SubtractingTheSameSliverTwiceIsIdempotent)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    auto sliver = cornerSliver({ 0, 0 }, { 4, 0 }, { 0, 4 });
+
+    auto once = subtractLoopFromLoop(square, sliver);
+    ASSERT_EQ(1u, once.size());
+    auto twice = subtractLoopFromLoop(once[0], sliver);
+    ASSERT_EQ(1u, twice.size());
+
+    EXPECT_EQ(once[0].size(), twice[0].size());
+    EXPECT_EQ(0, windingNumberForLoop(twice[0], { 0.5, 0.5 }));
+    EXPECT_NE(0, windingNumberForLoop(twice[0], { 5, 5 }));
+}
+
+// A curved sliver, so the arrangement is exercised on cubics rather than only on lines.
+TEST(BezierUtilities, SubtractingACurvedSliverKeepsTheCurveInTheResult)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    BezierLoop sliver = {
+        lineCurve({ 0, 0 }, { 5, 0 }),
+        BezierSegment { { 5, 0 }, { 3, 1 }, { 1, 3 }, { 0, 5 } },
+        lineCurve({ 0, 5 }, { 0, 0 }),
+    };
+
+    auto result = subtractLoopFromLoop(square, sliver);
+    ASSERT_EQ(1u, result.size());
+
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 0.5, 0.5 }));
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 5, 5 }));
+    // The scooped side is inside the result, since the curve bows towards the corner.
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 3.5, 3.5 }));
+}
+
+// A wedge touching the region's edges only at its endpoints: the plain crossing case, unlike the slivers above.
+TEST(BezierUtilities, SubtractingAWedgeTouchingTheRegionsEdgesAtPoints)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    BezierLoop wedge = {
+        lineCurve({ 0, 4 }, { 4, 0 }),
+        lineCurve({ 4, 0 }, { -40, -40 }),
+        lineCurve({ -40, -40 }, { 0, 4 }),
+    };
+
+    auto result = subtractLoopFromLoop(square, wedge);
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(0, windingNumberForLoop(result[0], { 0.5, 0.5 }));
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 5, 5 }));
+    EXPECT_NE(0, windingNumberForLoop(result[0], { 9.5, 0.5 }));
+}
+
+// A 54px double border on a 120px box with a 40px radius: every chord has left the 54..66 target rect and all
+// four cross, leaving a diamond. Values from the corner-shape oracle (demos/corner-shape-oracle).
+TEST(BezierUtilities, SubtractingFourBevelWedgesLeavesADiamond)
+{
+    // Each corner closes through a point far outside the box on its own diagonal, as the contour builder does.
+    auto wedgeFor = [](FloatPoint start, FloatPoint end, FloatPoint apex) -> BezierLoop {
+        return { lineCurve(start, end), lineCurve(end, apex), lineCurve(apex, start) };
+    };
+
+    BezierLoop region = rectangleLoop({ 54, 54, 12, 12 });
+    const BezierLoop wedges[] = {
+        wedgeFor({ 41.816f, 38.184f }, { 81.816f, 78.184f }, { 66 + 96, 54 - 96 }), // TopRight
+        wedgeFor({ 81.816f, 41.816f }, { 41.816f, 81.816f }, { 66 + 96, 66 + 96 }), // BottomRight
+        wedgeFor({ 78.184f, 81.816f }, { 38.184f, 41.816f }, { 54 - 96, 66 + 96 }), // BottomLeft
+        wedgeFor({ 38.184f, 78.184f }, { 78.184f, 38.184f }, { 54 - 96, 54 - 96 }), // TopLeft
+    };
+
+    for (const auto& wedge : wedges) {
+        auto loops = subtractLoopFromLoop(region, wedge);
+        ASSERT_EQ(1u, loops.size());
+        region = loops[0];
+    }
+
+    EXPECT_EQ(4u, region.size());
+    EXPECT_NE(0, windingNumberForLoop(region, { 60, 60 }));
+    // Just outside each diamond vertex, and well inside the target rect, so only the diamond can exclude it.
+    EXPECT_EQ(0, windingNumberForLoop(region, { 56, 56 }));
+    EXPECT_EQ(0, windingNumberForLoop(region, { 64, 64 }));
+
+    auto bounds = loopBounds(region);
+    EXPECT_NEAR(56.4, bounds.x(), 0.2);
+    EXPECT_NEAR(63.6, bounds.maxX(), 0.2);
+    EXPECT_NEAR(56.4, bounds.y(), 0.2);
+    EXPECT_NEAR(63.6, bounds.maxY(), 0.2);
+}
+
+// A wedge whose apex touches the far edge exactly cuts the region in two, with four pieces meeting at that point.
+// Proximity cannot pick between the two leaving it, so the branch goes by turning angle, as SkOpSegment::findNextOp.
+TEST(BezierUtilities, SubtractingAWedgeTouchingTheOppositeEdgeSplitsTheRegion)
+{
+    auto square = rectangleLoop({ 0, 0, 10, 10 });
+    BezierLoop wedge = {
+        lineCurve({ 0, 0 }, { 10, 0 }),
+        lineCurve({ 10, 0 }, { 5, 10 }),
+        lineCurve({ 5, 10 }, { 0, 0 }),
+    };
+
+    auto result = subtractLoopFromLoop(square, wedge);
+    ASSERT_EQ(2u, result.size());
+
+    // One piece holds the bottom left, the other the bottom right, and neither holds the middle.
+    bool leftHeld = false;
+    bool rightHeld = false;
+    for (const auto& loop : result) {
+        bool holdsLeft = windingNumberForLoop(loop, { 1, 9 });
+        bool holdsRight = windingNumberForLoop(loop, { 9, 9 });
+        leftHeld |= holdsLeft;
+        rightHeld |= holdsRight;
+        EXPECT_EQ(0, windingNumberForLoop(loop, { 5, 5 }));
+        // Taking the wrong branch at the touch point joins the two into one loop spanning both sides.
+        EXPECT_FALSE(holdsLeft && holdsRight);
+    }
+    EXPECT_TRUE(leftHeld);
+    EXPECT_TRUE(rightHeld);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 71e58e2572ea3a10f3330b8863f851ea7a108f00
<pre>
corner-shape: curve versus curve case doesn&apos;t have support
<a href="https://bugs.webkit.org/show_bug.cgi?id=322658">https://bugs.webkit.org/show_bug.cgi?id=322658</a>
<a href="https://rdar.apple.com/185931169">rdar://185931169</a>

Reviewed by NOBODY (OOPS!).

Two neighbouring corner curves that reach far enough along a
shared edge run through one another, and trimming each
curve to the inner rect independently cannot tell a curve
that has overrun its neighbour from one that has not, so the
contour doubles back on itself. This adds curve/curve
intersection to BezierUtilities, crossing, tangency and
coincident-span detection, plus a Bézier-loop subtraction
operator and uses it to build the inner contour by taking
each corner&apos;s wedge out of the target rect, falling back to
cutting overlapping neighbours back to their crossing point.

Test: Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp

* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::pointOnBezierAtParameter):
(WebCore::tangentOnBezierAtParameter):
(WebCore::intersectBezierAndLine):
(WebCore::intersectBeziers):
(WebCore::splitBezierAtParameters):
(WebCore::windingNumberForLoop):
(WebCore::subtractLoopFromLoop):
* Source/WebCore/platform/graphics/BezierUtilities.h:
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::boundsOfLoop):
(WebCore::rectangleLoop):
(WebCore::cornerwardDiagonal):
(WebCore::cornerCurveSegments):
(WebCore::outsetCornerSegments):
(WebCore::closeWedgeThroughCorner):
(WebCore::contourBySubtractingCorners):
(WebCore::addLoopsToPath):
(WebCore::borderContourPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/platform/graphics/DoubleSize.h:
(WebCore::DoubleSize::diagonalLength const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::addInnerCornerShapeToPath):
(WebCore::BorderShape::pathForInnerCornerShape const):
* Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp:
(TestWebKitAPI::TEST(BezierUtilities, IntersectBeziersFindsSingleCrossing)):
(TestWebKitAPI::TEST(BezierUtilities, IntersectBeziersFindsNothingWhenApart)):
(TestWebKitAPI::TEST(BezierUtilities, IntersectBeziersFindsSharedEndpoint)):
(TestWebKitAPI::TEST(BezierUtilities, IntersectBeziersFlagsTangentialTouch)):
(TestWebKitAPI::TEST(BezierUtilities, IntersectBeziersReportsCoincidentCurves)):
(TestWebKitAPI::TEST(BezierUtilities, IntersectBezierAndLineFindsCrossing)):
(TestWebKitAPI::TEST(BezierUtilities, SplitBezierAtParametersTilesTheCurve)):
(TestWebKitAPI::TEST(BezierUtilities, TangentOnBezierAtParameterFollowsTheCurve)):
(TestWebKitAPI::rectangleLoop):
(TestWebKitAPI::cornerSliver):
(TestWebKitAPI::loopBounds):
(TestWebKitAPI::TEST(BezierUtilities, WindingNumberIsZeroOutsideAndNonZeroInside)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingAMissingSliverLeavesTheRegionAlone)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingACoveringSliverLeavesNothing)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingOneCornerSliverBevelsThatCorner)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingOverlappingSliversRemovesTheirUnion)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingTheSameSliverTwiceIsIdempotent)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingACurvedSliverKeepsTheCurveInTheResult)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingAWedgeTouchingTheRegionsEdgesAtPoints)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingFourBevelWedgesLeavesADiamond)):
(TestWebKitAPI::TEST(BezierUtilities, SubtractingAWedgeTouchingTheOppositeEdgeSplitsTheRegion)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71e58e2572ea3a10f3330b8863f851ea7a108f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193398 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147469 "Hash 71e58e25 for PR 72539 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56838 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142985 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed.html imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/147469 "Hash 71e58e25 for PR 72539 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43650 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43271 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4572 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56772 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57477 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152163 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46718 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129747 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126074 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55985 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18282 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->