### PR TITLE
[Swift in WebKit] Make it possible for CxxCompletionHandler to be used with noncopyable arguments

### DIFF
--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -26,9 +26,11 @@
 #pragma once
 
 #include <memory>
+#include <new>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <wtf/AlignedStorage.h>
 #include <wtf/Compiler.h>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
@@ -39,7 +41,7 @@ namespace WTF {
 
 // The C ABI a Swift closure reduces to, used by the `CxxCompletionHandler` Swift protocol to build a
 // CompletionHandler out of a Swift closure.
-using SwiftClosureInvoke = void (* WTF_NONNULL)(void* WTF_NONNULL context, const void* WTF_NULLABLE argument);
+using SwiftClosureInvoke = void (* WTF_NONNULL)(void* WTF_NONNULL context, void* WTF_NULLABLE argument);
 using SwiftClosureDestroy = void (* WTF_NONNULL)(void* WTF_NONNULL context);
 
 template<typename> class CompletionHandler;
@@ -60,11 +62,6 @@ public:
     using OutType = Out;
     using InTypes = std::tuple<In...>;
     using Impl = typename Function<Out(In...)>::Impl;
-
-#if !COMPILER(MSVC)
-    // Used by Swift's `CxxCompletionHandlerBase` protocol.
-    using Argument = std::tuple_element_t<0, std::tuple<In..., void>>;
-#endif
 
     CompletionHandler() = default;
 
@@ -91,18 +88,14 @@ public:
     }
 
 #ifdef __swift__
-    // This should only be called within the initializers of the `CxxCompletionHandler` protocol.
+    // This should only be called within the initializers of the `CxxCompletionHandler` protocols.
     CompletionHandler(SwiftClosureInvoke invoke, SwiftClosureDestroy destroy, void* WTF_NONNULL context) SWIFT_NAME(init(invoke:destroy:context:))
         : CompletionHandler([invoke, owner = std::unique_ptr<void, SwiftClosureDestroy> { context, destroy }](In... arguments) -> Out {
-            static_assert(std::is_void_v<Out>, "Swift closures can only be used with completion handlers that return void.");
-            static_assert(sizeof...(In) <= 1, "Swift closures can only be used with completion handlers that take at most one argument.");
-
-            if constexpr (!sizeof...(In))
-                invoke(owner.get(), nullptr);
-            else
-                invoke(owner.get(), std::addressof(arguments)...);
+            passArgumentToSwift(invoke, owner.get(), std::forward<In>(arguments)...);
         })
     {
+        static_assert(std::is_void_v<Out>, "Swift closures can only be used with completion handlers that return void.");
+        static_assert(sizeof...(In) <= 1, "Swift closures can only be used with completion handlers that take at most one argument.");
     }
 #endif
 
@@ -118,6 +111,33 @@ public:
     }
 
 private:
+#ifdef __swift__
+    static void passArgumentToSwift(SwiftClosureInvoke invoke, void* WTF_NONNULL context, In... arguments)
+    {
+        if constexpr (!sizeof...(In))
+            invoke(context, nullptr);
+        else {
+            using DeclaredArgument = std::tuple_element_t<0, std::tuple<In...>>;
+            using ArgumentType = std::remove_cvref_t<DeclaredArgument>;
+
+            static_assert(!std::is_lvalue_reference_v<DeclaredArgument>);
+
+            if constexpr (std::is_copy_constructible_v<ArgumentType>) {
+                static_assert(!std::is_rvalue_reference_v<DeclaredArgument>);
+
+                invoke(context, std::addressof(arguments)...);
+            } else {
+                static_assert(std::is_rvalue_reference_v<DeclaredArgument>);
+                static_assert(!std::is_trivially_destructible_v<ArgumentType>);
+
+                AlignedStorage<ArgumentType> storage;
+                new (storage.get()) ArgumentType(std::forward<In>(arguments)...);
+                invoke(context, storage.get());
+            }
+        }
+    }
+#endif
+
     Function<Out(In...)> m_function;
     NO_UNIQUE_ADDRESS ThreadLikeAssertion m_callThread;
 };

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -1,4 +1,4 @@
-// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 15.
+// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 18.
 
 module wtf [system] {
     explicit module Assertions {

--- a/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
+++ b/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
@@ -27,9 +27,10 @@
 
 import wtf.Core.CompletionHandler
 
-/// The machinery shared by ``CxxCompletionHandler`` and ``CxxVoidCompletionHandler``.
+/// The machinery shared by ``CxxCompletionHandler``, ``CxxConsumingCompletionHandler``, and
+/// ``CxxVoidCompletionHandler``.
 ///
-/// - Important: Do not conform to this directly. Conform to one of those two instead.
+/// - Important: Do not conform to this directly. Conform to one of those three instead.
 protocol CxxCompletionHandlerBase: ~Copyable {
     /// The type of the completion handler's only parameter, or `Void` if it has none.
     ///
@@ -38,11 +39,7 @@ protocol CxxCompletionHandlerBase: ~Copyable {
     /// ```swift
     /// typealias Argument = CInt
     /// ```
-    ///
-    /// - Note: This cannot be inferred from `WTF::CompletionHandler`'s own type alias, because an imported C++
-    ///   class-template member type alias is not accepted as an associated-type witness under
-    ///   `MemberImportVisibility`. See rdar://185766398.
-    associatedtype Argument: BitwiseCopyable & Sendable
+    associatedtype Argument: ~Copyable
 
     /// Creates a completion handler from the C ABI a Swift closure reduces to: a function pointer, an opaque context, and
     /// a destructor for that context.
@@ -58,7 +55,7 @@ protocol CxxCompletionHandlerBase: ~Copyable {
     init(invoke: WTF.SwiftClosureInvoke, destroy: WTF.SwiftClosureDestroy, context: UnsafeMutableRawPointer)
 }
 
-/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument to conform to.
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument by value to conform to.
 ///
 /// Conforming a specialization to this protocol allows Swift to easily call functions that accept `WTF::CompletionHandler` parameters.
 /// For example, this makes it possible to call a function like:
@@ -92,8 +89,10 @@ protocol CxxCompletionHandlerBase: ~Copyable {
 ///
 /// Common specializations like `WTF::VoidCompletionHandler` and `WTF::BoolCompletionHandler` already conform.
 ///
+/// - Note: If the C++ parameter is an rvalue reference (`T&&`) rather than a value, conform to
+///   ``CxxConsumingCompletionHandler`` instead.
 /// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
-protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable where Argument: Copyable {
     /// Invokes the completion handler.
     ///
     /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
@@ -101,6 +100,26 @@ protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
     ///
     /// - Important: Do not implement this yourself.
     mutating func callAsFunction(_ argument: Argument)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument by rvalue reference to
+/// conform to.
+///
+/// This is the same as ``CxxCompletionHandler`` except that it matches a C++ signature like:
+///
+/// ```cpp
+/// using DoSomethingCompletionHandler = WTF::CompletionHandler<void(MoveOnlyThing&&)>;
+/// ```
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+protocol CxxConsumingCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+    /// Invokes the completion handler.
+    ///
+    /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
+    /// the type C++ actually passes.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction(consuming: consuming Argument)
 }
 
 /// A protocol for concrete specializations of `WTF::CompletionHandler` that take no argument to conform to.
@@ -115,13 +134,12 @@ extension CxxCompletionHandlerBase where Self: ~Copyable {
     /// Creates a completion handler that owns `box` and dispatches to it.
     ///
     /// - Parameter box: The box holding the Swift closure to call.
-    @safe
     fileprivate init(box: SwiftClosureBoxBase) {
         // This is all safe because all uses of the raw pointer are encapsulated in the C++ implementation and its lifetime
         // is not modified elsewhere.
         unsafe self.init(
             invoke: { context, argument in
-                // This uses `ErasedSwiftClosureBox` and not `SwiftClosureBox<Argument>` because a C function pointer
+                // This uses `SwiftClosureBoxBase` and not `SwiftClosureBox<Argument>` because a C function pointer
                 // cannot be formed from a closure that captures generic parameters.
                 unsafe Unmanaged<SwiftClosureBoxBase>.fromOpaque(context).takeUnretainedValue().call(with: argument)
             },
@@ -138,12 +156,30 @@ extension CxxCompletionHandler where Self: ~Copyable {
 
     /// Creates a `WTF::CompletionHandler` type from a Swift closure.
     ///
-    /// - Parameter body: The Swift closure to use.
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
     @safe
-    init(_ body: @escaping (Argument) -> Void) {
-        self.init(box: SwiftClosureBox(body))
+    init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping (Argument) -> Void) {
+        self.init(box: SwiftCopyingClosureBox(isolation: isolation, body))
     }
+}
 
+extension CxxConsumingCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
+    @safe
+    init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping (consuming Argument) -> Void) {
+        self.init(box: SwiftTakingClosureBox(isolation: isolation, body))
+    }
+}
+
+extension CxxCompletionHandler where Self: ~Copyable, Argument: Sendable {
     /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
     /// context trivial.
     ///
@@ -163,8 +199,8 @@ extension CxxVoidCompletionHandler where Self: ~Copyable {
     ///
     /// - Parameter body: The Swift closure to use.
     @safe
-    init(_ body: @escaping () -> Void) {
-        self.init(box: SwiftVoidClosureBox(body))
+    init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping () -> Void) {
+        self.init(box: SwiftVoidClosureBox(isolation: isolation, body))
     }
 
     /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
@@ -180,44 +216,110 @@ extension CxxVoidCompletionHandler where Self: ~Copyable {
 }
 
 private class SwiftClosureBoxBase {
-    func call(with argument: UnsafeRawPointer?) {
+    private let isolation: (any Actor)?
+
+    init(isolation: (any Actor)?) {
+        self.isolation = isolation
+    }
+
+    func call(with argument: UnsafeMutableRawPointer?) {
         preconditionFailure("Subclasses must override call(with:)")
+    }
+
+    final func checkIsolation() {
+        isolation?.preconditionIsolated("A completion handler must be invoked on the isolation that created it")
     }
 }
 
 private final class SwiftVoidClosureBox: SwiftClosureBoxBase {
     private let body: () -> Void
 
-    init(_ body: @escaping () -> Void) {
+    init(isolation: (any Actor)?, _ body: @escaping () -> Void) {
         self.body = body
+        super.init(isolation: isolation)
     }
 
-    override func call(with pointer: UnsafeRawPointer?) {
+    override func call(with pointer: UnsafeMutableRawPointer?) {
         unsafe precondition(pointer == nil)
+        checkIsolation()
         body()
     }
 }
 
-private final class SwiftClosureBox<Argument: BitwiseCopyable & Sendable>: SwiftClosureBoxBase {
+/// Copies the argument out of the pointer C++ supplied, leaving C++ to destroy its own object.
+private final class SwiftCopyingClosureBox<Argument>: SwiftClosureBoxBase {
     private let body: (Argument) -> Void
 
-    init(_ body: @escaping (Argument) -> Void) {
+    init(isolation: (any Actor)?, _ body: @escaping (Argument) -> Void) {
         self.body = body
+        super.init(isolation: isolation)
     }
 
-    override func call(with pointer: UnsafeRawPointer?) {
+    override func call(with pointer: UnsafeMutableRawPointer?) {
         guard let pointer = unsafe pointer else {
             preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
         }
 
-        // This is safe because `pointer` always comes from a value that was originally an `Argument` type.
-        let argument = unsafe pointer.load(as: Argument.self)
-        body(argument)
+        checkIsolation()
+
+        // Safety properties:
+        //
+        // Non-null, initialized, aligned: guarded above, and C++ passes `std::addressof` of the live
+        //     parameter object it was invoked with, so it is the address of a fully constructed object.
+        // Really an `Argument`: the `callAsFunction` requirement is witnessed by the imported C++
+        //     `operator()`, so a conformance whose `Argument` disagrees with the C++ parameter type does
+        //     not compile. The typealias is checked, not merely promised.
+        // Lifetime: `invoke` is synchronous, so C++ is blocked inside the call for as long as this runs
+        //     and cannot have released the object. This method never stores `pointer`; only the copied
+        //     value may outlive the call.
+        // Aliasing: C++ still owns that same object, so this may only read it. `.pointee` copies, and
+        //     C++ is blocked and so cannot be writing concurrently. Taking the value instead would
+        //     leave C++'s object deinitialized behind its back.
+        // Isolation: `checkIsolation()` above.
+
+        body(unsafe pointer.assumingMemoryBound(to: Argument.self).pointee)
+    }
+}
+
+/// Takes the argument out of the pointer C++ supplied.
+private final class SwiftTakingClosureBox<Argument: ~Copyable>: SwiftClosureBoxBase {
+    private let body: (consuming Argument) -> Void
+
+    init(isolation: (any Actor)?, _ body: @escaping (consuming Argument) -> Void) {
+        self.body = body
+        super.init(isolation: isolation)
+    }
+
+    override func call(with pointer: UnsafeMutableRawPointer?) {
+        guard let pointer = unsafe pointer else {
+            preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
+        }
+
+        checkIsolation()
+
+        // Safety properties:
+        //
+        // As in `SwiftCopyingClosureBox`, with three differences that all follow from C++ having built
+        // this object solely to hand over:
+        //
+        // Aliasing: C++ placement-new'd the value into an `AlignedStorage` local and does not touch it
+        //     again -- `AlignedStorage`'s destructor does not run `~ArgumentType` -- so taking it here
+        //     races with nothing. Alignment comes from `alignas(alignment_of_v<T>)` on that storage.
+        // Consumed exactly once: `.move()` deinitializes the storage, and nothing else destroys it. C++
+        //     will not, and `CompletionHandler::operator()` clears its function before calling, so the
+        //     handler cannot run twice.
+        // Relocation: Swift moves a noncopyable imported C++ value byte-wise rather than running its
+        //     move constructor. `WTF::CompletionHandler` static-asserts that such an argument has a
+        //     non-trivial destructor, which is what makes Swift use the move constructor instead.
+
+        body(unsafe pointer.assumingMemoryBound(to: Argument.self).move())
     }
 }
 
 extension WTF.VoidCompletionHandler: @unsafe CxxVoidCompletionHandler {}
 
-extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {}
+extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {
+    typealias Argument = Bool
+}
 
 #endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
@@ -27,9 +27,10 @@
 
 import wtf.Core.CompletionHandler
 
-/// The machinery shared by ``CxxCompletionHandler`` and ``CxxVoidCompletionHandler``.
+/// The machinery shared by ``CxxCompletionHandler``, ``CxxConsumingCompletionHandler``, and
+/// ``CxxVoidCompletionHandler``.
 ///
-/// - Important: Do not conform to this directly. Conform to one of those two instead.
+/// - Important: Do not conform to this directly. Conform to one of those three instead.
 public protocol CxxCompletionHandlerBase: ~Copyable {
     /// The type of the completion handler's only parameter, or `Void` if it has none.
     ///
@@ -38,11 +39,7 @@ public protocol CxxCompletionHandlerBase: ~Copyable {
     /// ```swift
     /// typealias Argument = CInt
     /// ```
-    ///
-    /// - Note: This cannot be inferred from `WTF::CompletionHandler`'s own type alias, because an imported C++
-    ///   class-template member type alias is not accepted as an associated-type witness under
-    ///   `MemberImportVisibility`. See rdar://185766398.
-    associatedtype Argument: BitwiseCopyable & Sendable
+    associatedtype Argument: ~Copyable
 
     /// Creates a completion handler from the C ABI a Swift closure reduces to: a function pointer, an opaque context, and
     /// a destructor for that context.
@@ -58,7 +55,7 @@ public protocol CxxCompletionHandlerBase: ~Copyable {
     init(invoke: WTF.SwiftClosureInvoke, destroy: WTF.SwiftClosureDestroy, context: UnsafeMutableRawPointer)
 }
 
-/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument to conform to.
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument by value to conform to.
 ///
 /// Conforming a specialization to this protocol allows Swift to easily call functions that accept `WTF::CompletionHandler` parameters.
 /// For example, this makes it possible to call a function like:
@@ -92,8 +89,10 @@ public protocol CxxCompletionHandlerBase: ~Copyable {
 ///
 /// Common specializations like `WTF::VoidCompletionHandler` and `WTF::BoolCompletionHandler` already conform.
 ///
+/// - Note: If the C++ parameter is an rvalue reference (`T&&`) rather than a value, conform to
+///   ``CxxConsumingCompletionHandler`` instead.
 /// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
-public protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+public protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable where Argument: Copyable {
     /// Invokes the completion handler.
     ///
     /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
@@ -101,6 +100,26 @@ public protocol CxxCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
     ///
     /// - Important: Do not implement this yourself.
     mutating func callAsFunction(_ argument: Argument)
+}
+
+/// A protocol for concrete specializations of `WTF::CompletionHandler` that take one argument by rvalue reference to
+/// conform to.
+///
+/// This is the same as ``CxxCompletionHandler`` except that it matches a C++ signature like:
+///
+/// ```cpp
+/// using DoSomethingCompletionHandler = WTF::CompletionHandler<void(MoveOnlyThing&&)>;
+/// ```
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+public protocol CxxConsumingCompletionHandler: CxxCompletionHandlerBase, ~Copyable {
+    /// Invokes the completion handler.
+    ///
+    /// This is implemented by the imported C++ `operator()`, which is what makes the compiler verify that `Argument` matches
+    /// the type C++ actually passes.
+    ///
+    /// - Important: Do not implement this yourself.
+    mutating func callAsFunction(consuming: consuming Argument)
 }
 
 /// A protocol for concrete specializations of `WTF::CompletionHandler` that take no argument to conform to.
@@ -120,7 +139,7 @@ extension CxxCompletionHandlerBase where Self: ~Copyable {
         // is not modified elsewhere.
         unsafe self.init(
             invoke: { context, argument in
-                // This uses `ErasedSwiftClosureBox` and not `SwiftClosureBox<Argument>` because a C function pointer
+                // This uses `SwiftClosureBoxBase` and not `SwiftClosureBox<Argument>` because a C function pointer
                 // cannot be formed from a closure that captures generic parameters.
                 unsafe Unmanaged<SwiftClosureBoxBase>.fromOpaque(context).takeUnretainedValue().call(with: argument)
             },
@@ -139,10 +158,26 @@ extension CxxCompletionHandler where Self: ~Copyable {
     ///
     /// - Parameter body: The Swift closure to use.
     @safe
-    public init(_ body: @escaping (Argument) -> Void) {
-        self.init(box: SwiftClosureBox(body))
+    public init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping (Argument) -> Void) {
+        self.init(box: SwiftCopyingClosureBox(isolation: isolation, body))
     }
+}
 
+extension CxxConsumingCompletionHandler where Self: ~Copyable {
+    // These functions are safe because its implementation is safe.
+
+    /// Creates a `WTF::CompletionHandler` type from a Swift closure.
+    ///
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
+    @safe
+    public init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping (consuming Argument) -> Void) {
+        self.init(box: SwiftTakingClosureBox(isolation: isolation, body))
+    }
+}
+
+extension CxxCompletionHandler where Self: ~Copyable, Argument: Sendable {
     /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
     /// context trivial.
     ///
@@ -160,10 +195,12 @@ extension CxxVoidCompletionHandler where Self: ~Copyable {
 
     /// Creates a `WTF::CompletionHandler` type from a Swift closure.
     ///
-    /// - Parameter body: The Swift closure to use.
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
     @safe
-    public init(_ body: @escaping () -> Void) {
-        self.init(box: SwiftVoidClosureBox(body))
+    public init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping () -> Void) {
+        self.init(box: SwiftVoidClosureBox(isolation: isolation, body))
     }
 
     /// A convenience initializer to create a completion handler from a `CheckedContinuation` directly to make bridging to a Swift `async`
@@ -179,43 +216,111 @@ extension CxxVoidCompletionHandler where Self: ~Copyable {
 }
 
 private class SwiftClosureBoxBase {
-    func call(with argument: UnsafeRawPointer?) {
+    private let isolation: (any Actor)?
+
+    init(isolation: (any Actor)?) {
+        self.isolation = isolation
+    }
+
+    func call(with argument: UnsafeMutableRawPointer?) {
         preconditionFailure("Subclasses must override call(with:)")
+    }
+
+    final func checkIsolation() {
+        isolation?.preconditionIsolated("A completion handler must be invoked on the isolation that created it")
     }
 }
 
 private final class SwiftVoidClosureBox: SwiftClosureBoxBase {
     private let body: () -> Void
 
-    init(_ body: @escaping () -> Void) {
+    init(isolation: (any Actor)?, _ body: @escaping () -> Void) {
         self.body = body
+        super.init(isolation: isolation)
     }
 
-    override func call(with pointer: UnsafeRawPointer?) {
+    override func call(with pointer: UnsafeMutableRawPointer?) {
+        unsafe precondition(pointer == nil)
+        checkIsolation()
         body()
     }
 }
 
-private final class SwiftClosureBox<Argument: BitwiseCopyable & Sendable>: SwiftClosureBoxBase {
+/// Copies the argument out of the pointer C++ supplied, leaving C++ to destroy its own object.
+private final class SwiftCopyingClosureBox<Argument>: SwiftClosureBoxBase {
     private let body: (Argument) -> Void
 
-    init(_ body: @escaping (Argument) -> Void) {
+    init(isolation: (any Actor)?, _ body: @escaping (Argument) -> Void) {
         self.body = body
+        super.init(isolation: isolation)
     }
 
-    override func call(with pointer: UnsafeRawPointer?) {
+    override func call(with pointer: UnsafeMutableRawPointer?) {
         guard let pointer = unsafe pointer else {
             preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
         }
 
-        // This is safe because `pointer` always comes from a value that was originally an `Argument` type.
-        let argument = unsafe pointer.load(as: Argument.self)
-        body(argument)
+        checkIsolation()
+
+        // Safety properties:
+        //
+        // Non-null, initialized, aligned: guarded above, and C++ passes `std::addressof` of the live
+        //     parameter object it was invoked with, so it is the address of a fully constructed object.
+        // Really an `Argument`: the `callAsFunction` requirement is witnessed by the imported C++
+        //     `operator()`, so a conformance whose `Argument` disagrees with the C++ parameter type does
+        //     not compile. The typealias is checked, not merely promised.
+        // Lifetime: `invoke` is synchronous, so C++ is blocked inside the call for as long as this runs
+        //     and cannot have released the object. This method never stores `pointer`; only the copied
+        //     value may outlive the call.
+        // Aliasing: C++ still owns that same object, so this may only read it. `.pointee` copies, and
+        //     C++ is blocked and so cannot be writing concurrently. Taking the value instead would
+        //     leave C++'s object deinitialized behind its back.
+        // Isolation: `checkIsolation()` above.
+
+        body(unsafe pointer.assumingMemoryBound(to: Argument.self).pointee)
+    }
+}
+
+/// Takes the argument out of the pointer C++ supplied.
+private final class SwiftTakingClosureBox<Argument: ~Copyable>: SwiftClosureBoxBase {
+    private let body: (consuming Argument) -> Void
+
+    init(isolation: (any Actor)?, _ body: @escaping (consuming Argument) -> Void) {
+        self.body = body
+        super.init(isolation: isolation)
+    }
+
+    override func call(with pointer: UnsafeMutableRawPointer?) {
+        guard let pointer = unsafe pointer else {
+            preconditionFailure("A completion handler taking an argument must be passed a pointer to one")
+        }
+
+        checkIsolation()
+
+        // Safety properties:
+        //
+        // As in `SwiftCopyingClosureBox`, with three differences that all follow from C++ having built
+        // this object solely to hand over:
+        //
+        // Aliasing: C++ placement-new'd the value into an `AlignedStorage` local and does not touch it
+        //     again -- `AlignedStorage`'s destructor does not run `~ArgumentType` -- so taking it here
+        //     races with nothing. Alignment comes from `alignas(alignment_of_v<T>)` on that storage.
+        // Consumed exactly once: `.move()` deinitializes the storage, and nothing else destroys it. C++
+        //     will not, and `CompletionHandler::operator()` clears its function before calling, so the
+        //     handler cannot run twice.
+        // Relocation: Swift moves a noncopyable imported C++ value byte-wise rather than running its
+        //     move constructor. `WTF::CompletionHandler` static-asserts that such an argument has a
+        //     non-trivial destructor, which is what makes Swift use the move constructor instead.
+
+        body(unsafe pointer.assumingMemoryBound(to: Argument.self).move())
     }
 }
 
 extension WTF.VoidCompletionHandler: @unsafe CxxVoidCompletionHandler {}
 
-extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {}
+extension WTF.BoolCompletionHandler: @unsafe CxxCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = Bool
+}
 
 #endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
@@ -34,6 +34,91 @@ namespace SwiftCxxInteropTestbed {
 // Handed to a stored handler that resetStoredIntCompletionHandler() has to call itself.
 static constexpr int teardownValue = -2;
 
+// Left behind in a probe that has been moved from, so a test sees an obviously wrong value rather than a
+// plausible one if the bridge hands Swift the source of a move instead of the destination.
+static constexpr int movedFromValue = -1;
+
+static int& liveMoveOnlyProbes()
+{
+    static int count = 0;
+    return count;
+}
+
+MoveOnlyProbe::MoveOnlyProbe(int value)
+    : m_value(value)
+{
+    ++liveMoveOnlyProbes();
+}
+
+MoveOnlyProbe::MoveOnlyProbe(MoveOnlyProbe&& other)
+    : m_value(other.m_value)
+{
+    other.m_value = movedFromValue;
+    ++liveMoveOnlyProbes();
+}
+
+MoveOnlyProbe::~MoveOnlyProbe()
+{
+    --liveMoveOnlyProbes();
+}
+
+int liveMoveOnlyProbeCount()
+{
+    return liveMoveOnlyProbes();
+}
+
+static int& liveCopyCountingProbes()
+{
+    static int count = 0;
+    return count;
+}
+
+static int& copyCountingProbeCopies()
+{
+    static int count = 0;
+    return count;
+}
+
+CopyCountingProbe::CopyCountingProbe(int value)
+    : m_value(value)
+{
+    ++liveCopyCountingProbes();
+}
+
+CopyCountingProbe::CopyCountingProbe(const CopyCountingProbe& other)
+    : m_value(other.m_value)
+{
+    ++copyCountingProbeCopies();
+    ++liveCopyCountingProbes();
+}
+
+CopyCountingProbe::CopyCountingProbe(CopyCountingProbe&& other)
+    : m_value(other.m_value)
+{
+    other.m_value = movedFromValue;
+    ++liveCopyCountingProbes();
+}
+
+CopyCountingProbe::~CopyCountingProbe()
+{
+    --liveCopyCountingProbes();
+}
+
+int liveCopyCountingProbeCount()
+{
+    return liveCopyCountingProbes();
+}
+
+int copyCountingProbeCopyCount()
+{
+    return copyCountingProbeCopies();
+}
+
+void resetCopyCountingProbeCounts()
+{
+    copyCountingProbeCopies() = 0;
+}
+
 int callIntBoolFunction(bool argument, IntBoolFunction&& function)
 {
     return function(argument);
@@ -83,6 +168,129 @@ void resetStoredIntCompletionHandler()
     // must never assert itself, so check the handler has not already run.
     if (handler && *handler)
         (*handler)(teardownValue);
+}
+
+void callMoveOnlyProbeCompletionHandler(int argument, MoveOnlyProbeCompletionHandler&& completionHandler)
+{
+    completionHandler(MoveOnlyProbe { argument });
+}
+
+void callCopyCountingProbeCompletionHandler(int argument, CopyCountingProbeCompletionHandler&& completionHandler)
+{
+    completionHandler(CopyCountingProbe { argument });
+}
+
+static std::optional<MoveOnlyProbeCompletionHandler>& storedMoveOnlyProbeCompletionHandler()
+{
+    static std::optional<MoveOnlyProbeCompletionHandler> handler;
+    return handler;
+}
+
+void storeMoveOnlyProbeCompletionHandler(MoveOnlyProbeCompletionHandler&& completionHandler)
+{
+    // See storeIntCompletionHandler().
+    RELEASE_ASSERT(!storedMoveOnlyProbeCompletionHandler());
+    storedMoveOnlyProbeCompletionHandler().emplace(WTF::move(completionHandler));
+}
+
+void invokeStoredMoveOnlyProbeCompletionHandler(int argument)
+{
+    auto handler = WTF::move(storedMoveOnlyProbeCompletionHandler());
+    storedMoveOnlyProbeCompletionHandler().reset();
+
+    if (handler)
+        (*handler)(MoveOnlyProbe { argument });
+}
+
+void resetStoredMoveOnlyProbeCompletionHandler()
+{
+    auto handler = WTF::move(storedMoveOnlyProbeCompletionHandler());
+    storedMoveOnlyProbeCompletionHandler().reset();
+
+    // See resetStoredIntCompletionHandler().
+    if (handler && *handler)
+        (*handler)(MoveOnlyProbe { teardownValue });
+}
+
+static int& sharedProbeRefs()
+{
+    static int count = 0;
+    return count;
+}
+
+static int& sharedProbeDerefs()
+{
+    static int count = 0;
+    return count;
+}
+
+void SharedProbe::ref()
+{
+    ++sharedProbeRefs();
+    ++m_refCount;
+}
+
+void SharedProbe::deref()
+{
+    ++sharedProbeDerefs();
+    --m_refCount;
+
+    // Deliberately never freed: see the class comment. A test that drove the count to zero has to be
+    // able to report that rather than crash on the next access.
+}
+
+static SharedProbe& sharedProbe()
+{
+    static SharedProbe probe;
+    return probe;
+}
+
+int callSharedProbeHolderCompletionHandler(SharedProbeHolderCompletionHandler&& completionHandler)
+{
+    completionHandler(SharedProbeHolder { &sharedProbe() });
+    return sharedProbe().refCount();
+}
+
+int sharedProbeRefCalls()
+{
+    return sharedProbeRefs();
+}
+
+int sharedProbeDerefCalls()
+{
+    return sharedProbeDerefs();
+}
+
+void resetSharedProbe()
+{
+    sharedProbeRefs() = 0;
+    sharedProbeDerefs() = 0;
+    sharedProbe().resetRefCount();
+}
+
+SelfReferentialProbe::SelfReferentialProbe(int value)
+    : m_value(value)
+    , m_self(&m_value)
+{
+}
+
+SelfReferentialProbe::SelfReferentialProbe(SelfReferentialProbe&& other)
+    : m_value(other.m_value)
+    , m_self(&m_value)
+{
+    other.m_value = movedFromValue;
+}
+
+SelfReferentialProbe::~SelfReferentialProbe()
+{
+    // Non-trivial on purpose. See the class comment: this is what makes Swift relocate the value with
+    // the move constructor above instead of copying its bytes.
+    m_self = nullptr;
+}
+
+void callSelfReferentialProbeCompletionHandler(int argument, SelfReferentialProbeCompletionHandler&& completionHandler)
+{
+    completionHandler(SelfReferentialProbe { argument });
 }
 
 };

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
@@ -35,12 +35,88 @@ namespace SwiftCxxInteropTestbed {
 
 // MARK: Types
 
+// Move-only, so that Swift imports it as `~Copyable`.
+class MoveOnlyProbe {
+public:
+    explicit MoveOnlyProbe(int);
+    MoveOnlyProbe(MoveOnlyProbe&&);
+    MoveOnlyProbe(const MoveOnlyProbe&) = delete;
+    MoveOnlyProbe& operator=(const MoveOnlyProbe&) = delete;
+    ~MoveOnlyProbe();
+
+    int value() const { return m_value; }
+
+private:
+    int m_value;
+};
+
+// Copyable but not trivially copyable, like WTF::String or WTF::Vector: the bridge has to run the copy
+// constructor for one of these rather than copying its bytes.
+class CopyCountingProbe {
+public:
+    explicit CopyCountingProbe(int);
+    CopyCountingProbe(const CopyCountingProbe&);
+    CopyCountingProbe(CopyCountingProbe&&);
+    ~CopyCountingProbe();
+
+    int value() const { return m_value; }
+
+private:
+    int m_value;
+};
+
+// Refcounted, and imported by Swift as a managed reference. C++ and Swift disagree about who owns a
+// raw pointer to one of these, so the bridge has to let Swift copy any argument holding one rather
+// than take it. Nothing is ever freed, so a miscount fails an assertion instead of crashing the
+// test binary.
+class SharedProbe {
+public:
+    void ref();
+    void deref();
+
+    int refCount() const { return m_refCount; }
+    void resetRefCount() { m_refCount = 1; }
+
+private:
+    int m_refCount { 1 };
+} SWIFT_SHARED_REFERENCE(refSharedProbe, derefSharedProbe);
+
+// Trivially copyable in C++, so its copy constructor does not retain, but Swift imports `probe` as a
+// managed reference that Swift will release.
+struct SharedProbeHolder {
+    SharedProbe* probe;
+};
+
+// Holds a pointer into itself, so relocating it byte-wise would leave that pointer dangling. Its
+// non-trivial destructor is what makes Swift relocate it with the move constructor instead, which is
+// the property WTF::CompletionHandler's static_assert relies on.
+class SelfReferentialProbe {
+public:
+    explicit SelfReferentialProbe(int);
+    SelfReferentialProbe(SelfReferentialProbe&&);
+    SelfReferentialProbe(const SelfReferentialProbe&) = delete;
+    SelfReferentialProbe& operator=(const SelfReferentialProbe&) = delete;
+    ~SelfReferentialProbe();
+
+    bool interiorPointerIsValid() const { return m_self == &m_value; }
+    int valueThroughInteriorPointer() const { return *m_self; }
+
+private:
+    int m_value;
+    int* m_self;
+};
+
 // MARK: Using declarations
 
 using IntBoolFunction = WTF::Function<int(bool)>;
 
 using IntCompletionHandler = WTF::CompletionHandler<void(int)>;
 using VoidCompletionHandler = WTF::CompletionHandler<void()>;
+
+using MoveOnlyProbeCompletionHandler = WTF::CompletionHandler<void(MoveOnlyProbe&&)>;
+using CopyCountingProbeCompletionHandler = WTF::CompletionHandler<void(CopyCountingProbe)>;
+using SharedProbeHolderCompletionHandler = WTF::CompletionHandler<void(SharedProbeHolder)>;
+using SelfReferentialProbeCompletionHandler = WTF::CompletionHandler<void(SelfReferentialProbe&&)>;
 
 // MARK: Function declarations
 
@@ -57,6 +133,45 @@ void invokeStoredIntCompletionHandler(int);
 // otherwise leave it stranded for the next test to trip over.
 void resetStoredIntCompletionHandler();
 
+void callMoveOnlyProbeCompletionHandler(int, MoveOnlyProbeCompletionHandler&&);
+
+void storeMoveOnlyProbeCompletionHandler(MoveOnlyProbeCompletionHandler&&);
+void invokeStoredMoveOnlyProbeCompletionHandler(int);
+void resetStoredMoveOnlyProbeCompletionHandler();
+
+// A copyable argument reaches Swift as a copy, so exactly one copy constructor call should be observable.
+void callCopyCountingProbeCompletionHandler(int, CopyCountingProbeCompletionHandler&&);
+
+// Zero once every probe the bridge constructed has been destroyed, so a test can prove the argument's
+// destructor ran exactly once on the way across.
+int liveMoveOnlyProbeCount();
+int liveCopyCountingProbeCount();
+
+// How many times CopyCountingProbe's copy constructor has run since resetCopyCountingProbeCounts().
+int copyCountingProbeCopyCount();
+void resetCopyCountingProbeCounts();
+
+// Hands the handler a borrowed reference to the shared probe and returns its reference count once the
+// handler has run. A bridge that leaves the caller's ownership alone returns 1.
+int callSharedProbeHolderCompletionHandler(SharedProbeHolderCompletionHandler&&);
+
+// How many times the bridge caused a retain or a release. These must match.
+int sharedProbeRefCalls();
+int sharedProbeDerefCalls();
+void resetSharedProbe();
+
+void callSelfReferentialProbeCompletionHandler(int, SelfReferentialProbeCompletionHandler&&);
+
+}
+
+inline void refSharedProbe(SwiftCxxInteropTestbed::SharedProbe* WTF_NONNULL probe)
+{
+    probe->ref();
+}
+
+inline void derefSharedProbe(SwiftCxxInteropTestbed::SharedProbe* WTF_NONNULL probe)
+{
+    probe->deref();
 }
 
 #endif // __cplusplus

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
@@ -39,6 +39,32 @@ extension Cxx.IntCompletionHandler: @unsafe TestWTFLibrary.CxxCompletionHandler 
     public typealias Argument = CInt
 }
 
+// `MoveOnlyProbe` is move-only in C++, so Swift imports it as `~Copyable`. This one takes it by rvalue
+// reference, which the importer spells as `callAsFunction(consuming:)`, hence `CxxConsumingCompletionHandler`.
+extension Cxx.MoveOnlyProbeCompletionHandler: @unsafe TestWTFLibrary.CxxConsumingCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = SwiftCxxInteropTestbed.MoveOnlyProbe
+}
+
+// Copyable but not trivially copyable: this argument reaches Swift through its copy constructor.
+extension Cxx.CopyCountingProbeCompletionHandler: @unsafe TestWTFLibrary.CxxCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = SwiftCxxInteropTestbed.CopyCountingProbe
+}
+
+// Trivially copyable in C++, but Swift imports the `probe` field as a managed reference, so the bridge
+// has to let Swift copy this argument rather than take it.
+extension Cxx.SharedProbeHolderCompletionHandler: @unsafe TestWTFLibrary.CxxCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = SwiftCxxInteropTestbed.SharedProbeHolder
+}
+
+// Noncopyable, so it is transferred to Swift, and it notices if Swift relocates it byte-wise.
+extension Cxx.SelfReferentialProbeCompletionHandler: @unsafe TestWTFLibrary.CxxConsumingCompletionHandler {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public typealias Argument = SwiftCxxInteropTestbed.SelfReferentialProbe
+}
+
 // MARK: - Helpers
 
 /// Observed via a weak reference to prove the closure context was released.
@@ -172,6 +198,112 @@ struct SwiftCxxInteropTests {
         }
 
         #expect(result == 9)
+    }
+
+    // MARK: Noncopyable arguments
+
+    @Test
+    func moveOnlyCompletionHandlerReceivesItsArgument() async throws {
+        let recorder = Recorder()
+
+        Cxx.callMoveOnlyProbeCompletionHandler(
+            5,
+            consuming: .init { (probe: consuming Cxx.MoveOnlyProbe) in
+                recorder.values.append(probe.value())
+            }
+        )
+
+        #expect(recorder.values == [5])
+        #expect(Cxx.liveMoveOnlyProbeCount() == 0, "the argument should be destroyed exactly once")
+    }
+
+    @Test
+    func moveOnlyArgumentIsDestroyedWhenTheClosureIgnoresIt() async throws {
+        // C++ hands ownership of the argument to Swift, so nothing else will destroy it if the closure
+        // does not look at it.
+        Cxx.callMoveOnlyProbeCompletionHandler(8, consuming: .init { _ in })
+
+        #expect(Cxx.liveMoveOnlyProbeCount() == 0, "an ignored argument should still be destroyed")
+    }
+
+    @Test
+    func storedMoveOnlyCompletionHandlerSurvivesUntilInvoked() async throws {
+        // See contextSurvivesUntilTheHandlerIsInvokedLater().
+        defer { Cxx.resetStoredMoveOnlyProbeCompletionHandler() }
+
+        let recorder = Recorder()
+
+        Cxx.storeMoveOnlyProbeCompletionHandler(
+            consuming: .init { (probe: consuming Cxx.MoveOnlyProbe) in
+                recorder.values.append(probe.value())
+            }
+        )
+        Cxx.invokeStoredMoveOnlyProbeCompletionHandler(9)
+
+        #expect(recorder.values == [9])
+        #expect(Cxx.liveMoveOnlyProbeCount() == 0, "the argument should be destroyed exactly once")
+    }
+
+    // MARK: Copyable, non-trivially-copyable arguments
+
+    @Test
+    func copyableArgumentIsCopiedRatherThanTakenFromTheCaller() async throws {
+        Cxx.resetCopyCountingProbeCounts()
+
+        let recorder = Recorder()
+
+        // A copyable argument reaches Swift as a copy made by Swift, not by C++.
+        Cxx.callCopyCountingProbeCompletionHandler(
+            11,
+            consuming: .init { (probe: Cxx.CopyCountingProbe) in
+                recorder.values.append(probe.value())
+            }
+        )
+
+        #expect(recorder.values == [11], "Swift should see the value C++ passed")
+        #expect(Cxx.copyCountingProbeCopyCount() == 1, "exactly one copy should be made for Swift")
+        #expect(Cxx.liveCopyCountingProbeCount() == 0, "every probe should be destroyed")
+    }
+
+    // MARK: Arguments holding a managed reference
+
+    @Test
+    func argumentHoldingAManagedReferenceLeavesTheCallersCountAlone() async throws {
+        Cxx.resetSharedProbe()
+
+        // The closure never looks at the argument, so any change to the reference count is the bridge's
+        // doing rather than the closure's. C++ passed a borrowed reference and still holds it.
+        let refCountAfter = Cxx.callSharedProbeHolderCompletionHandler(consuming: .init { _ in })
+
+        #expect(
+            Cxx.sharedProbeRefCalls() == Cxx.sharedProbeDerefCalls(),
+            "the bridge must balance every retain and release it causes"
+        )
+        #expect(refCountAfter == 1, "the caller's own reference must survive the handler")
+    }
+
+    // MARK: Relocation
+
+    @Test
+    func noncopyableArgumentIsRelocatedWithItsMoveConstructor() async throws {
+        let recorder = Recorder()
+
+        // Pins the property that WTF::CompletionHandler's static_assert relies on: a noncopyable
+        // argument with a non-trivial destructor is relocated by running its C++ move constructor, so
+        // a pointer into the object stays valid. If Swift ever copies the bytes instead, the interior
+        // pointer is left aimed at storage C++ has already abandoned.
+        Cxx.callSelfReferentialProbeCompletionHandler(
+            7,
+            consuming: .init { (probe: consuming Cxx.SelfReferentialProbe) in
+                unsafe recorder.values.append(probe.interiorPointerIsValid() ? 1 : 0)
+                unsafe recorder.values.append(probe.valueThroughInteriorPointer())
+            }
+        )
+
+        #expect(
+            recorder.values == [1, 7],
+            "a noncopyable argument must be relocated with its move constructor, not by copying its bytes"
+        )
     }
 }
 


### PR DESCRIPTION
#### 436d708da9283630f51ba699e2ef24d8fecd1edb
<pre>
[Swift in WebKit] Make it possible for CxxCompletionHandler to be used with noncopyable arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=322659">https://bugs.webkit.org/show_bug.cgi?id=322659</a>
<a href="https://rdar.apple.com/185932647">rdar://185932647</a>

Reviewed by Adrian Taylor.

CxxCompletionHandler currently has `BitwiseCopyable &amp; Sendable` for its `Argument` associatedtype,
and uses `pointer.load(as:)` to copy the value. This is fine for trivial copyable types, but meant
that noncopyable argument types were prohibited.

Relax this restriction by changing the requirement to `~Copyable` and transfer the ownership of the
argument instead of copying it. In the non-trivial case, this works by constructing the argument
into a new buffer which Swift then relocates and moves the value out of.

To facilitate this, a new `CxxConsumingCompletionHandler` protocol is added because the importer
spells `operator()` as `callAsFunction(consuming:)` when the C++ parameter is an rvalue reference.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift

* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
* Source/WTF/wtf/module.modulemap:
* Source/WebKit/Shared/WTFCompletionHandler+Extras.swift:
(CxxCompletionHandler.callAsFunction(_:)):
(CxxConsumingCompletionHandler.callAsFunction(_:)):
(SwiftClosureBoxBase.call(with:)):
(SwiftVoidClosureBox.call(with:)):
(SwiftClosureBox.call(with:)):
* Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift:
(CxxCompletionHandler.callAsFunction(_:)):
(CxxConsumingCompletionHandler.callAsFunction(_:)):
(SwiftClosureBoxBase.call(with:)):
(SwiftVoidClosureBox.call(with:)):
(SwiftClosureBox.call(with:)):
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp:
(SwiftCxxInteropTestbed::liveMoveOnlyProbes):
(SwiftCxxInteropTestbed::MoveOnlyProbe::MoveOnlyProbe):
(SwiftCxxInteropTestbed::MoveOnlyProbe::~MoveOnlyProbe):
(SwiftCxxInteropTestbed::liveMoveOnlyProbeCount):
(SwiftCxxInteropTestbed::liveCopyCountingProbes):
(SwiftCxxInteropTestbed::copyCountingProbeCopies):
(SwiftCxxInteropTestbed::CopyCountingProbe::CopyCountingProbe):
(SwiftCxxInteropTestbed::CopyCountingProbe::~CopyCountingProbe):
(SwiftCxxInteropTestbed::liveCopyCountingProbeCount):
(SwiftCxxInteropTestbed::copyCountingProbeCopyCount):
(SwiftCxxInteropTestbed::resetCopyCountingProbeCounts):
(SwiftCxxInteropTestbed::callMoveOnlyProbeCompletionHandler):
(SwiftCxxInteropTestbed::callMoveOnlyProbeByValueCompletionHandler):
(SwiftCxxInteropTestbed::callCopyCountingProbeCompletionHandler):
(SwiftCxxInteropTestbed::storedMoveOnlyProbeCompletionHandler):
(SwiftCxxInteropTestbed::storeMoveOnlyProbeCompletionHandler):
(SwiftCxxInteropTestbed::invokeStoredMoveOnlyProbeCompletionHandler):
(SwiftCxxInteropTestbed::resetStoredMoveOnlyProbeCompletionHandler):
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h:
(SwiftCxxInteropTestbed::MoveOnlyProbe::value const):
(SwiftCxxInteropTestbed::CopyCountingProbe::value const):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift:
(SwiftCxxInteropTests.moveOnlyCompletionHandlerReceivesItsArgument):
(SwiftCxxInteropTests.moveOnlyByValueCompletionHandlerReceivesItsArgument):
(SwiftCxxInteropTests.moveOnlyArgumentIsDestroyedWhenTheClosureIgnoresIt):
(SwiftCxxInteropTests.storedMoveOnlyCompletionHandlerSurvivesUntilInvoked):
(SwiftCxxInteropTests.copyableArgumentIsCopiedRatherThanTakenFromTheCaller):

Canonical link: <a href="https://commits.webkit.org/319991@main">https://commits.webkit.org/319991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57275c1a2f506db85183cedc815a931aea8c0408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183378 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193599 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ec91af8-1d0e-44b8-b4ef-8d5f00092bd5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57037 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98b6565b-005f-4526-9f7c-3eb64a46c68f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163915 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba94a6cf-136f-48c9-b56a-1cb5efc9dca1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45593 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12383 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43439 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44654 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49957 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195538 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56972 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40906 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57676 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152332 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46890 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56184 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18449 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55622 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->