### PR TITLE
Cherry-pick 319858@main (9d3acc999bfd). https://bugs.webkit.org/show_bug.cgi?id=322572

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -380,7 +380,7 @@ std::optional<int64_t> IconDatabase::addIcon(const String& iconURL, const Vector
     ASSERT(m_allowDatabaseWrite == AllowDatabaseWrite::Yes);
 
     if (!m_addIconStatement) {
-        m_addIconStatement = m_db->prepareStatement("INSERT INTO IconInfo (url, stamp) VALUES (?, 0);"_s);
+        m_addIconStatement = m_db->prepareStatement("INSERT INTO IconInfo (url, stamp) VALUES (?, unixepoch());"_s);
         if (!m_addIconStatement) {
             LOG_ERROR("Preparing statement addIcon failed");
             return std::nullopt;


### PR DESCRIPTION
#### ba5e31eb3db9381617d6a6ede211f8472c016b38
<pre>
Cherry-pick 319858@main (9d3acc999bfd). <a href="https://bugs.webkit.org/show_bug.cgi?id=322572">https://bugs.webkit.org/show_bug.cgi?id=322572</a>

    [GTK][WPE] IconDatabase should use current timestamp when inserting new icons
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322572">https://bugs.webkit.org/show_bug.cgi?id=322572</a>

    Reviewed by Carlos Garcia Campos.

    Use the current Unix epoch as timestamp when adding a new item in
    IconDatabase::addIcon(). Another option that was considered was changing
    the database schema to include &quot;default (unixepoch())&quot; in the timestamp
    column; but it was discarded to avoid changing the schema version.

    Prior to the fix, using zero as timestamp when adding a new page icon in
    IconDatabase::addIcon() made it always look as if it were immediately
    expired:

    - IconDatabase::iconIDForIconURL() would flag icons as expired,
      resulting in them being re-downloaded.

    - IconDatabase::pruneTimerFired() would remove icons from the database
      if their timestamp has not been touched, making icons prone to be
      removed before they have a chance to be used if the timer kicks in
      before their first use.

    Unfortunately writing a proper test for this would be tricky it would
    need access to the IconDatabase internals, and testing would be slow
    because it would need a 10s pause for every test case.

    * Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
    (WebKit::IconDatabase::addIcon):

    Canonical link: <a href="https://commits.webkit.org/319858@main">https://commits.webkit.org/319858@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1123@webkitglib/2.52">https://commits.webkit.org/305877.1123@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6addf4d1a2ad27cc941b49537d9458af588cc419

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183192 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57115 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147481 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58457 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56850 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147481 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186147 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58457 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58457 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56850 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58457 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/4584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49762 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56850 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195351 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56784 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57489 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/152167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27794 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57489 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129759 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125998 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55997 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50932 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55368 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55606 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55435 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->