### PR TITLE
Persist the resolved IP address space with a cached response

### DIFF
--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -699,6 +699,7 @@ void Coder<WebCore::ResourceResponse>::encodeForPersistence(Encoder& encoder, co
     WebCore::WasPrivateRelayed wasPrivateRelayed = instance.m_wasPrivateRelayed;
     encoder << wasPrivateRelayed;
     encoder << instance.m_isRangeRequested;
+    encoder << static_cast<WebCore::IPAddressSpace>(instance.m_ipAddressSpace);
 }
 
 std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decodeForPersistence(Decoder& decoder)
@@ -809,6 +810,12 @@ std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decod
     if (!isRangeRequested)
         return std::nullopt;
     response.m_isRangeRequested = WTF::move(*isRangeRequested);
+
+    std::optional<WebCore::IPAddressSpace> ipAddressSpace;
+    decoder >> ipAddressSpace;
+    if (!ipAddressSpace)
+        return std::nullopt;
+    response.m_ipAddressSpace = WTF::move(*ipAddressSpace);
 
     return { WTF::move(response) };
 }

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -950,6 +950,7 @@ void Coder<WebCore::ResourceResponseData>::encodeForPersistence(Encoder& encoder
     encoder << data.wasPrivateRelayed;
     encoder << data.proxyName;
     encoder << data.isRangeRequested;
+    encoder << data.ipAddressSpace;
 }
 
 std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData>::decodeForPersistence(Decoder& decoder)
@@ -1039,6 +1040,11 @@ std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData
     if (!isRangeRequested)
         return std::nullopt;
 
+    std::optional<WebCore::IPAddressSpace> ipAddressSpace;
+    decoder >> ipAddressSpace;
+    if (!ipAddressSpace)
+        return std::nullopt;
+
     return WebCore::ResourceResponseData {
         WTF::move(*url),
         WTF::move(*mimeType),
@@ -1058,7 +1064,7 @@ std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData
         WTF::move(*proxyName),
         *isRangeRequested,
         WTF::move(*certificateInfo),
-        WebCore::IPAddressSpace::Unknown
+        *ipAddressSpace
     };
 }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -395,6 +395,16 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Source
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::IPAddressSpace> {
+    using values = EnumValues<
+        WebCore::IPAddressSpace,
+        WebCore::IPAddressSpace::Public,
+        WebCore::IPAddressSpace::Local,
+        WebCore::IPAddressSpace::Loopback,
+        WebCore::IPAddressSpace::Unknown
+    >;
+};
+
 namespace Persistence {
 
 class Decoder;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -614,6 +614,7 @@ std::unique_ptr<Entry> Cache::update(const WebCore::ResourceRequest& originalReq
 
     WebCore::ResourceResponse response = existingEntry.response();
     WebCore::updateResponseHeadersAfterRevalidation(response, validatingResponse);
+    response.setIPAddressSpace(validatingResponse.ipAddressSpace());
 
     auto updateEntry = makeUnique<Entry>(existingEntry.key(), response, privateRelayed, existingEntry.buffer(), WebCore::collectVaryingRequestHeaders(protect(m_networkProcess->storageSession(m_sessionID)), originalRequest, response));
     auto updateRecord = updateEntry->encodeAsStorageRecord();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -131,7 +131,7 @@ public:
     size_t NODELETE approximateSize() const;
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
-    static const unsigned version = 17;
+    static const unsigned version = 18;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -29,7 +29,11 @@
 #include <WebCore/IPAddressSpace.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/Site.h>
+#include <WebCore/WebCorePersistentCoders.h>
 #include <wtf/URL.h>
+#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 namespace TestWebKitAPI {
 
@@ -457,6 +461,45 @@ TEST(IPAddressSpace, DoesNotOvermatchReservedNames)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://localhost.example.com/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://mylocal/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://local.example.com/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Both persistence coders are covered: ResourceResponseData is what the network cache stores, and
+// ResourceResponse is what other persistent callers encode.
+TEST(IPAddressSpace, SurvivesResponseDataPersistenceRoundTrip)
+{
+    for (auto space : { WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Unknown }) {
+        WebCore::ResourceResponse response { URL { "http://192.168.1.1/"_s }, "text/plain"_s, 5, "UTF-8"_s };
+        response.setIPAddressSpace(space);
+
+        auto data = response.getResponseData();
+        ASSERT_TRUE(data.has_value());
+
+        WTF::Persistence::Encoder encoder;
+        WTF::Persistence::Coder<WebCore::ResourceResponseData>::encodeForPersistence(encoder, *data);
+
+        WTF::Persistence::Decoder decoder(encoder.span());
+        auto decoded = WTF::Persistence::Coder<WebCore::ResourceResponseData>::decodeForPersistence(decoder);
+        ASSERT_TRUE(decoded.has_value());
+
+        EXPECT_EQ(decoded->ipAddressSpace, space);
+    }
+}
+
+TEST(IPAddressSpace, SurvivesResourceResponsePersistenceRoundTrip)
+{
+    for (auto space : { WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Unknown }) {
+        WebCore::ResourceResponse response { URL { "http://192.168.1.1/"_s }, "text/plain"_s, 5, "UTF-8"_s };
+        response.setIPAddressSpace(space);
+
+        WTF::Persistence::Encoder encoder;
+        WTF::Persistence::Coder<WebCore::ResourceResponse>::encodeForPersistence(encoder, response);
+
+        WTF::Persistence::Decoder decoder(encoder.span());
+        auto decoded = WTF::Persistence::Coder<WebCore::ResourceResponse>::decodeForPersistence(decoder);
+        ASSERT_TRUE(decoded.has_value());
+
+        EXPECT_EQ(decoded->ipAddressSpace(), space);
+    }
 }
 
 }


### PR DESCRIPTION
#### bc7a9e0619dd06c2f3332aaf5ca1ea1e612640d2
<pre>
Persist the resolved IP address space with a cached response
<a href="https://bugs.webkit.org/show_bug.cgi?id=322661">https://bugs.webkit.org/show_bug.cgi?id=322661</a>
<a href="https://rdar.apple.com/185933660">rdar://185933660</a>

Reviewed by Chris Dumez.

Part of the Local Network Access implementation, <a href="https://wicg.github.io/local-network-access/">https://wicg.github.io/local-network-access/</a> - the
check compares the address space a connection resolved to against the client&apos;s, so that space has to
survive being written to the network cache.

ResourceResponse carries the address space the connection resolved to, but it was dropped on the way
to disk: neither persistence coder encoded it, and the ResourceResponseData decoder hardcoded
IPAddressSpace::Unknown. A response read back from the network cache therefore lost the space its
connection had originally resolved to.

Both coders now encode and decode it, and EnumTraitsForPersistence is declared for IPAddressSpace so
the enum can be persisted at all. The cache version is bumped, since existing entries were written
without the field and cannot be read back with it.

Cache::update() takes the space from the validating response rather than keeping the stored one. The
body is reused on a 304, but the resource is being served now from the validating connection, and a
host that has since moved to a local address must not be reachable on the address space it used to
have.

Two tests cover the coders separately, across all four enum values. Reverting either coder fails only
its own test.

* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::decodeForPersistence):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseData&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseData&gt;::decodeForPersistence):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::update):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:

Canonical link: <a href="https://commits.webkit.org/320077@main">https://commits.webkit.org/320077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c253c22535fe8903fa68803567aa22c47a5e15fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143350 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99531 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45816 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43629 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5064 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57256 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57960 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152572 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47111 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130239 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126553 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->