### PR TITLE
JSDOMException is not reconciling it's weak stack trace

### DIFF
--- a/LayoutTests/fast/dom/DOMException/stack-trace-survives-gc-expected.txt
+++ b/LayoutTests/fast/dom/DOMException/stack-trace-survives-gc-expected.txt
@@ -1,0 +1,12 @@
+A DOMException captures a stack trace whose frames point at the functions that were on the stack, and the GC does not trace those pointers. When one of those functions dies the trace must be turned into strings, or reading .stack afterwards reads cells that have been freed and handed out again. That requires the GC to reconcile weak references in the DOMException subspace.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS exceptions.length is 1000
+PASS exceptions[0] instanceof DOMException is true
+PASS brokenTraces is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/DOMException/stack-trace-survives-gc.html
+++ b/LayoutTests/fast/dom/DOMException/stack-trace-survives-gc.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/gc.js"></script>
+<script>
+
+description("A DOMException captures a stack trace whose frames point at the functions that were on "
+    + "the stack, and the GC does not trace those pointers. When one of those functions dies the trace "
+    + "must be turned into strings, or reading .stack afterwards reads cells that have been freed and "
+    + "handed out again. That requires the GC to reconcile weak references in the DOMException subspace.");
+
+// Each exception is thrown from a function object created fresh by this call, so once it returns the
+// captured stack trace is the only thing pointing at that function.
+function makeException() {
+    function inner() {
+        document.appendChild(document);
+    }
+
+    try {
+        inner();
+    } catch (e) {
+        return e;
+    }
+}
+
+var exceptions = [];
+for (var i = 0; i < 1000; ++i)
+    exceptions.push(makeException());
+
+shouldBe("exceptions.length", "1000");
+shouldBeTrue("exceptions[0] instanceof DOMException");
+
+// No stack is read before this point: an unmaterialized trace is what the GC has to rescue.
+gc();
+
+// Churn through enough new functions to hand the collected cells back out, so a trace that still
+// points into them no longer reads what it captured.
+var churn = [];
+for (var i = 0; i < 20000; ++i)
+    churn.push(function churnedFunction() { return i; });
+churn = null;
+gc();
+
+var brokenTraces = 0;
+for (var i = 0; i < exceptions.length; ++i) {
+    if (exceptions[i].stack.indexOf("inner") === -1)
+        ++brokenTraces;
+}
+
+shouldBe("brokenTraces", "0");
+
+</script>

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -840,6 +840,9 @@ void Heap::reconcileWeakReferencesAtGCEnd()
 #endif
 
     vm().reconcileWeakReferencesAtGCEnd();
+
+    if (auto* clientData = vm().clientData)
+        clientData->reconcileWeakReferencesAtGCEnd(vm(), collectionScope);
 }
 
 void Heap::willStartIterating()

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -119,7 +119,7 @@ public:
             m_stackPropertyAlreadyMaterialized = true;
     }
 
-    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
+    JS_EXPORT_PRIVATE void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 protected:
     JS_EXPORT_PRIVATE explicit ErrorInstance(VM&, Structure*, ErrorType);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -248,6 +248,11 @@ public:
 
         JS_EXPORT_PRIVATE virtual String overrideSourceURL(const StackFrame&, const String& originalSourceURL) const = 0;
 
+        // Called after marking and before sweeping, alongside the cell types the Heap reconciles
+        // itself. The client owns the subspaces for its own cell types, so it has to visit the
+        // marked cells of those that hold weak references and settle them.
+        virtual void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope) { }
+
         virtual bool isWebCoreJSClientData() const { return false; }
     };
 

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -126,6 +126,17 @@ JSHeapData::JSHeapData(Heap& heap)
 {
 }
 
+void JSHeapData::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope collectionScope)
+{
+    for (auto& [space, reconcileCell] : m_weakReconciliationSpaces) {
+        space->forEachMarkedCell(
+            [&] (HeapCell* cell, HeapCell::Kind kind) {
+                RELEASE_ASSERT(kind == HeapCell::Kind::JSCell);
+                reconcileCell(cell, vm, collectionScope);
+            });
+    }
+}
+
 JSHeapData* JSHeapData::ensureHeapData(Heap& heap)
 {
     if (!Options::useGlobalGC())

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -58,6 +58,13 @@ public:
 
     Vector<JSC::IsoSubspace*>& outputConstraintSpaces() LIFETIME_BOUND { return m_outputConstraintSpaces; }
 
+    // Each entry pairs a subspace whose cell type declares reconcileWeakReferencesAtGCEnd() with a
+    // functor that recovers that cell type, which only the code creating the subspace knows.
+    using ReconcileWeakReferencesAtGCEndFunction = void (*)(JSC::HeapCell*, JSC::VM&, JSC::CollectionScope);
+    Vector<std::pair<JSC::IsoSubspace*, ReconcileWeakReferencesAtGCEndFunction>>& weakReconciliationSpaces() LIFETIME_BOUND { return m_weakReconciliationSpaces; }
+
+    void reconcileWeakReferencesAtGCEnd(JSC::VM&, JSC::CollectionScope);
+
     template<typename Func>
     void forEachOutputConstraintSpace(const Func& func)
     {
@@ -118,6 +125,7 @@ private:
 
     const UniqueRef<ExtendedDOMIsoSubspaces> m_subspaces;
     Vector<JSC::IsoSubspace*> m_outputConstraintSpaces;
+    Vector<std::pair<JSC::IsoSubspace*, ReconcileWeakReferencesAtGCEndFunction>> m_weakReconciliationSpaces;
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSVMClientData);
@@ -183,6 +191,11 @@ public:
 
 private:
     bool isWebCoreJSClientData() const final { return true; }
+
+    void reconcileWeakReferencesAtGCEnd(JSC::VM& vm, JSC::CollectionScope collectionScope) final
+    {
+        m_heapData->reconcileWeakReferencesAtGCEnd(vm, collectionScope);
+    }
 
     HashSet<DOMWrapperWorld*> m_worldSet;
     RefPtr<DOMWrapperWorld> m_normalWorld;
@@ -260,6 +273,14 @@ IGNORE_WARNINGS_BEGIN("tautological-compare")
             heapData.outputConstraintSpaces().append(space);
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
+
+        if constexpr (requires (T* cell, JSC::VM& vm, JSC::CollectionScope collectionScope) { cell->reconcileWeakReferencesAtGCEnd(vm, collectionScope); }) {
+            auto reconcileCell = [] (JSC::HeapCell* heapCell, JSC::VM& vm, JSC::CollectionScope collectionScope) {
+                SUPPRESS_MEMORY_UNSAFE_CAST auto* cell = static_cast<T*>(heapCell);
+                cell->reconcileWeakReferencesAtGCEnd(vm, collectionScope);
+            };
+            heapData.weakReconciliationSpaces().append({ space, reconcileCell });
+        }
     }
 
     auto uniqueClientSubspace = makeUnique<JSC::GCClient::IsoSubspace>(*space);


### PR DESCRIPTION
#### 4d79cb17ccd3cf72215b33bdccf186af491affce
<pre>
JSDOMException is not reconciling it&apos;s weak stack trace
<a href="https://rdar.apple.com/185934634">rdar://185934634</a>

Reviewed by Yusuke Suzuki.

319782@main added .stack (and similar) properties to DOMException
objects. However, it failed to add a weak reference reconciliation
mechanism so the stack traces collected could be collected under the
instance. This patch adds a reconcileWeakReferencesAtGCEnd hook to
JSClientData, which forwards to the various ErrorInstance subclasses&apos;
ISOSubspaces.

Test: fast/dom/DOMException/stack-trace-survives-gc.html
Canonical link: <a href="https://commits.webkit.org/319952@main">https://commits.webkit.org/319952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aba616c596c55e9470e96954a8a3b67fcc55391

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183205 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147494 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bb10271-9403-4209-8517-d638c4f41d11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143016 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b76247f-d631-48c3-bf65-e5db1f8c0508) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c220a798-9fde-416f-8551-760ec38ff383) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45424 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43671 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5413 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12232 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43292 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4597 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44475 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195364 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152184 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46737 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129772 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56010 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18303 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->