### PR TITLE
Harden `DateTimeFieldElement` by making `DateTimeFieldElementFieldOwner` ref-countable

### DIFF
--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -66,6 +66,10 @@ public:
     static Ref<DateTimeEditElement> create(Document&, DateTimeEditElementEditControlOwner&);
 
     virtual ~DateTimeEditElement();
+
+    void ref() const final { HTMLDivElement::ref(); }
+    void deref() const final { HTMLDivElement::deref(); }
+
     void addField(Ref<DateTimeFieldElement>);
     Element& NODELETE fieldsWrapperElement() const;
     void focusByOwner();

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -111,13 +111,14 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
     auto stepUpKeyIdentifier = isHorizontal ? "Up"_s : "Right"_s;
     auto stepDownKeyIdentifier = isHorizontal ? "Down"_s : "Left"_s;
 
-    if (key == previousKeyIdentifier && m_fieldOwner && m_fieldOwner->focusOnPreviousField(*this)) {
+    RefPtr fieldOwner = m_fieldOwner;
+    if (key == previousKeyIdentifier && fieldOwner && fieldOwner->focusOnPreviousField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
     }
 
     if ((key == nextKeyIdentifier || code == "Comma"_s || code == "Minus"_s || code == "Period"_s || code == "Slash"_s || code == "Semicolon"_s)
-        && m_fieldOwner && m_fieldOwner->focusOnNextField(*this)) {
+        && fieldOwner && fieldOwner->focusOnNextField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
     }
@@ -147,19 +148,20 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
 
 bool DateTimeFieldElement::isFieldOwnerDisabled() const
 {
-    return m_fieldOwner && m_fieldOwner->isFieldOwnerDisabled();
+    RefPtr fieldOwner = m_fieldOwner;
+    return fieldOwner && fieldOwner->isFieldOwnerDisabled();
 }
 
 bool DateTimeFieldElement::isFieldOwnerReadOnly() const
 {
-    return m_fieldOwner && m_fieldOwner->isFieldOwnerReadOnly();
+    RefPtr fieldOwner = m_fieldOwner;
+    return fieldOwner && fieldOwner->isFieldOwnerReadOnly();
 }
 
 bool DateTimeFieldElement::isFieldOwnerHorizontal() const
 {
-    if (m_fieldOwner)
-        return m_fieldOwner->isFieldOwnerHorizontal();
-    return true;
+    RefPtr fieldOwner = m_fieldOwner;
+    return !fieldOwner || fieldOwner->isFieldOwnerHorizontal();
 }
 
 bool DateTimeFieldElement::isFocusable() const
@@ -171,8 +173,8 @@ bool DateTimeFieldElement::isFocusable() const
 
 void DateTimeFieldElement::handleBlurEvent(Event& event)
 {
-    if (m_fieldOwner)
-        m_fieldOwner->didBlurFromField(event);
+    if (RefPtr fieldOwner = m_fieldOwner)
+        fieldOwner->didBlurFromField(event);
 }
 
 Locale& DateTimeFieldElement::localeForOwner() const
@@ -182,7 +184,8 @@ Locale& DateTimeFieldElement::localeForOwner() const
 
 AtomString DateTimeFieldElement::localeIdentifier() const
 {
-    return m_fieldOwner ? m_fieldOwner->localeIdentifier() : nullAtom();
+    RefPtr fieldOwner = m_fieldOwner;
+    return fieldOwner ? fieldOwner->localeIdentifier() : nullAtom();
 }
 
 String DateTimeFieldElement::visibleValue() const
@@ -208,8 +211,10 @@ void DateTimeFieldElement::updateVisibleValue(EventBehavior eventBehavior)
         invalidateStyle();
     }
 
-    if (eventBehavior == DispatchInputAndChangeEvents && m_fieldOwner)
-        m_fieldOwner->fieldValueChanged();
+    if (eventBehavior == DispatchInputAndChangeEvents) {
+        if (RefPtr fieldOwner = m_fieldOwner)
+            fieldOwner->fieldValueChanged();
+    }
 }
 
 bool DateTimeFieldElement::supportsFocus() const
@@ -219,13 +224,14 @@ bool DateTimeFieldElement::supportsFocus() const
 
 bool DateTimeFieldElement::transferredFocusToPicker() const
 {
-    return m_fieldOwner && m_fieldOwner->didFieldOwnerTransferFocusToPicker();
+    RefPtr fieldOwner = m_fieldOwner;
+    return fieldOwner && fieldOwner->didFieldOwnerTransferFocusToPicker();
 }
 
 void DateTimeFieldElement::didSuppressBlurDueToPickerFocusTransfer()
 {
-    if (m_fieldOwner)
-        m_fieldOwner->didSuppressBlurDueToPickerFocusTransfer();
+    if (RefPtr fieldOwner = m_fieldOwner)
+        fieldOwner->didSuppressBlurDueToPickerFocusTransfer();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -28,18 +28,10 @@
 
 #include "HTMLDivElement.h"
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/GregorianDateTime.h>
 #include <wtf/ValueOrReference.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class DateTimeFieldElementFieldOwner;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DateTimeFieldElementFieldOwner> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -53,7 +45,7 @@ class ComputedStyle;
 
 enum class DateTimePlaceholderIfNoValue : bool { No, Yes };
 
-class DateTimeFieldElementFieldOwner : public CanMakeWeakPtr<DateTimeFieldElementFieldOwner> {
+class DateTimeFieldElementFieldOwner : public AbstractRefCountedAndCanMakeWeakPtr<DateTimeFieldElementFieldOwner> {
 public:
     virtual ~DateTimeFieldElementFieldOwner();
     virtual void didBlurFromField(Event&) = 0;


### PR DESCRIPTION
#### a7c0b0f9062b64c36bba6b192ab725c010990afb
<pre>
Harden `DateTimeFieldElement` by making `DateTimeFieldElementFieldOwner` ref-countable
<a href="https://bugs.webkit.org/show_bug.cgi?id=322668">https://bugs.webkit.org/show_bug.cgi?id=322668</a>
<a href="https://rdar.apple.com/185940168">rdar://185940168</a>

Reviewed by Chris Dumez.

This makes `DateTimeFieldElementFieldOwner` ref-countable since nothing enforces
that the owner stays alive across its virtual functions.

No new tests since there should be no behavioral changes.

* Source/WebCore/html/shadow/DateTimeEditElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::defaultKeyboardEventHandler):
(WebCore::DateTimeFieldElement::isFieldOwnerDisabled const):
(WebCore::DateTimeFieldElement::isFieldOwnerReadOnly const):
(WebCore::DateTimeFieldElement::isFieldOwnerHorizontal const):
(WebCore::DateTimeFieldElement::handleBlurEvent):
(WebCore::DateTimeFieldElement::localeIdentifier const):
(WebCore::DateTimeFieldElement::updateVisibleValue):
(WebCore::DateTimeFieldElement::transferredFocusToPicker const):
(WebCore::DateTimeFieldElement::didSuppressBlurDueToPickerFocusTransfer):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:

Canonical link: <a href="https://commits.webkit.org/319982@main">https://commits.webkit.org/319982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fef878c67956c51f4041169f07ab56a5c186563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186275 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46824 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 2 new passes 2 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45535 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43771 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43380 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4713 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56913 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57617 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152272 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46826 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129897 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56125 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18392 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->