### PR TITLE
[JSC] Monomorphic call fast path loads two adjacent CallLinkInfo fields as two separate loads

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -332,15 +332,18 @@ void CallLinkInfo::emitFastPathImpl(CallLinkInfo* callLinkInfo, CCallHelpers& ji
     // address for each branch operation. Other MacroAssembler implementations handle this better by
     // using a wider range of scratch registers or more potent branching instructions.
     CCallHelpers::JumpList found;
-    jit.loadPtr(CCallHelpers::Address(BaselineJITRegisters::Call::callLinkInfoGPR, offsetOfMonomorphicCallDestination()), BaselineJITRegisters::Call::callTargetGPR);
     if constexpr (isRISCV64()) {
+        jit.loadPtr(CCallHelpers::Address(BaselineJITRegisters::Call::callLinkInfoGPR, offsetOfMonomorphicCallDestination()), BaselineJITRegisters::Call::callTargetGPR);
         CCallHelpers::Address calleeAddress(BaselineJITRegisters::Call::callLinkInfoGPR, offsetOfCallee());
         found.append(jit.branchPtr(CCallHelpers::Equal, calleeAddress, BaselineJITRegisters::Call::calleeGPR));
         found.append(jit.branchTestPtr(CCallHelpers::NonZero, calleeAddress, CCallHelpers::TrustedImm32(polymorphicCalleeMask)));
     } else {
         GPRReg scratchGPR = jit.scratchRegister();
         DisallowMacroScratchRegisterUsage disallowScratch(jit);
-        jit.loadPtr(CCallHelpers::Address(BaselineJITRegisters::Call::callLinkInfoGPR, offsetOfCallee()), scratchGPR);
+        // m_callee is laid out immediately after m_monomorphicCallDestination,
+        // so the two fields this path needs come back in one paired load.
+        static_assert(offsetOfCallee() == offsetOfMonomorphicCallDestination() + static_cast<ptrdiff_t>(sizeof(void*)));
+        jit.loadPairPtr(CCallHelpers::Address(BaselineJITRegisters::Call::callLinkInfoGPR, offsetOfMonomorphicCallDestination()), BaselineJITRegisters::Call::callTargetGPR, scratchGPR);
         found.append(jit.branchPtr(CCallHelpers::Equal, scratchGPR, BaselineJITRegisters::Call::calleeGPR));
         found.append(jit.branchTestPtr(CCallHelpers::NonZero, scratchGPR, CCallHelpers::TrustedImm32(polymorphicCalleeMask)));
     }


### PR DESCRIPTION
#### 06f75cd90b3a3fb8bbbb4c9be42745a099a62cef
<pre>
[JSC] Monomorphic call fast path loads two adjacent CallLinkInfo fields as two separate loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=322675">https://bugs.webkit.org/show_bug.cgi?id=322675</a>

Reviewed by NOBODY (OOPS!).

Every JIT call site emits CallLinkInfo::emitFastPathImpl, and every one
of them reads two adjacent pointers out of the CallLinkInfo:

    add  x2, x25, #0x68       ; &amp;metadata-&gt;m_callLinkInfo
    ldur x5,  [x2, #0x20]     ; m_monomorphicCallDestination
    ldur x16, [x2, #0x28]     ; m_callee
    cmp  x16, x0

m_callee is declared immediately after m_monomorphicCallDestination and
both are pointer-sized, so those two loads are one ldp. The reason they
were not already is placement rather than intent: the destination load
sat above the isRISCV64() branch and the callee load inside it, so the
two never met. Sinking the first into each arm lets the non-RISCV64 arm
pair them, and leaves the RISCV64 arm exactly as it was -- it reads the
callee address twice instead of taking a scratch, on purpose, because
its scratch collides with what the MacroAssembler needs for the
test-and-branch.

A static_assert on the adjacency turns a future field reordering into a
build error rather than a silent pessimization, matching the guard
ThunkGenerators.cpp already has over CallSlot::offsetOfTarget() and
offsetOfCodeBlock() for the same rewrite.

The DisallowMacroScratchRegisterUsage in scope stays satisfied:
offsetOfMonomorphicCallDestination() is 0x20, well inside ldp&apos;s imm7,
so loadPairPtr() emits the pair outright and never reaches the fallback
that would want the macro scratch. x86_64 and riscv64 expand
loadPairPtr() into the two loads they already emit, so nothing changes
there.

Measured on matched dumps of every block the JITs link while running
JetStream 3, with only this patch differing: 146,405 unpaired
x5/x16 fast paths and no paired ones becomes zero unpaired and 146,340
ldps -- the whole population, since unlike a shuffle-driven fold this
one has no preconditions to miss. That is about 146,000 instructions,
some 572 KB, and it is the largest single class of foldable adjacent
loads in the corpus by a factor of three.

It does not show up in a benchmark score, and the claim here is not
that it should. Forty interleaved JetStream 3 runs on an Apple silicon
laptop, ten pairs in each order so run-order bias cancels: mean +0.19%,
95% CI -0.14% to +0.52%, 11 of 20 pairs positive, and the two orders
disagreeing in sign (+0.33% and -0.20%). That is a coin flip. The
removed instruction was already free on a core this wide -- the load
feeds a compare against a monomorphic callee, so the branch is
well-predicted by construction and its operand is off the critical path
whether it arrives as one ldp or two ldrs. Being on a hot path is what
makes the static count large; it is not what would make the saving
visible.

What is left is what was measured: an instruction and four bytes per
call site, on every core, and worth proportionally more on the in-order
little cores that weight instruction count far more heavily than the
machine these numbers come from.

JSTests/stress passes 85,375 / 85,376 on arm64; the one failure,
stress/sampling-profiler-line-column.js.ftl-eager, is the sampling
profiler collecting zero samples (&quot;Bad stack trace&quot; with an empty
traces array) on a machine running fourteen test jobs at once, and
passes 12 for 12 when re-run. testmasm (465 tests), testb3 and testair
all pass. testapi aborts, but it does so on unpatched main as well,
with a different set of promise / unhandled-rejection failures on every
run.

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::emitFastPathImpl):

Found with armlint.

Co-Authored-By: Claude Opus 5 (1M context) &lt;noreply@anthropic.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06f75cd90b3a3fb8bbbb4c9be42745a099a62cef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147510 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99311 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43678 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5402 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12238 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43298 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4613 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44491 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56813 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152497 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57518 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39918 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152193 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46742 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129788 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126097 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56026 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18309 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->