### PR TITLE
Cherry-pick(s) 82b25523db98. rdar://185368291

### DIFF
--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash the GPU process.

--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true MediaContainmentEnabled=false ] -->
+<html><body>
+<p>This test passes if it does not crash the GPU process.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+window.onerror = () => testRunner?.notifyDone();
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// RemoteSourceBufferProxy::RemoveCodedFrames with an invalid MediaTime end argument
+// produced an inverted iterator range in TrackBuffer::removeCodedFrames, which
+// std::minmax_element walked past end(). MediaContainmentEnabled=false ensures the
+// SourceBufferPrivate / TrackBuffer live in the GPU process.
+async function main() {
+    if (!window.IPC)
+        return;
+
+    // Populate a GPU-side TrackBuffer via vanilla MSE.
+    const buf = await (await fetch('../media/media-source/content/test-fragmented-video.mp4')).arrayBuffer();
+    const init = buf.slice(0, 721);
+    const seg0 = buf.slice(721, 721 + 53533);
+    const seg1 = buf.slice(54254, 54254 + 56293);
+
+    const v = document.createElement('video');
+    v.disableRemotePlayback = true;
+    document.body.appendChild(v);
+    const ms = new MediaSource();
+    v.src = URL.createObjectURL(ms);
+    await new Promise(r => ms.addEventListener('sourceopen', r, { once: true }));
+
+    const sb = ms.addSourceBuffer('video/mp4; codecs="avc1.4d281e"');
+    const upd = () => new Promise(r => sb.addEventListener('updateend', r, { once: true }));
+    sb.appendBuffer(init); await upd();
+    sb.appendBuffer(seg0); await upd();
+    sb.appendBuffer(seg1); await upd();
+
+    // start = mid-range valid, end = invalid (timeFlags == 0), currentTime = valid zero.
+    // MediaTime is encoded as { int64_t timeValue, uint32_t timeScale, uint8_t timeFlags }.
+    const args = [
+        { type: 'int64_t', value: 1000000 }, { type: 'uint32_t', value: 1000000 }, { type: 'uint8_t', value: 1 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 0 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 1 },
+    ];
+
+    // The RemoteSourceBufferIdentifier is a small GPU-allocated counter; sweep a generous range.
+    // ignoreInvalidMessageForTesting drops messages to non-existent receivers.
+    const conn = IPC.connectionForProcessTarget('GPU');
+    for (let i = 1; i <= 200; i++)
+        conn.sendWithAsyncReply(i, IPC.messages.RemoteSourceBufferProxy_RemoveCodedFrames.name, args, () => { });
+
+    await sleep(2000);
+}
+
+setTimeout(() => main().finally(() => testRunner?.notifyDone()), 0);
+setTimeout(() => testRunner?.notifyDone(), 30000);
+</script>
+</body></html>

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -551,8 +551,10 @@ void SourceBufferPrivate::removeCodedFramesInternal(const MediaTime& start, cons
 {
     assertIsCurrent(m_dispatcher.get());
 
+    ASSERT(start.isValid());
+    ASSERT(end.isValid());
     ASSERT(start < end);
-    if (start >= end)
+    if (start.isInvalid() || end.isInvalid() || start >= end)
         return;
 
     // 3.5.9 Coded Frame Removal Algorithm

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -492,6 +492,8 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& startIn, const MediaTime
     MediaTime start = startIn;
     ASSERT(start.isValid());
     ASSERT(end.isValid());
+    if (start.isInvalid() || end.isInvalid() || start > end)
+        return 0;
     // 3.5.9 Coded Frame Removal Algorithm
     // https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html#sourcebuffer-coded-frame-removal
     

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteSourceBufferProxy.h"
+
+#if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
+
+#include "Connection.h"
+#include "InitializationSegmentInfo.h"
+#include "Logging.h"
+#include "RemoteMediaPlayerProxy.h"
+#include "RemoteSourceBufferProxyMessages.h"
+#include "SharedBufferReference.h"
+#include "SourceBufferPrivateRemoteMessageReceiverMessages.h"
+#include <WebCore/AudioTrackPrivate.h>
+#include <WebCore/ContentType.h>
+#include <WebCore/MediaDescription.h>
+#include <WebCore/PlatformTimeRanges.h>
+#include <WebCore/SourceBufferPrivateClient.h>
+#include <WebCore/VideoTrackPrivate.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_OPTIONAL_CONNECTION_BASE(assertion, connection())
+#define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection(), completion)
+
+namespace WebKit {
+
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSourceBufferProxy);
+
+Ref<RemoteSourceBufferProxy> RemoteSourceBufferProxy::create(GPUConnectionToWebProcess& connectionToWebProcess, RemoteSourceBufferIdentifier identifier, Ref<SourceBufferPrivate>&& sourceBufferPrivate, RemoteMediaPlayerProxy& remoteMediaPlayerProxy)
+{
+    auto remoteSourceBufferProxy = adoptRef(*new RemoteSourceBufferProxy(connectionToWebProcess, identifier, WTF::move(sourceBufferPrivate), remoteMediaPlayerProxy));
+    return remoteSourceBufferProxy;
+}
+
+RemoteSourceBufferProxy::RemoteSourceBufferProxy(GPUConnectionToWebProcess& connectionToWebProcess, RemoteSourceBufferIdentifier identifier, Ref<SourceBufferPrivate>&& sourceBufferPrivate, RemoteMediaPlayerProxy& remoteMediaPlayerProxy)
+    : m_connectionToWebProcess(connectionToWebProcess)
+    , m_identifier(identifier)
+    , m_sourceBufferPrivate(WTF::move(sourceBufferPrivate))
+    , m_remoteMediaPlayerProxy(remoteMediaPlayerProxy)
+{
+    connectionToWebProcess.messageReceiverMap().addMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64(), *this);
+    protectedSourceBufferPrivate()->setClient(*this);
+}
+
+RemoteSourceBufferProxy::~RemoteSourceBufferProxy()
+{
+    disconnect();
+}
+
+void RemoteSourceBufferProxy::setMediaPlayer(RemoteMediaPlayerProxy& remoteMediaPlayerProxy)
+{
+    m_remoteMediaPlayerProxy = remoteMediaPlayerProxy;
+}
+
+RefPtr<IPC::Connection> RemoteSourceBufferProxy::connection() const
+{
+    RefPtr connection = m_connectionToWebProcess.get();
+    if (!connection)
+        return nullptr;
+    return &connection->connection();
+}
+
+void RemoteSourceBufferProxy::disconnect()
+{
+    auto connection = m_connectionToWebProcess.get();
+    if (!connection)
+        return;
+    connection->messageReceiverMap().removeMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64());
+    m_connectionToWebProcess = nullptr;
+}
+
+Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&& segment)
+{
+    ASSERT(isMainRunLoop());
+
+    RefPtr remoteMediaPlayerProxy { m_remoteMediaPlayerProxy.get() };
+
+    auto segmentInfo = createInitializationSegmentInfo(WTF::move(segment));
+    if (!segmentInfo)
+        return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
+
+    ASSERT(remoteMediaPlayerProxy);
+    // We need to wait for the CP's MediaPlayerRemote to have created all the tracks
+    return remoteMediaPlayerProxy->commitAllTransactions()->whenSettled(RunLoop::currentSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, segmentInfo = WTF::move(*segmentInfo)](auto&& result) mutable -> Ref<MediaPromise> {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+        RefPtr connection = protectedThis->m_connectionToWebProcess.get();
+        if (!result || !connection)
+            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+
+        return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidReceiveInitializationSegment(WTF::move(segmentInfo)), protectedThis->m_identifier);
+    });
+}
+
+void RemoteSourceBufferProxy::sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime& timestamp)
+{
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateHighestPresentationTimestampChanged(timestamp), m_identifier);
+}
+
+Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged(const MediaTime& duration)
+{
+    RefPtr connection = m_connectionToWebProcess.get();
+    if (!connection)
+        return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+
+    return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDurationChanged(duration), m_identifier);
+}
+
+Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(const Vector<WebCore::PlatformTimeRanges>& trackRanges)
+{
+    RefPtr connection = m_connectionToWebProcess.get();
+    if (!connection)
+        return MediaPromise::createAndResolve();
+
+    return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateBufferedChanged(trackRanges), m_identifier);
+}
+
+void RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample()
+{
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidDropSample(), m_identifier);
+}
+
+void RemoteSourceBufferProxy::sourceBufferPrivateEvictionDataChanged(const WebCore::SourceBufferEvictionData& evictionData)
+{
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateEvictionDataChanged(evictionData), m_identifier);
+}
+
+void RemoteSourceBufferProxy::append(IPC::SharedBufferReference&& buffer, CompletionHandler<void(MediaPromise::Result, const MediaTime&)>&& completionHandler)
+{
+    auto sharedMemory = buffer.sharedCopy();
+    Ref sourceBufferPrivate = m_sourceBufferPrivate;
+
+    if (!sharedMemory)
+        return completionHandler(makeUnexpected(PlatformMediaError::MemoryError), sourceBufferPrivate->timestampOffset());
+
+    auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+    RefPtr connection = m_connectionToWebProcess.get();
+    if (handle && connection)
+        connection->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::TakeOwnershipOfMemory(WTF::move(*handle)), m_identifier);
+
+    sourceBufferPrivate->append(sharedMemory->createSharedBuffer(buffer.size()))->whenSettled(RunLoop::currentSingleton(), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+        completionHandler(WTF::move(result), protectedSourceBufferPrivate()->timestampOffset());
+    });
+}
+
+void RemoteSourceBufferProxy::abort()
+{
+    protectedSourceBufferPrivate()->abort();
+}
+
+void RemoteSourceBufferProxy::resetParserState()
+{
+    protectedSourceBufferPrivate()->resetParserState();
+}
+
+void RemoteSourceBufferProxy::removedFromMediaSource()
+{
+    protectedSourceBufferPrivate()->removedFromMediaSource();
+}
+
+void RemoteSourceBufferProxy::setMediaSourceEnded(bool isEnded)
+{
+    protectedSourceBufferPrivate()->setMediaSourceEnded(isEnded);
+}
+
+void RemoteSourceBufferProxy::setActive(bool active)
+{
+    protectedSourceBufferPrivate()->setActive(active);
+}
+
+void RemoteSourceBufferProxy::canSwitchToType(const ContentType& contentType, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(protectedSourceBufferPrivate()->canSwitchToType(contentType));
+}
+
+void RemoteSourceBufferProxy::setMode(WebCore::SourceBufferAppendMode appendMode)
+{
+    protectedSourceBufferPrivate()->setMode(appendMode);
+}
+
+void RemoteSourceBufferProxy::startChangingType()
+{
+    protectedSourceBufferPrivate()->startChangingType();
+}
+
+void RemoteSourceBufferProxy::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, CompletionHandler<void()>&& completionHandler)
+{
+    MESSAGE_CHECK_COMPLETION(start.isValid() && end.isValid() && start < end, completionHandler());
+    protectedSourceBufferPrivate()->removeCodedFrames(start, end, currentTime)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+}
+
+void RemoteSourceBufferProxy::evictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime, CompletionHandler<void(Vector<WebCore::PlatformTimeRanges>&&, WebCore::SourceBufferEvictionData&&)>&& completionHandler)
+{
+    Ref sourceBufferPrivate { m_sourceBufferPrivate };
+    sourceBufferPrivate->evictCodedFrames(newDataSize, currentTime);
+    completionHandler(sourceBufferPrivate->trackBuffersRanges(), sourceBufferPrivate->evictionData());
+}
+
+void RemoteSourceBufferProxy::asyncEvictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime)
+{
+    protectedSourceBufferPrivate()->asyncEvictCodedFrames(newDataSize, currentTime);
+}
+
+void RemoteSourceBufferProxy::addTrackBuffer(TrackID trackId)
+{
+    MESSAGE_CHECK(m_mediaDescriptions.contains(trackId));
+    protectedSourceBufferPrivate()->addTrackBuffer(trackId, m_mediaDescriptions.find(trackId)->second.ptr());
+}
+
+void RemoteSourceBufferProxy::resetTrackBuffers()
+{
+    protectedSourceBufferPrivate()->resetTrackBuffers();
+}
+
+void RemoteSourceBufferProxy::clearTrackBuffers()
+{
+    protectedSourceBufferPrivate()->clearTrackBuffers();
+}
+
+void RemoteSourceBufferProxy::setAllTrackBuffersNeedRandomAccess()
+{
+    protectedSourceBufferPrivate()->setAllTrackBuffersNeedRandomAccess();
+}
+
+void RemoteSourceBufferProxy::reenqueueMediaIfNeeded(const MediaTime& currentMediaTime)
+{
+    protectedSourceBufferPrivate()->reenqueueMediaIfNeeded(currentMediaTime);
+}
+
+void RemoteSourceBufferProxy::setGroupStartTimestamp(const MediaTime& timestamp)
+{
+    protectedSourceBufferPrivate()->setGroupStartTimestamp(timestamp);
+}
+
+void RemoteSourceBufferProxy::setGroupStartTimestampToEndTimestamp()
+{
+    protectedSourceBufferPrivate()->setGroupStartTimestampToEndTimestamp();
+}
+
+void RemoteSourceBufferProxy::setShouldGenerateTimestamps(bool shouldGenerateTimestamps)
+{
+    protectedSourceBufferPrivate()->setShouldGenerateTimestamps(shouldGenerateTimestamps);
+}
+
+void RemoteSourceBufferProxy::resetTimestampOffsetInTrackBuffers()
+{
+    protectedSourceBufferPrivate()->resetTimestampOffsetInTrackBuffers();
+}
+
+void RemoteSourceBufferProxy::setTimestampOffset(const MediaTime& timestampOffset)
+{
+    protectedSourceBufferPrivate()->setTimestampOffset(timestampOffset);
+}
+
+void RemoteSourceBufferProxy::setAppendWindowStart(const MediaTime& appendWindowStart)
+{
+    protectedSourceBufferPrivate()->setAppendWindowStart(appendWindowStart);
+}
+
+void RemoteSourceBufferProxy::setAppendWindowEnd(const MediaTime& appendWindowEnd)
+{
+    protectedSourceBufferPrivate()->setAppendWindowEnd(appendWindowEnd);
+}
+
+void RemoteSourceBufferProxy::setMaximumBufferSize(uint64_t size, CompletionHandler<void()>&& completionHandler)
+{
+    protectedSourceBufferPrivate()->setMaximumBufferSize(size)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+}
+
+void RemoteSourceBufferProxy::computeSeekTime(const SeekTarget& target, CompletionHandler<void(SourceBufferPrivate::ComputeSeekPromise::Result&&)>&& completionHandler)
+{
+    protectedSourceBufferPrivate()->computeSeekTime(target)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+}
+
+void RemoteSourceBufferProxy::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs)
+{
+    if (!trackIdPairs.isEmpty())
+        protectedSourceBufferPrivate()->updateTrackIds(WTF::move(trackIdPairs));
+}
+
+void RemoteSourceBufferProxy::bufferedSamplesForTrackId(TrackID trackId, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&& completionHandler)
+{
+    protectedSourceBufferPrivate()->bufferedSamplesForTrackId(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+}
+
+void RemoteSourceBufferProxy::enqueuedSamplesForTrackID(TrackID trackId, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&& completionHandler)
+{
+    protectedSourceBufferPrivate()->enqueuedSamplesForTrackID(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+}
+
+void RemoteSourceBufferProxy::memoryPressure(const MediaTime& currentTime)
+{
+    protectedSourceBufferPrivate()->memoryPressure(currentTime);
+}
+
+void RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID(TrackID trackID, CompletionHandler<void(MediaTime)>&& completionHandler)
+{
+    completionHandler(protectedSourceBufferPrivate()->minimumUpcomingPresentationTimeForTrackID(trackID));
+}
+
+void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(TrackID trackID, uint64_t depth)
+{
+    protectedSourceBufferPrivate()->setMaximumQueueDepthForTrackID(trackID, depth);
+}
+
+void RemoteSourceBufferProxy::detach()
+{
+    protectedSourceBufferPrivate()->detach();
+}
+
+void RemoteSourceBufferProxy::attach()
+{
+    protectedSourceBufferPrivate()->attach();
+}
+
+Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDidAttach(InitializationSegment&& segment)
+{
+    ASSERT(isMainRunLoop());
+
+    RefPtr remoteMediaPlayerProxy { m_remoteMediaPlayerProxy.get() };
+
+    auto segmentInfo = createInitializationSegmentInfo(WTF::move(segment));
+    if (!segmentInfo)
+        return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
+
+    ASSERT(remoteMediaPlayerProxy);
+    // We need to wait for the CP's MediaPlayerRemote to have created all the tracks
+    return remoteMediaPlayerProxy->commitAllTransactions()->whenSettled(RunLoop::currentSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, segmentInfo = WTF::move(*segmentInfo)](auto&& result) mutable -> Ref<MediaPromise> {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+        RefPtr connection = protectedThis->m_connectionToWebProcess.get();
+        if (!result || !connection)
+            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+
+        return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidAttach(WTF::move(segmentInfo)), protectedThis->m_identifier);
+    });
+}
+
+std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitializationSegmentInfo(InitializationSegment&& segment)
+{
+    RefPtr remoteMediaPlayerProxy { m_remoteMediaPlayerProxy.get() };
+    if (!remoteMediaPlayerProxy)
+        return { };
+
+    InitializationSegmentInfo segmentInfo;
+    segmentInfo.duration = segment.duration;
+
+    segmentInfo.audioTracks = segment.audioTracks.map([&](const InitializationSegment::AudioTrackInformation& audioTrackInfo) {
+        RefPtr track = audioTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteAudioTrackProxy(*track);
+        m_mediaDescriptions.try_emplace(id, *audioTrackInfo.protectedDescription());
+        return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*audioTrackInfo.description), id };
+    });
+
+    segmentInfo.videoTracks = segment.videoTracks.map([&](const InitializationSegment::VideoTrackInformation& videoTrackInfo) {
+        RefPtr track = videoTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteVideoTrackProxy(*track);
+        m_mediaDescriptions.try_emplace(id, *videoTrackInfo.protectedDescription());
+        return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*videoTrackInfo.description), id };
+    });
+
+    segmentInfo.textTracks = segment.textTracks.map([&](const InitializationSegment::TextTrackInformation& textTrackInfo) {
+        RefPtr track = textTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteTextTrackProxy(*track);
+        m_mediaDescriptions.try_emplace(id, *textTrackInfo.protectedDescription());
+        return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*textTrackInfo.description), id };
+    });
+
+    return segmentInfo;
+}
+
+std::optional<SharedPreferencesForWebProcess> RemoteSourceBufferProxy::sharedPreferencesForWebProcess() const
+{
+    if (auto connectionToWebProcess = m_connectionToWebProcess.get())
+        return connectionToWebProcess->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
+
+void RemoteSourceBufferProxy::connectionToWebProcessClosed()
+{
+    ASSERT(isMainRunLoop());
+    disconnect();
+}
+
+#undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_COMPLETION
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185368291 to main. [82b25523db98] caused a merge conflict. 

```
Validate MediaTime arguments in RemoteSourceBufferProxy::removeCodedFrames
rdar://175520822

Reviewed by Jean-Yves Avenard.

RemoteSourceBufferProxy::removeCodedFrames forwarded its three MediaTime IPC
arguments to SourceBufferPrivate::removeCodedFramesInternal without validation,
and the generated ArgumentCoder<MediaTime> has no [Validator=], so a MediaTime
with timeFlags == 0 (isInvalid()) survived decode. The release-mode guard
"if (start >= end) return" in removeCodedFramesInternal was defeated because
valid <=> invalid is std::partial_ordering::unordered, so start >= end is false.
In TrackBuffer::removeCodedFrames, lower_bound(invalid) on the
std::map<MediaTime, ...> walked left to begin() while a valid mid-range start
resolved to a mid-map iterator; the inverted [mid, begin()) range was passed to
std::minmax_element, which incremented past end() and dereferenced out-of-range
tree pointers, crashing the GPU process. A compromised WebContent process could
trigger this deterministically.

Reject invalid or unordered start/end at the IPC boundary with
MESSAGE_CHECK_COMPLETION, and harden SourceBufferPrivate::removeCodedFramesInternal
and TrackBuffer::removeCodedFrames to early-return when either bound is invalid
or start is not strictly less than end, mirroring the existing guard in
SourceBufferPrivate::evictFrames.

* LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt: Added.
* LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::removeCodedFrames):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::removeCodedFrames):

Originally-landed-as: 305413.1074@safari-7624.5-branch (82b25523db98). rdar://185368291


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd3f3b89a60edce5045350a673721a44905957c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183224 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56882 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143007 "Found 2 new test failures: fast/dom/lazy-image-loading-document-leak.html ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123434 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45437 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/user-valid.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43681 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43308 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4616 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49794 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47944 "Found 1 new test failure: ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195383 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163273 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152499 "Found 1 new test failure: ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152195 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46747 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129791 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56029 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18319 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->