### PR TITLE
[Site Isolation] Use Page::hasRemoteFrames in more places

### DIFF
--- a/LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The scroll position is only broadcast to other processes when the frame tree has a remote frame
+

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists.html
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists.html
@@ -1,0 +1,81 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body style="margin: 0">
+<div style="height: 3000px"></div>
+<script>
+
+let broadcastCount = 0;
+
+// Since multiple frame geometry updates share this IPC, we calculate the number of these IPCs sent
+// on an idle rendering update vs. a scrolling rendering update, and use the difference to figure
+// out if a scroll position IPC was sent.
+if (window.IPC) {
+    IPC.addOutgoingMessageListener("UI", message => {
+        if (message.description === "WebPageProxy_BroadcastFrameTreeSyncData")
+            broadcastCount++;
+    });
+}
+
+async function settle()
+{
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function countBroadcastsFor(action)
+{
+    await settle();
+    broadcastCount = 0;
+    action();
+    await settle();
+    return broadcastCount;
+}
+
+function addIframe(url)
+{
+    return new Promise(resolve => {
+        const iframe = document.createElement("iframe");
+        iframe.onload = () => resolve(iframe);
+        iframe.src = url;
+        document.body.appendChild(iframe);
+    });
+}
+
+promise_test(async t => {
+    // IPC interception only works in debug builds.
+    if (!window.IPC)
+        return;
+
+    t.add_cleanup(() => {
+        document.querySelectorAll("iframe").forEach(iframe => iframe.remove());
+        window.scrollTo(0, 0);
+    });
+
+    const sameSiteIframe = await addIframe("http://127.0.0.1:8000/site-isolation/resources/frame-with-text.html");
+
+    let idleCount = await countBroadcastsFor(() => {});
+    let scrollCount = await countBroadcastsFor(() => window.scrollTo(0, 100));
+    assert_equals(scrollCount, idleCount,
+        "a page with a fully local frame tree must not broadcast its scroll position");
+
+    const crossSiteIframe = await addIframe("http://localhost:8000/site-isolation/resources/frame-with-text.html");
+
+    idleCount = await countBroadcastsFor(() => {});
+    scrollCount = await countBroadcastsFor(() => window.scrollTo(0, 200));
+    assert_greater_than(scrollCount, idleCount,
+        "a page with a remote frame must broadcast its scroll position");
+
+    const sameScrollPositionCount = await countBroadcastsFor(() => window.scrollTo(0, 200));
+    assert_equals(sameScrollPositionCount, idleCount,
+        "scrolling to the current scroll position must not broadcast");
+
+    crossSiteIframe.remove();
+
+    idleCount = await countBroadcastsFor(() => {});
+    scrollCount = await countBroadcastsFor(() => window.scrollTo(0, 300));
+    assert_equals(scrollCount, idleCount,
+        "a page must stop broadcasting its scroll position once its last remote frame is gone");
+}, "The scroll position is only broadcast to other processes when the frame tree has a remote frame");
+</script>

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists-expected.txt
@@ -1,0 +1,3 @@
+
+PASS User activation is only broadcast to other processes when the frame tree has a remote frame
+

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists.html
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists.html
@@ -1,0 +1,88 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body style="margin: 0">
+<script>
+
+let messageCounts = new Map();
+
+const observedMessages = [
+    "WebPageProxy_DidNotifyUserActivation",
+    "WebPageProxy_DidConsumeUserActivation",
+];
+
+if (window.IPC) {
+    IPC.addOutgoingMessageListener("UI", message => {
+        if (observedMessages.includes(message.description))
+            messageCounts.set(message.description, (messageCounts.get(message.description) ?? 0) + 1);
+    });
+}
+
+async function settle()
+{
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function countBroadcastsForInteraction()
+{
+    await settle();
+    messageCounts = new Map();
+
+    eventSender.mouseMoveTo(10, 10);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+    await settle();
+
+    // window.open() consumes a transient activation.
+    const openedWindow = window.open("about:blank");
+    if (openedWindow)
+        openedWindow.close();
+    await settle();
+
+    return messageCounts;
+}
+
+function addIframe(url)
+{
+    return new Promise(resolve => {
+        const iframe = document.createElement("iframe");
+        iframe.onload = () => resolve(iframe);
+        iframe.src = url;
+        document.body.appendChild(iframe);
+    });
+}
+
+promise_test(async t => {
+    // IPC interception only works in debug builds.
+    if (!window.IPC)
+        return;
+
+    t.add_cleanup(() => document.querySelectorAll("iframe").forEach(iframe => iframe.remove()));
+
+    const sameSiteIframe = await addIframe("http://127.0.0.1:8000/site-isolation/resources/frame-with-text.html");
+
+    let counts = await countBroadcastsForInteraction();
+    assert_equals(counts.get("WebPageProxy_DidNotifyUserActivation") ?? 0, 0,
+        "a page with a fully local frame tree must not broadcast user activation");
+    assert_equals(counts.get("WebPageProxy_DidConsumeUserActivation") ?? 0, 0,
+        "a page with a fully local frame tree must not broadcast activation consumption");
+
+    const crossSiteIframe = await addIframe("http://localhost:8000/site-isolation/resources/frame-with-text.html");
+
+    counts = await countBroadcastsForInteraction();
+    assert_greater_than(counts.get("WebPageProxy_DidNotifyUserActivation") ?? 0, 0,
+        "a page with a remote frame must broadcast user activation");
+    assert_greater_than(counts.get("WebPageProxy_DidConsumeUserActivation") ?? 0, 0,
+        "a page with a remote frame must broadcast activation consumption");
+
+    crossSiteIframe.remove();
+
+    counts = await countBroadcastsForInteraction();
+    assert_equals(counts.get("WebPageProxy_DidNotifyUserActivation") ?? 0, 0,
+        "a page must stop broadcasting user activation once its last remote frame is gone");
+    assert_equals(counts.get("WebPageProxy_DidConsumeUserActivation") ?? 0, 0,
+        "a page must stop broadcasting activation consumption once its last remote frame is gone");
+}, "User activation is only broadcast to other processes when the frame tree has a remote frame");
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8654,7 +8654,7 @@ void Document::enforceSandboxFlags(SandboxFlags flags, SandboxFlagsSource source
     bool wasSandboxedOrigin = isSandboxed(SandboxFlag::Origin);
     SecurityContext::enforceSandboxFlags(flags, source);
 
-    if (m_frame && settings().siteIsolationEnabled()) {
+    if (RefPtr page = this->page(); page && page->hasRemoteFrames()) {
         bool sandboxedStateDidChange = wasSandboxedOrigin != isSandboxed(SandboxFlag::Origin);
         if (!sandboxedStateDidChange)
             return;

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -222,12 +222,12 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     if (!pasteboard.isStatic()) {
         if (!document->isTextDocument()) {
             content.dataInWebArchiveFormat = selectionInWebArchiveFormat();
-            LegacyWebArchive::ArchiveOptions options {
-                LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::Yes,
-                LegacyWebArchive::ShouldArchiveSubframes::No
-            };
             HashMap<FrameIdentifier, AttributedString> remoteFrameContent;
-            if (document->settings().siteIsolationEnabled()) {
+            if (RefPtr page = document->page(); page && page->hasRemoteFrames()) {
+                LegacyWebArchive::ArchiveOptions options {
+                    LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::Yes,
+                    LegacyWebArchive::ShouldArchiveSubframes::No
+                };
                 content.webArchive = LegacyWebArchive::createFromSelection(protect(document->frame()), WTF::move(options));
                 RefPtr localFrame = document->frame();
                 if (content.webArchive && localFrame) {

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1606,7 +1606,7 @@ bool LocalDOMWindow::consumeTransientActivation()
             window->consumeLastActivationIfNecessary();
     }
 
-    if (thisFrame && thisFrame->settings().siteIsolationEnabled())
+    if (RefPtr page = thisFrame ? thisFrame->page() : nullptr; page && page->hasRemoteFrames())
         thisFrame->loader().client().didConsumeUserActivation();
 
     return true;
@@ -1692,7 +1692,7 @@ void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
         updateActivationTimestampAndNotify(*descendantWindow, activationTime, closeWatcherEnabled);
     }
 
-    if (frame->settings().siteIsolationEnabled())
+    if (RefPtr page = frame->page(); page && page->hasRemoteFrames())
         frame->loader().client().didNotifyUserActivation(activationTime);
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3821,8 +3821,10 @@ void LocalFrameView::scrollPositionChanged(const ScrollPosition& oldPosition, co
             m_frame->editor().renderLayerDidScroll(*layer);
     }
 
-    if (m_frame->settings().siteIsolationEnabled() && oldPosition != newPosition)
-        static_cast<Frame&>(m_frame).loaderClient().broadcastFrameScrollPositionToOtherProcesses(newPosition);
+    if (oldPosition != newPosition) {
+        if (RefPtr page = m_frame->page(); page && page->hasRemoteFrames())
+            static_cast<Frame&>(m_frame).loaderClient().broadcastFrameScrollPositionToOtherProcesses(newPosition);
+    }
 }
 
 void LocalFrameView::applyRecursivelyWithVisibleRect(NOESCAPE const Function<void(LocalFrameView& frameView, const IntRect& visibleRect)>& apply)


### PR DESCRIPTION
#### abf4ece815c84c17c7aeafc1bf8b5b75692f5367
<pre>
[Site Isolation] Use Page::hasRemoteFrames in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=322680">https://bugs.webkit.org/show_bug.cgi?id=322680</a>
<a href="https://rdar.apple.com/185951553">rdar://185951553</a>

Reviewed by Alex Christensen and Kiet Ho.

Replace site isolation enabled settings checks with Page::hasRemoteFrames (added in 319884@main) in
more places. This is so that a page that has no remote frames doesn&apos;t pay the extra IPC cost of Site
Isolation unless it&apos;s necessary.

Tests: http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists.html
       http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists.html

* LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-scroll-position-if-remote-frame-exists.html: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-user-activation-if-remote-frame-exists.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enforceSandboxFlags):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::writeSelectionToPasteboard):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::consumeTransientActivation):
(WebCore::LocalDOMWindow::notifyActivated):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollPositionChanged):

Canonical link: <a href="https://commits.webkit.org/319993@main">https://commits.webkit.org/319993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2850ae3dfd4446e358662861dc79a943b76698c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e033060-dba9-407c-a430-834e209f57b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143022 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f66b913-ca23-463a-bc86-8560f9ea2050) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96c7e4f1-9381-40b9-aaaa-779089079b8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45450 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43694 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43311 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4633 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195399 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57537 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39931 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152208 "Found 1 new API test failure: TestWTF.WTF_ThreadSafeWeakPtr.GetRacingWithLastWeakReferenceRelease (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46762 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129807 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56045 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18323 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->