### PR TITLE
AX: AXTextMarkerRangeForUIElement covers a native text control as a replaced object rather than its value

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control-expected.txt
@@ -1,0 +1,31 @@
+Asserts that AXTextMarkerRangeForUIElement covers a text control's value rather than the
+control as a single replaced object. A genuinely replaced element still answers with itself.
+
+textarea:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha\nbravo\n"
+PASS: webArea.textMarkerRangeLength(range) === 12
+
+text input:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha bravo"
+PASS: webArea.textMarkerRangeLength(range) === 11
+
+search input:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha bravo"
+PASS: webArea.textMarkerRangeLength(range) === 11
+
+contenteditable:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha\nbravo\n"
+PASS: webArea.textMarkerRangeLength(range) === 12
+
+image:
+PASS: webArea.stringForTextMarkerRange(range) === "￼"
+PASS: webArea.textMarkerRangeLength(range) === 1
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+alpha
+bravo
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control.html
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A native text control's value lives in its shadow inner text element, so the host has no light
+     DOM children whose contents a range could cover. AXObjectCache::rangeForNodeContents therefore
+     answered with a range over the control as a single replaced object, whose string is one object
+     replacement character (U+FFFC) and whose endpoints carry no useful index. VoiceOver measures a
+     field's line span with this attribute, so the bogus answer dropped it onto a fallback path. The
+     isolated tree builds the same range from its text runs, which descend into the shadow text, and
+     was already correct. -->
+<textarea id="textarea" style="width: 200px; height: 60px">alpha
+bravo
+</textarea>
+<input id="input" type="text" value="alpha bravo">
+<input id="search" type="search" value="alpha bravo">
+<div id="contenteditable" contenteditable style="width: 200px">alpha<br>bravo<br></div>
+<img id="image" src="resources/cake.png" alt="A cake">
+
+<script>
+var output = "Asserts that AXTextMarkerRangeForUIElement covers a text control's value rather than the\n"
+    + "control as a single replaced object. A genuinely replaced element still answers with itself.\n\n";
+
+// `string` is the expected AXStringForTextMarkerRange of the element's text marker range. U+FFFC,
+// the object replacement character, is what a range over a replaced object stringifies to, and is
+// correct only for the image. A text control with no value keeps pointing at itself, so it answers
+// with U+FFFC too; that case is left out here because the two trees disagree about it.
+var cases = [
+    { id: "textarea", label: "textarea", string: "alpha\nbravo\n" },
+    { id: "input", label: "text input", string: "alpha bravo" },
+    { id: "search", label: "search input", string: "alpha bravo" },
+    { id: "contenteditable", label: "contenteditable", string: "alpha\nbravo\n" },
+    { id: "image", label: "image", string: "\uFFFC" },
+];
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var webArea, axElement, range;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        webArea = accessibilityController.rootElement.childAtIndex(0);
+
+        for (var testCase of cases) {
+            axElement = await waitForElementById(testCase.id);
+            if (!axElement) {
+                output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n\n`;
+                continue;
+            }
+
+            // VoiceOver asks the web area, and the handler answers about the element it is passed,
+            // so the receiver does not matter; matching VoiceOver's usage keeps this faithful.
+            range = webArea.textMarkerRangeForElement(axElement);
+            output += `${testCase.label}:\n`;
+            output += expect("webArea.stringForTextMarkerRange(range)", JSON.stringify(testCase.string));
+            output += expect("webArea.textMarkerRangeLength(range)", `${testCase.string.length}`);
+            output += "\n";
+        }
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-range-for-text-control-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-range-for-text-control-expected.txt
@@ -1,0 +1,31 @@
+Asserts that AXTextMarkerRangeForUIElement covers a text control's value rather than the
+control as a single replaced object. A genuinely replaced element still answers with itself.
+
+textarea:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha\nbravo\n"
+PASS: webArea.textMarkerRangeLength(range) === 12
+
+text input:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha bravo"
+PASS: webArea.textMarkerRangeLength(range) === 11
+
+search input:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha bravo"
+PASS: webArea.textMarkerRangeLength(range) === 11
+
+contenteditable:
+PASS: webArea.stringForTextMarkerRange(range) === "alpha\nbravo\n"
+PASS: webArea.textMarkerRangeLength(range) === 12
+
+image:
+PASS: webArea.stringForTextMarkerRange(range) === "￼"
+PASS: webArea.textMarkerRangeLength(range) === 1
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+alpha
+bravo
+

--- a/LayoutTests/accessibility/mac/text-marker-range-for-text-control.html
+++ b/LayoutTests/accessibility/mac/text-marker-range-for-text-control.html
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A native text control's value lives in its shadow inner text element, so the host has no light
+     DOM children whose contents a range could cover. AXObjectCache::rangeForNodeContents therefore
+     answered with a range over the control as a single replaced object, whose string is one object
+     replacement character (U+FFFC) and whose endpoints carry no useful index. VoiceOver measures a
+     field's line span with this attribute, so the bogus answer dropped it onto a fallback path. The
+     isolated tree builds the same range from its text runs, which descend into the shadow text, and
+     was already correct. -->
+<textarea id="textarea" style="width: 200px; height: 60px">alpha
+bravo
+</textarea>
+<input id="input" type="text" value="alpha bravo">
+<input id="search" type="search" value="alpha bravo">
+<div id="contenteditable" contenteditable style="width: 200px">alpha<br>bravo<br></div>
+<img id="image" src="resources/cake.png" alt="A cake">
+
+<script>
+var output = "Asserts that AXTextMarkerRangeForUIElement covers a text control's value rather than the\n"
+    + "control as a single replaced object. A genuinely replaced element still answers with itself.\n\n";
+
+// `string` is the expected AXStringForTextMarkerRange of the element's text marker range. U+FFFC,
+// the object replacement character, is what a range over a replaced object stringifies to, and is
+// correct only for the image. A text control with no value keeps pointing at itself, so it answers
+// with U+FFFC too; that case is left out here because the two trees disagree about it.
+var cases = [
+    { id: "textarea", label: "textarea", string: "alpha\nbravo\n" },
+    { id: "input", label: "text input", string: "alpha bravo" },
+    { id: "search", label: "search input", string: "alpha bravo" },
+    { id: "contenteditable", label: "contenteditable", string: "alpha\nbravo\n" },
+    { id: "image", label: "image", string: "\uFFFC" },
+];
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var webArea, axElement, range;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        webArea = accessibilityController.rootElement.childAtIndex(0);
+
+        for (var testCase of cases) {
+            axElement = await waitForElementById(testCase.id);
+            if (!axElement) {
+                output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n\n`;
+                continue;
+            }
+
+            // VoiceOver asks the web area, and the handler answers about the element it is passed,
+            // so the receiver does not matter; matching VoiceOver's usage keeps this faithful.
+            range = webArea.textMarkerRangeForElement(axElement);
+            output += `${testCase.label}:\n`;
+            output += expect("webArea.stringForTextMarkerRange(range)", JSON.stringify(testCase.string));
+            output += expect("webArea.textMarkerRangeLength(range)", `${testCase.string.length}`);
+            output += "\n";
+        }
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1107,15 +1107,6 @@ static bool NODELETE isFlowContent(Node& node)
     return text && !text->data().containsOnly<isASCIIWhitespace>();
 }
 
-bool AccessibilityNodeObject::isNativeTextControl() const
-{
-    if (is<HTMLTextAreaElement>(node()))
-        return true;
-
-    auto* input = dynamicDowncast<HTMLInputElement>(node());
-    return input && (input->isText() || input->isNumberField());
-}
-
 bool AccessibilityNodeObject::isSearchField() const
 {
     RefPtr node = this->node();
@@ -4135,9 +4126,9 @@ String AccessibilityNodeObject::text() const
     if (!isTextControl())
         return { };
 
+    if (RefPtr textControl = nativeTextControl())
+        return textControl->value();
     RefPtr element = dynamicDowncast<Element>(node());
-    if (RefPtr formControl = dynamicDowncast<HTMLTextFormControlElement>(element); formControl && isNativeTextControl())
-        return formControl->value();
     return element ? element->innerText() : String();
 }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -65,7 +65,6 @@ public:
     bool isDescriptionList() const final;
     bool isMultiSelectable() const override;
     bool NODELETE isNativeImage() const;
-    bool isNativeTextControl() const final;
     bool isSecureField() const final;
     bool isSearchField() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -68,6 +68,7 @@
 #include "FrameSelection.h"
 #include "GeometryUtilities.h"
 #include "HTMLAreaElement.h"
+#include "HTMLBRElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDataListElement.h"
 #include "HTMLDetailsElement.h"
@@ -943,6 +944,38 @@ std::optional<SimpleRange> AccessibilityObject::simpleRange() const
             return range;
     }
     return AXObjectCache::rangeForNodeContents(*node);
+}
+
+HTMLTextFormControlElement* AccessibilityObject::nativeTextControl() const
+{
+    if (auto* textArea = dynamicDowncast<HTMLTextAreaElement>(node()))
+        return textArea;
+
+    auto* input = dynamicDowncast<HTMLInputElement>(node());
+    return input && (input->isText() || input->isNumberField()) ? input : nullptr;
+}
+
+AXTextMarkerRange AccessibilityObject::textMarkerRange() const
+{
+    // A native text control's value lives in its shadow inner text element, so the host has no
+    // children whose contents to take: simpleRange covers the control as a single replaced object,
+    // which stringifies to an object replacement character rather than the value.
+    if (RefPtr textControl = nativeTextControl()) {
+        if (RefPtr innerText = textControl->innerTextElement()) {
+            auto range = AXObjectCache::rangeForNodeContents(*innerText);
+            // A value ending in a line break renders an empty final line, which
+            // HTMLTextFormControlElement::setInnerTextValue gives a line box by appending a
+            // placeholder <br>. That <br>'s newline is collapsed out by rendering and is not a
+            // character of the value, so leave it out.
+            if (is<HTMLBRElement>(innerText->lastChild()) && range.end.offset)
+                --range.end.offset;
+            // A control with no value has no text to point at, so leave it pointing at itself,
+            // which is the only marker its callers can place in the document.
+            if (range.start != range.end)
+                return AXTextMarkerRange { std::optional { range } };
+        }
+    }
+    return simpleRange();
 }
 
 Vector<BoundaryPoint> AccessibilityObject::previousLineStartBoundaryPoints(const VisiblePosition& startingPosition, const SimpleRange& targetRange, unsigned positionsToRetrieve) const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -64,6 +64,7 @@ WTF_ALLOW_COMPACT_POINTERS_TO_INCOMPLETE_TYPE(WebCore::AXObjectRareData);
 
 namespace WebCore {
 
+class HTMLTextFormControlElement;
 class IntPoint;
 class IntSize;
 class ScrollableArea;
@@ -140,7 +141,9 @@ public:
 
     bool isSecureField() const override { return false; }
     bool isContainedBySecureField() const;
-    bool isNativeTextControl() const override { return false; }
+    bool isNativeTextControl() const final { return nativeTextControl(); }
+    // The <textarea> or text <input> whose value this object exposes, or null.
+    HTMLTextFormControlElement* nativeTextControl() const;
     virtual bool isSearchField() const { return false; }
     bool isAttachment() const override { return false; }
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -85,11 +85,6 @@ inline bool AccessibilityObject::hasTreeRole() const
     return element && hasRole(*element, "tree"_s);
 }
 
-inline AXTextMarkerRange AccessibilityObject::textMarkerRange() const
-{
-    return simpleRange();
-}
-
 inline LocalFrame* AccessibilityObject::frame() const
 {
     Node* node = this->node();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2053,13 +2053,8 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
     // else branch below would fail because contains<ComposedTree> returns
     // false for cross-document positions, clamping the selection to the web
     // area start.
-    RefPtr<HTMLTextFormControlElement> textControl;
-    if (isNativeTextControl()) {
-        // isNativeTextControl returns true only for HTMLTextAreaElement or HTMLInputElement,
-        // both of which derive from HTMLTextFormControlElement.
-        ASSERT(is<HTMLTextFormControlElement>(node()));
-        textControl = downcast<HTMLTextFormControlElement>(node());
-    } else
+    RefPtr textControl = nativeTextControl();
+    if (!textControl)
         textControl = enclosingTextFormControl(range.start.deepEquivalent());
 
     if (textControl) {


### PR DESCRIPTION
#### 585cb45609b37a90566b0b114c25043c7f3f6680
<pre>
AX: AXTextMarkerRangeForUIElement covers a native text control as a replaced object rather than its value
<a href="https://bugs.webkit.org/show_bug.cgi?id=322688">https://bugs.webkit.org/show_bug.cgi?id=322688</a>
<a href="https://rdar.apple.com/185960907">rdar://185960907</a>

Reviewed by Tyler Wilcock.

On the live AX tree, asking for a &lt;textarea&gt;&apos;s or &lt;input type=text&gt;&apos;s
text marker range was giving back a range whose string was a single object
replacement character (U+FFFC) and whose endpoints carried no useful
index. This doesn&apos;t match the isolated tree, which returns a useful
range derived from its shadow tree.

textMarkerRange() now descends into the inner text element for native text
controls, leaving out the trailing placeholder &lt;br&gt; to match other APIs
like AXNumberOfCharacters.

A special case is needed for a control with no value.

Tests: accessibility/isolated-tree/mac/text-marker-range-for-text-control.html
       accessibility/mac/text-marker-range-for-text-control.html

* LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-range-for-text-control.html: Added.
* LayoutTests/accessibility/mac/text-marker-range-for-text-control-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-range-for-text-control.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::isNativeTextControl const): Deleted.
(WebCore::AccessibilityNodeObject::text const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::nativeTextControl const):
(WebCore::AccessibilityObject::textMarkerRange const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::isNativeTextControl const):
* Source/WebCore/accessibility/AccessibilityObjectInlines.h:
(WebCore::AccessibilityObject::textMarkerRange const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::setSelectedVisiblePositionRange):

Canonical link: <a href="https://commits.webkit.org/320011@main">https://commits.webkit.org/320011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/697c1a0a8404b8ff1193e92b79a0ac893e00d5d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147702 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e455d176-8422-425b-93d4-a66c24b64899) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143162 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9897c205-de11-4a3f-a2d1-80f8b83b0ef0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123581 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d4633f8-2177-4bdc-8e68-e33ac0f15d00) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45617 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43458 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4806 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40919 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57709 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152356 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46909 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129988 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56217 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18467 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55655 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->