### PR TITLE
[Site Isolation] Coalesce per-rendering-update frame geometry IPCs

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2026,6 +2026,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/FrameConsoleClient.h
     page/FrameDestructionObserver.h
     page/FrameDestructionObserverInlines.h
+    page/FrameGeometrySyncData.h
     page/FrameIdentifier.h
     page/FrameInlines.h
     page/FrameSnapshotting.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2290,6 +2290,7 @@ page/FocusController.cpp
 page/Frame.cpp
 page/FrameConsoleClient.cpp
 page/FrameDestructionObserver.cpp
+page/FrameGeometrySyncData.cpp
 page/FrameIdentifier.cpp
 page/FrameSnapshotting.cpp @header:RenderStyleGetters @cost:6
 page/FrameTree.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		0F099D0917B968A100FF84B9 /* WebCoreTypedArrayController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F099D0717B968A100FF84B9 /* WebCoreTypedArrayController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F0E009C26F92D8400ACE9C6 /* ScrollAnimationMomentum.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0E009A26F92D7B00ACE9C6 /* ScrollAnimationMomentum.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F11781822E3C47F008BD570 /* FrameIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F11781622E3C47E008BD570 /* FrameIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81ED7B1F003A5A7768139C21 /* FrameGeometrySyncData.h in Headers */ = {isa = PBXBuildFile; fileRef = 26B3A704C67CF84C8688D269 /* FrameGeometrySyncData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F11A54F0F39233100C37884 /* RenderSelectionGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F11A54E0F39233100C37884 /* RenderSelectionGeometry.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F13163E16ED0CC80035CC04 /* PlatformCAFilters.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F13163D16ED0CC80035CC04 /* PlatformCAFilters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F1774801378B772009DA76A /* ScrollAnimatorIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F17747E1378B771009DA76A /* ScrollAnimatorIOS.h */; };
@@ -8385,6 +8386,8 @@
 		0F0E009A26F92D7B00ACE9C6 /* ScrollAnimationMomentum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollAnimationMomentum.h; sourceTree = "<group>"; };
 		0F0E009B26F92D7B00ACE9C6 /* ScrollAnimationMomentum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollAnimationMomentum.cpp; sourceTree = "<group>"; };
 		0F11781622E3C47E008BD570 /* FrameIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameIdentifier.h; sourceTree = "<group>"; };
+		26B3A704C67CF84C8688D269 /* FrameGeometrySyncData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameGeometrySyncData.h; sourceTree = "<group>"; };
+		3D9194F39EFB04C0917E9354 /* FrameGeometrySyncData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameGeometrySyncData.cpp; sourceTree = "<group>"; };
 		0F11A54E0F39233100C37884 /* RenderSelectionGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderSelectionGeometry.h; sourceTree = "<group>"; };
 		0F13163D16ED0CC80035CC04 /* PlatformCAFilters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCAFilters.h; sourceTree = "<group>"; };
 		0F13163F16ED0CDE0035CC04 /* PlatformCAFiltersCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformCAFiltersCocoa.mm; sourceTree = "<group>"; };
@@ -31299,6 +31302,8 @@
 				974A862014B7ADBB003FDC76 /* FrameDestructionObserver.cpp */,
 				974A862114B7ADBB003FDC76 /* FrameDestructionObserver.h */,
 				46014ACB28333F52004C0B84 /* FrameDestructionObserverInlines.h */,
+				3D9194F39EFB04C0917E9354 /* FrameGeometrySyncData.cpp */,
+				26B3A704C67CF84C8688D269 /* FrameGeometrySyncData.h */,
 				FA63420E2D9CB95B00A6BECE /* FrameIdentifier.cpp */,
 				0F11781622E3C47E008BD570 /* FrameIdentifier.h */,
 				9B46C04A2DC4A867002E22C4 /* FrameInlines.h */,
@@ -45843,6 +45848,7 @@
 				46014ACC28333F65004C0B84 /* FrameDestructionObserverInlines.h in Headers */,
 				5E3DD8092F903C9A00250DF5 /* FrameDOMAgent.h in Headers */,
 				5E3DD80C2F903C9A00250DF5 /* FrameDOMStorageAgent.h in Headers */,
+				81ED7B1F003A5A7768139C21 /* FrameGeometrySyncData.h in Headers */,
 				0F11781822E3C47F008BD570 /* FrameIdentifier.h in Headers */,
 				9B46C04B2DC4A867002E22C4 /* FrameInlines.h in Headers */,
 				F30EE46B2E721BA800935B60 /* FrameInspectorController.h in Headers */,

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -358,6 +358,11 @@ void Frame::updateFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)
 
 void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
 {
+    if (static_cast<FrameTreeSyncDataType>(data.value.index()) != FrameTreeSyncDataType::FrameGeometry) {
+        protect(frameTreeSyncData())->update(data);
+        return;
+    }
+
     auto invalidateChildFrameForDarkAppearanceChange = [&](const auto& oldMap, const auto& newMap) {
         for (RefPtr child = tree().firstChild(); child; child = child->tree().nextSibling()) {
             RefPtr localChild = dynamicDowncast<LocalFrame>(child);
@@ -369,6 +374,8 @@ void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
 
             if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark) != newFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark)) {
                 RefPtr localChildView = localChild->view();
+                if (!localChildView)
+                    continue;
 
                 localChildView->invalidateForFrameOwnerColorSchemeChange();
                 protect(localChildView->layoutContext())->scheduleLayout();
@@ -376,11 +383,11 @@ void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
         }
     };
 
-    auto oldChildrenFrameLayoutMap = m_frameTreeSyncData->childrenFrameLayoutInfo;
+    auto oldChildrenFrameLayoutMap = m_frameTreeSyncData->frameGeometry.childrenFrameLayoutInfo;
 
     protect(frameTreeSyncData())->update(data);
 
-    invalidateChildFrameForDarkAppearanceChange(oldChildrenFrameLayoutMap, m_frameTreeSyncData->childrenFrameLayoutInfo);
+    invalidateChildFrameForDarkAppearanceChange(oldChildrenFrameLayoutMap, m_frameTreeSyncData->frameGeometry.childrenFrameLayoutInfo);
 }
 
 bool Frame::frameCanCreatePaymentSession() const

--- a/Source/WebCore/page/FrameGeometrySyncData.cpp
+++ b/Source/WebCore/page/FrameGeometrySyncData.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameGeometrySyncData.h"
+
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(FrameGeometrySyncData);
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const FrameGeometrySyncData& data)
+{
+    WTF::TextStream::GroupScope scope(ts);
+    ts << "FrameGeometrySyncData"_s;
+    ts.dumpProperty("layoutViewportRect"_s, data.layoutViewportRect);
+    ts.dumpProperty("contentsSize"_s, data.contentsSize);
+    ts.dumpProperty("childrenFrameLayoutInfo"_s, data.childrenFrameLayoutInfo);
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/FrameGeometrySyncData.h
+++ b/Source/WebCore/page/FrameGeometrySyncData.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/IntSize.h>
+#include <WebCore/LayoutRect.h>
+#include <WebCore/RemoteFrameLayoutInfo.h>
+#include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+struct FrameGeometrySyncData {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(FrameGeometrySyncData, WEBCORE_EXPORT);
+
+    LayoutRect layoutViewportRect;
+    IntSize contentsSize;
+    HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FrameGeometrySyncData&);
+
+} // namespace WebCore

--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -36,9 +36,4 @@ FrameScrollPosition : WebCore::ScrollPosition [Headers=<WebCore/ScrollTypes.h>]
 
 ## Layout information for Intersection Observer
 
-FrameLayoutViewportRect : WebCore::LayoutRect [Headers=<WebCore/LayoutRect.h>]
-
-FrameContentsSize : WebCore::IntSize [Headers=<WebCore/IntSize.h>]
-
-# Collection of layout info regarding children frames of this frame.
-ChildrenFrameLayoutInfo : HashMap<WebCore::FrameIdentifier, Ref<WebCore::RemoteFrameLayoutInfo>> [Headers=<WebCore/FrameIdentifier.h>,<WebCore/RemoteFrameLayoutInfo.h>]
+FrameGeometry : WebCore::FrameGeometrySyncData [Headers=<WebCore/FrameGeometrySyncData.h>]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2050,16 +2050,6 @@ LayoutRect LocalFrameView::layoutViewportRect() const
     return LayoutRect(m_layoutViewportOrigin, baseLayoutViewportSize());
 }
 
-void LocalFrameView::updateLayoutViewportRect()
-{
-    m_frame->loader().client().broadcastFrameLayoutViewportRectToOtherProcesses(layoutViewportRect());
-}
-
-void LocalFrameView::updateContentsSizeForRemoteFrames()
-{
-    m_frame->loader().client().broadcastFrameContentsSizeToOtherProcesses(contentsSize());
-}
-
 // visibleContentRect is in the bounds of the scroll view content. That consists of an
 // optional header, the document, and an optional footer. Only the document is scaled,
 // so we have to compute the visible part of the document in unscaled document coordinates.

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -321,8 +321,6 @@ public:
 
     // These are in document coordinates, unaffected by page scale (but affected by zooming).
     WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
-    void updateLayoutViewportRect();
-    void updateContentsSizeForRemoteFrames();
     WEBCORE_EXPORT LayoutRect visualViewportRect() const;
 
     LayoutRect layoutViewportRectIncludingObscuredInsets() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2272,9 +2272,6 @@ void Page::syncLocalFrameInfoToRemote()
     forEachLocalFrame([] (LocalFrame& frame) {
         RefPtr<LocalFrameView> frameView = frame.view();
 
-        frameView->updateLayoutViewportRect();
-        frameView->updateContentsSizeForRemoteFrames();
-
         HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
         auto windowClipRectInContentCoordinates = [&frameView, rect = std::optional<LayoutRect> { }]() mutable {
             if (!rect)
@@ -2318,7 +2315,11 @@ void Page::syncLocalFrameInfoToRemote()
             ));
         }
 
-        frame.loader().client().broadcastChildrenFrameLayoutInfoToOtherProcesses(childrenFrameLayoutInfo);
+        frame.loader().client().broadcastFrameGeometryToOtherProcesses({
+            frameView->layoutViewportRect(),
+            frameView->contentsSize(),
+            WTF::move(childrenFrameLayoutInfo)
+        });
     });
 }
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -257,7 +257,7 @@ ColorSchemePreference RemoteFrame::colorSchemePreference() const
 
 float RemoteFrame::usedZoomForChild(const Frame& child) const
 {
-    if (RefPtr info = frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->usedZoom();
 
     return 1.0;

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -28,6 +28,7 @@
 
 #include "FloatRect.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -76,6 +77,37 @@ std::optional<FloatRect> RemoteFrameLayoutInfo::mapParentContentsToChildWindow(c
     if (m_usedZoom > 0)
         ownerLocal.scale(1.0f / m_usedZoom);
     return ownerLocal;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, FrameOwnerElementAppearance appearance)
+{
+    switch (appearance) {
+    case FrameOwnerElementAppearance::IsDark:
+        ts << "IsDark"_s;
+        break;
+    case FrameOwnerElementAppearance::ExplicitlySet:
+        ts << "ExplicitlySet"_s;
+        break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const RemoteFrameLayoutInfo& info)
+{
+    WTF::TextStream::GroupScope scope(ts);
+    ts << "RemoteFrameLayoutInfo"_s;
+    ts.dumpProperty("windowClipRectInParent"_s, info.windowClipRectInParent());
+    ts.dumpProperty("visibleRectInParent"_s, info.visibleRectInParent());
+#if PLATFORM(IOS_FAMILY)
+    ts.dumpProperty("exposedContentRectInParent"_s, info.exposedContentRectInParent());
+#endif
+    ts.dumpProperty("ownerHasRenderer"_s, info.ownerHasRenderer());
+    ts.dumpProperty("childFrameOwnerToRootContentTransform"_s, info.childFrameOwnerToRootContentTransform());
+    ts.dumpProperty("absoluteToChildFrameOwnerLocalTransform"_s, info.absoluteToChildFrameOwnerLocalTransform());
+    ts.dumpProperty("usedZoom"_s, info.usedZoom());
+    ts.dumpProperty("contentBoxLocation"_s, info.contentBoxLocation());
+    ts.dumpProperty("ownerElementAppearance"_s, info.ownerElementAppearance());
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -120,4 +120,7 @@ private:
     OptionSet<FrameOwnerElementAppearance> m_ownerElementAppearance;
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, FrameOwnerElementAppearance);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const RemoteFrameLayoutInfo&);
+
 };

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -74,17 +74,17 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
 
 LayoutRect RemoteFrameView::layoutViewportRect() const
 {
-    return m_frame->frameTreeSyncData().frameLayoutViewportRect;
+    return m_frame->frameTreeSyncData().frameGeometry.layoutViewportRect;
 }
 
 IntSize RemoteFrameView::contentsSize() const
 {
-    return m_frame->frameTreeSyncData().frameContentsSize;
+    return m_frame->frameTreeSyncData().frameGeometry.contentsSize;
 }
 
 std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child) const
 {
-    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->visibleRectInParent();
 
     return std::nullopt;
@@ -92,7 +92,7 @@ std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child
 
 OptionSet<FrameOwnerElementAppearance> RemoteFrameView::appearanceOfOwnerElementOfChildFrame(const Frame& child) const
 {
-    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->ownerElementAppearance();
 
     return { };
@@ -100,7 +100,7 @@ OptionSet<FrameOwnerElementAppearance> RemoteFrameView::appearanceOfOwnerElement
 
 LayoutPoint RemoteFrameView::childFrameOwnerContentBoxLocation(const Frame& child) const
 {
-    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->contentBoxLocation();
 
     return { };
@@ -108,7 +108,7 @@ LayoutPoint RemoteFrameView::childFrameOwnerContentBoxLocation(const Frame& chil
 
 TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(const Frame& child) const
 {
-    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->childFrameOwnerToRootContentTransform();
 
     return { };
@@ -116,7 +116,7 @@ TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(cons
 
 TransformationMatrix RemoteFrameView::absoluteToChildFrameOwnerLocalTransform(const Frame& child) const
 {
-    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+    if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->absoluteToChildFrameOwnerLocalTransform();
 
     return { };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1349,6 +1349,13 @@ using WebCore::ScrollPosition = WebCore::IntPoint;
     OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance();
 };
 
+header: <WebCore/FrameGeometrySyncData.h>
+struct WebCore::FrameGeometrySyncData {
+    WebCore::LayoutRect layoutViewportRect;
+    WebCore::IntSize contentsSize;
+    HashMap<WebCore::FrameIdentifier, Ref<WebCore::RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
+};
+
 header: <WebCore/VP9Utilities.h>
 [CustomHeader] struct WebCore::ScreenDataOverrides {
     double width;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -905,7 +905,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, m_effectiveSandboxFlags.contains(WebCore::SandboxFlag::Origin), url().protocol().toString(), IntRect { }, ScrollPosition { }, LayoutRect { }, IntSize { }, HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, m_effectiveSandboxFlags.contains(WebCore::SandboxFlag::Origin), url().protocol().toString(), IntRect { }, ScrollPosition { }, FrameGeometrySyncData { });
 }
 
 Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1453,7 +1453,7 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
             view->scrollTo(coreFrame->frameTreeSyncData().frameScrollPosition);
         break;
 
-    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+    case FrameTreeSyncDataType::FrameGeometry:
         updateChildFrameVisibleRectsFromParent(*coreFrame);
         break;
 
@@ -1465,8 +1465,7 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
     switch (dataType) {
     case FrameTreeSyncDataType::FrameRect:
     case FrameTreeSyncDataType::FrameScrollPosition:
-    case FrameTreeSyncDataType::FrameLayoutViewportRect:
-    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+    case FrameTreeSyncDataType::FrameGeometry:
         updatePDFHUDLocationsAfterRemoteFrameGeometryChange();
         break;
     default:
@@ -1495,7 +1494,7 @@ void WebPage::updateChildFrameVisibleRectsFromParent(WebCore::Frame& parentCoreF
     if (!m_page || !m_page->settings().siteIsolationEnabled())
         return;
 
-    auto& childrenInfo = parentCoreFrame.frameTreeSyncData().childrenFrameLayoutInfo;
+    auto& childrenInfo = parentCoreFrame.frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo;
     if (childrenInfo.isEmpty())
         return;
 


### PR DESCRIPTION
#### 119fd8268d356250ef15a870e5dd136fee765972
<pre>
[Site Isolation] Coalesce per-rendering-update frame geometry IPCs
<a href="https://bugs.webkit.org/show_bug.cgi?id=322691">https://bugs.webkit.org/show_bug.cgi?id=322691</a>
<a href="https://rdar.apple.com/problem/185961490">rdar://problem/185961490</a>

Reviewed by Alex Christensen and Kiet Ho.

When Site Isolation is enabled, we currently send three separate frame geometry related IPCs in
Page::syncLocalFrameInfoToRemote(). Consolidate these in to a single IPC instead.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateFrameTreeSyncData):
* Source/WebCore/page/FrameGeometrySyncData.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/FrameGeometrySyncData.h: Added.
* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateLayoutViewportRect): Deleted.
(WebCore::LocalFrameView::updateContentsSizeForRemoteFrames): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::usedZoomForChild const):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::layoutViewportRect const):
(WebCore::RemoteFrameView::contentsSize const):
(WebCore::RemoteFrameView::visibleRectOfChild const):
(WebCore::RemoteFrameView::appearanceOfOwnerElementOfChildFrame const):
(WebCore::RemoteFrameView::childFrameOwnerContentBoxLocation const):
(WebCore::RemoteFrameView::childFrameOwnerToRootContentTransform const):
(WebCore::RemoteFrameView::absoluteToChildFrameOwnerLocalTransform const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):
(WebKit::WebPage::updateChildFrameVisibleRectsFromParent):

Canonical link: <a href="https://commits.webkit.org/320043@main">https://commits.webkit.org/320043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ef54af5448c58acbce8874eefcda76d29577f71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147801 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc8f500d-bc41-4783-a2c9-01cc97228271) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143240 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99451 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49907f16-fe9b-4328-91ae-b11544bf8737) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123662 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bc6204b-31d3-47d1-b8df-d26ee6200dec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43922 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43520 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4909 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57104 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40936 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57808 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40146 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152437 "Found 9 new API test failures: TestSSL:/webkit/WebKitWebView/tls-errors-policy, TestWebKit.WebKit.WKPageCopySessionStateWithFiltering, TestInspector:/webkit/WebKitWebInspector/default, TestLoaderClient:/webkit/WebKitURIResponse/http-headers, TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, TestWebKit.WebKit.GeolocationWatchMultiprocess (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46987 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130087 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126386 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18529 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->