### PR TITLE
[JSC] Make MarkedSpace::stopAllocating faster

### DIFF
--- a/Source/JavaScriptCore/heap/FreeList.h
+++ b/Source/JavaScriptCore/heap/FreeList.h
@@ -87,16 +87,16 @@ public:
     void NODELETE clear();
     
     JS_EXPORT_PRIVATE void initialize(FreeCell* head, uint64_t secret, unsigned bytes);
-    
+
     bool allocationWillFail() const { return m_intervalStart >= m_intervalEnd && isSentinel(nextInterval()); }
     bool allocationWillSucceed() const { return !allocationWillFail(); }
-    
-    template<typename Func>
-    HeapCell* allocateWithCellSize(const Func& slowPath, size_t cellSize);
-    
-    template<typename Func>
-    void forEach(const Func&) const;
-    
+
+    HeapCell* allocateWithCellSize(const Invocable<void()> auto& slowPath, size_t cellSize);
+
+    void forEach(const Invocable<void(HeapCell*)> auto&) const;
+
+    void forEachInterval(const Invocable<void(char*, char*)> auto&) const;
+
     unsigned originalSize() const { return m_originalSize; }
 
     static bool isSentinel(FreeCell* cell) { return std::bit_cast<uintptr_t>(cell) & 1; }

--- a/Source/JavaScriptCore/heap/FreeListInlines.h
+++ b/Source/JavaScriptCore/heap/FreeListInlines.h
@@ -32,8 +32,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-template<typename Func>
-ALWAYS_INLINE HeapCell* FreeList::allocateWithCellSize(const Func& slowPath, size_t cellSize)
+ALWAYS_INLINE HeapCell* FreeList::allocateWithCellSize(const Invocable<void()> auto& slowPath, size_t cellSize)
 {
     if (m_intervalStart < m_intervalEnd) [[likely]] {
         char* result = m_intervalStart;
@@ -54,8 +53,7 @@ ALWAYS_INLINE HeapCell* FreeList::allocateWithCellSize(const Func& slowPath, siz
     return std::bit_cast<HeapCell*>(result);
 }
 
-template<typename Func>
-void FreeList::forEach(const Func& func) const
+void FreeList::forEachInterval(const Invocable<void(char*, char*)> auto& func) const
 {
     FreeCell* cell = nextInterval();
     char* intervalStart = m_intervalStart;
@@ -63,8 +61,8 @@ void FreeList::forEach(const Func& func) const
     ASSERT(intervalEnd - intervalStart < (ptrdiff_t)MarkedBlock::blockSize);
 
     while (true) {
-        for (; intervalStart < intervalEnd; intervalStart += m_cellSize)
-            func(std::bit_cast<HeapCell*>(intervalStart));
+        if (intervalStart < intervalEnd)
+            func(intervalStart, intervalEnd);
 
         // If we explore the whole interval and the cell is the sentinel value, though, we should
         // immediately exit so we don't decode anything out of bounds.
@@ -73,6 +71,15 @@ void FreeList::forEach(const Func& func) const
 
         FreeCell::advance(m_secret, cell, intervalStart, intervalEnd);
     }
+}
+
+void FreeList::forEach(const Invocable<void(HeapCell*)> auto& func) const
+{
+    forEachInterval(
+        [&] (char* intervalStart, char* intervalEnd) {
+            for (char* cell = intervalStart; cell < intervalEnd; cell += m_cellSize)
+                func(std::bit_cast<HeapCell*>(cell));
+        });
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -162,13 +162,19 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList, StopAllocatin
     blockHeader().m_newlyAllocatedVersion = heap()->objectSpace().newlyAllocatedVersion();
     blockHeader().m_newlyAllocated.setEachNthBit(m_atomsPerCell, m_startAtom, endAtom);
 
-    freeList.forEach(
-        [&] (HeapCell* cell) {
-            if constexpr (MarkedBlockInternal::verbose)
-                dataLog("Free cell: ", RawPointer(cell), "\n");
-            if (m_attributes.destruction != DoesNotNeedDestruction)
-                cell->zap(HeapCell::StopAllocating);
-            block().clearNewlyAllocated(cell);
+    ASSERT(freeList.cellSize() == m_atomsPerCell * atomSize);
+    bool needsZapping = m_attributes.destruction != DoesNotNeedDestruction;
+    freeList.forEachInterval(
+        [&](char* intervalStart, char* intervalEnd) {
+            if (needsZapping || MarkedBlockInternal::verbose) {
+                for (char* cell = intervalStart; cell < intervalEnd; cell += freeList.cellSize()) {
+                    if constexpr (MarkedBlockInternal::verbose)
+                        dataLog("Free cell: ", RawPointer(cell), "\n");
+                    if (needsZapping)
+                        std::bit_cast<HeapCell*>(cell)->zap(HeapCell::StopAllocating);
+                }
+            }
+            blockHeader().m_newlyAllocated.clearEachNthBit(m_atomsPerCell, block().candidateAtomNumber(intervalStart), block().candidateAtomNumber(intervalEnd));
         });
     
     m_isFreeListed = false;

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -127,6 +127,7 @@ public:
     constexpr void setAndClear(BitSet&);
 
     void setEachNthBit(size_t n, size_t start = 0, size_t end = bitSetSize);
+    void clearEachNthBit(size_t n, size_t start = 0, size_t end = bitSetSize);
 
     constexpr bool operator==(const BitSet&) const;
 
@@ -476,6 +477,39 @@ inline void BitSet<bitSetSize, WordType>::setEachNthBit(size_t n, size_t start, 
     }
 
     cleanseLastWord();
+}
+
+template<size_t bitSetSize, typename WordType>
+inline void BitSet<bitSetSize, WordType>::clearEachNthBit(size_t n, size_t start, size_t end)
+{
+    ASSERT(start <= end);
+    ASSERT(end <= bitSetSize);
+
+    size_t wordIndex = start / wordSize;
+    size_t endWordIndex = end / wordSize;
+    size_t index = start - wordIndex * wordSize;
+    while (wordIndex < endWordIndex) {
+        if (index < wordSize) {
+            WordType word = bits[wordIndex];
+            do {
+                word &= ~(one << index);
+                index += n;
+            } while (index < wordSize);
+            bits[wordIndex] = word;
+        }
+        index -= wordSize;
+        wordIndex++;
+    }
+
+    size_t endIndex = end - endWordIndex * wordSize;
+    if (index < endIndex) {
+        WordType word = bits[wordIndex];
+        do {
+            word &= ~(one << index);
+            index += n;
+        } while (index < endIndex);
+        bits[wordIndex] = word;
+    }
 }
 
 template<size_t bitSetSize, typename WordType>

--- a/Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp
@@ -1120,6 +1120,65 @@ void testBitSetSetEachNthBit()
     testBitSetSetEachNthBitImpl(smallSize, wordSize, smallBitSetZeroes, smallBitSetOnes);
 }
 
+template<typename BitSet>
+void testBitSetClearEachNthBitImpl(size_t size, size_t wordSize, const BitSet& zeroes, const BitSet& ones)
+{
+    BitSet temp;
+
+    temp.setAll();
+    EXPECT_TRUE(temp == ones);
+    temp.clearEachNthBit(1);
+    EXPECT_TRUE(temp == zeroes);
+
+    size_t nValues[] = { 1, 2, wordSize / 2, wordSize - 1, wordSize, size / 2, size - 1, size };
+    size_t nValuesCount = sizeof(nValues) / sizeof(nValues[0]);
+
+    size_t startEndValues[] = { 0, 1, 2, wordSize / 2, wordSize - 1, wordSize, size / 2, size - 1, size };
+    constexpr size_t numberOfStartEndValues = sizeof(startEndValues) / sizeof(startEndValues[0]);
+
+    for (size_t start = 0; start < numberOfStartEndValues; ++start) {
+        for (size_t end = start; end < numberOfStartEndValues; ++end) {
+            size_t startIndex = startEndValues[start];
+            size_t endIndex = startEndValues[end];
+            if (endIndex < startIndex)
+                continue;
+            if (startIndex > size)
+                continue;
+            if (endIndex > size)
+                continue;
+
+            for (size_t j = 0; j < nValuesCount; ++j) {
+                size_t n = nValues[j];
+                temp.setAll();
+                temp.clearEachNthBit(n, startIndex, endIndex);
+
+                for (size_t i = 0; i < startIndex; ++i)
+                    EXPECT_TRUE(temp.get(i));
+
+                size_t count = 0;
+                for (size_t i = startIndex; i < endIndex; ++i) {
+                    bool expectedToStaySet = !!count;
+                    EXPECT_TRUE(temp.get(i) == expectedToStaySet);
+                    count++;
+                    count = count % n;
+                }
+
+                for (size_t i = endIndex; i < size; ++i)
+                    EXPECT_TRUE(temp.get(i));
+            }
+        }
+    }
+}
+
+template<typename WordType>
+void testBitSetClearEachNthBit()
+{
+    DECLARE_AND_INIT_BITMAPS_FOR_TEST();
+    constexpr size_t wordSize = sizeof(WordType) * 8;
+    testBitSetClearEachNthBitImpl(size, wordSize, bitSetZeroes, bitSetOnes);
+    testBitSetClearEachNthBitImpl(smallSize, wordSize, smallBitSetZeroes, smallBitSetOnes);
+}
+
 template<typename WordType>
 void testBitSetOperatorEqual()
 {
@@ -1483,6 +1542,7 @@ TEST(WTF_BitSet, Iteration_uint32_t) { testBitSetIteration<uint32_t>(); }
 TEST(WTF_BitSet, MergeAndClear_uint32_t) { testBitSetMergeAndClear<uint32_t>(); }
 TEST(WTF_BitSet, SetAndClear_uint32_t) { testBitSetSetAndClear<uint32_t>(); }
 TEST(WTF_BitSet, SetEachNthBit_uint32_t) { testBitSetSetEachNthBit<uint32_t>(); }
+TEST(WTF_BitSet, ClearEachNthBit_uint32_t) { testBitSetClearEachNthBit<uint32_t>(); }
 TEST(WTF_BitSet, OperatorEqualAccess_uint32_t) { testBitSetOperatorEqual<uint32_t>(); }
 TEST(WTF_BitSet, OperatorNotEqualAccess_uint32_t) { testBitSetOperatorNotEqual<uint32_t>(); }
 TEST(WTF_BitSet, OperatorAssignment_uint32_t) { testBitSetOperatorAssignment<uint32_t>(); }
@@ -1520,6 +1580,7 @@ TEST(WTF_BitSet, Iteration_uint64_t) { testBitSetIteration<uint64_t>(); }
 TEST(WTF_BitSet, MergeAndClear_uint64_t) { testBitSetMergeAndClear<uint64_t>(); }
 TEST(WTF_BitSet, SetAndClear_uint64_t) { testBitSetSetAndClear<uint64_t>(); }
 TEST(WTF_BitSet, SetEachNthBit_uint64_t) { testBitSetSetEachNthBit<uint64_t>(); }
+TEST(WTF_BitSet, ClearEachNthBit_uint64_t) { testBitSetClearEachNthBit<uint64_t>(); }
 TEST(WTF_BitSet, OperatorEqualAccess_uint64_t) { testBitSetOperatorEqual<uint64_t>(); }
 TEST(WTF_BitSet, OperatorNotEqualAccess_uint64_t) { testBitSetOperatorNotEqual<uint64_t>(); }
 TEST(WTF_BitSet, OperatorAssignment_uint64_t) { testBitSetOperatorAssignment<uint64_t>(); }


### PR DESCRIPTION
#### 041ad12a187e01224e67d9cb591b4e1b7197c84e
<pre>
[JSC] Make MarkedSpace::stopAllocating faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=322693">https://bugs.webkit.org/show_bug.cgi?id=322693</a>
<a href="https://rdar.apple.com/185962296">rdar://185962296</a>

Reviewed by Keith Miller.

Tighten MarkedSpace::stopAllocating faster by,

1. introducing BitSet::clearEachNthBit, which clears m_newlyAllocated in
   bulk style.
2. introducing freeList.forEachInterval, avoiding per cell processing
   and making zap loop excluded when it is not necessary.

Test: Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp

* Source/JavaScriptCore/heap/FreeList.h:
* Source/JavaScriptCore/heap/FreeListInlines.h:
(JSC::FreeList::allocateWithCellSize):
(JSC::FreeList::forEachInterval const):
(JSC::FreeList::forEach const):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::stopAllocating):
* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::clearEachNthBit):
* Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp:
(TestWebKitAPI::testBitSetClearEachNthBitImpl):
(TestWebKitAPI::testBitSetClearEachNthBit):
(TestWebKitAPI::TEST(WTF_BitSet, ClearEachNthBit_uint32_t)):
(TestWebKitAPI::TEST(WTF_BitSet, ClearEachNthBit_uint64_t)):

Canonical link: <a href="https://commits.webkit.org/319965@main">https://commits.webkit.org/319965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3d50017a5c7c9a882a591cfd09f70a6bd3d85fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147556 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e909e27d-4a45-41f8-917c-842b63ca83e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143067 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1de7ed52-ecec-40ab-bf27-f14bbd1ccdd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e7b9daf-6077-432b-b6a6-b54af79da08f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43726 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5474 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12282 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43342 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4660 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44537 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195426 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56859 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152539 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152236 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46791 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129862 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56072 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18354 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55443 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55681 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->