### PR TITLE
Fractional-sized SVG images are letterboxed inside their own rect

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8527,5 +8527,3 @@ imported/w3c/web-platform-tests/css/css-box/margin-trim/multicol-spanner-007.htm
 fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html [ ImageOnlyFailure ]
 fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html [ ImageOnlyFailure ]
 fast/shadow-dom/svg-pattern-href-in-shadow-tree.html [ ImageOnlyFailure ]
-
-imported/w3c/web-platform-tests/svg/as-image/sprite-sheet-fractional-size.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -366,12 +366,15 @@ void RenderImage::updateIntrinsicSizeIfNeeded(const LayoutSize& newSize)
 
 void RenderImage::updateInnerContentRect()
 {
-    // Propagate container size to image resource.
-    IntSize containerSize = isDimensionlessSVG()
-        ? flooredIntSize(contentBoxRect().size())
-        : flooredIntSize(replacedContentRect().size());
+    // Propagate container size to image resource. It is deliberately not rounded: an SVG image has
+    // to be laid out at the exact size it is asked to fill, or preserveAspectRatio letterboxes it
+    // inside its own rect.
+    LayoutSize containerSize = isDimensionlessSVG()
+        ? contentBoxRect().size()
+        : replacedContentRect().size();
 
-    if (!containerSize.isEmpty()) {
+    // The container is less than a pixel wide or tall.
+    if (!flooredIntSize(containerSize).isEmpty()) {
         URL imageSourceURL;
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element()))
             imageSourceURL = imageElement->currentURL();

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -145,7 +145,7 @@ bool RenderImageResource::currentFrameIsComplete() const
     return protect(m_styleImage)->currentFrameIsComplete(m_renderer.get());
 }
 
-void RenderImageResource::setContainerContext(const IntSize& imageContainerSize, const URL& url)
+void RenderImageResource::setContainerContext(const LayoutSize& imageContainerSize, const URL& url)
 {
     if (!m_styleImage || !m_renderer)
         return;

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -59,7 +59,7 @@ public:
     bool currentFrameIsComplete() const;
     bool errorOccurred() const { return m_styleImage && m_styleImage->errorOccurred(); }
 
-    void setContainerContext(const IntSize&, const URL&);
+    void setContainerContext(const LayoutSize&, const URL&);
 
     bool imageHasRelativeWidth() const { return m_styleImage && m_styleImage->imageHasRelativeWidth(); }
     bool imageHasRelativeHeight() const { return m_styleImage && m_styleImage->imageHasRelativeHeight(); }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -53,8 +53,8 @@ public:
     bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }
     bool isInLayout() const { return m_inLayout; }
 
-    IntSize containerSize() const { return m_containerSize; }
-    void setContainerSize(const IntSize& containerSize) { m_containerSize = containerSize; }
+    LayoutSize containerSize() const { return m_containerSize; }
+    void setContainerSize(const LayoutSize& containerSize) { m_containerSize = containerSize; }
 
     bool NODELETE hasRelativeDimensions() const final;
 
@@ -130,7 +130,7 @@ private:
     // descendant transform changed via the deferred (layout-free) SVG transform-attribute flush.
     void updateSVGTransformDependentBoundingBoxesIfNeeded() const;
 
-    IntSize m_containerSize;
+    LayoutSize m_containerSize;
     mutable FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect> m_strokeBoundingBox;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -54,8 +54,8 @@ public:
     void setNeedsBoundariesUpdate() override { m_needsBoundariesOrTransformUpdate = true; }
     void setNeedsTransformUpdate() override { m_needsBoundariesOrTransformUpdate = true; }
 
-    IntSize containerSize() const { return m_containerSize; }
-    void setContainerSize(const IntSize& containerSize) { m_containerSize = containerSize; }
+    LayoutSize containerSize() const { return m_containerSize; }
+    void setContainerSize(const LayoutSize& containerSize) { m_containerSize = containerSize; }
 
     bool hasRelativeDimensions() const override;
 
@@ -119,7 +119,7 @@ private:
     void updateCachedBoundaries();
     void buildLocalToBorderBoxTransform();
 
-    IntSize m_containerSize;
+    LayoutSize m_containerSize;
     FloatRect m_repaintBoundingBox;
     Markable<FloatRect> m_objectBoundingBox;
     mutable Markable<FloatRect> m_strokeBoundingBox;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -172,12 +172,12 @@ void SVGImage::setContainerSize(const FloatSize& size)
         return;
 
     if (CheckedPtr renderer = dynamicDowncast<LegacyRenderSVGRoot>(rootElement->renderer())) {
-        renderer->setContainerSize(IntSize(size));
+        renderer->setContainerSize(LayoutSize(size));
         return;
     }
 
     if (CheckedPtr renderer = dynamicDowncast<RenderSVGRoot>(rootElement->renderer())) {
-        renderer->setContainerSize(IntSize(size));
+        renderer->setContainerSize(LayoutSize(size));
         return;
     }
 }
@@ -189,7 +189,7 @@ IntSize SVGImage::containerSize() const
         return { };
 
     // If a container size is available it has precedence.
-    auto computeContainerSize = [&]() -> IntSize {
+    auto computeContainerSize = [&]() -> LayoutSize {
         if (auto* renderer = dynamicDowncast<LegacyRenderSVGRoot>(rootElement->renderer()))
             return renderer->containerSize();
 
@@ -199,9 +199,10 @@ IntSize SVGImage::containerSize() const
         return { };
     };
 
+    // The container size may be fractional; the frame view has to be large enough to hold all of it.
     auto containerSize = computeContainerSize();
     if (!containerSize.isEmpty())
-        return containerSize;
+        return expandedIntSize(FloatSize(containerSize));
 
     // Assure that a container size is always given for a non-identity zoom level.
     ASSERT(rootElement->renderer()->style().usedZoom() == 1);
@@ -227,16 +228,13 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
     ImageObserverDisableScope imageObserverDisabler(*this);
 
-    IntSize roundedContainerSize = roundedIntSize(containerSize);
-    setContainerSize(roundedContainerSize);
+    // The container size is the concrete object size the SVG has to fill, and is not necessarily
+    // integral. Laying the document out at a rounded size would give the SVG viewport a different
+    // aspect ratio than the one asked for, which preserveAspectRatio would then letterbox.
+    setContainerSize(containerSize);
 
     FloatRect scaledSrc = srcRect;
     scaledSrc.scale(1 / containerZoom);
-
-    // Compensate for the container size rounding by adjusting the source rect.
-    FloatSize adjustedSrcSize = scaledSrc.size();
-    adjustedSrcSize.scale(roundedContainerSize.width() / containerSize.width(), roundedContainerSize.height() / containerSize.height());
-    scaledSrc.setSize(adjustedSrcSize);
 
     protect(frameView())->scrollToFragment(initialFragmentURL);
 

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -40,7 +40,7 @@ FloatSize SVGImageForContainer::size(ImageOrientation) const
 {
     FloatSize scaledContainerSize(m_containerSize);
     scaledContainerSize.scale(m_containerZoom);
-    return FloatSize(roundedIntSize(scaledContainerSize));
+    return scaledContainerSize;
 }
 
 ImageDrawResult SVGImageForContainer::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)


### PR DESCRIPTION
#### 0bf726c4bc5eb26030bbfbed22cf6bc9fd26017b
<pre>
Fractional-sized SVG images are letterboxed inside their own rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=322697">https://bugs.webkit.org/show_bug.cgi?id=322697</a>
<a href="https://rdar.apple.com/185963769">rdar://185963769</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

RenderImage::updateInnerContentRect() floored the used size before handing it to
the image as its container size, and SVGImage::drawForContainer() rounded it a
second time before laying the SVG document out. An &lt;img&gt; used at 804x20.1 was
therefore laid out in an 804x20 viewport, which does not have the aspect ratio
that was asked for, so preserveAspectRatio letterboxed the content inside it:
with a viewBox of &quot;0 0 800 20&quot; the drawing was centered with a 2px gap either
side. drawForContainer() then scaled the source rect to compensate, which undoes
the scale the rounding introduced but cannot undo the letterbox translation, so
the content stayed 2px off. The wider the SVG, the further off it lands - a 40
frame sprite sheet drawn at 1332x33.3 was shifted by 6px, a third of a frame,
which puts a window onto frame 0 mostly over frame 1.

Stop rounding. Keep the container size fractional from RenderImage down to the
SVG root so the SVG viewport has exactly the aspect ratio of the used size and
preserveAspectRatio has nothing to letterbox. The source rect compensation in
drawForContainer() and the rounding in SVGImageForContainer::size() go away with
it, since the source rect and the destination rect now agree. The frame view is
still sized in whole pixels, expanded rather than rounded so that it holds all of
a fractional container size.

A used size that is not representable in LayoutUnit still letterboxes by the
1/64px it was quantized by, amplified by the viewBox aspect ratio; 804x20.1
retains a 0.125px gap. Sizes that are representable, such as 830x20.75, are now
exact. A used size whose aspect ratio genuinely differs from the viewBox is
letterboxed as before.

* LayoutTests/TestExpectations: Now Passing (so removing)
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::updateInnerContentRect):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setContainerContext):
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::setContainerSize):
(WebCore::SVGImage::containerSize const):
(WebCore::SVGImage::drawForContainer):
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
(WebCore::SVGImageForContainer::size const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bf726c4bc5eb26030bbfbed22cf6bc9fd26017b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147558 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9ea1425-0a2a-4582-b5df-8cfcc7a9009b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56927 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143041 "Found 1 new test failure: fast/backgrounds/background-image-large-float-intrinsic-ratio.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99338 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ed7089c-8bbf-45c0-a710-922f73b6078a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123467 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11cd9ef1-c093-4ae4-9f0f-173adaeee90e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45478 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43727 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43335 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152229 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46785 "Found 1 new test failure: interaction-region/icon-masking.html (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129863 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126145 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56074 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18347 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->