### PR TITLE
REGRESSION(319347@main): Touchmove is dropped when it arrives while touchstart is still in flight

### DIFF
--- a/LayoutTests/fast/events/touch/touch-move-during-pending-touch-start-expected.txt
+++ b/LayoutTests/fast/events/touch/touch-move-during-pending-touch-start-expected.txt
@@ -1,0 +1,10 @@
+Tests that a touch move dispatched before the preceding touch start has been processed is still delivered to the page.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS receivedEvents.join(' ') is "touchstart touchmove touchend"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/touch-move-during-pending-touch-start.html
+++ b/LayoutTests/fast/events/touch/touch-move-during-pending-touch-start.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body onload="runTest();">
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description('Tests that a touch move dispatched before the preceding touch start has been processed is still delivered to the page.');
+
+window.jsTestIsAsync = true;
+
+var receivedEvents = [];
+
+function logEvent(event)
+{
+    receivedEvents.push(event.type);
+}
+
+// The listeners must be non-passive so that the touch start is tracked synchronously and its
+// reply cannot reach the UI process before the touch move is dispatched below.
+for (const type of ['touchstart', 'touchmove', 'touchend'])
+    document.addEventListener(type, logEvent, { passive: false });
+
+async function runTest()
+{
+    // Touch event regions must reach the scrolling tree before touch events are dispatched.
+    await UIHelper.renderingComplete();
+
+    if (!window.eventSender) {
+        debug('This test requires WebKitTestRunner.');
+        finishJSTest();
+        return;
+    }
+
+    eventSender.clearTouchPoints();
+    eventSender.addTouchPoint(50, 50);
+
+    // Deliberately use the synchronous eventSender API rather than the asyncTouch* variants:
+    // the whole sequence has to be pushed back to back, the way a touchscreen or WebDriver
+    // delivers it, so that the touch move reaches the UI process while the touch start is
+    // still waiting for its reply from the web process. Awaiting each event instead would
+    // drain the pending touch event queue between events and not cover this case.
+    eventSender.touchStart();
+    eventSender.updateTouchPoint(0, 60, 150);
+    eventSender.touchMove();
+    eventSender.releaseTouchPoint(0);
+    eventSender.touchEnd();
+
+    await UIHelper.waitForCondition(() => receivedEvents.includes('touchend'));
+
+    shouldBeEqualToString("receivedEvents.join(' ')", 'touchstart touchmove touchend');
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5566,14 +5566,16 @@ void WebPageProxy::handleTouchEvent(IPC::Connection*, const NativeWebTouchEvent&
 
     if (event.type() == WebEventType::TouchMove && !internals().touchEventQueue.isEmpty()) {
         QueuedTouchEvents& lastEvent = internals().touchEventQueue.last();
-        if (lastEvent.forwardedEvent.type() == WebEventType::TouchMove)
+        if (lastEvent.forwardedEvent.type() == WebEventType::TouchMove) {
             lastEvent.deferredTouchEvents.append(event);
-    } else {
-        internals().touchEventQueue.append(event);
-
-        if (internals().touchEventQueue.size() == 1)
-            processNextQueuedTouchEvent();
+            return;
+        }
     }
+
+    internals().touchEventQueue.append(event);
+
+    if (internals().touchEventQueue.size() == 1)
+        processNextQueuedTouchEvent();
 }
 #elif ENABLE(TOUCH_EVENTS)
 void WebPageProxy::touchEventHandlingCompleted(IPC::Connection* connection, std::optional<WebEventType> eventType, bool handled)


### PR DESCRIPTION
#### f0c538173039a9a42c2e4ee039fa4a536f81a8b1
<pre>
REGRESSION(319347@main): Touchmove is dropped when it arrives while touchstart is still in flight
<a href="https://bugs.webkit.org/show_bug.cgi?id=322698">https://bugs.webkit.org/show_bug.cgi?id=322698</a>

Reviewed by Fujii Hironori.

319347@main ([GTK][WPE] Support touch event asynchronous scrolling) introduced a
serialized touch event queue in the UI process for the COORDINATED_TOUCH_EVENTS
path, which coalesces consecutive touch moves onto the queued one. The coalescing
condition, however, has no fallback:

    if (event.type() == WebEventType::TouchMove &amp;&amp; !touchEventQueue.isEmpty()) {
        QueuedTouchEvents&amp; lastEvent = touchEventQueue.last();
        if (lastEvent.forwardedEvent.type() == WebEventType::TouchMove)
            lastEvent.deferredTouchEvents.append(event);
    } else {
        touchEventQueue.append(event);
        ...
    }

When a TouchMove arrives while the queue is non-empty but the last queued event is
not itself a TouchMove -- that is, while the TouchStart is still awaiting its
asynchronous reply from the web process -- neither branch runs and the event is
silently discarded. It is not forwarded to the web process and it is not appended
to deferredTouchEvents, so it never reaches the DOM and, because
PageClientImpl::doneWithTouchEvent() is only called for events that made it into
the queue, it never reaches the WPE gesture controller either.

The practical effect is that a touch drag delivered as a back-to-back
down/move/up burst degenerates into a second tap: the page observes touchstart
and touchend with no touchmove, the gesture controller sees no motion and
synthesizes mousemove/mousedown/mouseup/click, and nothing scrolls. This is how
touch events arrive both from a real touchscreen and from WebDriver, which emits
a single WPE_EVENT_TOUCH_MOVE per move action with no interpolation and no wait
between events (see the TODO in WebAutomationSession::platformSimulateTouchInteraction,
<a href="https://bugs.webkit.org/show_bug.cgi?id=275031).">https://bugs.webkit.org/show_bug.cgi?id=275031).</a>

Before 319347@main, the generic ENABLE(TOUCH_EVENTS) path sent every touch event
straight through with sendWithAsyncReply and no queue at all, and on non-Cocoa
platforms updateTouchEventTracking() unconditionally marked every tracking type
Synchronous, so every touchmove reached the DOM.

Restructure the condition so that coalescing is an early return and every other
event, including a TouchMove that cannot be coalesced, falls through to the
enqueue path. The intended coalescing behaviour is unchanged.

This went unnoticed because every test in fast/events/touch/ drives the engine
through eventSender.asyncTouchStart()/asyncTouchMove()/asyncTouchEnd(), each of
which awaits its round trip via doAfterProcessingAllPendingTouchAndWheelEvents().
The queue is therefore always empty by the time the next event is dispatched, and
the dropped-event path is never exercised.

The new test uses the synchronous eventSender touch API instead, which dispatches
the event and returns without waiting, so the whole sequence is pushed back to
back the way a touchscreen or WebDriver delivers it. Its listeners are registered
non-passive so that the touch start is tracked synchronously: its reply then
requires the web process main thread, which is blocked in the synchronous
eventSender message for the touch move, making the reproduction deterministic
rather than a race.

Test: fast/events/touch/touch-move-during-pending-touch-start.html
* LayoutTests/fast/events/touch/touch-move-during-pending-touch-start-expected.txt: Added.
* LayoutTests/fast/events/touch/touch-move-during-pending-touch-start.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleTouchEvent):

Co-Authored-By: Claude Sonnet 5 &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/319960@main">https://commits.webkit.org/319960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ae3dfa9c85e6fbcac8d51d19a8115c191d8283f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43751 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43361 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4687 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40887 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152254 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46816 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129871 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56099 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18373 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->