### PR TITLE
[JSC] Remove valueProfileLock

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -3018,7 +3018,7 @@ bool CodeBlock::hasIdentifier(UniquedStringImpl* uid)
 }
 #endif
 
-void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const ConcurrentJSLocker& locker, unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles)
+void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles)
 {
     numberOfLiveNonArgumentValueProfiles = 0;
     numberOfSamplesInProfiles = 0;
@@ -3030,7 +3030,7 @@ void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const Co
     forEachValueProfile([&](auto& profile, bool isArgument) {
         using Profile = std::remove_reference_t<decltype(profile)>;
         static_assert(Profile::numberOfBuckets == 1);
-        bool wasLive = profile.computeUpdatedPrediction(locker) != SpecNone;
+        bool wasLive = profile.computeUpdatedPrediction() != SpecNone;
         if (wasLive) {
             ++numberOfSamplesInProfiles;
             if (!isArgument)
@@ -3045,25 +3045,23 @@ void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const Co
         m_metadata->forEach<OpCatch>([&](auto& metadata) {
             if (metadata.m_buffer) {
                 metadata.m_buffer->forEach([&](ValueProfileAndVirtualRegister& profile) {
-                    profile.computeUpdatedPrediction(locker);
+                    profile.computeUpdatedPrediction();
                 });
             }
         });
     }
 }
 
-void CodeBlock::updateAllNonLazyValueProfilePredictions(const ConcurrentJSLocker& locker)
+void CodeBlock::updateAllNonLazyValueProfilePredictions()
 {
     unsigned ignoredValue1, ignoredValue2;
-    updateAllNonLazyValueProfilePredictionsAndCountLiveness(locker, ignoredValue1, ignoredValue2);
+    updateAllNonLazyValueProfilePredictionsAndCountLiveness(ignoredValue1, ignoredValue2);
 }
 
-void CodeBlock::updateAllLazyValueProfilePredictions(const ConcurrentJSLocker& locker)
+void CodeBlock::updateAllLazyValueProfilePredictions()
 {
 #if ENABLE(DFG_JIT)
-    lazyValueProfiles().computeUpdatedPredictions(locker, this);
-#else
-    UNUSED_PARAM(locker);
+    lazyValueProfiles().computeUpdatedPredictions(this);
 #endif
 }
 
@@ -3107,11 +3105,8 @@ void CodeBlock::updateAllArrayAllocationProfilePredictions()
 // readable: after marking, before sweep.
 void CodeBlock::updateAllPredictions()
 {
-    {
-        ConcurrentJSLocker locker(valueProfileLock());
-        updateAllNonLazyValueProfilePredictions(locker);
-        updateAllLazyValueProfilePredictions(locker);
-    }
+    updateAllNonLazyValueProfilePredictions();
+    updateAllLazyValueProfilePredictions();
     updateAllArrayAllocationProfilePredictions();
     updateAllArrayProfilePredictions();
 }
@@ -3125,11 +3120,8 @@ bool CodeBlock::shouldOptimizeNowFromBaseline()
     
     unsigned numberOfLiveNonArgumentValueProfiles;
     unsigned numberOfSamplesInProfiles;
-    {
-        ConcurrentJSLocker locker(valueProfileLock());
-        updateAllNonLazyValueProfilePredictionsAndCountLiveness(locker, numberOfLiveNonArgumentValueProfiles, numberOfSamplesInProfiles);
-        updateAllLazyValueProfilePredictions(locker);
-    }
+    updateAllNonLazyValueProfilePredictionsAndCountLiveness(numberOfLiveNonArgumentValueProfiles, numberOfSamplesInProfiles);
+    updateAllLazyValueProfilePredictions();
     updateAllArrayAllocationProfilePredictions();
     updateAllArrayProfilePredictions();
 
@@ -3393,12 +3385,12 @@ ValueProfile* CodeBlock::tryGetValueProfileForBytecodeIndex(BytecodeIndex byteco
     }
 }
 
-SpeculatedType CodeBlock::valueProfilePredictionForBytecodeIndex(const ConcurrentJSLocker& locker, BytecodeIndex bytecodeIndex, JSValue* specFailValue)
+SpeculatedType CodeBlock::valueProfilePredictionForBytecodeIndex(BytecodeIndex bytecodeIndex, JSValue* specFailValue)
 {
     if (ValueProfile* valueProfile = tryGetValueProfileForBytecodeIndex(bytecodeIndex)) {
         if (specFailValue)
-            valueProfile->computeUpdatedPredictionForExtraValue(locker, *specFailValue);
-        return valueProfile->computeUpdatedPrediction(locker);
+            valueProfile->computeUpdatedPredictionForExtraValue(*specFailValue);
+        return valueProfile->computeUpdatedPrediction();
     }
     return SpecNone;
 }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -437,7 +437,7 @@ public:
 
     ValueProfile* NODELETE tryGetValueProfileForBytecodeIndex(BytecodeIndex);
     ValueProfile& NODELETE valueProfileForBytecodeIndex(BytecodeIndex);
-    SpeculatedType valueProfilePredictionForBytecodeIndex(const ConcurrentJSLocker&, BytecodeIndex, JSValue* specFailValue = nullptr);
+    SpeculatedType valueProfilePredictionForBytecodeIndex(BytecodeIndex, JSValue* specFailValue = nullptr);
 
     template<typename Functor> void forEachValueProfile(const Functor&);
     template<typename Functor> void forEachArrayAllocationProfile(const Functor&);
@@ -754,8 +754,8 @@ public:
 #endif
 
     bool shouldOptimizeNowFromBaseline();
-    void updateAllNonLazyValueProfilePredictions(const ConcurrentJSLocker&);
-    void updateAllLazyValueProfilePredictions(const ConcurrentJSLocker&);
+    void updateAllNonLazyValueProfilePredictions();
+    void updateAllLazyValueProfilePredictions();
     void updateAllArrayProfilePredictions();
     void updateAllArrayAllocationProfilePredictions();
     void updateAllPredictions();
@@ -810,8 +810,6 @@ public:
     mutable ConcurrentJSLock m_lock;
 
     bool m_shouldAlwaysBeInlined { true }; // Not a bitfield because the JIT wants to store to it.
-
-    NoLockingNecessaryTag valueProfileLock() { return NoLockingNecessary; }
 
     static constexpr ptrdiff_t offsetOfShouldAlwaysBeInlined() { return OBJECT_OFFSETOF(CodeBlock, m_shouldAlwaysBeInlined); }
 
@@ -913,7 +911,7 @@ private:
     
     void noticeIncomingCall(JSCell* caller);
 
-    void updateAllNonLazyValueProfilePredictionsAndCountLiveness(const ConcurrentJSLocker&, unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles);
+    void updateAllNonLazyValueProfilePredictionsAndCountLiveness(unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles);
 
     Vector<unsigned> setConstantRegisters(const FixedVector<WriteBarrier<Unknown>>& constants, const FixedVector<SourceCodeRepresentation>& constantsSourceCodeRepresentation);
     void initializeTemplateObjects(ScriptExecutable* topLevelExecutable, const Vector<unsigned>& templateObjectIndices);

--- a/Source/JavaScriptCore/bytecode/LazyValueProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/LazyValueProfile.cpp
@@ -34,17 +34,17 @@ namespace JSC {
 
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(CompressedLazyValueProfileHolder::LazyValueProfileHolder);
 
-void CompressedLazyValueProfileHolder::computeUpdatedPredictions(const ConcurrentJSLocker& locker, CodeBlock* codeBlock)
+void CompressedLazyValueProfileHolder::computeUpdatedPredictions(CodeBlock* codeBlock)
 {
     if (!m_data)
         return;
 
     for (auto& profile : m_data->operandValueProfiles)
-        profile.computeUpdatedPrediction(locker);
+        profile.computeUpdatedPrediction();
 
     for (auto& pair : m_data->speculationFailureValueProfileBuckets) {
         ValueProfile& profile = codeBlock->valueProfileForBytecodeIndex(pair.first);
-        profile.computeUpdatedPredictionForExtraValue(locker, pair.second);
+        profile.computeUpdatedPredictionForExtraValue(pair.second);
     }
 }
 
@@ -125,13 +125,13 @@ LazyOperandValueProfile* LazyOperandValueProfileParser::getIfPresent(const LazyO
     return iter->value;
 }
 
-SpeculatedType LazyOperandValueProfileParser::prediction(const ConcurrentJSLocker& locker, const LazyOperandValueProfileKey& key) const
+SpeculatedType LazyOperandValueProfileParser::prediction(const LazyOperandValueProfileKey& key) const
 {
     LazyOperandValueProfile* profile = getIfPresent(key);
     if (!profile)
         return SpecNone;
 
-    return profile->computeUpdatedPrediction(locker);
+    return profile->computeUpdatedPrediction();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/LazyValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/LazyValueProfile.h
@@ -39,7 +39,7 @@ class CompressedLazyValueProfileHolder {
 public:
     CompressedLazyValueProfileHolder() = default;
 
-    void computeUpdatedPredictions(const ConcurrentJSLocker&, CodeBlock*);
+    void computeUpdatedPredictions(CodeBlock*);
 
     LazyOperandValueProfile* addOperandValueProfile(const LazyOperandValueProfileKey&);
     JSValue* addSpeculationFailureValueProfile(BytecodeIndex);
@@ -69,7 +69,7 @@ public:
 
     LazyOperandValueProfile* NODELETE getIfPresent(const LazyOperandValueProfileKey& key) const;
 
-    SpeculatedType prediction(const ConcurrentJSLocker&, const LazyOperandValueProfileKey&) const;
+    SpeculatedType prediction(const LazyOperandValueProfileKey&) const;
 private:
     UncheckedKeyHashMap<LazyOperandValueProfileKey, LazyOperandValueProfile*> m_map;
 };

--- a/Source/JavaScriptCore/bytecode/ValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/ValueProfile.h
@@ -84,9 +84,9 @@ struct ValueProfileBase {
 
     bool isSampledBefore() const { return m_prediction != SpecNone; }
     
-    CString briefDescription(const ConcurrentJSLocker& locker)
+    CString briefDescription()
     {
-        SpeculatedType prediction = computeUpdatedPrediction(locker);
+        SpeculatedType prediction = computeUpdatedPrediction();
         
         StringPrintStream out;
         out.print("predicting ", SpeculationDump(prediction));
@@ -109,15 +109,15 @@ struct ValueProfileBase {
             }
         }
     }
-    
-    SpeculatedType computeUpdatedPrediction(const ConcurrentJSLocker&)
+
+    SpeculatedType computeUpdatedPrediction()
     {
         SpeculatedType merged = SpecNone;
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i) {
             JSValue value = JSValue::decodeConcurrent(&m_buckets[i]);
             if (!value)
                 continue;
-            
+
             mergeSpeculation(merged, speculationFromValueForProfiling(value));
 
             updateEncodedJSValueConcurrent(m_buckets[i], JSValue::encode(JSValue()));
@@ -128,7 +128,7 @@ struct ValueProfileBase {
         return m_prediction;
     }
 
-    void computeUpdatedPredictionForExtraValue(const ConcurrentJSLocker&, JSValue& value)
+    void computeUpdatedPredictionForExtraValue(JSValue& value)
     {
         if (value)
             mergeSpeculation(m_prediction, speculationFromValueForProfiling(value));

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -756,9 +756,8 @@ private:
     {
         ASSERT(node->op() == GetLocal);
         ASSERT(node->origin.semantic.bytecodeIndex() == m_currentIndex);
-        ConcurrentJSLocker locker(m_inlineStackTop->m_profiledBlock->m_lock);
         LazyOperandValueProfileKey key(m_currentIndex, node->operand());
-        SpeculatedType prediction = m_inlineStackTop->m_lazyOperands.prediction(locker, key);
+        SpeculatedType prediction = m_inlineStackTop->m_lazyOperands.prediction(key);
         node->variableAccessData()->predict(prediction);
         return node;
     }
@@ -1262,12 +1261,8 @@ private:
             if (opcodeID == op_call_ignore_result)
                 return SpecFullTop;
 
-            SpeculatedType prediction;
-            {
-                JSValue* specFailValue = inlineStackEntry->m_specFailValueProfileBuckets.get(bytecodeIndex);
-                ConcurrentJSLocker locker(codeBlock->valueProfileLock());
-                prediction = codeBlock->valueProfilePredictionForBytecodeIndex(locker, codeOrigin.bytecodeIndex(), specFailValue);
-            }
+            JSValue* specFailValue = inlineStackEntry->m_specFailValueProfileBuckets.get(bytecodeIndex);
+            SpeculatedType prediction = codeBlock->valueProfilePredictionForBytecodeIndex(codeOrigin.bytecodeIndex(), specFailValue);
             auto* fuzzerAgent = m_vm->fuzzerAgent();
             if (fuzzerAgent) [[unlikely]]
                 return fuzzerAgent->getPrediction(codeBlock, codeOrigin, prediction) & SpecBytecodeTop;
@@ -2584,9 +2579,8 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
             // arguments received inside the callee. But that probably won't matter for most
             // calls.
             if (codeBlock && argument < static_cast<unsigned>(codeBlock->numParameters())) {
-                ConcurrentJSLocker locker(codeBlock->valueProfileLock());
                 ArgumentValueProfile& profile = codeBlock->valueProfileForArgument(argument);
-                variable->predict(profile.computeUpdatedPrediction(locker));
+                variable->predict(profile.computeUpdatedPrediction());
             }
             
             Node* setArgument = addToGraph(numSetArguments >= mandatoryMinimum ? SetArgumentMaybe : SetArgumentDefinitely, OpInfo(variable));
@@ -10069,11 +10063,9 @@ void ByteCodeParser::parseBlock(unsigned limit)
             UncheckedKeyHashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenArguments;
 
             {
-                ConcurrentJSLocker locker(m_inlineStackTop->m_profiledBlock->valueProfileLock());
-
                 buffer->forEach([&](ValueProfileAndVirtualRegister& profile) {
                     VirtualRegister operand(profile.m_operand);
-                    SpeculatedType prediction = profile.computeUpdatedPrediction(locker);
+                    SpeculatedType prediction = profile.computeUpdatedPrediction();
                     if (operand.isLocal())
                         localPredictions.append(prediction);
                     else {

--- a/Source/JavaScriptCore/dfg/DFGPredictionInjectionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionInjectionPhase.cpp
@@ -48,15 +48,13 @@ public:
         
         ASSERT(codeBlock()->numParameters() >= 1);
         {
-            ConcurrentJSLocker locker(profiledBlock()->valueProfileLock());
-            
             // We only do this for the arguments at the first block. The arguments from
             // other entrypoints have already been populated with their predictions.
             auto& arguments = m_graph.m_rootToArguments.find(m_graph.block(0))->value;
 
             for (size_t arg = 0; arg < static_cast<size_t>(codeBlock()->numParameters()); ++arg) {
                 ArgumentValueProfile& profile = profiledBlock()->valueProfileForArgument(arg);
-                arguments[arg]->variableAccessData()->predict(profile.computeUpdatedPrediction(locker));
+                arguments[arg]->variableAccessData()->predict(profile.computeUpdatedPrediction());
             }
         }
         

--- a/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
@@ -41,11 +41,8 @@ BaselineJITPlan::BaselineJITPlan(CodeBlock* codeBlock)
 
 auto BaselineJITPlan::compileInThreadImpl(JITCompilationEffort effort) -> CompilationPath
 {
-    {
-        ConcurrentJSLocker locker(m_codeBlock->valueProfileLock());
-        m_codeBlock->updateAllNonLazyValueProfilePredictions(locker);
-        m_codeBlock->updateAllLazyValueProfilePredictions(locker);
-    }
+    m_codeBlock->updateAllNonLazyValueProfilePredictions();
+    m_codeBlock->updateAllLazyValueProfilePredictions();
 
     // BaselineJITPlan can keep underlying CodeBlock alive while running.
     // So we do not need to suspend this compilation thread while running GC.

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -39,9 +39,8 @@ BytecodeSequence::BytecodeSequence(CodeBlock* codeBlock)
 
     {
         unsigned index = 0;
-        ConcurrentJSLocker locker(codeBlock->valueProfileLock());
         for (auto& profile : codeBlock->argumentValueProfiles()) {
-            CString description = profile.briefDescription(locker);
+            CString description = profile.briefDescription();
             if (!description.length())
                 continue;
             out.reset();


### PR DESCRIPTION
#### f6a959b7e8e4d37d7e891d3a37cf7f45072d15bd
<pre>
[JSC] Remove valueProfileLock
<a href="https://bugs.webkit.org/show_bug.cgi?id=322701">https://bugs.webkit.org/show_bug.cgi?id=322701</a>
<a href="https://rdar.apple.com/185966544">rdar://185966544</a>

Reviewed by Keith Miller.

ValueProfile collection was taking a lock only on 32bit before, and
valueProfileLock was empty on 64bit. Now 32bit JIT is dropped and we no
longer need to consider about this locking case. This patch removes
valueProfileLock (It was NoLockingNecessaryTag so no effect).

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness):
(JSC::CodeBlock::updateAllNonLazyValueProfilePredictions):
(JSC::CodeBlock::updateAllLazyValueProfilePredictions):
(JSC::CodeBlock::updateAllPredictions):
(JSC::CodeBlock::shouldOptimizeNowFromBaseline):
(JSC::CodeBlock::valueProfilePredictionForBytecodeIndex):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::valueProfileLock): Deleted.
* Source/JavaScriptCore/bytecode/LazyValueProfile.cpp:
(JSC::CompressedLazyValueProfileHolder::computeUpdatedPredictions):
(JSC::LazyOperandValueProfileParser::prediction const):
* Source/JavaScriptCore/bytecode/LazyValueProfile.h:
* Source/JavaScriptCore/bytecode/ValueProfile.h:
(JSC::ValueProfileBase::briefDescription):
(JSC::ValueProfileBase::computeUpdatedPrediction):
(JSC::ValueProfileBase::computeUpdatedPredictionForExtraValue):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::injectLazyOperandSpeculation):
(JSC::DFG::ByteCodeParser::getPredictionWithoutOSRExit):
(JSC::DFG::ByteCodeParser::handleVarargsInlining):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGPredictionInjectionPhase.cpp:
(JSC::DFG::PredictionInjectionPhase::run):
* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::compileInThreadImpl):
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp:
(JSC::Profiler::BytecodeSequence::BytecodeSequence):

Canonical link: <a href="https://commits.webkit.org/319964@main">https://commits.webkit.org/319964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/935b8d50bb925007d91b78b307e434a0ca6e00de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147596 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cd34c56-74d5-433c-9220-856125d2a485) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143075 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74c1d725-adec-439b-9558-21ade955b61a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123501 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d28547f6-0e79-4b3b-b34d-edf1419d939b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43760 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5476 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12320 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43373 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4698 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44575 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56898 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152264 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46817 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129882 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56110 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18385 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55481 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55548 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->