### PR TITLE
[GTK] Use display refresh rate for vblank timer fallback

### DIFF
--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
@@ -28,8 +28,15 @@
 
 #include "DisplayVBlankMonitorTimer.h"
 #include "Logging.h"
+#include <WebCore/AnimationFrameRate.h>
+#include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
+
+#if PLATFORM(GTK)
+#include "ScreenManager.h"
+#include <gtk/gtk.h>
+#endif
 
 #if USE(LIBDRM)
 #include "DisplayVBlankMonitorDRM.h"
@@ -44,12 +51,37 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayVBlankMonitor);
 
+#if PLATFORM(GTK)
+static unsigned refreshRateForDisplay(PlatformDisplayID displayID)
+{
+    auto* monitor = ScreenManager::singleton().screen(displayID);
+    if (!monitor)
+        return WebCore::FullSpeedFramesPerSecond;
+
+    int refreshRate = gdk_monitor_get_refresh_rate(monitor);
+    if (refreshRate <= 0)
+        return WebCore::FullSpeedFramesPerSecond;
+
+    return std::max((refreshRate + 500) / 1000, 1);
+}
+#endif
+
+static std::unique_ptr<DisplayVBlankMonitor> createTimerMonitor(PlatformDisplayID displayID)
+{
+#if PLATFORM(GTK)
+    return DisplayVBlankMonitorTimer::create(refreshRateForDisplay(displayID));
+#else
+    UNUSED_PARAM(displayID);
+    return DisplayVBlankMonitorTimer::create(WebCore::FullSpeedFramesPerSecond);
+#endif
+}
+
 IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDisplayID displayID)
 {
     static const char* forceTimer = getenv("WEBKIT_FORCE_VBLANK_TIMER");
-    if (!displayID || (forceTimer && strcmp(forceTimer, "0")))
-        return DisplayVBlankMonitorTimer::create();
+    if (!displayID || (forceTimer && strcmp(forceTimer, "0"))) // NOLINT
+        return createTimerMonitor(displayID);
 
 #if ENABLE(WPE_PLATFORM)
     if (WKWPE::isUsingWPEPlatformAPI()) {
@@ -57,7 +89,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDispl
             return monitor;
 
         RELEASE_LOG_FAULT(DisplayLink, "Failed to create WPE vblank monitor, falling back to timer");
-        return DisplayVBlankMonitorTimer::create();
+        return createTimerMonitor(displayID);
     }
 #endif
 
@@ -67,7 +99,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDispl
     RELEASE_LOG_FAULT(DisplayLink, "Failed to create DRM vblank monitor, falling back to timer");
 #endif
 
-    return DisplayVBlankMonitorTimer::create();
+    return createTimerMonitor(displayID);
 }
 IGNORE_CLANG_WARNINGS_END
 

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.cpp
@@ -26,25 +26,24 @@
 #include "config.h"
 #include "DisplayVBlankMonitorTimer.h"
 
-#include <WebCore/AnimationFrameRate.h>
 #include <chrono>
 #include <thread>
 
 namespace WebKit {
 
-std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorTimer::create()
+std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorTimer::create(unsigned refreshRate)
 {
-    return makeUnique<DisplayVBlankMonitorTimer>();
+    return makeUnique<DisplayVBlankMonitorTimer>(refreshRate);
 }
 
-DisplayVBlankMonitorTimer::DisplayVBlankMonitorTimer()
-    : DisplayVBlankMonitorThreaded(WebCore::FullSpeedFramesPerSecond)
+DisplayVBlankMonitorTimer::DisplayVBlankMonitorTimer(unsigned refreshRate)
+    : DisplayVBlankMonitorThreaded(refreshRate)
 {
 }
 
 bool DisplayVBlankMonitorTimer::waitForVBlank() const
 {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000 / m_refreshRate));
+    std::this_thread::sleep_for(std::chrono::duration<double>(1. / m_refreshRate));
     return true;
 }
 

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
@@ -31,8 +31,8 @@ namespace WebKit {
 
 class DisplayVBlankMonitorTimer final : public DisplayVBlankMonitorThreaded {
 public:
-    static std::unique_ptr<DisplayVBlankMonitor> create();
-    explicit DisplayVBlankMonitorTimer();
+    static std::unique_ptr<DisplayVBlankMonitor> create(unsigned refreshRate);
+    explicit DisplayVBlankMonitorTimer(unsigned refreshRate);
 
 private:
     Type type() const override { return Type::Timer; }


### PR DESCRIPTION
When the DRM vblank monitor cannot be created, the timer fallback always reports and targets 60 Hz. This limits requestAnimationFrame to 60 FPS even when GDK reports a high-refresh display. This occurs on NVIDIA Wayland systems where opening the primary DRM node succeeds but drmWaitVBlank fails with EPERM.

Use the refresh rate of the GDK monitor associated with the display ID for the GTK timer fallback. Keep the existing 60 Hz default when the display or refresh rate is unavailable and for non-GTK ports. Use a sub-millisecond duration so refresh rates above 60 are not truncated to whole milliseconds.

Validation:
- Tools/Scripts/check-webkit-style on the three changed files
- git diff --check
- Minimal GTK WebKit requestAnimationFrame test with WEBKIT_FORCE_VBLANK_TIMER=1: 62.2-62.3 FPS with the existing 60 Hz fallback
- Runtime debugger test changing only the timer construction rate to 260 Hz: timer object confirmed at 260 Hz and requestAnimationFrame exceeded 60 FPS

A complete WebKit build was not run locally.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d273b38662421b6bd49e41555936bbdc85e0966

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143056 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45491 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43349 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4677 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49854 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195443 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56877 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57581 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152245 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46797 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56089 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->