### PR TITLE
[scroll-animations] sync WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play-forwards-backwards.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play-forwards-backwards.tentative.html
@@ -67,17 +67,17 @@
           ACTIVATION_RANGE_START_PX, ACTIVATION_RANGE_END_PX,
           scroller);
 
-      const reset = (target) => {
+      const reset = async (target) => {
         const animation = target.getAnimations()[0];
         animation.pause();
         animation.playbackRate = 1;
         animation.currentTime = 0;
-        scroller.scrollTop = 0;
+        return setScrollTop(scroller, 0);
       }
 
       promise_test(async (test) => {
         const target = document.getElementById("target_forwards");
-        reset(target);
+        await reset(target);
         const animation = target.getAnimations()[0];
         // Setup finished at start (playbackRate = -1, finished -> currentTime = 0).
         animation.playbackRate = -1;
@@ -114,7 +114,7 @@
 
       promise_test(async (test) => {
         const target = document.getElementById("target_backwards");
-        reset(target);
+        await reset(target);
         const animation = target.getAnimations()[0];
         // Manually finish it (finished at end, playbackRate = 1).
         animation.finish();

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html
@@ -64,11 +64,11 @@
           COVER_START_OFFSET + CSS_TRIGGER_END_PX,
           scroller);
 
-      const reset = () => {
+      const reset = async () => {
         const animation = target.getAnimations()[0];
         animation.pause();
         animation.currentTime = 0;
-        scroller.scrollTop = 0;
+        return setScrollTop(scroller, 0);
       }
 
       promise_test(async (test) => {
@@ -99,7 +99,7 @@
       }, "play behavior resumes a paused animation");
 
       promise_test(async (test) => {
-        reset();
+        await reset();
         const animation = target.getAnimations()[0];
         assert_equals(animation.playState, "paused", "initial state");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html
@@ -64,11 +64,11 @@
           COVER_START_OFFSET + CSS_TRIGGER_END_PX,
           scroller);
 
-      const reset = () => {
+      const reset = async () => {
         const animation = target.getAnimations()[0];
         animation.pause();
         animation.currentTime = 0;
-        scroller.scrollTop = 0;
+        return setScrollTop(scroller, 0);
       }
 
       promise_test(async (test) => {
@@ -96,7 +96,7 @@
       }, "replay behavior restarts a paused animation");
 
       promise_test(async (test) => {
-        reset();
+        await reset();
         const animation = target.getAnimations()[0];
         assert_equals(animation.playState, "paused");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative-expected.txt
@@ -83,6 +83,13 @@ FAIL e.style['timeline-trigger'] = "--my-trigger --my-timeline" should set timel
 FAIL e.style['timeline-trigger'] = "--my-trigger --my-timeline" should set timeline-trigger-name assert_equals: timeline-trigger-name should be canonical expected "--my-trigger" but got ""
 FAIL e.style['timeline-trigger'] = "--my-trigger --my-timeline" should set timeline-trigger-source assert_equals: timeline-trigger-source should be canonical expected "--my-timeline" but got ""
 FAIL e.style['timeline-trigger'] = "--my-trigger --my-timeline" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "auto" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-name assert_equals: timeline-trigger-name should be canonical expected "--my-trigger" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set timeline-trigger-source assert_equals: timeline-trigger-source should be canonical expected "none" but got ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should not set unrelated longhands assert_true: expected true got false
 FAIL e.style['timeline-trigger'] = "--my-trigger1, --my-trigger2" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal, normal" but got ""
 FAIL e.style['timeline-trigger'] = "--my-trigger1, --my-trigger2" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal, normal" but got ""
 FAIL e.style['timeline-trigger'] = "--my-trigger1, --my-trigger2" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto, auto" but got ""
@@ -153,8 +160,10 @@ FAIL Property timeline-trigger value '--my-trigger view() contain 20% contain 80
 FAIL Property timeline-trigger value '--my-trigger view() contain 0% contain 100%' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value 'view()' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value '--my-trigger --my-timeline' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
+FAIL Property timeline-trigger value '--my-trigger none' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value '--trigger1, --trigger2' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value '--trigger1 view(), --trigger2 scroll()' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
+FAIL Property timeline-trigger value '--trigger1 none, --trigger2 view()' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value '--my-trigger --my-timeline normal / contain' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL Property timeline-trigger value '--my-trigger --my-timeline / contain' assert_true: timeline-trigger doesn't seem to be supported in the computed style expected true got false
 FAIL e.style['timeline-trigger'] = "--my-trigger view() contain 0% contain 100% / cover 0% cover 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
@@ -164,8 +173,10 @@ FAIL e.style['timeline-trigger'] = "--my-trigger view() contain 20% contain 80% 
 FAIL e.style['timeline-trigger'] = "--my-trigger view() contain 0% contain 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "view()" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--my-trigger --my-timeline" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['timeline-trigger'] = "--my-trigger none" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--trigger1, --trigger2" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--trigger1 view(), --trigger2 scroll()" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['timeline-trigger'] = "--trigger1 none, --trigger2 view()" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--my-trigger view() normal normal / auto auto" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--my-trigger view() normal normal / normal auto" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger'] = "--my-trigger view() normal normal / cover auto" should set the property value assert_not_equals: property should be set got disallowed value ""

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative.html
@@ -126,6 +126,15 @@
       'timeline-trigger-active-range-start': 'auto',
       'timeline-trigger-active-range-end': 'auto',
     });
+  test_shorthand_value('timeline-trigger', '--my-trigger none',
+    {
+      'timeline-trigger-name': '--my-trigger',
+      'timeline-trigger-source': 'none',
+      'timeline-trigger-activation-range-start': 'normal',
+      'timeline-trigger-activation-range-end': 'normal',
+      'timeline-trigger-active-range-start': 'auto',
+      'timeline-trigger-active-range-end': 'auto',
+    });
 
   test_shorthand_value('timeline-trigger', '--my-trigger1, --my-trigger2',
     {
@@ -235,12 +244,18 @@
   test_computed_value('timeline-trigger',
       '--my-trigger --my-timeline',
       '--my-trigger --my-timeline');
+  test_computed_value('timeline-trigger',
+      '--my-trigger none',
+      '--my-trigger none');
 
   test_computed_value('timeline-trigger', '--trigger1, --trigger2');
 
   test_computed_value('timeline-trigger',
       '--trigger1 view(), --trigger2 scroll()',
       '--trigger1 view(), --trigger2 scroll()');
+  test_computed_value('timeline-trigger',
+      '--trigger1 none, --trigger2 view()',
+      '--trigger1 none, --trigger2 view()');
   test_computed_value('timeline-trigger',
       '--my-trigger --my-timeline normal / contain',
       '--my-trigger --my-timeline / contain');
@@ -263,12 +278,16 @@
       '--my-trigger view() contain');
   test_valid_value('timeline-trigger', 'view()');
   test_valid_value('timeline-trigger', '--my-trigger --my-timeline');
+  test_valid_value('timeline-trigger', '--my-trigger none');
 
   test_valid_value('timeline-trigger', '--trigger1, --trigger2');
 
   test_valid_value('timeline-trigger',
       '--trigger1 view(), --trigger2 scroll()',
       '--trigger1 view(), --trigger2 scroll()');
+  test_valid_value('timeline-trigger',
+      '--trigger1 none, --trigger2 view()',
+      '--trigger1 none, --trigger2 view()');
 
   test_valid_value('timeline-trigger',
     '--my-trigger view() normal normal / auto auto',

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/support/support.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/support/support.js
@@ -5,7 +5,8 @@ function assertAnimationTriggerSupport() {
   assert_true(document.documentElement.style.animationTrigger !== undefined);
 }
 
-const setScrollTop = (scroller, y) => {
+const setScrollTop = async (scroller, y) => {
+  if (scroller.scrollTop == y) return;
   const scrollend_promise =
     waitForScrollEndFallbackToDelayWithoutScrollEvent(scroller);
   scroller.scrollTop = y;
@@ -54,9 +55,7 @@ function getRangeBoundariesForTest(trigger_start, trigger_end,
 // (main-thread-originating) scroll update, and one frame to let the main thread
 // observe the trigger's response to the scroll update.
 function runAndWaitForTriggerResponse(callback) {
-  return runAndWaitForFrameUpdate(() => {
-    callback();
-  }).then(waitForNextFrame);
+  return runAndWaitForFrameUpdate(callback).then(waitForNextFrame);
 }
 
 // Helper function for tests using timeline-trigger[1].
@@ -66,7 +65,7 @@ function runAndWaitForTriggerResponse(callback) {
 // [1] https://drafts.csswg.org/css-animations-2/#timeline-triggers
 const enter = (rangeBoundaries) => {
   return runAndWaitForTriggerResponse(() => {
-    rangeBoundaries.enterTriggerRange();
+    return rangeBoundaries.enterTriggerRange();
   });
 }
 
@@ -78,9 +77,9 @@ const enter = (rangeBoundaries) => {
 const exit = (rangeBoundaries, exitAbove = true) => {
   return runAndWaitForTriggerResponse(() => {
     if (exitAbove) {
-      rangeBoundaries.exitExitRangeAbove();
+      return rangeBoundaries.exitExitRangeAbove();
     } else {
-      rangeBoundaries.exitExitRangeBelow();
+      return rangeBoundaries.exitExitRangeBelow();
     }
   });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL timeline-trigger-source: none does not trigger animation; auto does assert_equals: animation should be paused when trigger source is none expected "paused" but got "running"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="help" src="https://drafts.csswg.org/css-animations-2/#animation-trigger">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/web-animations/testcommon.js"></script>
+</head>
+<body>
+  <style>
+    @keyframes anim {
+      from { width: 100px; }
+      to { width: 200px; }
+    }
+    #target {
+      width: 100px;
+      height: 50px;
+      animation: anim 1s both;
+      timeline-trigger: --trigger none;
+      animation-trigger: --trigger play;
+    }
+  </style>
+  <div id="target"></div>
+  <script>
+    promise_test(async (test) => {
+      const target = document.getElementById("target");
+      const animation = target.getAnimations()[0];
+
+      // A trigger with timeline-trigger-source: none has no timeline and does
+      // not trip, so the attached animation remains paused.
+      assert_equals(animation.playState, "paused",
+                    "animation should be paused when trigger source is none");
+
+      // When changing timeline-trigger-source from 'none' to 'auto', the
+      // trigger receives the document timeline, trips immediately, and the
+      // animation starts running.
+      target.style.timelineTriggerSource = "auto";
+      await waitForNextFrame();
+      assert_equals(animation.playState, "running",
+                    "animation should run when trigger source is changed to auto");
+    }, "timeline-trigger-source: none does not trigger animation; auto does");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/w3c-import.log
@@ -36,6 +36,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-state.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-timeline-subject-removed.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-untriggered-animations-exposed.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-source-starts-in-trigger-range.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-toggle.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/change-timeline-from-finite-to-monotonic-crash-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/change-timeline-from-finite-to-monotonic-crash-002.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2047032">
+<div id=target>
+  <div id=dut></div>
+</div>
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const rect = dut;
+  target.remove();
+  const st = new ScrollTimeline({});
+  const ani = rect.animate([{}], {timeline: st});
+  ani.timeline = document.timeline;
+})
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/w3c-import.log
@@ -12,6 +12,7 @@ Properties requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/change-timeline-from-finite-to-monotonic-crash-002.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/change-timeline-from-finite-to-monotonic-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/clip-path-with-view-timeline.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/effect-target-set-to-null.html

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -1,12 +1,11 @@
 
 PASS scroll-timeline-name is referenceable in animation-timeline on the declaring element itself
 PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
-PASS scroll-timeline-name is not referenceable in animation-timeline on that element's siblings
 PASS scroll-timeline-name on an element which is not a scroll-container
-PASS Change in scroll-timeline-name to match animation timeline updates animation.
-PASS Change in scroll-timeline-name to no longer match animation timeline updates animation.
+FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected "none" but got "50px"
+FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: expected "none" but got "75px"
 PASS Timeline lookup updates candidate when closer match available.
-PASS Timeline lookup updates candidate when match becomes available.
+FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "none" but got "50px"
 PASS scroll-timeline-axis is block
 PASS scroll-timeline-axis is inline
 PASS scroll-timeline-axis is x

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative.html
@@ -144,30 +144,6 @@ promise_test(async t => {
 }, "scroll-timeline-name is referenceable in animation-timeline on that " +
    "element's descendants");
 
-// See https://github.com/w3c/csswg-drafts/issues/7047
-promise_test(async t => {
-  let [sibling, target] = createScrollerAndTarget(t);
-
-  await runAndWaitForFrameUpdate(() => {
-    // <div id='sibling' class='scroller'> ... </div>
-    // <div id='target'></div>
-    document.body.appendChild(sibling);
-    document.body.appendChild(target);
-
-    // Resolvable if using a deferred timeline, but otherwise can only resolve
-    // if an ancestor container of the target element.
-    sibling.style.scrollTimelineName = '--timeline';
-    target.style.animation = "anim 10s linear";
-    target.style.animationTimeline = '--timeline';
-
-    sibling.scrollTop = 50; // 50%
-  });
-
-  assert_equals(getComputedStyle(target).translate, '50px',
-    'Animation with unknown timeline name holds current time at zero');
-}, "scroll-timeline-name is not referenceable in animation-timeline on that " +
-   "element's siblings");
-
 promise_test(async t => {
   let parent = document.createElement('div');
   parent.className = 'square';
@@ -213,9 +189,9 @@ promise_test(async t => {
 
   const anim = target.getAnimations()[0];
   assert_true(!!anim, 'Failed to create animation');
-  assert_equals(anim.timeline, null);
-  // Hold time of animation is zero.
-  assert_equals(getComputedStyle(target).translate, '50px');
+  // https://github.com/w3c/csswg-drafts/issues/9256
+  // Animation with unresolved timeline produces no effect.
+  assert_equals(getComputedStyle(target).translate, 'none');
 
   scroller.style.scrollTimelineName = '--timeline-B';
   await waitForNextFrame();
@@ -251,11 +227,12 @@ promise_test(async t => {
   scroller.style.scrollTimelineName = '--timeline-B';
   await waitForNextFrame();
 
-  // Switching to a null timeline pauses the animation.
+  // Switching to an unknown timeline causes the animation to
+  // stop producing the effect.
   assert_equals(anim.timeline, null, 'Failed to remove timeline');
-  assert_equals(getComputedStyle(target).translate, '75px');
+  assert_equals(getComputedStyle(target).translate, 'none');
   assert_equals(anim.startTime, null);
-  assert_times_equal(anim.currentTime, 2500);
+  assert_equals(anim.currentTime, null);
 }, 'Change in scroll-timeline-name to no longer match animation timeline updates animation.');
 
 promise_test(async t => {
@@ -313,10 +290,10 @@ promise_test(async t => {
     target.style.animationTimeline = '--timeline';
   });
 
-  // Timeline initially cannot be resolved, resulting in a null
-  // timeline. The animation's hold time is zero.
+  // Timeline initially cannot be resolved, resulting in an unknown
+  // timeline. The animation produces no effect.
   // let anim = document.getAnimations()[0];
-  assert_equals(getComputedStyle(target).translate, '50px');
+  assert_equals(getComputedStyle(target).translate, 'none');
 
   await runAndWaitForFrameUpdate(() => {
     // <div id='wrapper' class="scroller"> ...

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Animation with animation-timeline:none holds current time at zero
-PASS Animation with unknown timeline name holds current time at zero
+FAIL Animation with unknown timeline name produces no effect assert_equals: expected "0px" but got "100px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html
@@ -33,9 +33,10 @@
     assert_equals(getComputedStyle(element_timeline_none).width, '100px');
   }, 'Animation with animation-timeline:none holds current time at zero');
 
+  // https://github.com/w3c/csswg-drafts/issues/9256
   promise_test(async (t) => {
-    assert_equals(getComputedStyle(element_unknown_timeline).width, '100px');
+    assert_equals(getComputedStyle(element_unknown_timeline).width, '0px');
     await waitForAnimationFrames(3);
-    assert_equals(getComputedStyle(element_unknown_timeline).width, '100px');
-  }, 'Animation with unknown timeline name holds current time at zero');
+    assert_equals(getComputedStyle(element_unknown_timeline).width, '0px');
+  }, 'Animation with unknown timeline name produces no effect');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-play-state
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-composition
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-timing-function
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-duration
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-iteration-count
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-direction
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-delay
+PASS Anonymous scroll timeline does not get reconstructed when modifying animation-fill-mode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2046965">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/scroll-animations/scroll-timelines/testcommon.js"></script>
+<script src="/css/css-animations/support/testcommon.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+  @keyframes anim {
+    from { width: 100px; }
+    to { width: 200px; }
+  }
+
+  .fill-vh {
+    width: 100px;
+    height: 100vh;
+  }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+const tests = [
+  { prop: 'animation-play-state', value: 'paused' },
+  { prop: 'animation-composition', value: 'accumulate' },
+  { prop: 'animation-timing-function', value: 'ease' },
+  { prop: 'animation-duration', value: '1s' },
+  { prop: 'animation-iteration-count', value: '3' },
+  { prop: 'animation-direction', value: 'reverse' },
+  { prop: 'animation-delay', value: '1s' },
+  { prop: 'animation-fill-mode', value: 'both' },
+];
+
+async function do_test(prop, value, t) {
+  const div = addDiv(t, { style: 'width: 50px; height: 100px;' });
+  const filling = addDiv(t, { class: 'fill-vh' });
+  const scroller = document.scrollingElement;
+  await waitForNextFrame();
+
+  div.style.animation = 'anim 100s linear forwards';
+  div.style.animationTimeline = 'scroll(root)';
+  await waitForCSSScrollTimelineStyle();
+
+  const anim = div.getAnimations()[0];
+  await anim.ready;
+
+  await waitForNextFrame();
+  let prev_timeline = anim.timeline;
+  div.style.setProperty(prop, value);
+  // Force a style flush.
+  getComputedStyle(div).width;
+  const timeline = anim.timeline;
+  assert_equals(timeline, prev_timeline);
+}
+
+for (const {prop: prop, value: value} of tests) {
+  promise_test(async t => {
+    await do_test(prop, value, t);
+  }, `Anonymous scroll timeline does not get reconstructed when modifying ${prop}`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -5,8 +5,8 @@ PASS Switching pending animation from document to scroll timelines [immediate]
 PASS Switching pending animation from document to scroll timelines [scroll]
 PASS Changing computed value of animation-timeline changes effective timeline [immediate]
 PASS Changing computed value of animation-timeline changes effective timeline [scroll]
-PASS Changing to/from animation-timeline:none [immediate]
-PASS Changing to/from animation-timeline:none [scroll]
+FAIL Changing to/from unresolved timeline [immediate] assert_equals: expected "0px" but got "120px"
+FAIL Changing to/from unresolved timeline [scroll] assert_equals: expected "0px" but got "120px"
 PASS Reverse animation direction [immediate]
 PASS Reverse animation direction [scroll]
 PASS Change to timeline attachment while paused [immediate]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html
@@ -174,11 +174,12 @@
     // time.
     await element.getAnimations()[0].ready;
 
-    // DocumentTimeline -> none
+    // DocumentTimeline -> unresolved timeline
+    // Produces no effect. See https://github.com/w3c/csswg-drafts/issues/9256
     element.style.animationTimeline = '--none';
     await assert_width(element, '0px');
 
-    // none -> DocumentTimeline
+    // unresolved timeline -> DocumentTimeline
     element.style.animationTimeline = '';
     await assert_width(element, '100px');
 
@@ -186,14 +187,14 @@
     element.style.animationTimeline = '--timeline';
     await assert_width(element, '120px');
 
-    // ScrollTimeline -> none
+    // ScrollTimeline -> unresolved timeline
     element.style.animationTimeline = '--none';
-    await assert_width(element, '120px');
+    await assert_width(element, '0px');
 
-    // none -> ScrollTimeline
+    // unresolved timeline -> ScrollTimeline
     element.style.animationTimeline = '--timeline';
     await assert_width(element, '120px');
-  }, 'Changing to/from animation-timeline:none');
+  }, 'Changing to/from unresolved timeline');
 
 
   dynamic_rule_test(async (t, assert_width) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt
@@ -1,5 +1,5 @@
 
-PASS timeline-scope:all scopes all names (basic)
-PASS timeline-scope:all scopes all names (multiple)
+FAIL timeline-scope:all scopes all names (basic) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.timeline')"
+FAIL timeline-scope:all scopes all names (multiple) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim1.timeline')"
 PASS Inner scope is isolated from outer scope
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all.html
@@ -47,22 +47,18 @@
 <template id=timeline_scope_all_basic>
   <div class="scope-all">
     <div class=target style="animation-timeline:--mytimeline">Test</div>
-    <div class=scroller style="scroll-timeline-name:--mytimeline">
-      <div class=content></div>
-    </div>
+  </div>
+  <div class=scroller style="scroll-timeline-name:--mytimeline">
+    <div class=content></div>
   </div>
 </template>
 <script>
   promise_test(async (t) => {
     await inflate(t, timeline_scope_all_basic);
-    let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
 
     const anim = target.getAnimations()[0];
-    await anim.ready;
-
-    await scrollTop(scroller, 350); // 50%
-    assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
+    assert_false(!!anim.timeline);
   }, 'timeline-scope:all scopes all names (basic)');
 </script>
 
@@ -71,9 +67,9 @@
   <div class="scope-all">
     <div class=target style="animation-timeline:--t1">Test</div>
     <div class=target style="animation-timeline:--t2">Test</div>
-    <div class=scroller style="scroll-timeline-name:--t1, --t2">
-      <div class=content></div>
-    </div>
+  </div>
+  <div class=scroller style="scroll-timeline-name:--t1, --t2">
+    <div class=content></div>
   </div>
 </template>
 <script>
@@ -84,13 +80,9 @@
     let target2 = main.querySelector('.target:nth-child(2)');
 
     const anim1 = target1.getAnimations()[0];
-    await anim1.ready;
+    assert_false(!!anim1.timeline);
     const anim2 = target2.getAnimations()[0];
-    await anim2.ready;
-
-    await scrollTop(scroller, 350); // 50%
-    assert_equals(getComputedStyle(target1).width, '100px'); // 0px => 200px, 50%
-    assert_equals(getComputedStyle(target2).width, '100px'); // 0px => 200px, 50%
+    assert_false(!!anim2.timeline);
   }, 'timeline-scope:all scopes all names (multiple)');
 </script>
 
@@ -126,6 +118,7 @@
     await scrollTop(outer_scroller, 350); // 50%
     await scrollTop(inner_scroller, 140); // 20%
     assert_equals(getComputedStyle(outer_target).width, '100px'); // 0px => 200px, 50%
+    // Timeline lookup stopped by the inner scope.
     assert_equals(getComputedStyle(inner_target).width, '40px'); // 0px => 200px, 20%
   }, 'Inner scope is isolated from outer scope');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -1,12 +1,14 @@
 
-PASS Descendant can attach to deferred timeline
-PASS Deferred timeline with no attachments
-PASS Inner timeline does not interfere with outer timeline
-PASS Deferred timeline with two attachments
+FAIL Timelines are visible by default promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+PASS Descendant can attach to a timeline under the same timeline-scope
+PASS Timeline outside of the target's scope subtree is inaccessible
+FAIL Timeline lookups isn't stopped by timeline-scope if the name doesn't match assert_equals: expected "100px" but got "0px"
+FAIL Timeline under a different timeline-scope subtree is not visible to the target. assert_equals: expected "100px" but got "0px"
+FAIL Timeline with a different timeline-scope is not visible to the target. assert_equals: expected "100px" but got "0px"
 PASS Dynamically re-attaching
 PASS Dynamically detaching
 PASS Removing/inserting element with attaching timeline
 PASS Ancestor attached element becoming display:none/block
-PASS A deferred timeline appearing dynamically in the ancestor chain
-PASS Animations prefer non-deferred timelines
+FAIL A timline scope in the ancestor chain assert_equals: expected "100px" but got "0px"
+FAIL Timeline search prioritizes ancestors assert_equals: expected "100px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope.html
@@ -53,17 +53,15 @@
 
 <!-- Basic Behavior -->
 
-<template id=deferred_timeline>
-  <div class="scope">
-    <div class=target>Test</div>
-    <div class="scroller timeline">
-      <div class=content></div>
-    </div>
+<template id=default_visible>
+  <div class=target>Test</div>
+  <div class="scroller timeline">
+    <div class=content></div>
   </div>
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline);
+    await inflate(t, default_visible);
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
 
@@ -72,70 +70,118 @@
 
     await scrollTop(scroller, 350); // 50%
     assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
-  }, 'Descendant can attach to deferred timeline');
+  }, 'Timelines are visible by default');
 </script>
 
-<template id=deferred_timeline_no_attachments>
-  <div class="scope">
-    <div class=target>Test</div>
-    <div class="scroller">
-      <div class=content></div>
-    </div>
-  </div>
-</template>
-<script>
-  promise_test(async (t) => {
-    await inflate(t, deferred_timeline_no_attachments);
-    let scroller = main.querySelector('.scroller');
-    let target = main.querySelector('.target');
-    await scrollTop(scroller, 350); // 50%
-    assert_equals(getComputedStyle(target).width, '0px');
-  }, 'Deferred timeline with no attachments');
-</script>
-
-<template id=scroll_timeline_inner_interference>
-  <div class="scroller timeline">
-    <div class=content>
-      <div class=target>Test</div>
-      <div class="scroller timeline">
-        <div class=content></div>
-      </div>
-    </div>
-  </div>
-</template>
-<script>
-  promise_test(async (t) => {
-    await inflate(t, scroll_timeline_inner_interference);
-    let scroller = main.querySelector('.scroller');
-    let target = main.querySelector('.target');
-    await scrollTop(scroller, 350); // 50%
-    assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
-  }, 'Inner timeline does not interfere with outer timeline');
-</script>
-
-<template id=deferred_timeline_two_attachments>
+<template id=visible_in_scope_subtree>
   <div class="scope">
     <div class=target>Test</div>
     <div class="scroller timeline">
       <div class=content></div>
     </div>
-    <!-- Extra attachment -->
-    <div class="timeline"></div>
   </div>
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_two_attachments);
+    await inflate(t, visible_in_scope_subtree);
+    let scroller = main.querySelector('.scroller');
+    let target = main.querySelector('.target');
+
+    const anim = target.getAnimations()[0];
+    await anim.ready;
+
+    await scrollTop(scroller, 350); // 50%
+    assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
+  }, 'Descendant can attach to a timeline under the same timeline-scope');
+</script>
+
+<template id=out_of_scope_subtree>
+  <div class="scope">
+    <div class=target>Test</div>
+  </div>
+  <div class="scroller timeline">
+    <div class=content></div>
+  </div>
+</template>
+<script>
+  promise_test(async (t) => {
+    await inflate(t, out_of_scope_subtree);
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
     await scrollTop(scroller, 350); // 50%
     assert_equals(getComputedStyle(target).width, '0px');
-  }, 'Deferred timeline with two attachments');
+  }, 'Timeline outside of the target\'s scope subtree is inaccessible');
+</script>
+
+<template id=out_of_scope_subtree_different_name>
+  <div style="timeline-scope: --t2;">
+    <div class=target>Test</div>
+  </div>
+  <div class="scroller timeline">
+    <div class=content></div>
+  </div>
+</template>
+<script>
+  promise_test(async (t) => {
+    await inflate(t, out_of_scope_subtree_different_name);
+    let scroller = main.querySelector('.scroller');
+    let target = main.querySelector('.target');
+    await scrollTop(scroller, 350); // 50%
+    assert_equals(getComputedStyle(target).width, '100px');
+  }, 'Timeline lookups isn\'t stopped by timeline-scope if the name doesn\'t match');
+</script>
+
+<template id=tree_order_out_of_scope>
+  <div class=target>Test</div>
+  <div>
+    <div class="scroller timeline">
+      <div class=content></div>
+    </div>
+  </div>
+  <div class=scope>
+    <div class="scroller timeline">
+      <div class=content></div>
+    </div>
+  </div>
+</template>
+<script>
+  promise_test(async (t) => {
+    await inflate(t, tree_order_out_of_scope);
+    let scrollers = main.querySelectorAll('.scroller');
+    assert_equals(scrollers.length, 2);
+    let target = main.querySelector('.target');
+    await scrollTop(scrollers[0], 350); // 50%
+    await scrollTop(scrollers[1], 175); // 25%
+    // scrollers[1] is later in tree order, but should not be visible.
+    assert_equals(getComputedStyle(target).width, '100px');
+  }, 'Timeline under a different timeline-scope subtree is not visible to the target.');
+</script>
+
+<template id=tree_order_out_of_scope_self>
+  <div class=target>Test</div>
+  <div class="scroller timeline">
+    <div class=content></div>
+  </div>
+  <div class="scope scroller timeline">
+    <div class=content></div>
+  </div>
+</template>
+<script>
+  promise_test(async (t) => {
+    await inflate(t, tree_order_out_of_scope_self);
+    let scrollers = main.querySelectorAll('.scroller');
+    assert_equals(scrollers.length, 2);
+    let target = main.querySelector('.target');
+    await scrollTop(scrollers[0], 350); // 50%
+    await scrollTop(scrollers[1], 175); // 25%
+    // scrollers[1] is later in tree order, but should not be visible.
+    assert_equals(getComputedStyle(target).width, '100px');
+  }, 'Timeline with a different timeline-scope is not visible to the target.');
 </script>
 
 <!-- Dynamic Reattachment -->
 
-<template id=deferred_timeline_reattach>
+<template id=scoped_timeline_reattach>
   <div class="scope">
     <div class=target>Test</div>
     <div class="scroller timeline">
@@ -148,7 +194,7 @@
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_reattach);
+    await inflate(t, scoped_timeline_reattach);
     let scrollers = main.querySelectorAll('.scroller');
     assert_equals(scrollers.length, 2);
     let target = main.querySelector('.target');
@@ -168,7 +214,7 @@
   }, 'Dynamically re-attaching');
 </script>
 
-<template id=deferred_timeline_dynamic_detach>
+<template id=scoped_timeline_dynamic_detach>
   <div class="scope">
     <div class=target>Test</div>
     <div class="scroller timeline">
@@ -181,7 +227,7 @@
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_dynamic_detach);
+    await inflate(t, scoped_timeline_dynamic_detach);
     let scrollers = main.querySelectorAll('.scroller');
     assert_equals(scrollers.length, 2);
     let target = main.querySelector('.target');
@@ -207,7 +253,7 @@
   }, 'Dynamically detaching');
 </script>
 
-<template id=deferred_timeline_attached_removed>
+<template id=scoped_timeline_attached_removed>
   <div class="scope">
     <div class=target>Test</div>
     <div class="scroller timeline">
@@ -217,7 +263,7 @@
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_attached_removed);
+    await inflate(t, scoped_timeline_attached_removed);
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
     await scrollTop(scroller, 350); // 50%
@@ -234,7 +280,7 @@
   }, 'Removing/inserting element with attaching timeline');
 </script>
 
-<template id=deferred_timeline_attached_display_none>
+<template id=scoped_timeline_attached_display_none>
   <div class="scope">
     <div class=target>Test</div>
     <div class="scroller timeline">
@@ -244,7 +290,7 @@
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_attached_display_none);
+    await inflate(t, scoped_timeline_attached_display_none);
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
     await scrollTop(scroller, 350); // 50%
@@ -260,9 +306,9 @@
   }, 'Ancestor attached element becoming display:none/block');
 </script>
 
-<template id=deferred_timeline_appearing>
-  <div class=container>
-    <div class=target>Test</div>
+<template id=scoped_timeline_appearing>
+  <div class=target>Test</div>
+  <div class="container scope">
     <div class="scroller timeline">
       <div class=content></div>
     </div>
@@ -270,7 +316,7 @@
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_appearing);
+    await inflate(t, scoped_timeline_appearing);
     let container = main.querySelector('.container');
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
@@ -280,44 +326,36 @@
     // Not attached to any timeline initially.
     assert_equals(getComputedStyle(target).width, '0px');
 
-    // Add the deferred timeline.
-    container.classList.add('scope');
+    // Remove the scoping.
+    container.classList.remove('scope');
     await waitForNextFrame();
     assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
 
-    // Remove the deferred timeline.
-    container.classList.remove('scope');
+    // Add back the scoping.
+    container.classList.add('scope');
     await waitForNextFrame();
     assert_equals(getComputedStyle(target).width, '0px');
-  }, 'A deferred timeline appearing dynamically in the ancestor chain');
+  }, 'A timline scope in the ancestor chain');
 </script>
 
-<template id=deferred_timeline_on_self>
-  <div class="scroller timeline scope">
-    <div class=content>
-      <div class=target></div>
+<template id=scroll_timeline_prioritize_ancestor>
+  <div class=scope>
+    <div class="scroller timeline">
+      <div class=content>
+        <div class=target>Test</div>
+        <div class="scroller timeline">
+          <div class=content></div>
+        </div>
+      </div>
     </div>
-    <div class=scroller2></div>
   </div>
 </template>
 <script>
   promise_test(async (t) => {
-    await inflate(t, deferred_timeline_on_self);
+    await inflate(t, scroll_timeline_prioritize_ancestor);
     let scroller = main.querySelector('.scroller');
     let target = main.querySelector('.target');
-    await scrollTop(scroller, 525); // 75%
-
-    assert_equals(getComputedStyle(target).width, '150px'); // 0px => 200px, 75%
-
-    // A second scroll-timeline now attaches to the same root.
-    let scroller2 = main.querySelector('.scroller2');
-    scroller2.classList.add('timeline');
-    await waitForNextFrame();
-
-    // The deferred timeline produced by timeline-scope is now inactive,
-    // but it doesn't matter, because we preferred to attach
-    // to the non-deferred timeline.
-    assert_equals(getComputedStyle(target).width, '150px'); // 0px => 200px, 75%
-  }, 'Animations prefer non-deferred timelines');
-
+    await scrollTop(scroller, 350); // 50%
+    assert_equals(getComputedStyle(target).width, '100px'); // 0px => 200px, 50%
+  }, 'Timeline search prioritizes ancestors');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log
@@ -52,6 +52,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-animation-initial-offset-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-animation-initial-offset-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-animation-initial-offset.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html
@@ -104,6 +105,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-range-name-offset-in-keyframes.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-computed.html
@@ -132,6 +134,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-bounds-update.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject.html

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -2,6 +2,7 @@
 PASS Scroll timeline with percentage range [JavaScript API]
 PASS Scroll timeline with px range [JavaScript API]
 PASS Scroll timeline with calculated range [JavaScript API]
+PASS Scroll timeline with relative units range [JavaScript API]
 PASS Scroll timeline with percentage range [CSS]
 PASS Scroll timeline with px range [CSS]
 PASS Scroll timeline with calculated range [CSS]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html
@@ -108,6 +108,37 @@
     });
   }, 'Scroll timeline with calculated range [JavaScript API]');
 
+  promise_test(async t => {
+    t.add_cleanup(() => {
+      target.style.fontSize = '';
+    });
+
+    const timeline = new ScrollTimeline({source: scroller, axis: 'block'});
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "5em",
+          rangeEnd: "calc(100% - 5em)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid font-relative units');
+
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "2vh",
+          rangeEnd: "calc(100% - 2vw)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid viewport units');
+  }, 'Scroll timeline with relative units range [JavaScript API]');
+
   // Test via CSS.
   async function test_range_css(t, options) {
     t.add_cleanup(() => {
@@ -149,7 +180,7 @@
     });
   }, 'Scroll timeline with calculated range [CSS]');
 
-promise_test(async t => {
+  promise_test(async t => {
     t.add_cleanup(() => {
       target.style.fontSize = '';
     });

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt
@@ -1,4 +1,3 @@
 
-
 PASS View timeline delay
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
@@ -34,9 +34,7 @@
 <body>
 <div id="container">
     <div id="content">
-      <div class="spacer"></div>
-      <div id="target"></div>
-      <div class="spacer"></div>
+      <div class="spacer"></div><div id="target"></div><div class="spacer"></div>
     </div>
   </div>
 </body>
@@ -50,7 +48,7 @@
                                 { timeline: timeline });
     // Make sure the scroll overflow is ready.
     await waitForAnimationFrames(2);
-    assert_px_equals(timeline.startOffset, 604, 'startOffset');
-    assert_px_equals(timeline.endOffset, 904, 'endOffset');
+    assert_px_equals(timeline.startOffset, 600, 'startOffset');
+    assert_px_equals(timeline.endOffset, 900, 'endOffset');
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -4,4 +4,5 @@ PASS View timeline with range and inferred name or offset.
 PASS View timeline with range as <name> <px> pair.
 PASS View timeline with range as <name> <percent+px> pair.
 PASS View timeline with range as strings.
+PASS View timeline with range as strings with relative units.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range.html
@@ -179,12 +179,52 @@
     });
 
     await runTimelineRangeTest(t, {
+      rangeStart: "contain calc(sign(1000px - 1px) * 20px)",
+      rangeEnd: "contain calc(100%)",
+      startOffset: 720,
+      endOffset: 800
+    });
+
+    await runTimelineRangeTest(t, {
       rangeStart: "contain calc(0% + 20px)",
       rangeEnd: "contain calc(100% - 10px)",
       startOffset: 720,
       endOffset: 790
     });
 
+    await runTimelineRangeTest(t, {
+      rangeStart: "exit 20px",
+      rangeEnd: "exit 80px",
+      startOffset: 820,
+      endOffset: 880
+    });
   }, 'View timeline with range as strings.');
+
+  promise_test(async t => {
+    const timeline = new ViewTimeline({subject: target, axis: 'block'});
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "exit 2em",
+          rangeEnd: "exit 8em",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid font-relative units');
+
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "cover 2vh",
+          rangeEnd: "cover calc(100% - 2vw)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid viewport units');
+  }, 'View timeline with range as strings with relative units.');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/w3c-import.log
@@ -48,5 +48,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html


### PR DESCRIPTION
#### 35ba184789d512edadc119d464f3a1fa48801b6d
<pre>
[scroll-animations] sync WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=322704">https://bugs.webkit.org/show_bug.cgi?id=322704</a>
<a href="https://rdar.apple.com/185970209">rdar://185970209</a>

Reviewed by Dan Glastonbury.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/32e9879045d3231fb45d1ea479aeed00888f7117">https://github.com/web-platform-tests/wpt/commit/32e9879045d3231fb45d1ea479aeed00888f7117</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play-forwards-backwards.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-shorthand.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/support/support.js:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-none-auto.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/change-timeline-from-finite-to-monotonic-crash-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-reuse.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/319962@main">https://commits.webkit.org/319962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559a5ab3d0875ebe0319bfeb5cf507380e9caa13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147588 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e24f22c7-629c-47a9-9729-89603e58a65e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5540cdfb-c7d1-4df0-a0ad-53543465ed08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123496 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49f5be6e-8f5b-4c01-8cf1-0d47d125aefb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45504 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155900 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43364 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure(s) based on results-db; Uploaded test results") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4690 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152556 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57594 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152253 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46809 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18376 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55540 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->