### PR TITLE
[JSC] Skip the global StructureCache when the prototype has never been a prototype

### DIFF
--- a/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
@@ -54,8 +54,12 @@ inline Structure* InternalFunctionAllocationProfile::createAllocationStructureFr
     // https://bugs.webkit.org/show_bug.cgi?id=177318
     if (prototype == baseStructure->storedPrototype())
         structure = baseStructure;
-    else
-        structure = baseGlobalObject->structureCache().emptyStructureForPrototypeFromBaseStructure(baseGlobalObject, prototype, baseStructure);
+    else {
+        // A structure already here means this profile keeps rotating between bases, so our own
+        // memoization is not working for this function and only the global cache bounds the churn.
+        auto shouldCacheStructure = m_structureID ? StructureCache::ShouldCacheStructure::Yes : StructureCache::ShouldCacheStructure::No;
+        structure = baseGlobalObject->structureCache().emptyStructureForPrototypeFromBaseStructure(baseGlobalObject, prototype, baseStructure, shouldCacheStructure);
+    }
 
     // Ensure that if another thread sees the structure, it will see it properly created.
     WTF::storeStoreFence();

--- a/Source/JavaScriptCore/runtime/StructureCache.cpp
+++ b/Source/JavaScriptCore/runtime/StructureCache.cpp
@@ -37,22 +37,31 @@ void StructureCache::clear()
     m_structures.clear();
 }
 
-inline Structure* StructureCache::createEmptyStructure(JSGlobalObject* globalObject, JSObject* prototype, const TypeInfo& typeInfo, const ClassInfo* classInfo, IndexingType indexingType, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable* executable)
+inline Structure* StructureCache::createEmptyStructure(JSGlobalObject* globalObject, JSObject* prototype, const TypeInfo& typeInfo, const ClassInfo* classInfo, IndexingType indexingType, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable* executable, ShouldCacheStructure shouldCacheStructure)
 {
     RELEASE_ASSERT(!!prototype); // We use nullptr inside the UncheckedKeyHashMap for prototype to mean poly proto, so user's of this API must provide non-null prototypes.
+    ASSERT_IMPLIES(makePolyProtoStructure, shouldCacheStructure == ShouldCacheStructure::Yes); // Poly proto structures are keyed by executable rather than by prototype, so sharing them is the point.
 
     // We don't need to lock here because only the main thread can get here, and only the main thread can mutate the cache
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
     VM& vm = globalObject->vm();
+
+    // Every mono-proto entry was inserted right after didBecomePrototype() set that bit on its
+    // prototype, and the bit is never cleared. So an object that has never been anyone's prototype
+    // cannot be in the table and looking it up can only miss.
+    bool mayBeInCache = makePolyProtoStructure || prototype->mayBePrototype();
+
     PrototypeKey key { makePolyProtoStructure ? nullptr : prototype, executable, inlineCapacity, classInfo };
-    if (Structure* structure = m_structures.get(key)) {
-        if (makePolyProtoStructure) {
-            prototype->didBecomePrototype(vm);
-            RELEASE_ASSERT(structure->hasPolyProto());
-        } else
-            RELEASE_ASSERT(structure->hasMonoProto());
-        ASSERT(prototype->mayBePrototype());
-        return structure;
+    if (mayBeInCache) {
+        if (Structure* structure = m_structures.get(key)) {
+            if (makePolyProtoStructure) {
+                prototype->didBecomePrototype(vm);
+                RELEASE_ASSERT(structure->hasPolyProto());
+            } else
+                RELEASE_ASSERT(structure->hasMonoProto());
+            ASSERT(prototype->mayBePrototype());
+            return structure;
+        }
     }
 
     prototype->didBecomePrototype(vm);
@@ -65,8 +74,10 @@ inline Structure* StructureCache::createEmptyStructure(JSGlobalObject* globalObj
         structure = Structure::create(
             vm, globalObject, prototype, typeInfo, classInfo, indexingType, inlineCapacity);
     }
-    Locker locker { m_lock };
-    m_structures.set(key, structure);
+    if (shouldCacheStructure == ShouldCacheStructure::Yes) {
+        Locker locker { m_lock };
+        m_structures.set(key, structure);
+    }
     return structure;
 }
 
@@ -83,19 +94,19 @@ Structure* StructureCache::emptyObjectStructureConcurrently(JSObject* prototype,
     return nullptr;
 }
 
-Structure* StructureCache::emptyStructureForPrototypeFromBaseStructure(JSGlobalObject* globalObject, JSObject* prototype, Structure* baseStructure)
+Structure* StructureCache::emptyStructureForPrototypeFromBaseStructure(JSGlobalObject* globalObject, JSObject* prototype, Structure* baseStructure, ShouldCacheStructure shouldCacheStructure)
 {
     // We currently do not have inline capacity static analysis for subclasses and all internal function constructors have a default inline capacity of 0.
     IndexingType indexingType = baseStructure->indexingType();
     if (prototype->anyObjectInChainMayInterceptIndexedAccesses() && hasIndexedProperties(indexingType))
         indexingType = (indexingType & ~IndexingShapeMask) | SlowPutArrayStorageShape;
 
-    return createEmptyStructure(globalObject, prototype, baseStructure->typeInfo(), baseStructure->classInfoForCells(), indexingType, 0, false, nullptr);
+    return createEmptyStructure(globalObject, prototype, baseStructure->typeInfo(), baseStructure->classInfoForCells(), indexingType, 0, false, nullptr, shouldCacheStructure);
 }
 
 Structure* StructureCache::emptyObjectStructureForPrototype(JSGlobalObject* globalObject, JSObject* prototype, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable* executable)
 {
-    return createEmptyStructure(globalObject, prototype, JSFinalObject::typeInfo(), JSFinalObject::info(), JSFinalObject::defaultIndexingType, inlineCapacity, makePolyProtoStructure, executable);
+    return createEmptyStructure(globalObject, prototype, JSFinalObject::typeInfo(), JSFinalObject::info(), JSFinalObject::defaultIndexingType, inlineCapacity, makePolyProtoStructure, executable, ShouldCacheStructure::Yes);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StructureCache.h
+++ b/Source/JavaScriptCore/runtime/StructureCache.h
@@ -46,10 +46,12 @@ public:
     inline explicit StructureCache(VM&); // Defined in StructureInlines.h.
     inline ~StructureCache(); // Defined in StructureInlines.h.
 
+    enum class ShouldCacheStructure : bool { No, Yes };
+
     JS_EXPORT_PRIVATE void clear();
 
     JS_EXPORT_PRIVATE Structure* emptyObjectStructureForPrototype(JSGlobalObject*, JSObject*, unsigned inlineCapacity, bool makePolyProtoStructure = false, FunctionExecutable* = nullptr);
-    JS_EXPORT_PRIVATE Structure* emptyStructureForPrototypeFromBaseStructure(JSGlobalObject*, JSObject*, Structure*);
+    JS_EXPORT_PRIVATE Structure* emptyStructureForPrototypeFromBaseStructure(JSGlobalObject*, JSObject*, Structure*, ShouldCacheStructure = ShouldCacheStructure::Yes);
     JS_EXPORT_PRIVATE Structure* emptyObjectStructureConcurrently(JSObject* prototype, unsigned inlineCapacity);
 
     template<typename Func>
@@ -60,7 +62,7 @@ public:
     }
 
 private:
-    Structure* createEmptyStructure(JSGlobalObject*, JSObject* prototype, const TypeInfo&, const ClassInfo*, IndexingType, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable*);
+    Structure* createEmptyStructure(JSGlobalObject*, JSObject* prototype, const TypeInfo&, const ClassInfo*, IndexingType, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable*, ShouldCacheStructure);
 
     WeakGCMap<PrototypeKey, Structure> m_structures;
     Lock m_lock;


### PR DESCRIPTION
#### 57d983744d8291b14fccd688f04669011fe80254
<pre>
[JSC] Skip the global StructureCache when the prototype has never been a prototype
<a href="https://bugs.webkit.org/show_bug.cgi?id=322703">https://bugs.webkit.org/show_bug.cgi?id=322703</a>
<a href="https://rdar.apple.com/185969611">rdar://185969611</a>

Reviewed by Keith Miller.

We optimize StructureCache lookup cases.

1. When inserting a new entry, we set mayBePrototype bit and then insert
   it into the Map. This means that, if your prototype is not having
   mayBePrototype bit, it must not exist in the Map. So we can skip
   looking up.
2. emptyStructureForPrototypeFromBaseStructure caller is caching the
   result in InternalFunction::createSubclassStructure by storing the
   result into targetFunction-&gt;ensureRareData()-&gt;internalFunctionAllocationProfile().
   We skip using a cache when it is cached in a different way.

* Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h:
(JSC::InternalFunctionAllocationProfile::createAllocationStructureFromBase):
* Source/JavaScriptCore/runtime/StructureCache.cpp:
(JSC::StructureCache::createEmptyStructure):
(JSC::StructureCache::emptyStructureForPrototypeFromBaseStructure):
(JSC::StructureCache::emptyObjectStructureForPrototype):
* Source/JavaScriptCore/runtime/StructureCache.h:

Canonical link: <a href="https://commits.webkit.org/319984@main">https://commits.webkit.org/319984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c287ccb3f755972148e86e9fa3d22703ef2f6a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183395 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186350 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/4790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/44671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/195555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/195555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/195555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27824 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/56201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->