### PR TITLE
Drop RefCounted's adoption requirement assertion

### DIFF
--- a/Source/WTF/wtf/NeverDestroyed.h
+++ b/Source/WTF/wtf/NeverDestroyed.h
@@ -72,13 +72,13 @@ public:
     template<typename... Args> NeverDestroyed(Args&&... args)
     {
         AccessTraits::assertAccess();
-        MaybeRelax<T>(new (storagePointer()) T(std::forward<Args>(args)...));
+        new (storagePointer()) T(std::forward<Args>(args)...);
     }
 
     NeverDestroyed(NeverDestroyed&& other)
     {
         AccessTraits::assertAccess();
-        MaybeRelax<T>(new (storagePointer()) T(WTF::move(*other.storagePointer())));
+        new (storagePointer()) T(WTF::move(*other.storagePointer()));
     }
 
     operator T&() { return *storagePointer(); }
@@ -99,13 +99,6 @@ private:
         AccessTraits::assertAccess();
         return const_cast<PointerType>(m_storage.get());
     }
-
-    template<typename PtrType, bool ShouldRelax = std::is_base_of<RefCountedBase, PtrType>::value> struct MaybeRelax {
-        explicit MaybeRelax(PtrType*) { }
-    };
-    template<typename PtrType> struct MaybeRelax<PtrType, true> {
-        explicit MaybeRelax(PtrType* ptr) { ptr->relaxAdoptionRequirement(); }
-    };
 
     // FIXME: Investigate whether we should allocate a hunk of virtual memory
     // and hand out chunks of it to NeverDestroyed instead, to reduce fragmentation.
@@ -135,7 +128,7 @@ public:
 #if ASSERT_ENABLED
         m_isConstructed = true;
 #endif
-        MaybeRelax<T>(new (storagePointerWithoutAccessCheck()) T(std::forward<Args>(args)...));
+        new (storagePointerWithoutAccessCheck()) T(std::forward<Args>(args)...);
     }
 
     operator T&() { return *storagePointer(); }
@@ -166,13 +159,6 @@ private:
         AccessTraits::assertAccess();
         return storagePointerWithoutAccessCheck();
     }
-
-    template<typename PtrType, bool ShouldRelax = std::is_base_of<RefCountedBase, PtrType>::value> struct MaybeRelax {
-        explicit MaybeRelax(PtrType*) { }
-    };
-    template<typename PtrType> struct MaybeRelax<PtrType, true> {
-        explicit MaybeRelax(PtrType* ptr) { ptr->relaxAdoptionRequirement(); }
-    };
 
 #if ASSERT_ENABLED
     // LazyNeverDestroyed objects are always static, so this variable is initialized to false.

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -43,8 +43,6 @@ extern "C" int __asan_address_is_poisoned(void const volatile *addr);
 
 namespace WTF {
 
-inline void adopted(const void*) { }
-
 template<typename T> struct DefaultRefDerefTraits {
     static constexpr bool isDefaultImplementation = true;
 
@@ -353,7 +351,6 @@ struct IsSmartPtr<Ref<T, _PtrTraits, RefDerefTraits>> {
 template<typename T, typename _PtrTraits, typename RefDerefTraits>
 inline Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T& reference)
 {
-    adopted(&reference);
     return Ref<T, _PtrTraits, RefDerefTraits>(reference, Ref<T, _PtrTraits, RefDerefTraits>::Adopt);
 }
 

--- a/Source/WTF/wtf/RefCountDebugger.h
+++ b/Source/WTF/wtf/RefCountDebugger.h
@@ -63,7 +63,6 @@ public:
     ~RefCountDebuggerImpl()
     {
         ASSERT(m_deletionHasBegun);
-        ASSERT(!m_adoptionIsRequired);
     }
 #else
     ~RefCountDebuggerImpl() = default;
@@ -73,25 +72,6 @@ public:
     {
         applyRefDerefThreadingCheck(refCount);
         applyRefDuringDestructionCheck();
-
-#if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT(!m_adoptionIsRequired);
-#endif
-    }
-
-    void adopted()
-    {
-#if CHECK_REF_COUNTED_LIFECYCLE
-        m_adoptionIsRequired = false;
-#endif
-    }
-
-    void relaxAdoptionRequirement()
-    {
-#if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT(m_adoptionIsRequired);
-        m_adoptionIsRequired = false;
-#endif
     }
 
     // Unsafe precondition: The caller must ensure thread-safe access to this object,
@@ -155,10 +135,6 @@ public:
     {
         applyRefDerefThreadingCheck(refCount);
 
-#if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT(!m_adoptionIsRequired);
-#endif
-
         ASSERT(refCount);
     }
 
@@ -185,7 +161,6 @@ private:
 #endif
 #if CHECK_REF_COUNTED_LIFECYCLE
     mutable std::atomic<bool> m_deletionHasBegun { false };
-    mutable bool m_adoptionIsRequired { true };
 #endif
 };
 

--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -39,8 +39,6 @@ public:
     uint32_t refCount() const { return m_refCount; }
 
     // Debug APIs
-    void adopted() { m_refCountDebugger.adopted(); }
-    void relaxAdoptionRequirement() { m_refCountDebugger.relaxAdoptionRequirement(); }
     void disableThreadingChecks() { m_refCountDebugger.disableThreadingChecks(); }
     RefCountDebugger& refCountDebugger() LIFETIME_BOUND { return m_refCountDebugger; }
 
@@ -87,13 +85,6 @@ protected:
     RefCounted() = default;
     ~RefCounted() = default;
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
-
-inline void adopted(RefCountedBase* object)
-{
-    if (!object)
-        return;
-    object->adopted();
-}
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
+++ b/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
@@ -193,16 +193,6 @@ private:
     RefCountHeader& header() const { return refCountHeader(object()); }
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
-template<typename U>
-    requires requires { typename U::RefCountedType; }
-inline void adopted(U* object)
-{
-    if (!object)
-        return;
-    using T = typename U::RefCountedType;
-    refCountHeader(static_cast<const T*>(object)).refCountDebugger().adopted();
-}
-
 template<typename U, typename... Args>
 Ref<U> createRefCountedWithInlineWeakPtr(Args&&... args)
 {

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -265,7 +265,6 @@ inline bool operator==(const RefPtr<T, U, V>& a, X* b)
 template<typename T, typename U, typename V>
 inline RefPtr<T, U, V> adoptRef(T* p)
 {
-    adopted(p);
     return RefPtr<T, U, V>(p, RefPtr<T, U, V>::Adopt);
 }
 

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -48,18 +48,11 @@ public:
     uint32_t refCount() const { return m_refCount.load(std::memory_order_relaxed); }
 
     // Debug APIs
-    void adopted() { m_refCountDebugger.adopted(); }
-    void relaxAdoptionRequirement() { m_refCountDebugger.relaxAdoptionRequirement(); }
     void disableThreadingChecks() { m_refCountDebugger.disableThreadingChecks(); }
     ThreadSafeRefCountDebugger& refCountDebugger() LIFETIME_BOUND { return m_refCountDebugger; }
 
 protected:
-    ThreadSafeRefCountedBase()
-    {
-        // FIXME: Lots of subclasses violate our adoption requirements. Migrate
-        // this call into only those subclasses that need it.
-        m_refCountDebugger.relaxAdoptionRequirement();
-    }
+    ThreadSafeRefCountedBase() = default;
 
     ~ThreadSafeRefCountedBase()
     {
@@ -113,13 +106,6 @@ protected:
     ThreadSafeRefCounted() = default;
     ~ThreadSafeRefCounted() = default;
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
-
-inline void adopted(ThreadSafeRefCountedBase* object)
-{
-    if (!object)
-        return;
-    object->adopted();
-}
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -50,18 +50,11 @@ public:
     uint32_t refCount() const { return m_refCount.load(std::memory_order_relaxed); }
 
     // Debug APIs
-    void adopted() { m_refCountDebugger.adopted(); }
-    void relaxAdoptionRequirement() { m_refCountDebugger.relaxAdoptionRequirement(); }
     void disableThreadingChecks() { m_refCountDebugger.disableThreadingChecks(); }
     ThreadSafeRefCountDebugger& refCountDebugger() LIFETIME_BOUND { return m_refCountDebugger; }
 
 protected:
-    ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
-    {
-        // FIXME: Lots of subclasses violate our adoption requirements. Migrate
-        // this call into only those subclasses that need it.
-        m_refCountDebugger.relaxAdoptionRequirement();
-    }
+    ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase() = default;
 
     ~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
     {
@@ -113,13 +106,6 @@ public:
             STATIC_ASSERT_NOT_REACHED_FOR_VALUE(destructionThread, "Unexpected destructionThread enumerator value");
     }
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
-
-inline void adopted(ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase* object)
-{
-    if (!object)
-        return;
-    object->adopted();
-}
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/UniquelyOwnedPtr.h
+++ b/Source/WTF/wtf/UniquelyOwnedPtr.h
@@ -43,7 +43,6 @@ UniquelyOwnedPtr<U> makeUniquelyOwned(Args&&... args)
 {
     using T = typename U::RefCountedType;
     auto* object = RefCountedWithInlineWeakPtr<T>::template create<U>(std::forward<Args>(args)...);
-    adopted(object);
     return UniquelyOwnedPtr<U>(object);
 }
 

--- a/Source/WTF/wtf/glib/SocketConnection.cpp
+++ b/Source/WTF/wtf/glib/SocketConnection.cpp
@@ -39,8 +39,6 @@ SocketConnection::SocketConnection(GRefPtr<GSocketConnection>&& connection, cons
     , m_messageHandlers(messageHandlers)
     , m_userData(userData)
 {
-    relaxAdoptionRequirement();
-
     m_readBuffer.reserveInitialCapacity(defaultBufferSize);
     m_writeBuffer.reserveInitialCapacity(defaultBufferSize);
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -93,7 +93,6 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
     , m_muted(m_private->muted())
     , m_isCaptureTrack(is<Document>(context) && m_private->isCaptureTrack())
 {
-    relaxAdoptionRequirement();
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_private->addObserver(*this);

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -130,7 +130,6 @@ RTCPeerConnection::RTCPeerConnection(Document& document)
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    relaxAdoptionRequirement();
 }
 
 RTCPeerConnection::~RTCPeerConnection()

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -139,8 +139,6 @@ auto NotificationResourcesLoader::ResourceLoader::create(ScriptExecutionContext&
 NotificationResourcesLoader::ResourceLoader::ResourceLoader(ScriptExecutionContext& context, const URL& url, CompletionHandler<void(ResourceLoader*, RefPtr<BitmapImage>&&)>&& completionHandler)
     : m_completionHandler(WTF::move(completionHandler))
 {
-    relaxAdoptionRequirement();
-
     ThreadableLoaderOptions options;
     options.mode = FetchOptions::Mode::Cors;
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -48,8 +48,6 @@ AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderObject& renderer, 
 Ref<AccessibilityMenuList> AccessibilityMenuList::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
     Ref menuList = adoptRef(*new AccessibilityMenuList(axID, renderer, cache));
-    // We have to do this setup here and not in the constructor to avoid an
-    // adoptionIsRequired ASSERT in RefCounted.h.
     menuList->m_popup->setParent(menuList.ptr());
     menuList->addChild(menuList->m_popup.get());
     menuList->m_childrenInitialized = true;

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -53,8 +53,6 @@ AccessibilitySpinButton::AccessibilitySpinButton(AXID axID, SpinButtonElement& s
 Ref<AccessibilitySpinButton> AccessibilitySpinButton::create(AXID axID, SpinButtonElement& spinButtonElement, AXObjectCache& cache)
 {
     Ref spinButton = adoptRef(*new AccessibilitySpinButton(axID, spinButtonElement, cache));
-    // We have to do this setup here and not in the constructor to avoid an
-    // adoptionIsRequired ASSERT in RefCounted.h.
     spinButton->m_incrementor->setParent(spinButton.ptr());
     spinButton->m_decrementor->setParent(spinButton.ptr());
     spinButton->addChild(spinButton->m_incrementor.get());

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -100,7 +100,6 @@ private:
         , m_eventLoop(EmptyEventLoop::create(vm))
         , m_eventLoopTaskGroup(makeUniqueRef<EventLoopTaskGroup>(m_eventLoop))
     {
-        relaxAdoptionRequirement();
         m_eventLoop->addAssociatedContext(*this);
     }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -123,7 +123,6 @@ struct SameSizeAsNode : EventTarget, CanMakeCheckedPtr<SameSizeAsNode> {
 public:
 #if ASSERT_ENABLED
     bool inRemovedLastRefFunction;
-    bool adoptionIsRequired;
     bool deletionHasBegun;
 #endif
     uint32_t refCountAndParentBit;
@@ -385,10 +384,7 @@ Node::Node(Document& document, NodeType type, OptionSet<TypeFlag> flags)
     ASSERT(nodeType() == type);
     ASSERT(isMainThread());
 
-    // Allow code to ref the Document while it is being constructed to make our life easier.
-    if (isDocumentNode())
-        relaxAdoptionRequirement();
-    else
+    if (!isDocumentNode())
         document.incrementReferencingNodeCount();
 
 #if !defined(NDEBUG) || DUMP_NODE_STATISTICS
@@ -411,7 +407,6 @@ Node::~Node()
 {
     ASSERT(isMainThread());
     ASSERT(deletionHasBegun());
-    ASSERT(!m_adoptionIsRequired);
 
     InspectorInstrumentation::willDestroyDOMNode(*this);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -572,8 +572,6 @@ public:
     ALWAYS_INLINE unsigned refCount() const;
     void applyRefDuringDestructionCheck() const;
 
-    inline void relaxAdoptionRequirement();
-
     HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> registeredMutationObservers(MutationObserverOptionType, const QualifiedName* attributeName);
     void registerMutationObserver(MutationObserver&, MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     void unregisterMutationObserver(MutationObserverRegistration&);
@@ -812,10 +810,7 @@ private:
 
 #if ASSERT_ENABLED
     mutable bool m_inRemovedLastRefFunction { false };
-    bool m_adoptionIsRequired { true };
     bool m_deletionHasBegun { false };
-
-    friend inline void adopted(Node*);
 #endif
 
     mutable uint32_t m_refCountAndParentBit { s_refCountIncrement };
@@ -843,21 +838,9 @@ WEBCORE_EXPORT std::partial_ordering treeOrderForTesting(TreeType, const Node&, 
 
 bool NODELETE isTouchRelatedEventType(const EventTypeInfo&, const EventTarget&);
 
-#if ASSERT_ENABLED
-
-inline void adopted(Node* node)
-{
-    if (!node)
-        return;
-    node->m_adoptionIsRequired = false;
-}
-
-#endif // ASSERT_ENABLED
-
 ALWAYS_INLINE void Node::ref() const
 {
     ASSERT(isMainThread());
-    ASSERT(!m_adoptionIsRequired);
     applyRefDuringDestructionCheck();
     m_refCountAndParentBit += s_refCountIncrement;
 }
@@ -874,7 +857,6 @@ inline void Node::applyRefDuringDestructionCheck() const
 ALWAYS_INLINE void Node::deref() const
 {
     ASSERT(isMainThread());
-    ASSERT(!m_adoptionIsRequired);
 
     ASSERT_WITH_SECURITY_IMPLICATION(refCount());
     auto updatedRefCount = m_refCountAndParentBit - s_refCountIncrement;

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -238,15 +238,6 @@ inline NodeClass& Node::traverseToRootNodeInternal(const NodeClass& node)
     return *current;
 }
 
-inline void Node::relaxAdoptionRequirement()
-{
-#if ASSERT_ENABLED
-    ASSERT_WITH_SECURITY_IMPLICATION(!deletionHasBegun());
-    ASSERT(m_adoptionIsRequired);
-    m_adoptionIsRequired = false;
-#endif
-}
-
 inline IntRect Node::pixelSnappedAbsoluteBoundingRect(bool* isReplaced)
 {
     return snappedIntRect(absoluteBoundingRect(isReplaced));

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -51,7 +51,6 @@ Subscriber::Subscriber(ScriptExecutionContext& context, Ref<InternalObserver>&& 
     , m_options(options)
 {
     m_observer->setSubscriber(*this);
-    relaxAdoptionRequirement();
     followSignal(m_signal);
     if (RefPtr signal = options.signal)
         followSignal(*signal);

--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -44,8 +44,6 @@ MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, con
 {
     ASSERT(isMainThread());
 
-    relaxAdoptionRequirement();
-
     m_processes[0] = port1.processIdentifier;
     m_entangledToProcessProtectors[0] = this;
     m_processes[1] = port2.processIdentifier;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -397,7 +397,6 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
         BlobStreamSource(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
             : m_loader(FileReaderLoader::create(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))
         {
-            relaxAdoptionRequirement();
             m_loader->start(&scriptExecutionContext, blob);
         }
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -132,8 +132,6 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
     , m_crossOriginEmbedderPolicy(WTF::move(crossOriginEmbedderPolicy))
     , m_shouldLogError(shouldLogError)
 {
-    relaxAdoptionRequirement();
-
     // Setting a referrer header is only supported in the async code path.
     ASSERT(m_async || m_referrer.isEmpty());
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -126,7 +126,6 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
     , m_opener(opener)
     , m_frameTreeSyncData(WTF::move(frameTreeSyncData))
 {
-    relaxAdoptionRequirement();
     if (parent && addToFrameTree == AddToFrameTree::Yes)
         parent->tree().appendChild(*this);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -367,7 +367,6 @@ static constexpr OptionSet<ActivityState> pageInitialActivityState()
 
 GCC_MAYBE_NO_INLINE static Ref<Frame> createMainFrame(Page& page, PageConfiguration::MainFrameCreationParameters&& clientCreator, RefPtr<Frame> mainFrameOpener, FrameIdentifier identifier, Ref<FrameTreeSyncData>&& frameTreeSyncData)
 {
-    page.relaxAdoptionRequirement();
     return switchOn(WTF::move(clientCreator), [&] (PageConfiguration::LocalMainFrameCreationParameters&& creationParameters) -> Ref<Frame> {
         return LocalFrame::createMainFrame(page, WTF::move(creationParameters.clientCreator), identifier, creationParameters.effectiveSandboxFlags, creationParameters.effectiveReferrerPolicy, mainFrameOpener.get(), WTF::move(frameTreeSyncData));
     }, [&] (CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>&& remoteFrameClientCreator) -> Ref<Frame> {

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -105,7 +105,6 @@ Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial i
     , m_shouldNotBeUsedForArabic(false)
 #endif
 {
-    relaxAdoptionRequirement();
     platformInit();
     platformGlyphInit();
     platformCharWidthInit();

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -55,9 +55,6 @@ RenderScrollbar::RenderScrollbar(ScrollableArea& scrollableArea, ScrollbarOrient
 {
     ASSERT(ownerElement || owningFrame);
 
-    // FIXME: We need to do this because RenderScrollbar::styleChanged is called as soon as the scrollbar is created.
-    relaxAdoptionRequirement();
-
     // Update the scrollbar size.
     int width = 0;
     int height = 0;

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -103,7 +103,6 @@ static void moveWidgetToParentSoon(Widget& child, LocalFrameView* parent)
 RenderWidget::RenderWidget(Type type, HTMLFrameOwnerElement& element, Style::ComputedStyle&& style)
     : RenderReplaced(type, element, WTF::move(style), ReplacedFlag::IsWidget)
 {
-    relaxAdoptionRequirement();
     setInline(false);
 }
 

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -56,7 +56,6 @@ WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope(WorkerThreadType type, PA
     , m_noiseInjectionHashSalt(noiseInjectionHashSalt)
     , m_advancedPrivacyProtections(advancedPrivacyProtections)
 {
-    relaxAdoptionRequirement();
 }
 
 WorkerOrWorkletGlobalScope::~WorkerOrWorkletGlobalScope() = default;

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -71,7 +71,6 @@ ServiceWorker::ServiceWorker(ScriptExecutionContext& context, ServiceWorkerData&
 {
     context.registerServiceWorker(*this);
 
-    relaxAdoptionRequirement();
     updatePendingActivityForEventDispatch();
 
     WORKER_RELEASE_LOG("serviceWorkerID=%" PRIu64 ", state=%hhu", identifier().toUInt64(), std::to_underlying(m_data.state));

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -609,7 +609,6 @@ SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
 {
     ASSERT(scriptExecutionContext());
     if (!m_swConnection || m_swConnection->isClosed()) {
-        // Using RefPtr here results in an m_adoptionIsRequired assert.
         if (RefPtr workerGlobal = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext()))
             m_swConnection = workerGlobal->swClientConnection();
         else

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -90,8 +90,6 @@ ServiceWorkerRegistration::ServiceWorkerRegistration(ScriptExecutionContext& con
     REGISTRATION_RELEASE_LOG("ServiceWorkerRegistration: ID %" PRIu64 ", installing=%" PRIu64 ", waiting=%" PRIu64 ", active=%" PRIu64, identifier().toUInt64(), m_installingWorker ? m_installingWorker->identifier().toUInt64() : 0, m_waitingWorker ? m_waitingWorker->identifier().toUInt64() : 0, m_activeWorker ? m_activeWorker->identifier().toUInt64() : 0);
 
     m_container->addRegistration(*this);
-
-    relaxAdoptionRequirement();
 }
 
 ServiceWorkerRegistration::~ServiceWorkerRegistration()

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -52,7 +52,6 @@ BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::Se
     , m_request(request.internalRequest)
     , m_networkLoadChecker(NetworkLoadChecker::create(networkProcess, nullptr, nullptr, FetchOptions { request.options }, m_sessionID, std::nullopt, HTTPHeaderMap { request.httpHeaders }, URL { m_request.url() }, URL { }, clientOrigin.clientOrigin.securityOrigin(), clientOrigin.topOrigin.securityOrigin(), RefPtr<SecurityOrigin> { }, PreflightPolicy::Consider, String { request.referrer }, true, OptionSet<AdvancedPrivacyProtections> { }))
 {
-    relaxAdoptionRequirement();
     if (!m_request.url().protocolIsInHTTPFamily()) {
         didFinish(ResourceError { String { }, 0, m_request.url(), "URL is not HTTP(S)"_s, ResourceError::Type::Cancellation });
         return;

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -53,8 +53,6 @@ PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, Netwo
     , m_fromDownloadAttribute(fromDownloadAttribute)
     , m_webProcessID(webProcessID)
 {
-    relaxAdoptionRequirement();
-
 #if ENABLE(CONTENT_FILTERING)
 #if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary();

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -56,7 +56,6 @@ NetworkLoad::NetworkLoad(NetworkLoadClient& client, NetworkLoadParameters&& para
     , m_parameters(WTF::move(parameters))
     , m_currentRequest(m_parameters.request)
 {
-    relaxAdoptionRequirement();
     if (m_parameters.request.url().protocolIsBlob())
         m_task = NetworkDataTaskBlob::create(networkSession, *this, m_parameters.request, m_parameters.blobFileReferences, m_parameters.topOrigin);
     else

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -60,7 +60,6 @@ NetworkSocketChannel::NetworkSocketChannel(NetworkConnectionToWebProcess& connec
     , m_errorTimer(*this, &NetworkSocketChannel::sendDelayedError)
     , m_webPageProxyID(webPageProxyID)
 {
-    relaxAdoptionRequirement();
     if (!session)
         return;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -54,7 +54,6 @@ ServiceWorkerNavigationPreloader::ServiceWorkerNavigationPreloader(NetworkSessio
     , m_shouldCaptureExtraNetworkLoadMetrics(shouldCaptureExtraNetworkLoadMetrics)
     , m_startTime(MonotonicTime::now())
 {
-    relaxAdoptionRequirement();
     RELEASE_LOG(ServiceWorker, "ServiceWorkerNavigationPreloader::ServiceWorkerNavigationPreloader %p", this);
     start();
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -54,7 +54,6 @@ ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& ses
     , m_jobData(WTF::move(jobData))
     , m_session(session)
 {
-    relaxAdoptionRequirement();
     ASSERT(!request.isConditional());
 
     if (RefPtr cache = session.cache()) {

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -65,7 +65,6 @@ WebSharedWorkerServerToContextConnection::WebSharedWorkerServerToContextConnecti
     , m_crossOriginEmbedderPolicyValue(crossOriginEmbedderPolicy)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("WebSharedWorkerServerToContextConnection:");
-    relaxAdoptionRequirement();
     server.addContextConnection(*this);
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -231,7 +231,6 @@ private:
                 protectedThis->markLoadAsCompleted();
         })
     {
-        relaxAdoptionRequirement();
         m_loadHysteresisActivity.impulse();
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -100,8 +100,6 @@ WebExtensionMenuItem::WebExtensionMenuItem(WebExtensionContext& extensionContext
     , m_enabled(parameters.enabled.value_or(true))
     , m_visible(parameters.visible.value_or(true))
 {
-    relaxAdoptionRequirement();
-
     if (parameters.parentIdentifier) {
         if (RefPtr parentMenuItem = extensionContext.menuItem(parameters.parentIdentifier.value()))
             parentMenuItem->addSubmenuItem(*this);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -106,7 +106,6 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
 #endif
 #endif
 {
-    relaxAdoptionRequirement();
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "ProvisionalPageProxy: suspendedPage=%p", suspendedPage.get());
 
     Ref process = this->process();

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -59,7 +59,6 @@ Ref<WebIDBConnectionToServer> WebIDBConnectionToServer::create(PAL::SessionID se
 
 WebIDBConnectionToServer::WebIDBConnectionToServer(PAL::SessionID sessionID)
 {
-    relaxAdoptionRequirement();
     lazyInitialize(m_connectionToServer, IDBClient::IDBConnectionToServer::create(*this, sessionID));
 }
 

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -183,7 +183,6 @@ PushService::PushService(Ref<PushServiceConnection>&& pushServiceConnection, Ref
     , m_incomingPushMessageHandler(WTF::move(incomingPushMessageHandler))
 {
     RELEASE_ASSERT(m_incomingPushMessageHandler);
-    relaxAdoptionRequirement();
 
     Ref connection = m_connection;
     connection->startListeningForPublicToken([weakThis = WeakPtr { *this }](auto&& token) mutable {


### PR DESCRIPTION
#### 0d9f8faf3642c18971c354d7a3d756d116b5fa9b
<pre>
Drop RefCounted&apos;s adoption requirement assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=322707">https://bugs.webkit.org/show_bug.cgi?id=322707</a>

Reviewed by Ryosuke Niwa.

The point of this assertion was to make sure that we do not forget to
adopt a RefCounted object after constructing it. However, it also
prevents ref&apos;ing the object while it is in the middle of construction.

Ref&apos;ing the object while it is in the middle of construction is safer
and something that happens routinely, especially when adopting our
modern safer cpp programming patterns. This assertion was thus slowing
down safer cpp adoption and we would keep addressing the crashes by
adding calls to `relaxAdoptionRequirement()`, which disables the
adoption requirement assertion for a specific object type.

As a result, it makes little sense to keep this assertion around and
I am thus removing it in this patch.

* Source/WTF/wtf/NeverDestroyed.h:
(WTF::NeverDestroyed::NeverDestroyed):
(WTF::LazyNeverDestroyed::constructWithoutAccessCheck):
(WTF::NeverDestroyed::MaybeRelax::MaybeRelax): Deleted.
(): Deleted.
(WTF::LazyNeverDestroyed::MaybeRelax::MaybeRelax): Deleted.
* Source/WTF/wtf/Ref.h:
(WTF::adoptRef):
(WTF::adopted): Deleted.
* Source/WTF/wtf/RefCountDebugger.h:
(WTF::RefCountDebuggerImpl::~RefCountDebuggerImpl):
(WTF::RefCountDebuggerImpl::willRef const):
(WTF::RefCountDebuggerImpl::willDeref const):
(WTF::RefCountDebuggerImpl::adopted): Deleted.
(WTF::RefCountDebuggerImpl::relaxAdoptionRequirement): Deleted.
* Source/WTF/wtf/RefCounted.h:
(WTF::RefCountedBase::adopted): Deleted.
(WTF::RefCountedBase::relaxAdoptionRequirement): Deleted.
(WTF::adopted): Deleted.
* Source/WTF/wtf/RefCountedWithInlineWeakPtr.h:
(WTF::adopted): Deleted.
* Source/WTF/wtf/RefPtr.h:
(WTF::adoptRef):
* Source/WTF/wtf/ThreadSafeRefCounted.h:
(WTF::adopted): Deleted.
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:
(WTF::adopted): Deleted.
* Source/WTF/wtf/UniquelyOwnedPtr.h:
(WTF::makeUniquelyOwned):
* Source/WTF/wtf/glib/SocketConnection.cpp:
(WTF::SocketConnection::SocketConnection):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::RTCPeerConnection):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::ResourceLoader::ResourceLoader):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::create):
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::create):
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
(WebCore::Node::~Node):
* Source/WebCore/dom/Node.h:
(WebCore::Node::ref const):
(WebCore::Node::deref const):
(WebCore::adopted): Deleted.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::relaxAdoptionRequirement): Deleted.
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::Subscriber):
* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::m_registry):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
* Source/WebCore/page/Page.cpp:
(WebCore::createMainFrame):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::m_shouldNotBeUsedForArabic):
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::RenderScrollbar):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::RenderWidget):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope):
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::ServiceWorker):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ensureSWClientConnection):
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::ServiceWorkerRegistration):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::PendingDownload):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::NetworkLoad):
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
(WebKit::NetworkSocketChannel::NetworkSocketChannel):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::ServiceWorkerNavigationPreloader):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::WebSharedWorkerServerToContextConnection):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::WebExtensionMenuItem):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::WebIDBConnectionToServer):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::PushService):

Canonical link: <a href="https://commits.webkit.org/320014@main">https://commits.webkit.org/320014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd5a61d894b13323e937c25fae0ef04d42c4c67e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57419 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9df31f74-8e40-4c3d-b2eb-00839d891a2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57154 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4949714b-33d8-4ef0-9ece-b84e3abd9738) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186450 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a25007a-22de-4736-94e3-076a1b95638f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/4894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44771 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195655 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57089 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40918 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57793 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/152426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46974 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56301 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->