### PR TITLE
CG: Avoid getting, setting text matrix many times when drawing glyphs

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -35,7 +35,6 @@ platform/cf/KeyedDecoderCF.cpp
 platform/cf/KeyedEncoderCF.cpp
 platform/cf/MainThreadSharedTimerCF.cpp
 [ Mac ] platform/cocoa/DragDataCocoa.mm
-[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/FileMonitorCocoa.mm
 platform/cocoa/LocalizedStringsCocoa.mm
 platform/cocoa/NetworkExtensionContentFilter.mm

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -278,6 +278,7 @@ static void showText(CGContextRef context, float x, float y, CGColorRef color, c
     auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, byteCast<UInt8>(cstrSpan.data()), cstrSpan.size(), kCFStringEncodingASCII, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
+    CGContextSetTextMatrix(context, CGAffineTransformIdentity);
     CGContextSetTextPosition(context, x, y);
     CTLineDraw(line.get(), context);
 

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -31,11 +31,9 @@
 #import "BitmapImage.h"
 #import "ColorMac.h"
 #import "Element.h"
-#import "FloatRoundedRect.h"
 #import "FontCascade.h"
 #import "FontDescription.h"
 #import "FontSelector.h"
-#import "GraphicsContextCG.h"
 #import "Image.h"
 #import "ImageAdapter.h"
 #import "LocalDefaultSystemAppearance.h"
@@ -297,14 +295,19 @@ DragImageData createDragImageForLink(Element& element, URL& url, const String& t
     RetainPtr<NSImage> dragImage = adoptNS([[NSImage alloc] initWithSize:imageSize]);
     [dragImage _web_lockFocusWithDeviceScaleFactor:deviceScaleFactor];
 
-    GraphicsContextCG context([NSGraphicsContext currentContext].CGContext);
+    RetainPtr<CGContextRef> cgContext = [NSGraphicsContext currentContext].CGContext;
 
-    context.fillRoundedRect(FloatRoundedRect(layout.boundingRect, CornerRadii(linkImageCornerRadius)), colorFromCocoaColor([NSColor controlBackgroundColor]));
+    RetainPtr backgroundPath = adoptCF(CGPathCreateWithRoundedRect(layout.boundingRect, linkImageCornerRadius, linkImageCornerRadius, nullptr));
+    CGContextSetFillColorWithColor(cgContext.get(), cachedCGColor(colorFromCocoaColor([NSColor controlBackgroundColor])).get());
+    CGContextAddPath(cgContext.get(), backgroundPath.get());
+    CGContextFillPath(cgContext.get());
+    CGContextSetTextMatrix(cgContext.get(), CGAffineTransformIdentity);
 
     for (const auto& label : layout.labels) {
-        GraphicsContextStateSaver saver(context);
-        context.translate(label.origin.x(), layout.boundingRect.height() - label.origin.y() - linkImagePadding);
-        CTFrameDraw(label.frame.get(), context.platformContext());
+        CGContextSaveGState(cgContext.get());
+        CGContextTranslateCTM(cgContext.get(), label.origin.x(), layout.boundingRect.height() - label.origin.y() - linkImagePadding);
+        CTFrameDraw(label.frame.get(), cgContext.get());
+        CGContextRestoreGState(cgContext.get());
     }
 
     [dragImage unlockFocus];

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -69,9 +69,10 @@ class ComputedStyle;
 
 #if USE(CORE_TEXT)
 AffineTransform computeBaseOverallTextMatrix(const std::optional<AffineTransform>& syntheticOblique);
-AffineTransform computeOverallTextMatrix(const Font&);
 AffineTransform computeBaseVerticalTextMatrix(const AffineTransform& previousTextMatrix);
-AffineTransform computeVerticalTextMatrix(const Font&, const AffineTransform& previousTextMatrix);
+// The text matrix to use when drawing a run of `font`, including the Y-flip, synthetic oblique and, for vertical
+// fonts, the upright rotation.
+AffineTransform computeTextMatrix(const Font&);
 #endif
 
 class TextLayoutDeleter {

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -507,33 +507,6 @@ bool isSystemFont(CTFontRef);
 WEBCORE_EXPORT RetainPtr<CTFontRef> createCTFont(CFDictionaryRef attributes, float size, CTFontDescriptorOptions, CFStringRef referenceURL, CFStringRef desiredPostScriptName);
 #endif
 
-#if USE(CG)
-
-class ScopedTextMatrix {
-public:
-    ScopedTextMatrix(CGAffineTransform newMatrix, CGContextRef context)
-        : m_context(context)
-        , m_textMatrix(CGContextGetTextMatrix(context))
-    {
-        CGContextSetTextMatrix(m_context.get(), newMatrix);
-    }
-
-    ~ScopedTextMatrix()
-    {
-        CGContextSetTextMatrix(m_context.get(), m_textMatrix);
-    }
-
-    CGAffineTransform savedMatrix() const
-    {
-        return m_textMatrix;
-    }
-
-private:
-    RetainPtr<CGContextRef> m_context;
-    CGAffineTransform m_textMatrix;
-};
-
-#endif
 
 #if PLATFORM(WIN)
 // This is a scaling factor for Windows GDI fonts. We do this for

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -165,6 +165,7 @@ void PlatformCALayer::drawTextAtPoint(CGContextRef context, CGFloat x, CGFloat y
     auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, byteCast<UInt8>(text.data()), text.size(), kCFStringEncodingUTF8, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
+    CGContextSetTextMatrix(context, CGAffineTransformIdentity);
     CGContextSetTextPosition(context, x, y);
     CTLineDraw(line.get(), context);
 }

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -84,6 +84,7 @@ ImageDrawResult GraphicsContext::drawMultiRepresentationHEIC(Image& image, const
     CGContextTranslateCTM(cgContext, 0, -destination.height());
 
     // FIXME (rdar://123044459): This needs to account for vertical writing modes.
+    CGContextSetTextMatrix(cgContext, CGAffineTransformIdentity);
     CGContextSetTextPosition(cgContext, 0, font.metricsForMultiRepresentationHEIC().descent);
 
     CTFontDrawImageFromAdaptiveImageProviderAtPoint(font.ctFont(), multiRepresentationHEIC.get(), CGContextGetTextPosition(cgContext), cgContext);

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
@@ -154,9 +154,7 @@ void DrawGlyphsRecorder::prepareInternalContext(const Font& font, FontSmoothingM
     m_originalFont = font;
     m_smoothingMode = smoothingMode;
 
-    m_originalTextMatrix = computeOverallTextMatrix(font);
-    if (font.platformData().orientation() == FontOrientation::Vertical)
-        m_originalTextMatrix = computeVerticalTextMatrix(font, m_originalTextMatrix);
+    m_originalTextMatrix = computeTextMatrix(font);
 
     auto& contextState = m_owner.state();
     populateInternalState(contextState);
@@ -521,6 +519,7 @@ void DrawGlyphsRecorder::drawNativeText(CTFontRef font, CGFloat fontSize, CTLine
 
     prepareInternalContext(Font::create(FontPlatformData(font, fontSize)), FontSmoothingMode::SubpixelAntialiased);
     RetainPtr context = m_internalContext->platformContext();
+    CGContextSetTextMatrix(context.get(), CGAffineTransformIdentity);
     CGContextSetTextPosition(context.get(), 0, 0);
     CTLineDraw(line, context.get());
     concludeInternalContext();

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -76,24 +76,6 @@ AffineTransform NODELETE computeBaseOverallTextMatrix(const std::optional<Affine
     return result;
 }
 
-AffineTransform computeOverallTextMatrix(const Font& font)
-{
-    std::optional<AffineTransform> syntheticOblique;
-    auto& platformData = font.platformData();
-    if (platformData.syntheticOblique()) {
-        static const float obliqueSkew = std::tanf(deg2rad(FontCascade::syntheticObliqueAngle()));
-        if (platformData.orientation() == FontOrientation::Vertical) {
-            if (font.isTextOrientationFallback())
-                syntheticOblique = AffineTransform(1, obliqueSkew, 0, 1, 0, 0);
-            else
-                syntheticOblique = AffineTransform(1, -obliqueSkew, 0, 1, 0, 0);
-        } else
-            syntheticOblique = AffineTransform(1, 0, -obliqueSkew, 1, 0, 0);
-    }
-
-    return computeBaseOverallTextMatrix(syntheticOblique);
-}
-
 AffineTransform NODELETE computeBaseVerticalTextMatrix(const AffineTransform& previousTextMatrix)
 {
     // The translation here ("e" and "f" fields) are irrelevant, because
@@ -106,24 +88,41 @@ AffineTransform NODELETE computeBaseVerticalTextMatrix(const AffineTransform& pr
     return rotateLeftTransform() * previousTextMatrix;
 }
 
-AffineTransform NODELETE computeVerticalTextMatrix(const Font& font, const AffineTransform& previousTextMatrix)
+AffineTransform computeTextMatrix(const Font& font)
 {
-    ASSERT_UNUSED(font, font.platformData().orientation() == FontOrientation::Vertical);
-    return computeBaseVerticalTextMatrix(previousTextMatrix);
+    auto& platformData = font.platformData();
+    bool isVertical = platformData.orientation() == FontOrientation::Vertical;
+
+    std::optional<AffineTransform> syntheticOblique;
+    if (platformData.syntheticOblique()) {
+        static const float obliqueSkew = std::tanf(deg2rad(FontCascade::syntheticObliqueAngle()));
+        if (isVertical) {
+            if (font.isTextOrientationFallback())
+                syntheticOblique = AffineTransform(1, obliqueSkew, 0, 1, 0, 0);
+            else
+                syntheticOblique = AffineTransform(1, -obliqueSkew, 0, 1, 0, 0);
+        } else
+            syntheticOblique = AffineTransform(1, 0, -obliqueSkew, 1, 0, 0);
+    }
+
+    auto textMatrix = computeBaseOverallTextMatrix(syntheticOblique);
+    if (isVertical)
+        return computeBaseVerticalTextMatrix(textMatrix);
+    return textMatrix;
 }
 
-static void fillVectorWithHorizontalGlyphPositions(Vector<CGPoint, 256>& positions, CGContextRef context, std::span<const CGSize> advances, const FloatPoint& point)
+static void fillVectorWithHorizontalGlyphPositions(Vector<CGPoint, 256>& positions, std::span<const CGSize> advances, const FloatPoint& point, CGAffineTransform textMatrix)
 {
     // Keep this in sync as the inverse of `DrawGlyphsRecorder::recordDrawGlyphs`.
     // The input positions are in the context's coordinate system, without the text matrix.
     // However, the positions that CT/CG accept are in the text matrix's coordinate system.
-    // CGContextGetTextMatrix() gives us the matrix that maps from text's coordinate system to the context's (non-text) coordinate system.
+    // The text matrix maps from text's coordinate system to the context's (non-text) coordinate system.
     // We need to figure out what to deliver CT, inside the text's coordinate system, such that it ends up coincident with the input in the context's coordinate system.
     //
     // CTM * text matrix * positions we need to deliver to CT = CTM * input positions
     // Solving for the positions we need to deliver to CT, we get
     // positions we need to deliver to CT = inverse(text matrix) * input positions
-    CGAffineTransform matrix = CGAffineTransformInvert(CGContextGetTextMatrix(context));
+    CGAffineTransform matrix = CGAffineTransformInvert(textMatrix);
     positions[0] = CGPointApplyAffineTransform(point, matrix);
     for (size_t i = 1; i < advances.size(); ++i) {
         CGSize advance = CGSizeApplyAffineTransform(advances[i - 1], matrix);
@@ -147,7 +146,7 @@ static void fillVectorWithVerticalGlyphPositions(Vector<CGPoint, 256>& positions
     // 4. Synthetic-oblique-less text coordinate system. This would be identical to the text coordinate system if synthetic oblique was not in effect. This
     //        is useful because, when we're moving glyphs around, we usually don't want to consider synthetic oblique. Instead, synthetic oblique is just
     //        a rasterization-time effect, and not used for glyph positioning/layout.
-    //        FIXME: Does this mean that synthetic oblique should always be applied on the result of rotateLeftTransform() in computeVerticalTextMatrix(),
+    //        FIXME: Does this mean that synthetic oblique should always be applied on the result of rotateLeftTransform() in computeTextMatrix(),
     //        rather than the other way around?
 
     // Imagine an vertical upright glyph:
@@ -230,7 +229,7 @@ static void fillVectorWithVerticalGlyphPositions(Vector<CGPoint, 256>& positions
     // and "point" parameters to this function are in the user coordinate system. The "translations" parameter is in the "synthetic-oblique-less
     // text coordinate system."
 
-    // CGContextGetTextMatrix() transforms points from text coordinates to user coordinates. However, we're trying to produce text coordinates from
+    // The text matrix transforms points from text coordinates to user coordinates. However, we're trying to produce text coordinates from
     // user coordinates, so we invert it.
     CGAffineTransform transform = CGAffineTransformInvert(textMatrix);
 
@@ -265,27 +264,48 @@ static void fillVectorWithVerticalGlyphPositions(Vector<CGPoint, 256>& positions
     }
 }
 
-static void showGlyphsWithAdvances(const FloatPoint& point, const Font& font, CGContextRef context, std::span<const CGGlyph> glyphs, std::span<const CGSize> advances, const AffineTransform& textMatrix)
-{
-    if (glyphs.empty())
-        return;
+namespace {
+// CTFontDrawGlyphs state holder for invocations that call with same data but different points.
+class RepeatedDrawGlyphs {
+    WTF_MAKE_NONCOPYABLE(RepeatedDrawGlyphs);
+public:
+    RepeatedDrawGlyphs(const Font& font, std::span<const CGGlyph> glyphs, std::span<const CGSize> advances, const AffineTransform& textMatrix)
+        : m_ctFont(font.platformData().ctFont())
+        , m_glyphs(glyphs)
+        , m_advances(advances)
+        , m_textMatrix(textMatrix)
+        , m_positions(glyphs.size())
+    {
+        if (font.platformData().orientation() != FontOrientation::Vertical || m_glyphs.empty())
+            return;
 
-    const FontPlatformData& platformData = font.platformData();
-    Vector<CGPoint, 256> positions(glyphs.size());
-    if (platformData.orientation() == FontOrientation::Vertical) {
-        ScopedTextMatrix savedMatrix(computeVerticalTextMatrix(font, textMatrix), context);
-
-        Vector<CGSize, 256> translations(glyphs.size());
-        RetainPtr ctFont = platformData.ctFont();
-        CTFontGetVerticalTranslationsForGlyphs(ctFont.get(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
-
-        auto ascentDelta = font.fontMetrics().ascent(FontBaseline::Ideographic) - font.fontMetrics().ascent();
-        fillVectorWithVerticalGlyphPositions(positions, translations, advances, point, ascentDelta, CGContextGetTextMatrix(context));
-        CTFontDrawGlyphs(ctFont.get(), glyphs.data(), positions.span().data(), glyphs.size(), context);
-    } else {
-        fillVectorWithHorizontalGlyphPositions(positions, context, advances, point);
-        CTFontDrawGlyphs(RetainPtr { platformData.ctFont() }.get(), glyphs.data(), positions.span().data(), glyphs.size(), context);
+        m_translations = Vector<CGSize, 256>(m_glyphs.size());
+        CTFontGetVerticalTranslationsForGlyphs(m_ctFont.get(), m_glyphs.data(), m_translations->mutableSpan().data(), m_glyphs.size());
+        m_ascentDelta = font.fontMetrics().ascent(FontBaseline::Ideographic) - font.fontMetrics().ascent();
     }
+
+    void showGlyphsWithAdvances(const FloatPoint& point, CGContextRef context)
+    {
+        if (m_glyphs.empty())
+            return;
+
+        if (m_translations)
+            fillVectorWithVerticalGlyphPositions(m_positions, m_translations->span(), m_advances, point, m_ascentDelta, m_textMatrix);
+        else
+            fillVectorWithHorizontalGlyphPositions(m_positions, m_advances, point, m_textMatrix);
+
+        CTFontDrawGlyphs(m_ctFont.get(), m_glyphs.data(), m_positions.span().data(), m_glyphs.size(), context);
+    }
+
+private:
+    RetainPtr<CTFontRef> m_ctFont;
+    std::span<const CGGlyph> m_glyphs;
+    std::span<const CGSize> m_advances;
+    CGAffineTransform m_textMatrix;
+    float m_ascentDelta { 0 };
+    Vector<CGPoint, 256> m_positions;
+    std::optional<Vector<CGSize, 256>> m_translations;
+};
 }
 
 static void setCGFontRenderingMode(GraphicsContext& context)
@@ -348,9 +368,8 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
 
     FloatPoint point = anchorPoint;
 
-    auto textMatrix = computeOverallTextMatrix(font);
-    ScopedTextMatrix restorer(textMatrix, cgContext.get());
-
+    auto textMatrix = computeTextMatrix(font);
+    CGContextSetTextMatrix(cgContext.get(), textMatrix);
     setCGFontRenderingMode(context);
     CGContextSetFontSize(cgContext.get(), platformData.size());
 
@@ -365,9 +384,12 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
             // Make sure that a scaled down context won't blow up the gap between the glyphs.
             syntheticBoldOffset = std::min(syntheticBoldOffset, syntheticBoldOffset / horizontalUnitLengthInDevicePixels);
         }
-    };
+    }
 
     bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow && shadow->color.isValid() && !shadow->radius && !platformData.isColorBitmapFont() && (!context.shadowsIgnoreTransforms() || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
+
+    RepeatedDrawGlyphs repeatedDrawGlyphs { font, glyphs, advances, textMatrix };
+
     if (hasSimpleShadow) {
         // Paint simple shadows ourselves instead of relying on CG shadows, to avoid losing subpixel antialiasing.
         context.clearDropShadow();
@@ -375,18 +397,18 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
         Color shadowFillColor = shadow->color.colorWithAlphaMultipliedBy(fillColor.alphaAsFloat());
         context.setFillColor(shadowFillColor);
         auto shadowTextOffset = point + context.platformShadowOffset(shadow->offset);
-        showGlyphsWithAdvances(shadowTextOffset, font, cgContext.get(), glyphs, advances, textMatrix);
+        repeatedDrawGlyphs.showGlyphsWithAdvances(shadowTextOffset, cgContext.get());
         if (syntheticBoldOffset) {
             shadowTextOffset.move(syntheticBoldOffset, 0);
-            showGlyphsWithAdvances(shadowTextOffset, font, cgContext.get(), glyphs, advances, textMatrix);
+            repeatedDrawGlyphs.showGlyphsWithAdvances(shadowTextOffset, cgContext.get());
         }
         context.setFillColor(fillColor);
     }
 
-    showGlyphsWithAdvances(point, font, cgContext.get(), glyphs, advances, textMatrix);
+    repeatedDrawGlyphs.showGlyphsWithAdvances(point, cgContext.get());
 
     if (syntheticBoldOffset)
-        showGlyphsWithAdvances(FloatPoint(point.x() + syntheticBoldOffset, point.y()), font, cgContext.get(), glyphs, advances, textMatrix);
+        repeatedDrawGlyphs.showGlyphsWithAdvances(FloatPoint(point.x() + syntheticBoldOffset, point.y()), cgContext.get());
 
     if (hasSimpleShadow)
         context.setDropShadow(*shadow);

--- a/Source/WebCore/platform/ios/LegacyTileCache.mm
+++ b/Source/WebCore/platform/ios/LegacyTileCache.mm
@@ -592,6 +592,7 @@ void LegacyTileCache::drawLayer(LegacyTileLayer* layer, CGContextRef context, Dr
         auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
         auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
+        CGContextSetTextMatrix(context, CGAffineTransformIdentity);
         CGContextSetTextPosition(context, labelBounds.origin.x + 3, labelBounds.origin.y + 20);
         CTLineDraw(line.get(), context);
     

--- a/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
+++ b/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
@@ -154,6 +154,7 @@ static void drawPattern(void *overlayPtr, CGContextRef ctx)
 
     CGContextSetTextDrawingMode(ctx, kCGTextFill);
 
+    CGContextSetTextMatrix(ctx, CGAffineTransformIdentity);
     CGContextSetTextPosition(ctx, 0, 0);
     CGContextSetFillColorWithColor(ctx, cachedCGColor(WebCore::Color::black).get());
     CTLineDraw(line.get(), ctx);

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -77,6 +77,10 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
         NSGraphicsContext *nsContext = [NSGraphicsContext currentContext];
         RetainPtr cgContext = [nsContext CGContext];
+        // FIXME: This should not be needed, but is added
+        // conservatively.
+        CGAffineTransform savedTextMatrix = CGContextGetTextMatrix(cgContext.get());
+
         WebCore::GraphicsContextCG graphicsContext { cgContext.get() };
 
         // WebCore requires a flipped graphics context.
@@ -89,6 +93,8 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
         if (!flipped)
             CGContextScaleCTM(cgContext.get(), 1, -1);
+
+        CGContextSetTextMatrix(cgContext.get(), savedTextMatrix);
     } else {
         // The given point is on the baseline.
         if ([[NSView focusView] isFlipped])


### PR DESCRIPTION
#### de7d598f0aa689bca9a0b004459074b6ffb35686
<pre>
CG: Avoid getting, setting text matrix many times when drawing glyphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=322709">https://bugs.webkit.org/show_bug.cgi?id=322709</a>
<a href="https://rdar.apple.com/185974109">rdar://185974109</a>

Reviewed by Mike Wyrzykowski.

FontCascade would use ScopedTextMatrix get and restore the TextMatrix
CGContext property.
This state is not part of CGContext GState and is generally
modified by CT*Draw commands. As such it cannot be expected to be
saved by the CGContext using functions.

Instead always explicitly set the transform when using CT. Leave the
transform dirty.

Works towards making FontCascadeCoreText platform context property
modifications more consistent. This is needed to make GraphicsContextCG
state application lazy.

* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::ScopedTextMatrix::savedMatrix const): Deleted.
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContext::drawMultiRepresentationHEIC):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp:
(WebCore::DrawGlyphsRecorder::prepareInternalContext):
(WebCore::DrawGlyphsRecorder::drawNativeText):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::computeTextMatrix):
(WebCore::fillVectorWithHorizontalGlyphPositions):
(WebCore::fillVectorWithVerticalGlyphPositions):
(WebCore::FontCascade::drawGlyphs):
(WebCore::computeOverallTextMatrix): Deleted.
(WebCore::computeVerticalTextMatrix): Deleted.
(WebCore::showGlyphsWithAdvances): Deleted.

Canonical link: <a href="https://commits.webkit.org/320805@main">https://commits.webkit.org/320805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac78df64a645744b7f5c583e7829b32bb7e2bed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150452 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ce131d0-e532-4bb4-8000-1723d2ab2365) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145171 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100647 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af995f4c-7d28-4be6-b121-fe530302bb74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125468 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd41e125-311b-4634-8e21-4470c873778e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47574 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45607 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45305 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7128 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198031 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59325 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154709 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60033 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154360 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48814 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132383 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20328 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57878 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->