### PR TITLE
[TextureMapper] Remove unused BitmapTexture::Flags::DepthBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/egl/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexture.cpp
@@ -109,15 +109,6 @@ unsigned BitmapTexture::textureFormat() const
     return m_flags.contains(Flags::UseBGRALayout) ? GL_BGRA : GL_RGBA;
 }
 
-static GLenum depthBufferFormat()
-{
-    auto* glContext = GLContext::current();
-    if (glContext->version() >= 300 || glContext->glExtensions().OES_packed_depth_stencil)
-        return GL_DEPTH24_STENCIL8;
-
-    return GL_DEPTH_COMPONENT16;
-}
-
 BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
     : m_flags(flags)
     , m_size(size)
@@ -241,8 +232,6 @@ BitmapTexture::BitmapTexture(EGLImage image, const IntSize& size, OptionSet<Flag
 void BitmapTexture::swapTexture(BitmapTexture& other)
 {
     RELEASE_ASSERT(m_size == other.m_size);
-    RELEASE_ASSERT(!m_flags.contains(Flags::DepthBuffer));
-    RELEASE_ASSERT(!other.m_flags.contains(Flags::DepthBuffer));
 
 #if USE(GBM)
     std::swap(m_memoryMappedGPUBuffer, other.m_memoryMappedGPUBuffer);
@@ -271,25 +260,18 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
     m_pixelFormat = flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8;
     m_filterOperation = nullptr;
 
-    if (!flags.contains(Flags::DepthBuffer)) {
-        if (m_fbo) {
-            glDeleteFramebuffers(1, &m_fbo);
-            m_fbo = 0;
-        }
-
-        if (m_depthBufferObject) {
-            glDeleteRenderbuffers(1, &m_depthBufferObject);
-            m_depthBufferObject = 0;
-        }
-
-        if (m_stencilBufferObject) {
-            glDeleteRenderbuffers(1, &m_stencilBufferObject);
-            m_stencilBufferObject = 0;
-        }
-
-        m_stencilBound = false;
-        m_clipStack = { };
+    if (m_fbo) {
+        glDeleteFramebuffers(1, &m_fbo);
+        m_fbo = 0;
     }
+
+    if (m_stencilBufferObject) {
+        glDeleteRenderbuffers(1, &m_stencilBufferObject);
+        m_stencilBufferObject = 0;
+    }
+
+    m_stencilBound = false;
+    m_clipStack = { };
 
     if (m_size == size)
         return;
@@ -446,19 +428,6 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
 
 void BitmapTexture::initializeStencil()
 {
-    if (m_flags.contains(Flags::DepthBuffer)) {
-        // We have a depth buffer and we're asked to have a stencil buffer as well. This is only
-        // possible if packed depth stencil is available. If that's the case, just bind the depth
-        // buffer as the stencil one if haven't done so. If packed depth stencil is not available
-        // don't do anything, which will cause stencil clips on this surface to fail.
-        if (depthBufferFormat() == GL_DEPTH24_STENCIL8 && !m_stencilBound) {
-            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthBufferObject);
-            m_stencilBound = true;
-        }
-        return;
-    }
-
-    // We don't have a depth buffer. Use a stencil only buffer.
     if (m_stencilBufferObject)
         return;
 
@@ -469,18 +438,6 @@ void BitmapTexture::initializeStencil()
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_stencilBufferObject);
     glClearStencil(0);
     glClear(GL_STENCIL_BUFFER_BIT);
-}
-
-void BitmapTexture::initializeDepthBuffer()
-{
-    if (m_depthBufferObject)
-        return;
-
-    glGenRenderbuffers(1, &m_depthBufferObject);
-    glBindRenderbuffer(GL_RENDERBUFFER, m_depthBufferObject);
-    glRenderbufferStorage(GL_RENDERBUFFER, depthBufferFormat(), m_size.width(), m_size.height());
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthBufferObject);
 }
 
 void BitmapTexture::clearIfNeeded()
@@ -504,8 +461,6 @@ void BitmapTexture::createFboIfNeeded()
     glGenFramebuffers(1, &m_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_renderTarget, id(), 0);
-    if (m_flags.contains(Flags::DepthBuffer))
-        initializeDepthBuffer();
     m_shouldClear = true;
 }
 
@@ -515,10 +470,6 @@ void BitmapTexture::bindAsSurface()
     createFboIfNeeded();
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     glViewport(0, 0, m_size.width(), m_size.height());
-    if (m_flags.contains(Flags::DepthBuffer))
-        glEnable(GL_DEPTH_TEST);
-    else
-        glDisable(GL_DEPTH_TEST);
     clearIfNeeded();
     m_clipStack.apply();
 }
@@ -529,9 +480,6 @@ BitmapTexture::~BitmapTexture()
 
     if (m_fbo)
         glDeleteFramebuffers(1, &m_fbo);
-
-    if (m_depthBufferObject)
-        glDeleteRenderbuffers(1, &m_depthBufferObject);
 
     if (m_stencilBufferObject)
         glDeleteRenderbuffers(1, &m_stencilBufferObject);

--- a/Source/WebCore/platform/graphics/egl/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexture.h
@@ -62,15 +62,14 @@ class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
 public:
     enum class Flags : uint8_t {
         SupportsAlpha = 1 << 0,
-        DepthBuffer = 1 << 1,
 #if USE(GBM)
-        BackedByDMABuf = 1 << 2,
-        ForceLinearBuffer = 1 << 3,
-        ForceVivanteSuperTiledBuffer = 1 << 4,
+        BackedByDMABuf = 1 << 1,
+        ForceLinearBuffer = 1 << 2,
+        ForceVivanteSuperTiledBuffer = 1 << 3,
 #endif
-        UseBGRALayout = 1 << 5,
-        NearestFiltering = 1 << 6,
-        ExternalOESRenderTarget = 1 << 7,
+        UseBGRALayout = 1 << 4,
+        NearestFiltering = 1 << 5,
+        ExternalOESRenderTarget = 1 << 6,
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -94,7 +93,6 @@ public:
 
     void bindAsSurface();
     void initializeStencil();
-    void initializeDepthBuffer();
     uint32_t id() const { return m_id; }
 
     void updateContents(NativeImage*, const IntRect&, const IntPoint& offset);
@@ -149,7 +147,6 @@ private:
     unsigned m_renderTarget { 0 };
     unsigned m_binding { 0 };
     unsigned m_fbo { 0 };
-    unsigned m_depthBufferObject { 0 };
     unsigned m_stencilBufferObject { 0 };
     bool m_stencilBound { false };
     bool m_shouldClear { true };

--- a/Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp
@@ -80,7 +80,6 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
             && entry.texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
 #endif
             && entry.texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) == flags.contains(BitmapTexture::Flags::UseBGRALayout)
-            && entry.texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer)
             && entry.texture->flags().contains(BitmapTexture::Flags::NearestFiltering) == flags.contains(BitmapTexture::Flags::NearestFiltering);
     });
 


### PR DESCRIPTION
#### 31dc597d97b73503dba0b54721d70db30f0ffb78
<pre>
[TextureMapper] Remove unused BitmapTexture::Flags::DepthBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=322711">https://bugs.webkit.org/show_bug.cgi?id=322711</a>

Reviewed by Nikolas Zimmermann.

It&apos;s unused since 286605@main

* Source/WebCore/platform/graphics/egl/BitmapTexture.cpp:
(WebCore::BitmapTexture::swapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::initializeStencil):
(WebCore::BitmapTexture::createFboIfNeeded):
(WebCore::BitmapTexture::bindAsSurface):
(WebCore::BitmapTexture::~BitmapTexture):
(WebCore::BitmapTexture::initializeDepthBuffer): Deleted.
(WebCore::depthBufferFormat): Deleted.
* Source/WebCore/platform/graphics/egl/BitmapTexture.h:
* Source/WebCore/platform/graphics/egl/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):

Canonical link: <a href="https://commits.webkit.org/320020@main">https://commits.webkit.org/320020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/197a29da229e312b2a9714ee54d83fc4e66ad7c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143094 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99365 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45541 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43776 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12333 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43387 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4719 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48042 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195485 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56919 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152588 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57623 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152277 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46834 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129903 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56131 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18399 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55740 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->