### PR TITLE
[JSC] Store the DFG `VariableEventStream` as a byte stream

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -146,7 +146,7 @@ public:
     
     void createOSREntries();
     void linkOSREntries(LinkBuffer&);
-    Vector<VariableEvent> finalizeEventStream() { return m_stream.finalize(); }
+    VariableEventStream finalizeEventStream() { return m_stream.finalize(); }
 
     BasicBlock* nextBlock()
     {

--- a/Source/JavaScriptCore/dfg/DFGVariableEvent.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableEvent.h
@@ -97,14 +97,10 @@ public:
         ASSERT(kind == BirthToFill || kind == Fill);
         ASSERT(dataFormat != DataFormatDouble);
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
-        VariableRepresentation representation;
-        representation.gpr = gpr;
         event.m_kind = kind;
         event.m_dataFormat = dataFormat;
-        event.m_which = WTF::move(which);
-        event.m_representation = WTF::move(representation);
+        event.m_which.id = id.bits();
+        event.m_representation.gpr = gpr;
         return event;
     }
 
@@ -112,24 +108,18 @@ public:
     {
         ASSERT(kind == BirthToFill || kind == Fill);
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
-        VariableRepresentation representation;
-        representation.fpr = fpr;
         event.m_kind = kind;
         event.m_dataFormat = DataFormatDouble;
-        event.m_which = WTF::move(which);
-        event.m_representation = WTF::move(representation);
+        event.m_which.id = id.bits();
+        event.m_representation.fpr = fpr;
         return event;
     }
     
     static VariableEvent birth(MinifiedID id)
     {
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
         event.m_kind = Birth;
-        event.m_which = WTF::move(which);
+        event.m_which.id = id.bits();
         return event;
     }
     
@@ -137,24 +127,18 @@ public:
     {
         ASSERT(kind == BirthToSpill || kind == Spill);
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
-        VariableRepresentation representation;
-        representation.operand = virtualRegister;
         event.m_kind = kind;
         event.m_dataFormat = format;
-        event.m_which = WTF::move(which);
-        event.m_representation = WTF::move(representation);
+        event.m_which.id = id.bits();
+        event.m_representation.operand = virtualRegister;
         return event;
     }
     
     static VariableEvent death(MinifiedID id)
     {
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
         event.m_kind = Death;
-        event.m_which = WTF::move(which);
+        event.m_which.id = id.bits();
         return event;
     }
     
@@ -162,27 +146,19 @@ public:
         Operand bytecodeOperand, VirtualRegister machineReg, DataFormat format)
     {
         VariableEvent event;
-        WhichType which;
-        which.virtualReg = machineReg.offset();
-        VariableRepresentation representation;
-        representation.operand = bytecodeOperand;
         event.m_kind = SetLocalEvent;
         event.m_dataFormat = format;
-        event.m_which = WTF::move(which);
-        event.m_representation = WTF::move(representation);
+        event.m_which.virtualReg = machineReg.offset();
+        event.m_representation.operand = bytecodeOperand;
         return event;
     }
     
     static VariableEvent movHint(MinifiedID id, Operand bytecodeReg)
     {
         VariableEvent event;
-        WhichType which;
-        which.id = id.bits();
-        VariableRepresentation representation;
-        representation.operand = bytecodeReg;
         event.m_kind = MovHintEvent;
-        event.m_which = WTF::move(which);
-        event.m_representation = WTF::move(representation);
+        event.m_which.id = id.bits();
+        event.m_representation.operand = bytecodeReg;
         return event;
     }
     
@@ -196,7 +172,7 @@ public:
         ASSERT(
             m_kind == BirthToFill || m_kind == Fill || m_kind == BirthToSpill || m_kind == Spill
             || m_kind == Death || m_kind == MovHintEvent || m_kind == Birth);
-        return MinifiedID::fromBits(m_which.get().id);
+        return MinifiedID::fromBits(m_which.id);
     }
     
     DataFormat dataFormat() const
@@ -212,35 +188,35 @@ public:
         ASSERT(m_kind == BirthToFill || m_kind == Fill);
         ASSERT(m_dataFormat);
         ASSERT(m_dataFormat != DataFormatDouble);
-        return m_representation.get().gpr;
+        return m_representation.gpr;
     }
 
     MacroAssembler::FPRegisterID fpr() const
     {
         ASSERT(m_kind == BirthToFill || m_kind == Fill);
         ASSERT(m_dataFormat == DataFormatDouble);
-        return m_representation.get().fpr;
+        return m_representation.fpr;
     }
     
     VirtualRegister spillRegister() const
     {
         ASSERT(m_kind == BirthToSpill || m_kind == Spill);
-        return m_representation.get().operand.virtualRegister();
+        return m_representation.operand.virtualRegister();
     }
 
     Operand operand() const
     {
         ASSERT(m_kind == SetLocalEvent || m_kind == MovHintEvent);
-        return m_representation.get().operand;
+        return m_representation.operand;
     }
     
     VirtualRegister machineRegister() const
     {
         ASSERT(m_kind == SetLocalEvent);
-        return VirtualRegister(m_which.get().virtualReg);
+        return VirtualRegister(m_which.virtualReg);
     }
     
-    VariableRepresentation variableRepresentation() const { return m_representation.get(); }
+    VariableRepresentation variableRepresentation() const { return m_representation; }
     
     void dump(PrintStream&) const;
     
@@ -252,7 +228,7 @@ private:
         int virtualReg;
         unsigned id;
     };
-    Packed<WhichType> m_which;
+    WhichType m_which { };
     
     // For BirthToFill, Fill:
     //   - The GPR or FPR.
@@ -262,7 +238,7 @@ private:
     //   - The bytecode operand.
     // For Death:
     //   - Unused.
-    Packed<VariableRepresentation> m_representation;
+    VariableRepresentation m_representation;
     
     VariableEventKind m_kind;
     DataFormat m_dataFormat { DataFormatNone };

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
@@ -35,14 +35,114 @@
 #include "OperandsInlines.h"
 #include <wtf/DataLog.h>
 #include <wtf/HashMap.h>
+#include <wtf/LEBDecoder.h>
+#include <wtf/LEBEncoder.h>
 
 namespace JSC { namespace DFG {
 
 void VariableEventStreamBuilder::logEvent(const VariableEvent& event)
 {
-    dataLog("seq#", static_cast<unsigned>(m_stream.size()), ":");
+    dataLog("offset#", static_cast<unsigned>(m_bytes.size()), ":");
     event.dump(WTF::dataFile());
     dataLogLn(" ");
+}
+
+namespace {
+
+constexpr unsigned operandKindShift = 4;
+constexpr uint8_t eventKindMask = (1 << operandKindShift) - 1;
+
+static_assert(InvalidEventKind <= eventKindMask);
+static_assert(static_cast<unsigned>(lastOperandKind) < (1 << (CHAR_BIT - operandKindShift)));
+static_assert(sizeof(MacroAssembler::RegisterID) == 1);
+static_assert(sizeof(MacroAssembler::FPRegisterID) == 1);
+static_assert(sizeof(DataFormat) == 1);
+
+} // anonymous namespace
+
+void VariableEventStream::encode(Vector<uint8_t>& bytes, const VariableEvent& event)
+{
+    VariableEventKind kind = event.kind();
+    uint8_t tag = kind;
+    if (kind == MovHintEvent || kind == SetLocalEvent)
+        tag |= static_cast<uint8_t>(event.operand().kind()) << operandKindShift;
+    bytes.append(tag);
+    switch (kind) {
+    case Reset:
+        return;
+    case Birth:
+    case Death:
+        WTF::LEBEncoder::encodeUInt32(bytes, event.id().bits());
+        return;
+    case BirthToFill:
+    case Fill:
+        WTF::LEBEncoder::encodeUInt32(bytes, event.id().bits());
+        bytes.append(event.dataFormat());
+        if (event.dataFormat() == DataFormatDouble)
+            bytes.append(event.fpr());
+        else
+            bytes.append(event.gpr());
+        return;
+    case BirthToSpill:
+    case Spill:
+        WTF::LEBEncoder::encodeUInt32(bytes, event.id().bits());
+        bytes.append(event.dataFormat());
+        WTF::LEBEncoder::encodeInt32(bytes, event.spillRegister().offset());
+        return;
+    case MovHintEvent:
+        WTF::LEBEncoder::encodeUInt32(bytes, event.id().bits());
+        WTF::LEBEncoder::encodeInt32(bytes, event.operand().value());
+        return;
+    case SetLocalEvent:
+        WTF::LEBEncoder::encodeInt32(bytes, event.machineRegister().offset());
+        bytes.append(event.dataFormat());
+        WTF::LEBEncoder::encodeInt32(bytes, event.operand().value());
+        return;
+    case InvalidEventKind:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+VariableEvent VariableEventStream::decode(std::span<const uint8_t> bytes, size_t& offset)
+{
+    uint8_t tag = bytes[offset++];
+    VariableEventKind kind = static_cast<VariableEventKind>(tag & eventKindMask);
+    OperandKind operandKind = static_cast<OperandKind>(tag >> operandKindShift);
+    switch (kind) {
+    case Reset:
+        return VariableEvent::reset();
+    case Birth:
+        return VariableEvent::birth(MinifiedID::fromBits(WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset)));
+    case Death:
+        return VariableEvent::death(MinifiedID::fromBits(WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset)));
+    case BirthToFill:
+    case Fill: {
+        MinifiedID id = MinifiedID::fromBits(WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset));
+        DataFormat format = static_cast<DataFormat>(bytes[offset++]);
+        if (format == DataFormatDouble)
+            return VariableEvent::fillFPR(kind, id, static_cast<MacroAssembler::FPRegisterID>(bytes[offset++]));
+        return VariableEvent::fillGPR(kind, id, static_cast<MacroAssembler::RegisterID>(bytes[offset++]), format);
+    }
+    case BirthToSpill:
+    case Spill: {
+        MinifiedID id = MinifiedID::fromBits(WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset));
+        DataFormat format = static_cast<DataFormat>(bytes[offset++]);
+        return VariableEvent::spill(kind, id, VirtualRegister(WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset)), format);
+    }
+    case MovHintEvent: {
+        MinifiedID id = MinifiedID::fromBits(WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset));
+        return VariableEvent::movHint(id, Operand(operandKind, WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset)));
+    }
+    case SetLocalEvent: {
+        VirtualRegister machineRegister(WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset));
+        DataFormat format = static_cast<DataFormat>(bytes[offset++]);
+        return VariableEvent::setLocal(Operand(operandKind, WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset)), machineRegister, format);
+    }
+    case InvalidEventKind:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 namespace {
@@ -172,18 +272,19 @@ unsigned VariableEventStream::reconstruct(
         return numVariables;
     }
     
-    // Step 1: Find the last checkpoint, and figure out the number of virtual registers as we go.
-    unsigned startIndex = index - 1;
-    while (m_stream.at(startIndex).kind() != Reset)
-        startIndex--;
-    
+    // Step 1: Find the last checkpoint.
+    auto nextReset = std::lower_bound(m_resetOffsets.begin(), m_resetOffsets.end(), index);
+    RELEASE_ASSERT(nextReset != m_resetOffsets.begin());
+    size_t offset = *std::prev(nextReset);
+
     // Step 2: Create a mock-up of the DFG's state and execute the events.
     Operands<ValueSource> operandSources(codeBlock->numParameters(), numVariables, numTmps);
     for (unsigned i = operandSources.size(); i--;)
         operandSources[i] = ValueSource(SourceIsDead);
     UncheckedKeyHashMap<MinifiedID, MinifiedGenerationInfo> generationInfos;
-    for (unsigned i = startIndex; i < index; ++i) {
-        const VariableEvent& event = m_stream.at(i);
+    std::span<const uint8_t> bytes = m_bytes.span();
+    while (offset < index) {
+        VariableEvent event = decode(bytes, offset);
         dataLogLnIf(verbose, "Processing event ", event);
         switch (event.kind()) {
         case Reset:
@@ -218,6 +319,7 @@ unsigned VariableEventStream::reconstruct(
             break;
         }
     }
+    RELEASE_ASSERT(offset == index);
 
     dataLogLnIf(verbose, "Operand sources: ", operandSources);
     

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
@@ -31,6 +31,7 @@
 #include "DFGVariableEvent.h"
 #include "Operands.h"
 #include "ValueRecovery.h"
+#include <wtf/FixedVector.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
@@ -41,18 +42,36 @@ struct UndefinedOperandSpan {
     unsigned numberOfRegisters;
 };
 
+// Stores the VariableEvents as a byte stream; a stream index is a byte offset into it.
+// Each event is a tag byte followed by an optional payload:
+//
+//   tag = VariableEventKind in the low 4 bits; MovHintEvent and SetLocalEvent carry the
+//         OperandKind of their bytecode operand in the high 4 bits
+//
+//   Reset                     -
+//   Birth, Death              ULEB128 MinifiedID
+//   BirthToFill, Fill         ULEB128 MinifiedID, DataFormat, register (FPR when the
+//                             format is DataFormatDouble, GPR otherwise)
+//   BirthToSpill, Spill       ULEB128 MinifiedID, DataFormat, SLEB128 virtual register
+//   MovHintEvent              ULEB128 MinifiedID, SLEB128 operand
+//   SetLocalEvent             SLEB128 machine register, DataFormat, SLEB128 operand
 class VariableEventStream {
 public:
     VariableEventStream() = default;
-    VariableEventStream(Vector<VariableEvent>&& stream)
-        : m_stream(WTF::move(stream))
+    VariableEventStream(Vector<uint8_t>&& bytes, Vector<unsigned>&& resetOffsets)
+        : m_bytes(WTF::move(bytes))
+        , m_resetOffsets(WTF::move(resetOffsets))
     {
     }
 
     unsigned reconstruct(CodeBlock*, CodeOrigin, MinifiedGraph&, unsigned index, Operands<ValueRecovery>&) const;
     unsigned reconstruct(CodeBlock*, CodeOrigin, MinifiedGraph&, unsigned index, Operands<ValueRecovery>&, Vector<UndefinedOperandSpan>*) const;
 
+    static void encode(Vector<uint8_t>&, const VariableEvent&);
+
 private:
+    static VariableEvent decode(std::span<const uint8_t>, size_t& offset);
+
     enum class ReconstructionStyle {
         Combined,
         Separated
@@ -62,7 +81,8 @@ private:
         CodeBlock*, CodeOrigin, MinifiedGraph&,
         unsigned index, Operands<ValueRecovery>&, Vector<UndefinedOperandSpan>*) const;
 
-    FixedVector<VariableEvent> m_stream;
+    FixedVector<uint8_t> m_bytes;
+    FixedVector<unsigned> m_resetOffsets;
 };
 
 class VariableEventStreamBuilder {
@@ -72,24 +92,27 @@ public:
 
     VariableEventStreamBuilder()
     {
-        m_stream.reserveInitialCapacity(128);
+        m_bytes.reserveInitialCapacity(1024);
     }
 
     void appendAndLog(const VariableEvent& event)
     {
         if (verbose)
             logEvent(event);
-        m_stream.append(event);
+        if (event.kind() == Reset)
+            m_resetOffsets.append(m_bytes.size());
+        VariableEventStream::encode(m_bytes, event);
     }
 
-    unsigned size() const { return m_stream.size(); }
+    unsigned size() const { return m_bytes.size(); }
 
-    Vector<VariableEvent> finalize() { return WTF::move(m_stream); }
+    VariableEventStream finalize() { return { WTF::move(m_bytes), WTF::move(m_resetOffsets) }; }
 
 private:
     void logEvent(const VariableEvent&);
 
-    Vector<VariableEvent> m_stream;
+    Vector<uint8_t> m_bytes;
+    Vector<unsigned> m_resetOffsets;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/ftl/FTLOSRExit.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExit.cpp
@@ -34,6 +34,7 @@
 #include "FTLState.h"
 #include "JSCJSValueInlines.h"
 #include <wtf/LEBDecoder.h>
+#include <wtf/LEBEncoder.h>
 
 namespace JSC { namespace FTL {
 
@@ -54,23 +55,6 @@ static_assert(ExitValueInJSStackAsInt52 == ExitValueInJSStack + 2);
 static_assert(ExitValueInJSStackAsDouble == ExitValueInJSStack + 3);
 static_assert(inJSStackAtOwnRegisterTag + 4 == inJSStackTag);
 static_assert(inJSStackTag + 4 == constantTag);
-
-void appendLEB(Vector<uint8_t, 128>& bytes, uint32_t value)
-{
-    while (value >= 0x80) {
-        bytes.append(static_cast<uint8_t>(value | 0x80));
-        value >>= 7;
-    }
-    bytes.append(static_cast<uint8_t>(value));
-}
-
-uint32_t readLEB(std::span<const uint8_t> bytes, size_t& offset)
-{
-    uint32_t result = 0;
-    bool success = WTF::LEBDecoder::decodeUInt32(bytes, offset, result);
-    RELEASE_ASSERT(success);
-    return result;
-}
 
 ExitValueKind inJSStackKind(uint8_t tag, uint8_t baseTag)
 {
@@ -118,8 +102,7 @@ void OSRExitValues::encode(const Operands<ExitValue>& values, const Bag<ExitTime
                 break;
             }
             bytes.append(inJSStackTag + (value.kind() - ExitValueInJSStack));
-            int32_t offset = reg.offset();
-            appendLEB(bytes, (static_cast<uint32_t>(offset) << 1) ^ static_cast<uint32_t>(offset >> 31));
+            WTF::LEBEncoder::encodeInt32(bytes, reg.offset());
             break;
         }
         case ExitValueConstant: {
@@ -130,20 +113,20 @@ void OSRExitValues::encode(const Operands<ExitValue>& values, const Bag<ExitTime
                 constantIndex = constants.size();
                 constants.append(constant);
             }
-            appendLEB(bytes, constantIndex);
+            WTF::LEBEncoder::encodeUInt32(bytes, constantIndex);
             break;
         }
         case ExitValueMaterializeNewObject: {
             bytes.append(materializationTag);
             size_t materializationIndex = materializations.find(value.objectMaterialization());
             ASSERT(materializationIndex != notFound);
-            appendLEB(bytes, materializationIndex);
+            WTF::LEBEncoder::encodeUInt32(bytes, materializationIndex);
             break;
         }
         case ExitValueArgument:
             bytes.append(argumentTag);
             bytes.append(static_cast<uint8_t>(value.exitArgument().format()));
-            appendLEB(bytes, value.exitArgument().argument());
+            WTF::LEBEncoder::encodeUInt32(bytes, value.exitArgument().argument());
             break;
         case InvalidExitValue:
             RELEASE_ASSERT_NOT_REACHED();
@@ -172,23 +155,21 @@ FixedOperands<ExitValue> OSRExitValues::decode(const JITCode& jitCode, const Bag
             VirtualRegister reg;
             if (atOwnRegister)
                 reg = values.operandForIndex(index).virtualRegister();
-            else {
-                uint32_t zigzag = readLEB(bytes, offset);
-                reg = VirtualRegister(static_cast<int32_t>(zigzag >> 1) ^ -static_cast<int32_t>(zigzag & 1));
-            }
+            else
+                reg = VirtualRegister(WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset));
             values[index] = ExitValue::inJSStack(inJSStackKind(tag, atOwnRegister ? inJSStackAtOwnRegisterTag : inJSStackTag), reg).withLocalsOffset(localsOffset);
             continue;
         }
         switch (tag) {
         case constantTag:
-            values[index] = ExitValue::constant(JSValue::decode(jitCode.osrExitConstants[readLEB(bytes, offset)]));
+            values[index] = ExitValue::constant(JSValue::decode(jitCode.osrExitConstants[WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset)]));
             break;
         case materializationTag:
-            values[index] = ExitValue::materializeNewObject(materializations[readLEB(bytes, offset)]);
+            values[index] = ExitValue::materializeNewObject(materializations[WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset)]);
             break;
         case argumentTag: {
             DataFormat format = static_cast<DataFormat>(bytes[offset++]);
-            values[index] = ExitValue::exitArgument(ExitArgument(format, readLEB(bytes, offset)));
+            values[index] = ExitValue::exitArgument(ExitArgument(format, WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset)));
             break;
         }
         default:

--- a/Source/JavaScriptCore/ftl/FTLOSRExit.h
+++ b/Source/JavaScriptCore/ftl/FTLOSRExit.h
@@ -75,7 +75,7 @@ class JITCode;
 //
 //   0x00-0x3F  (tag + 1) consecutive dead values
 //   0x40-0x43  InJSStack / AsInt32 / AsInt52 / AsDouble, flushed to the operand's own virtual register
-//   0x44-0x47  the same, flushed to another virtual register: zigzag LEB128 register offset follows
+//   0x44-0x47  the same, flushed to another virtual register: SLEB128 register offset follows
 //   0x48       Constant: LEB128 index into JITCode::osrExitConstants follows
 //   0x49       MaterializeNewObject: LEB128 index into OSRExitDescriptor::m_materializations follows
 //   0x4A       Argument: DataFormat byte and LEB128 stackmap index follow

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		DD3DC88727A4BF8E007E5B61 /* CrossThreadTaskHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 517F82D61FD22F2F00DA3DEA /* CrossThreadTaskHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88827A4BF8E007E5B61 /* LoggingHashTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F30BA8F1E78708E002CA847 /* LoggingHashTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88927A4BF8E007E5B61 /* LEBDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 539EB0621D55284200C82EF7 /* LEBDecoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5301A2E52EE0C1A4009B4C3D /* LEBEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5301A2E42EE0C1A4009B4C3D /* LEBEncoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88A27A4BF8E007E5B61 /* WeakRandomNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FC151A825B004123FF /* WeakRandomNumber.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88B27A4BF8E007E5B61 /* SharedTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEB3DCE1BB5D684009D7AAD /* SharedTask.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88C27A4BF8E007E5B61 /* EnumTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AEA88E11D6BBCF400E5AD64 /* EnumTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1455,6 +1456,7 @@
 		53534F291EC0E10E00141B2F /* MachExceptions.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; path = MachExceptions.defs; sourceTree = "<group>"; };
 		5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h; sourceTree = "<group>"; };
 		539EB0621D55284200C82EF7 /* LEBDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LEBDecoder.h; sourceTree = "<group>"; };
+		5301A2E42EE0C1A4009B4C3D /* LEBEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LEBEncoder.h; sourceTree = "<group>"; };
 		53CAC0622C6FBD8200B1A77C /* ScopedPrintStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedPrintStream.h; sourceTree = "<group>"; };
 		53EC253C1E95AD30000831B9 /* PriorityQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityQueue.h; sourceTree = "<group>"; };
 		53F08A1BA39D49A8BAD369A1 /* StdSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdSet.h; sourceTree = "<group>"; };
@@ -2586,6 +2588,7 @@
 				E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */,
 				E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */,
 				539EB0621D55284200C82EF7 /* LEBDecoder.h */,
+				5301A2E42EE0C1A4009B4C3D /* LEBEncoder.h */,
 				337B2D6826546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp */,
 				337B2D6926546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.h */,
 				A70DA0831799F04D00529A9B /* ListDump.h */,
@@ -3766,6 +3769,7 @@
 				E32AB5012B5CE35D00B9FAAE /* LazyRef.h in Headers */,
 				E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */,
 				DD3DC88927A4BF8E007E5B61 /* LEBDecoder.h in Headers */,
+				5301A2E52EE0C1A4009B4C3D /* LEBEncoder.h in Headers */,
 				07F5EA712EE8A76A0085B185 /* library-modules-verifier.py in Headers */,
 				6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */,
 				DD3DC8B427A4BF8E007E5B61 /* LikelyDenseUnsignedIntegerSet.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -158,6 +158,7 @@ set(WTF_PUBLIC_HEADERS
     JSValueMalloc.h
     KeyValuePair.h
     LEBDecoder.h
+    LEBEncoder.h
     LLVMProfilingUtils.h
     Language.h
     LazyRef.h

--- a/Source/WTF/wtf/LEBDecoder.h
+++ b/Source/WTF/wtf/LEBDecoder.h
@@ -137,4 +137,43 @@ template<typename T>
     return decodeInt<int64_t>(bytes, offset, result);
 }
 
+// For streams this process encoded itself, where a malformed number is a bug rather than input.
+template<typename T>
+inline T decodeUIntOrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    T result = 0;
+    bool success = decodeUInt<T>(bytes, offset, result);
+    RELEASE_ASSERT(success);
+    return result;
+}
+
+template<typename T>
+inline T decodeIntOrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    T result = 0;
+    bool success = decodeInt<T>(bytes, offset, result);
+    RELEASE_ASSERT(success);
+    return result;
+}
+
+inline uint32_t decodeUInt32OrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    return decodeUIntOrCrash<uint32_t>(bytes, offset);
+}
+
+inline uint64_t decodeUInt64OrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    return decodeUIntOrCrash<uint64_t>(bytes, offset);
+}
+
+inline int32_t decodeInt32OrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    return decodeIntOrCrash<int32_t>(bytes, offset);
+}
+
+inline int64_t decodeInt64OrCrash(std::span<const uint8_t> bytes, size_t& offset)
+{
+    return decodeIntOrCrash<int64_t>(bytes, offset);
+}
+
 } } // WTF::LEBDecoder

--- a/Source/WTF/wtf/LEBEncoder.h
+++ b/Source/WTF/wtf/LEBEncoder.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <wtf/Vector.h>
+
+// Encodes LEB128 numbers into a byte vector; the counterpart of LEBDecoder.h.
+// See https://en.wikipedia.org/wiki/LEB128 for more information about the
+// LEB format.
+
+namespace WTF { namespace LEBEncoder {
+
+template<typename T, typename VectorType>
+inline void encodeUInt(VectorType& bytes, T value)
+{
+    static_assert(std::is_unsigned_v<T>);
+    while (value >= 0x80) {
+        bytes.append(static_cast<uint8_t>(value | 0x80));
+        value >>= 7;
+    }
+    bytes.append(static_cast<uint8_t>(value));
+}
+
+template<typename T, typename VectorType>
+inline void encodeInt(VectorType& bytes, T value)
+{
+    static_assert(std::is_signed_v<T>);
+    while (true) {
+        uint8_t byte = value & 0x7f;
+        value >>= 7;
+        if ((!value && !(byte & 0x40)) || (value == -1 && (byte & 0x40))) {
+            bytes.append(byte);
+            return;
+        }
+        bytes.append(static_cast<uint8_t>(byte | 0x80));
+    }
+}
+
+template<typename VectorType>
+inline void encodeUInt32(VectorType& bytes, uint32_t value)
+{
+    encodeUInt<uint32_t>(bytes, value);
+}
+
+template<typename VectorType>
+inline void encodeUInt64(VectorType& bytes, uint64_t value)
+{
+    encodeUInt<uint64_t>(bytes, value);
+}
+
+template<typename VectorType>
+inline void encodeInt32(VectorType& bytes, int32_t value)
+{
+    encodeInt<int32_t>(bytes, value);
+}
+
+template<typename VectorType>
+inline void encodeInt64(VectorType& bytes, int64_t value)
+{
+    encodeInt<int64_t>(bytes, value);
+}
+
+} } // WTF::LEBEncoder

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -84,6 +84,7 @@ set(TestWTF_SOURCES
     Tests/WTF/IteratorRange.cpp
     Tests/WTF/JSONValue.cpp
     Tests/WTF/LEBDecoder.cpp
+    Tests/WTF/LEBEncoder.cpp
     Tests/WTF/LazyRef.cpp
     Tests/WTF/LazyUniqueRef.cpp
     Tests/WTF/LifecycleLogger.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1259,6 +1259,7 @@
 				WTF/LazyRef.cpp,
 				WTF/LazyUniqueRef.cpp,
 				WTF/LEBDecoder.cpp,
+				WTF/LEBEncoder.cpp,
 				WTF/LifecycleLogger.cpp,
 				WTF/LineEnding.cpp,
 				WTF/ListHashSet.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/LEBEncoder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/LEBEncoder.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/LEBEncoder.h>
+
+#include <wtf/LEBDecoder.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+static void testUInt32LEBEncode(uint32_t value, std::initializer_list<uint8_t> expected)
+{
+    Vector<uint8_t> bytes;
+    WTF::LEBEncoder::encodeUInt32(bytes, value);
+    EXPECT_EQ(Vector<uint8_t>(expected), bytes) << value;
+
+    size_t offset = 0;
+    EXPECT_EQ(value, WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset));
+    EXPECT_EQ(bytes.size(), offset);
+}
+
+static void testInt32LEBEncode(int32_t value, std::initializer_list<uint8_t> expected)
+{
+    Vector<uint8_t> bytes;
+    WTF::LEBEncoder::encodeInt32(bytes, value);
+    EXPECT_EQ(Vector<uint8_t>(expected), bytes) << value;
+
+    size_t offset = 0;
+    EXPECT_EQ(value, WTF::LEBDecoder::decodeInt32OrCrash(bytes, offset));
+    EXPECT_EQ(bytes.size(), offset);
+}
+
+TEST(WTF, LEBEncoderUInt32)
+{
+    testUInt32LEBEncode(0, { 0x00 });
+    testUInt32LEBEncode(0x7f, { 0x7f });
+    testUInt32LEBEncode(0x80, { 0x80, 0x01 });
+    testUInt32LEBEncode(0x380, { 0x80, 0x07 });
+    testUInt32LEBEncode(0x82f3, { 0xf3, 0x85, 0x02 });
+    testUInt32LEBEncode(0xe9fc2f3, { 0xf3, 0x85, 0xff, 0x74 });
+    testUInt32LEBEncode(0xffffffff, { 0xff, 0xff, 0xff, 0xff, 0x0f });
+}
+
+TEST(WTF, LEBEncoderInt32)
+{
+    testInt32LEBEncode(0, { 0x00 });
+    testInt32LEBEncode(1, { 0x01 });
+    testInt32LEBEncode(-1, { 0x7f });
+    testInt32LEBEncode(63, { 0x3f });
+    testInt32LEBEncode(64, { 0xc0, 0x00 });
+    testInt32LEBEncode(-64, { 0x40 });
+    testInt32LEBEncode(-65, { 0xbf, 0x7f });
+    testInt32LEBEncode(-128, { 0x80, 0x7f });
+    testInt32LEBEncode(8191, { 0xff, 0x3f });
+    testInt32LEBEncode(-8192, { 0x80, 0x40 });
+    testInt32LEBEncode(std::numeric_limits<int32_t>::max(), { 0xff, 0xff, 0xff, 0xff, 0x07 });
+    testInt32LEBEncode(std::numeric_limits<int32_t>::min(), { 0x80, 0x80, 0x80, 0x80, 0x78 });
+}
+
+TEST(WTF, LEBEncoderRoundTrip64)
+{
+    for (uint64_t value : std::initializer_list<uint64_t> { 0, 0x7f, 0x80, 0xffffffff, 0x100000000, std::numeric_limits<uint64_t>::max() }) {
+        Vector<uint8_t> bytes;
+        WTF::LEBEncoder::encodeUInt64(bytes, value);
+        size_t offset = 0;
+        EXPECT_EQ(value, WTF::LEBDecoder::decodeUInt64OrCrash(bytes, offset));
+        EXPECT_EQ(bytes.size(), offset);
+    }
+    for (int64_t value : std::initializer_list<int64_t> { 0, -1, 63, -64, 64, -65, 0x7fffffff, -0x80000000, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::min() }) {
+        Vector<uint8_t> bytes;
+        WTF::LEBEncoder::encodeInt64(bytes, value);
+        size_t offset = 0;
+        EXPECT_EQ(value, WTF::LEBDecoder::decodeInt64OrCrash(bytes, offset));
+        EXPECT_EQ(bytes.size(), offset);
+    }
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 48985e195c6fddb7395ad65e72a7614f12366ae2
<pre>
[JSC] Store the DFG `VariableEventStream` as a byte stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=322713">https://bugs.webkit.org/show_bug.cgi?id=322713</a>

Reviewed by Yusuke Suzuki.

DFG::VariableEventStream keeps one 14 byte VariableEvent per event for as long
as the DFG code lives, and its only reader is reconstruct() on OSR exit, which
seeks back to the last Reset and replays the events from there. On JetStream3
(25,095 DFG compiles) the streams hold 4.76 million events, 66.6 MB over the run
and 2.65 KB per DFG compile, mostly SetLocal and MovHint events whose payloads
are small integers.

This patch makes VariableEventStreamBuilder encode each event into a byte stream
as SpeculativeJIT emits it, in the format described above the class in
DFGVariableEventStream.h, and record the byte offset of every Reset in a side
table. The stream index that SpeculativeJIT captures for each OSR exit, slow
path and OSR entry is now a byte offset, so nothing has to map event counts to
offsets afterwards; reconstruct() binary-searches the Reset table for the
checkpoint and decodes forward to that offset. The events are still
VariableEvents on both sides of the stream, so the emitters and the replay
switch are unchanged; VariableEvent only loses the Packed&lt;&gt; wrappers that
existed to make the stored array dense.

This is the DFG counterpart of 319934@main, which did the same for
FTL::OSRExitDescriptor. The LEB128 encoders that both streams need move to a
new wtf/LEBEncoder.h, the counterpart of LEBDecoder.h, which in turn gains
decode*OrCrash() for streams the process encoded itself, and the FTL stream
switches its hand-rolled zigzag register offsets to the SLEB128 that WTF
already decodes.

On the same JetStream3 run the byte streams and Reset tables total 17.8 MB (3.7
bytes per event, -73%), 0.71 KB per DFG compile. Decoding adds 0.5 us to each
reconstruct().

Test: Tools/TestWebKitAPI/Tests/WTF/LEBEncoder.cpp

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::finalizeEventStream):
* Source/JavaScriptCore/dfg/DFGVariableEvent.h:
(JSC::DFG::VariableEvent::fillGPR):
(JSC::DFG::VariableEvent::fillFPR):
(JSC::DFG::VariableEvent::birth):
(JSC::DFG::VariableEvent::spill):
(JSC::DFG::VariableEvent::death):
(JSC::DFG::VariableEvent::setLocal):
(JSC::DFG::VariableEvent::movHint):
(JSC::DFG::VariableEvent::id const):
(JSC::DFG::VariableEvent::gpr const):
(JSC::DFG::VariableEvent::fpr const):
(JSC::DFG::VariableEvent::spillRegister const):
(JSC::DFG::VariableEvent::operand const):
(JSC::DFG::VariableEvent::machineRegister const):
(JSC::DFG::VariableEvent::variableRepresentation const):
* Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp:
(JSC::DFG::VariableEventStreamBuilder::logEvent):
(JSC::DFG::VariableEventStream::encode):
(JSC::DFG::VariableEventStream::decode):
(JSC::DFG::VariableEventStream::reconstruct const):
* Source/JavaScriptCore/dfg/DFGVariableEventStream.h:
(JSC::DFG::VariableEventStream::VariableEventStream):
(JSC::DFG::VariableEventStreamBuilder::VariableEventStreamBuilder):
(JSC::DFG::VariableEventStreamBuilder::appendAndLog):
(JSC::DFG::VariableEventStreamBuilder::size const):
(JSC::DFG::VariableEventStreamBuilder::finalize):
* Source/JavaScriptCore/ftl/FTLOSRExit.cpp:
(JSC::FTL::OSRExitValues::encode):
(JSC::FTL::OSRExitValues::decode const):
(JSC::FTL::DFG::appendLEB): Deleted.
(JSC::FTL::DFG::readLEB): Deleted.
* Source/JavaScriptCore/ftl/FTLOSRExit.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/LEBDecoder.h:
(WTF::LEBDecoder::decodeUIntOrCrash):
(WTF::LEBDecoder::decodeIntOrCrash):
(WTF::LEBDecoder::decodeUInt32OrCrash):
(WTF::LEBDecoder::decodeUInt64OrCrash):
(WTF::LEBDecoder::decodeInt32OrCrash):
(WTF::LEBDecoder::decodeInt64OrCrash):
* Source/WTF/wtf/LEBEncoder.h: Added.
(WTF::LEBEncoder::encodeUInt):
(WTF::LEBEncoder::encodeInt):
(WTF::LEBEncoder::encodeUInt32):
(WTF::LEBEncoder::encodeUInt64):
(WTF::LEBEncoder::encodeInt32):
(WTF::LEBEncoder::encodeInt64):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/LEBEncoder.cpp: Added.
(TestWebKitAPI::testUInt32LEBEncode):
(TestWebKitAPI::testInt32LEBEncode):
(TestWebKitAPI::TEST(WTF, LEBEncoderUInt32)):
(TestWebKitAPI::TEST(WTF, LEBEncoderInt32)):
(TestWebKitAPI::TEST(WTF, LEBEncoderRoundTrip64)):

Canonical link: <a href="https://commits.webkit.org/320007@main">https://commits.webkit.org/320007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58cc657750b0fd1946ea3a14b1aa095a031d0fed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99364 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43775 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5485 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12332 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43391 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4716 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44597 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56916 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152587 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40914 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152276 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129900 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56128 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18398 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->