### PR TITLE
[GLIB] HighPriorityThreads hits an assertion crash when its RealtimeKit proxy timer fires

### DIFF
--- a/Source/WTF/wtf/linux/HighPriorityThreads.cpp
+++ b/Source/WTF/wtf/linux/HighPriorityThreads.cpp
@@ -57,7 +57,9 @@ HighPriorityThreads& HighPriorityThreads::singleton()
 HighPriorityThreads::HighPriorityThreads()
     : m_threadGroup(ThreadGroup::create())
 #if USE(GLIB)
-    , m_discardRealTimeKitProxyTimer(RunLoop::mainSingleton(), "HighPriorityThreads::DiscardRealTimeKitProxyTimer"_s, this, &HighPriorityThreads::discardRealTimeKitProxyTimerFired)
+    , m_discardRealTimeKitProxyTimer(RunLoop::mainSingleton(), "HighPriorityThreads::DiscardRealTimeKitProxyTimer"_s, [] {
+        singleton().discardRealTimeKitProxyTimerFired();
+    })
 #endif
 {
 #if USE(GLIB)

--- a/Source/WTF/wtf/linux/HighPriorityThreads.h
+++ b/Source/WTF/wtf/linux/HighPriorityThreads.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/ThreadGroup.h>
 
@@ -33,15 +32,11 @@ typedef struct _GDBusProxy GDBusProxy;
 
 namespace WTF {
 
-class HighPriorityThreads : public CanMakeWeakPtr<HighPriorityThreads> {
+class HighPriorityThreads {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(HighPriorityThreads);
     friend class LazyNeverDestroyed<HighPriorityThreads>;
 public:
     WTF_EXPORT_PRIVATE static HighPriorityThreads& singleton();
-
-    // Do nothing since this is a singleton.
-    void ref() const { }
-    void deref() const { }
 
     void registerThread(Thread&);
 


### PR DESCRIPTION
#### 1afb343a6d30aa01e0ce2fa57d7fa5e953baae06
<pre>
[GLIB] HighPriorityThreads hits an assertion crash when its RealtimeKit proxy timer fires
<a href="https://bugs.webkit.org/show_bug.cgi?id=322715">https://bugs.webkit.org/show_bug.cgi?id=322715</a>

Reviewed by Justin Michaud.

The singleton is built by the first high priority thread to start, since
Thread::initializeSchedulingAttributes() runs on the thread being started. The
member function form of RunLoop::Timer captures a WeakPtr bound to that thread,
while the timer runs on the main run loop; firing it trips the WeakPtr thread
assertion.

Give the timer a lambda that goes through singleton() instead. The object
outlives every run loop, so neither the weak reference nor the no-op ref/deref
that supported it were needed.

* Source/WTF/wtf/linux/HighPriorityThreads.cpp:
(WTF::HighPriorityThreads::HighPriorityThreads):
* Source/WTF/wtf/linux/HighPriorityThreads.h:
(WTF::HighPriorityThreads::ref const): Deleted.
(WTF::HighPriorityThreads::deref const): Deleted.

Canonical link: <a href="https://commits.webkit.org/319959@main">https://commits.webkit.org/319959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/087aaf424facf5c0fddf707983283ab9ffe2e076

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147622 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185194 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143099 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45547 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5492 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12342 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43398 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4726 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44605 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56925 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152595 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57629 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152283 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46841 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56137 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18408 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->