### PR TITLE
[css-mixins-1] Registered function arguments should evaluate in calling context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Parameter default resolves a dashed-function in the definition scope
+PASS result resolves a dashed-function in the definition scope
+PASS A local resolves a dashed-function in the definition scope
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>Custom Functions: parameter defaults resolve names in the definition scope</title>
+<link rel="help" href="https://drafts.csswg.org/css-mixins-1/#evaluate-a-custom-function">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<style>
+  /* Defined in the outer tree. A <dashed-function> inside these resolves where the
+     function was defined, so it must reach this --scoped() and never the shadow
+     tree's, however the function is called. */
+  @function --scoped() {
+    result: OUTER;
+  }
+  @function --default-calls-scoped(--x: --scoped()) {
+    result: var(--x);
+  }
+  @function --result-calls-scoped() {
+    result: --scoped();
+  }
+  @function --local-calls-scoped() {
+    --local: --scoped();
+    result: var(--local);
+  }
+</style>
+
+<!-- To pass, a test must produce matching computed values for --actual and
+     --expected on the #target inside each shadow root. -->
+
+<div data-name="Parameter default resolves a dashed-function in the definition scope">
+  <template shadowrootmode="open">
+    <style>
+      @function --scoped() { result: SHADOW; }
+      #target {
+        --actual: --default-calls-scoped();
+        --expected: OUTER;
+      }
+    </style>
+    <div id=target></div>
+  </template>
+</div>
+
+<div data-name="result resolves a dashed-function in the definition scope">
+  <template shadowrootmode="open">
+    <style>
+      @function --scoped() { result: SHADOW; }
+      #target {
+        --actual: --result-calls-scoped();
+        --expected: OUTER;
+      }
+    </style>
+    <div id=target></div>
+  </template>
+</div>
+
+<div data-name="A local resolves a dashed-function in the definition scope">
+  <template shadowrootmode="open">
+    <style>
+      @function --scoped() { result: SHADOW; }
+      #target {
+        --actual: --local-calls-scoped();
+        --expected: OUTER;
+      }
+    </style>
+    <div id=target></div>
+  </template>
+</div>
+
+<script>
+  test_all_shadows();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Default referencing an earlier parameter
+PASS Default referencing a later parameter is guaranteed-invalid
+PASS Default referencing a later parameter does not see the calling element
+PASS Default referencing itself does not see the calling element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>Custom Functions: name scoping in parameter defaults</title>
+<link rel="help" href="https://drafts.csswg.org/css-mixins-1/#evaluate-a-custom-function">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<style>
+  @property --actual { syntax: "<length>"; inherits: false; initial-value: -1px; }
+  @property --expected { syntax: "<length>"; inherits: false; initial-value: -1px; }
+</style>
+
+<div id=parent>
+  <div id=target></div>
+</div>
+<div id=main></div>
+
+<!-- To pass, a test must produce matching computed values for --actual and
+     --expected on #target.
+
+     A parameter shadows the calling element's custom property of the same name,
+     whether or not it has been resolved yet, so a default can reference an
+     earlier parameter but never sees the calling element's value of a later one.
+     https://drafts.csswg.org/css-mixins-1/#evaluating-custom-functions -->
+
+<template data-name="Default referencing an earlier parameter">
+  <style>
+    @function --f(--a <length>, --b <length>: var(--a)) returns <length> {
+      result: var(--b);
+    }
+    #target {
+      --actual: --f(6px);
+      --expected: 6px;
+    }
+  </style>
+</template>
+
+<template data-name="Default referencing a later parameter is guaranteed-invalid">
+  <style>
+    @function --f(--a <length>: var(--b), --b <length>: 3px) returns <length> {
+      result: var(--a);
+    }
+    #target {
+      --actual: --f();
+      --expected: -1px;
+    }
+  </style>
+</template>
+
+<template data-name="Default referencing a later parameter does not see the calling element">
+  <style>
+    @function --f(--a <length>: var(--b), --b <length>: 3px) returns <length> {
+      result: var(--a);
+    }
+    #target {
+      --b: 99px;
+      --actual: --f();
+      --expected: -1px;
+    }
+  </style>
+</template>
+
+<template data-name="Default referencing itself does not see the calling element">
+  <style>
+    @function --f(--a <length>: var(--a)) returns <length> {
+      result: var(--a);
+    }
+    #target {
+      --a: 99px;
+      --actual: --f();
+      --expected: -1px;
+    }
+  </style>
+</template>
+
+<script>
+  test_all_templates();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units-expected.txt
@@ -1,0 +1,13 @@
+
+PASS em in a typed parameter
+PASS rem in a typed parameter
+PASS em within calc() in a typed parameter
+PASS em in a typed parameter, untyped return
+PASS em in a typed parameter default
+PASS em in a typed parameter of a nested function
+PASS em in a typed result
+PASS em within calc() in a typed result
+PASS em in an untyped local substituted into a typed result
+PASS em in an untyped parameter
+PASS em in an untyped result
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<title>Custom Functions: font-relative units in parameters, locals and result</title>
+<link rel="help" href="https://drafts.csswg.org/css-mixins-1/#evaluate-a-custom-function">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<style>
+  /* Registering both sides as <length> makes each comparison exact without
+     depending on what 1em, 1rem or 1ex actually resolve to. The initial value is
+     nonzero so that a guaranteed-invalid result is distinguishable from a length
+     that wrongly resolved against a zero font size. */
+  @property --actual {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: -1px;
+  }
+  @property --expected {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: -1px;
+  }
+  /* #parent and #target have different font sizes, so a font-relative unit that
+     resolves against the wrong element is caught too, not just one that resolves
+     against no element at all. */
+  #parent {
+    font-size: 10px;
+  }
+  #target {
+    font-size: 20px;
+  }
+</style>
+
+<div id=parent>
+  <div id=target></div>
+</div>
+<div id=main></div>
+
+<!-- To pass, a test must produce matching computed values for --actual and
+     --expected on #target.
+
+     Every case below places the <dashed-function> in a custom property rather
+     than in 'font-size', so a font-relative unit resolves against the calling
+     element whichever context it is evaluated in. -->
+
+<!-- Typed parameters -->
+
+<template data-name="em in a typed parameter">
+  <style>
+    @function --f(--x <length>) returns <length> {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f(1em);
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<template data-name="rem in a typed parameter">
+  <style>
+    @function --f(--x <length>) returns <length> {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f(1rem);
+      --expected: 1rem;
+    }
+  </style>
+</template>
+
+<template data-name="em within calc() in a typed parameter">
+  <style>
+    @function --f(--x <length>) returns <length> {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f(calc(1em + 5px));
+      --expected: calc(1em + 5px);
+    }
+  </style>
+</template>
+
+<template data-name="em in a typed parameter, untyped return">
+  <style>
+    @function --f(--x <length>) {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f(1em);
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<template data-name="em in a typed parameter default">
+  <style>
+    @function --f(--x <length>: 1em) returns <length> {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f();
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<template data-name="em in a typed parameter of a nested function">
+  <style>
+    @function --inner(--y <length>) returns <length> {
+      result: var(--y);
+    }
+    @function --outer(--x <length>) returns <length> {
+      result: --inner(var(--x));
+    }
+    #target {
+      --actual: --outer(1em);
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<!-- Typed result -->
+
+<template data-name="em in a typed result">
+  <style>
+    @function --f() returns <length> {
+      result: 1em;
+    }
+    #target {
+      --actual: --f();
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<template data-name="em within calc() in a typed result">
+  <style>
+    @function --f() returns <length> {
+      result: calc(1em * 2);
+    }
+    #target {
+      --actual: --f();
+      --expected: calc(1em * 2);
+    }
+  </style>
+</template>
+
+<template data-name="em in an untyped local substituted into a typed result">
+  <style>
+    @function --f() returns <length> {
+      --local: 1em;
+      result: var(--local);
+    }
+    #target {
+      --actual: --f();
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<!-- Controls: with nothing typed, the unit is resolved as part of the calling
+     declaration, so these pass even where the cases above do not. -->
+
+<template data-name="em in an untyped parameter">
+  <style>
+    @function --f(--x) {
+      result: var(--x);
+    }
+    #target {
+      --actual: --f(1em);
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<template data-name="em in an untyped result">
+  <style>
+    @function --f() {
+      result: 1em;
+    }
+    #target {
+      --actual: --f();
+      --expected: 1em;
+    }
+  </style>
+</template>
+
+<script>
+  test_all_templates();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
@@ -7,4 +7,11 @@ PASS random() in same registered function same locals different positions
 FAIL random() in different function same default locals assert_true: expected true got false
 FAIL random() in function in local overrides argument assert_false: Random values should not be equal expected false got true
 PASS random() in function argument
+PASS random(fixed) outside a function
+PASS random(fixed) through an untyped argument
+PASS random(fixed) through a typed argument
+FAIL random(fixed) through an untyped argument into a typed result assert_equals: expected "50" but got "0"
+FAIL random(fixed) in an untyped local substituted into a typed result assert_equals: expected "50" but got "0"
+FAIL random(fixed) in a typed parameter default assert_equals: expected "50" but got "0"
+PASS random(fixed) written in a typed result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative.html
@@ -67,6 +67,29 @@
     @function --g-number() returns <number> {
         result: random(--foo property-index-scoped, 1, 1e6);
     }
+
+    /* random(fixed <number>) bypasses the random cache name entirely, so the
+       cases below test only whether a value is produced at all, independent of
+       how cache names are scoped inside custom functions. Each resolves to 50. */
+    @function --fixed-untyped(--x) {
+        result: var(--x);
+    }
+    @function --fixed-typed-argument(--x <number>) returns <number> {
+        result: var(--x);
+    }
+    @function --fixed-untyped-argument-typed-result(--x) returns <number> {
+        result: var(--x);
+    }
+    @function --fixed-untyped-local-typed-result() returns <number> {
+        --x: random(fixed 0.5, 0, 100);
+        result: var(--x);
+    }
+    @function --fixed-typed-default(--x <number>: random(fixed 0.5, 0, 100)) returns <number> {
+        result: var(--x);
+    }
+    @function --fixed-typed-result() returns <number> {
+        result: random(fixed 0.5, 0, 100);
+    }
 </style>
 <script>
 // Since actual and expected values are generated randomly, `assert_equals()`
@@ -266,4 +289,37 @@ test(() => {
     document.body.removeChild(holder);
   }
 }, `random() in function argument`);
+
+// random(fixed <number>) has a fixed random base value and ignores the random
+// cache name, so these cases are deterministic and independent of how cache
+// names are scoped inside a custom function.
+function test_fixed_random(value, description) {
+  test(() => {
+    const holder = document.createElement('div');
+    document.body.appendChild(holder);
+    try {
+      const el = document.createElement('div');
+      el.style.setProperty('--number', value);
+      holder.appendChild(el);
+      assert_equals(getComputedStyle(el).getPropertyValue('--number'), '50');
+    } finally {
+      document.body.removeChild(holder);
+    }
+  }, description);
+}
+
+test_fixed_random('random(fixed 0.5, 0, 100)',
+  'random(fixed) outside a function');
+test_fixed_random('--fixed-untyped(random(fixed 0.5, 0, 100))',
+  'random(fixed) through an untyped argument');
+test_fixed_random('--fixed-typed-argument(random(fixed 0.5, 0, 100))',
+  'random(fixed) through a typed argument');
+test_fixed_random('--fixed-untyped-argument-typed-result(random(fixed 0.5, 0, 100))',
+  'random(fixed) through an untyped argument into a typed result');
+test_fixed_random('--fixed-untyped-local-typed-result()',
+  'random(fixed) in an untyped local substituted into a typed result');
+test_fixed_random('--fixed-typed-default()',
+  'random(fixed) in a typed parameter default');
+test_fixed_random('--fixed-typed-result()',
+  'random(fixed) written in a typed result');
 </script>

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -775,7 +775,14 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyVa
     if (!registered)
         return { { CustomProperty::createForVariableData(name, *resolvedData) } };
 
-    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(registered->syntax, resolvedData->tokens(), resolvedData->context());
+    return computeCustomPropertyValueForSyntax(name, registered->syntax, *resolvedData);
+}
+
+// Parses an already-substituted value against a syntax and computes it on this builder's element.
+// Shared by registered custom properties and by custom function parameters.
+std::optional<Builder::CustomPropertyOrKeyword> Builder::computeCustomPropertyValueForSyntax(const AtomString& name, const CSSCustomPropertySyntax& syntax, const CSSVariableData& resolvedData)
+{
+    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(syntax, resolvedData.tokens(), resolvedData.context());
 
     // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles
     bool hasCycles = false;
@@ -803,18 +810,18 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyVa
     if (isFontDependent)
         m_state->updateFont();
 
-    auto isAttrTainted = resolvedData->isAttrTainted();
+    auto isAttrTainted = resolvedData.isAttrTainted();
 
     // https://drafts.csswg.org/css-values-5/#attr-security
     // A registered custom property with <url> or <image> syntax resolved from attr()-tainted data is IACVT.
     if (isAttrTainted == IsAttrTainted::Yes) {
-        for (auto& component : registered->syntax.definition) {
+        for (auto& component : syntax.definition) {
             if (component.type == CSSCustomPropertySyntax::Type::URL || component.type == CSSCustomPropertySyntax::Type::Image)
                 return { };
         }
     }
 
-    return CSSPropertyParser::parseTypedCustomPropertyValue(name, registered->syntax, resolvedData->tokens(), m_state, resolvedData->context(), isAttrTainted);
+    return CSSPropertyParser::parseTypedCustomPropertyValue(name, syntax, resolvedData.tokens(), m_state, resolvedData.context(), isAttrTainted);
 }
 
 void Builder::applyPageSizeDescriptor(CSSValue& value)

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -32,7 +32,9 @@
 namespace WebCore {
 
 class CSSCustomPropertyValue;
+class CSSVariableData;
 enum class CSSWideKeyword : uint8_t;
+struct CSSCustomPropertySyntax;
 struct CSSRegisteredCustomProperty;
 
 namespace Style {
@@ -63,6 +65,7 @@ public:
 
     RefPtr<const CustomProperty> resolveCustomPropertyForContainerQueries(const CSSCustomPropertyValue&);
     std::optional<CustomPropertyOrKeyword> resolveFunctionResult();
+    std::optional<CustomPropertyOrKeyword> computeCustomPropertyValueForSyntax(const AtomString&, const CSSCustomPropertySyntax&, const CSSVariableData&);
 
     BuilderState& state() { return m_state; }
     const MatchResult& matchResult() const { return m_cascade.matchResult(); }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -71,6 +71,8 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include <wtf/IndexedRange.h>
+#include <wtf/Scope.h>
+#include <wtf/SetForScope.h>
 
 namespace WebCore {
 namespace Style {
@@ -108,29 +110,11 @@ static CSSParserTokenRange unwrapArgumentBraces(CSSParserTokenRange argument)
     return range.atEnd() ? contents : argument;
 }
 
-static Ref<CSSVariableData> createFirstValidVariableData(std::span<const std::span<const CSSParserToken>> candidates, const CSSParserContext& context)
-{
-    // Uses the internal -internal-first-valid name rather than the public first-valid(). The public
-    // function must validate against any property's grammar, which is not implemented yet. See the
-    // FIXME on substituteFirstValid().
-    Vector<CSSParserToken> tokens;
-    tokens.append(CSSParserToken(FunctionToken, "-internal-first-valid"_s, CSSParserToken::BlockStart));
-    bool isFirst = true;
-    for (auto& candidate : candidates) {
-        if (!isFirst)
-            tokens.append(CSSParserToken(CommaToken));
-        isFirst = false;
-        tokens.append(candidate);
-    }
-    tokens.append(CSSParserToken(RightParenthesisToken, CSSParserToken::BlockEnd));
-    return CSSVariableData::create(CSSParserTokenRange { tokens }, context);
-}
-
 void SubstitutionResolver::propagateAttrTaint(IsAttrTainted isAttrTainted, std::span<const CSSParserToken> tokens)
 {
     if (isAttrTainted != IsAttrTainted::Yes)
         return;
-    m_isAttrTainted = true;
+    m_isAttrTainted = IsAttrTainted::Yes;
     if (isInURLContext() || containsURLTokens(tokens))
         m_hasTaintedURL = true;
 }
@@ -145,6 +129,14 @@ RefPtr<const CustomProperty> SubstitutionResolver::propertyValueForVariableName(
 {
     if (functionId == CSSValueEnv)
         return m_styleBuilder.state().document().styleScope().environmentVariables().values().get(variableName);
+
+    // Every parameter of the function whose arguments are being resolved shadows the calling element's
+    // custom property of the same name, resolved or not, so a default can reference an earlier
+    // parameter but never sees the calling element's value of a later one.
+    if (!m_parameterValues.isEmpty() && functionId == CSSValueVar) {
+        if (auto parameter = m_parameterValues.last().getOptional(variableName))
+            return *parameter;
+    }
 
     // Apply this variable first, in case it is still unresolved
     m_styleBuilder.applyCustomProperty(variableName);
@@ -189,10 +181,11 @@ auto SubstitutionResolver::substituteVarArgumentGrammar(CSSParserTokenRange rang
     // https://drafts.csswg.org/css-values-5/#attr-security
     // Isolate the flag to see whether resolving the name itself involved attr()-tainted values. Diffing
     // it would miss the taint when something earlier in the same value had already set it.
-    auto wasAttrTainted = std::exchange(m_isAttrTainted, false);
+    auto wasAttrTainted = std::exchange(m_isAttrTainted, IsAttrTainted::No);
     auto substitutedName = substituteTokenRange(nameArgRange, context);
-    auto isNameAttrTainted = m_isAttrTainted ? IsAttrTainted::Yes : IsAttrTainted::No;
-    m_isAttrTainted |= wasAttrTainted;
+    auto isNameAttrTainted = m_isAttrTainted;
+    if (wasAttrTainted == IsAttrTainted::Yes)
+        m_isAttrTainted = IsAttrTainted::Yes;
 
     if (!substitutedName)
         return { { }, fallbackRange, isNameAttrTainted };
@@ -360,9 +353,10 @@ bool SubstitutionResolver::substituteInheritFunction(CSSParserTokenRange range, 
 }
 
 // https://drafts.csswg.org/css-mixins/#evaluate-a-custom-function
-// Registers each parameter with its type, resolves argument styles, then updates registrations
-// to universal syntax with resolved values as initial values.
-// Returns resolved argument properties to prepend to the body rule, or nullptr on failure.
+// Computes each parameter from its argument, falling back to the default when there is no argument or
+// the argument does not match the parameter's type. Values are computed against the calling element.
+// Registers each parameter as universal with its computed value, and returns the properties to prepend
+// to the body rule, or nullptr on failure.
 RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>& parameters, const Vector<Vector<CSSParserToken>>& arguments, LocalPropertyRegistry& registrations, ScopeOrdinal definitionScope)
 {
     // A parameter without a default requires a corresponding argument. A missing one makes the whole
@@ -372,82 +366,95 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
             return nullptr;
     }
 
-    // "For each function parameter, create a custom property registration with the parameter's type."
-    auto argumentRegistrations = LocalPropertyRegistry { };
-    for (auto& parameter : parameters) {
-        argumentRegistrations.add({
-            .name = AtomString { parameter.name },
-            .syntax = parameter.type,
-            .inherits = true,
-        });
-    }
+    auto& context = m_substitutionValue->context();
 
-    // "Let argument rule be an initially empty style rule" with first-valid(arg value, default value) for each parameter.
-    auto argumentRule = MutableStyleProperties::create();
+    // A default may invoke another custom function, which resolves its own parameters, so these need a
+    // frame of their own rather than a single set.
+    m_parameterValues.append({ });
+    auto popParameterValues = makeScopeExit([&] {
+        m_parameterValues.removeLast();
+    });
+    // Seeded before any is resolved, so that a default referencing a parameter that is not resolved
+    // yet gets the guaranteed-invalid value instead of the calling element's property of that name.
+    for (auto& parameter : parameters)
+        m_parameterValues.last().set(parameter.name, nullptr);
+
+    SetForScope scopedLookupScope(m_dashedFunctionLookupScope, definitionScope);
+
+    auto resolvedArgumentProperties = MutableStyleProperties::create();
+
     for (auto [i, parameter] : indexedRange(parameters)) {
         bool hasArgument = i < arguments.size() && !arguments[i].isEmpty();
 
-        // first-valid(arg value, default value). A parameter with neither is omitted from the rule,
-        // resolving to the guaranteed-invalid value via its (valueless) registration.
-        auto candidates = [&] {
-            Vector<std::span<const CSSParserToken>, 2> candidates;
-            if (hasArgument)
-                candidates.append(arguments[i].span());
-            if (parameter.defaultValue)
-                candidates.append(parameter.defaultValue->tokens().span());
-            return candidates;
+        // Computes a candidate against the parameter's type, or returns null if it does not match.
+        auto computeCandidate = [&](std::span<const CSSParserToken> candidateTokens) -> RefPtr<const CustomProperty> {
+            if (candidateTokens.empty())
+                return nullptr;
+
+            auto data = CSSVariableData::create(CSSParserTokenRange { candidateTokens }, m_isAttrTainted, context);
+
+            if (parameter.type.isUniversal())
+                return CustomProperty::createForVariableData(parameter.name, WTF::move(data));
+
+            // https://drafts.csswg.org/css-values-5/#first-valid
+            if (!CSSPropertyParser::isValidCustomPropertyValueForSyntax(parameter.type, data->tokenRange(), context))
+                return nullptr;
+
+            auto computed = m_styleBuilder.computeCustomPropertyValueForSyntax(parameter.name, parameter.type, data);
+            if (!computed)
+                return nullptr;
+
+            return WTF::switchOn(*computed,
+                [](const Ref<const CustomProperty>& property) -> RefPtr<const CustomProperty> {
+                    return property.ptr();
+                },
+                // A declared type cannot be a CSS-wide keyword.
+                [](CSSWideKeyword) -> RefPtr<const CustomProperty> {
+                    return nullptr;
+                });
+        };
+
+        auto resolvedValue = [&] -> RefPtr<const CustomProperty> {
+            // A bare CSS-wide keyword keeps its keyword semantics rather than becoming a literal value.
+            // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+            // An argument that failed to substitute is empty, and may have no default to fall back to.
+            auto primaryTokens = [&] -> CSSParserTokenRange {
+                if (hasArgument)
+                    return CSSParserTokenRange { arguments[i].span() };
+                if (parameter.defaultValue)
+                    return parameter.defaultValue->tokenRange();
+                return { };
+            }();
+            primaryTokens.consumeWhitespace();
+            if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(primaryTokens); keyword && primaryTokens.atEnd()) {
+                // `initial` is the parameter's registered initial value, which does not exist yet at this
+                // point, and any keyword other than `inherit` is guaranteed-invalid.
+                if (*keyword != CSSWideKeyword::Inherit)
+                    return nullptr;
+                // `inherit` resolves like inherit() with the parameter name, reinterpreted with the
+                // parameter's type.
+                RefPtr inherited = propertyValueForVariableName(parameter.name, CSSValueInherit);
+                if (!inherited || inherited->isGuaranteedInvalid())
+                    return nullptr;
+                return computeCandidate(inherited->tokens());
+            }
+
+            // first-valid(arg value, default value): the default is used when there is no argument, or
+            // when the argument does not match the parameter's type.
+            // The argument is already substituted; a default is not.
+            if (hasArgument) {
+                if (RefPtr value = computeCandidate(arguments[i].span()))
+                    return value;
+            }
+            if (parameter.defaultValue) {
+                if (auto substituted = substituteTokenRange(parameter.defaultValue->tokenRange(), context))
+                    return computeCandidate(substituted->span());
+            }
+            return nullptr;
         }();
-        if (candidates.isEmpty())
-            continue;
 
-        // A bare CSS-wide keyword (e.g. a parameter defaulting to `inherit`) keeps its keyword semantics
-        // rather than becoming a literal value. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
-        auto primaryTokens = CSSParserTokenRange { candidates.first() };
-        primaryTokens.consumeWhitespace();
-        if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(primaryTokens); keyword && primaryTokens.atEnd()) {
-            argumentRule->addParsedProperty({ CSSPropertyCustom, CSSCustomPropertyValue::createWithCSSWideKeyword(parameter.name, *keyword) });
-            continue;
-        }
+        m_parameterValues.last().set(parameter.name, resolvedValue);
 
-        // Fast path: an untyped parameter with an argument needs no first-valid(). The argument is
-        // already substituted and, being non-empty, is always valid for the universal syntax, so it
-        // wins outright and the default is irrelevant.
-        if (hasArgument && parameter.type.isUniversal()) {
-            auto value = CSSCustomPropertyValue::createSyntaxAll(parameter.name, CSSVariableData::create(arguments[i], m_substitutionValue->context()));
-            argumentRule->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
-            continue;
-        }
-
-        auto firstValidData = createFirstValidVariableData(candidates.span(), m_substitutionValue->context());
-        auto value = CSSCustomPropertyValue::createUnresolved(parameter.name, CSSSubstitutionValue::create(WTF::move(firstValidData)));
-        argumentRule->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
-    }
-
-    // "Resolve function styles using custom function, argument rule, registrations, and calling context."
-    // The hypothetical element acts as a child of the calling element, inheriting its computed custom
-    // properties on demand, so defaults like `var(--caller-prop)` or `inherit` resolve against it.
-    auto argumentMatchResult = MatchResult::create();
-    argumentMatchResult->authorDeclarations.append({ .properties = WTF::move(argumentRule), .styleScopeOrdinal = definitionScope });
-
-    auto builderContext = BuilderContext {
-        .document = m_styleBuilder.state().document(),
-        .parentStyle = &m_styleBuilder.state().style(),
-        .element = m_styleBuilder.state().element(),
-        .localPropertyRegistry = &argumentRegistrations,
-        .callingContextBuilder = &m_styleBuilder
-    };
-
-    auto argumentStyles = Style::ComputedStyle::createPtr();
-    Builder argumentBuilder(*argumentStyles, WTF::move(builderContext), argumentMatchResult);
-    argumentBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
-    for (auto& parameter : parameters)
-        argumentBuilder.applyCustomProperty(parameter.name);
-
-    // "Set its initial value to the corresponding value in argument styles, set its syntax to the universal syntax definition,
-    // and prepend a custom property to body rule with the property name and value in argument styles."
-    auto resolvedArgumentProperties = MutableStyleProperties::create();
-    for (auto& parameter : parameters) {
-        RefPtr resolvedValue = argumentStyles->customPropertyValue(parameter.name);
         registrations.add({
             .name = AtomString { parameter.name },
             .syntax = CSSCustomPropertySyntax::universal(),
@@ -456,7 +463,7 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
         });
 
         if (resolvedValue && !resolvedValue->isGuaranteedInvalid()) {
-            auto tokenData = CSSVariableData::create(CSSParserTokenRange { resolvedValue->tokens() }, resolvedValue->isAttrTainted(), m_substitutionValue->context());
+            auto tokenData = CSSVariableData::create(CSSParserTokenRange { resolvedValue->tokens() }, resolvedValue->isAttrTainted(), context);
             auto value = CSSCustomPropertyValue::createSyntaxAll(parameter.name, WTF::move(tokenData));
             resolvedArgumentProperties->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
         }
@@ -472,7 +479,10 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     if (!m_styleBuilder.state().element())
         return false;
 
-    auto scopedFunctionName = ScopedName { functionName.toAtomString(), m_styleBuilder.state().styleScopeOrdinal() };
+    // A <dashed-function> in a parameter default resolves in the scope the enclosing function was
+    // defined in, not the calling element's scope.
+    auto scopeOrdinal = m_dashedFunctionLookupScope.value_or(m_styleBuilder.state().styleScopeOrdinal());
+    auto scopedFunctionName = ScopedName { functionName.toAtomString(), scopeOrdinal };
 
     CheckedPtr element = m_styleBuilder.state().element();
     auto resolved = resolveTreeScopedReference(*element, scopedFunctionName, [](const Scope& scope, const ScopedName& scopedName) -> std::optional<std::pair<CheckedRef<const CustomFunction>, ScopeOrdinal>> {
@@ -603,6 +613,9 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     };
 
     auto bodyStyles = Style::ComputedStyle::createPtr();
+    // Font-relative units in the body resolve against the hypothetical element's own font, so it has to
+    // inherit one. Custom properties are resolved lazily through the calling context's builder instead.
+    bodyStyles->inheritIgnoringCustomPropertiesFrom(protect(m_styleBuilder.state().style()));
     Builder bodyBuilder(*bodyStyles, WTF::move(builderContext), bodyMatchResult);
     bodyBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
 
@@ -1314,7 +1327,7 @@ bool SubstitutionResolver::isBaseAppearance()
 
 RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionValue& value)
 {
-    m_isAttrTainted = false;
+    m_isAttrTainted = IsAttrTainted::No;
     m_hasTaintedURL = false;
     m_randomItemAutoIndex = 0;
     m_substitutionValue = &value;
@@ -1332,7 +1345,7 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionVa
         return nullptr;
     }
 
-    auto data = CSSVariableData::create(*substitutedTokens, m_isAttrTainted ? IsAttrTainted::Yes : IsAttrTainted::No, context);
+    auto data = CSSVariableData::create(*substitutedTokens, m_isAttrTainted, context);
     m_intermediateTokenStrings.clear();
     m_intermediateCustomProperties.clear();
     return data;

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -116,11 +116,20 @@ private:
     Builder& m_styleBuilder;
     const CSSRegisteredCustomProperty* m_registration { nullptr };
     RefPtr<const CSSSubstitutionValue> m_substitutionValue;
+    // The scope to look up a <dashed-function> name in, while resolving the parameter defaults of a
+    // custom function: names there refer to the scope the function was defined in, not the calling
+    // element's.
+    std::optional<ScopeOrdinal> m_dashedFunctionLookupScope;
+    // Parameters of the custom functions whose arguments are currently being resolved, innermost last.
+    // A parameter appears once resolved, so a default can reference an earlier one. A null value is the
+    // guaranteed-invalid value. Present names shadow the calling element's custom properties.
+    using ParameterValues = HashMap<AtomString, RefPtr<const CustomProperty>>;
+    Vector<ParameterValues> m_parameterValues;
     Vector<WTF::String> m_intermediateTokenStrings;
     Vector<RefPtr<const CustomProperty>> m_intermediateCustomProperties;
     unsigned m_urlContextDepth { 0 };
     unsigned m_randomItemAutoIndex { 0 };
-    bool m_isAttrTainted { false };
+    IsAttrTainted m_isAttrTainted { IsAttrTainted::No };
     bool m_hasTaintedURL { false };
 };
 


### PR DESCRIPTION
#### 3b492a1ce76278e13f709737c5606545de35d189
<pre>
[css-mixins-1] Registered function arguments should evaluate in calling context
<a href="https://bugs.webkit.org/show_bug.cgi?id=322710">https://bugs.webkit.org/show_bug.cgi?id=322710</a>
<a href="https://rdar.apple.com/185975255">rdar://185975255</a>

Reviewed by Sam Weinig.

Implement <a href="https://github.com/w3c/csswg-drafts/issues/14338">https://github.com/w3c/csswg-drafts/issues/14338</a>

This mostly affects cycle detection:

@function --double(--len &lt;length&gt;) returns &lt;length&gt; { result: calc(var(--len) * 2); }
font-size: --double(1em);

used to be cycle because `em` unit was resolved in function context where we can&apos;t reference the
property we are computing. In calling context it evaluates against parent font-size which is fine.

A major benefit is that this allows significant code simplifications. We no longer need to instantiate a separate
Style::Builder to resolve arguments.

Arguments are now computed directly against the calling element, so first-valid() over the argument and
the default becomes a plain loop instead of a synthesized -internal-first-valid() token stream that had
to be substituted a second time.

The hypothetical element the body is applied to now inherits a font, since font-relative units resolve
against the element being styled rather than the parent style.

A default can reference an earlier parameter, so parameters are tracked while they resolve. They are all
seeded first, so referencing a later one gives the guaranteed-invalid value rather than the calling
element&apos;s property of that name. A &lt;dashed-function&gt; in a default is looked up in the scope the function
was defined in.

Tests: imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope.html
       imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping.html
       imported/w3c/web-platform-tests/css/css-mixins/function-relative-units.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-definition-scope.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-scoping.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-relative-units.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative.html:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyValue):
(WebCore::Style::Builder::computeCustomPropertyValueForSyntax):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::propertyValueForVariableName):
(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):
(WebCore::Style::createFirstValidVariableData): Deleted.
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/320022@main">https://commits.webkit.org/320022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd75f159da8d945a068b5e3b7c842c22000a8f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147677 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12de87c7-5d2c-41f2-8250-c20c2d37f393) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143144 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99400 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55c30a72-b8a4-40a8-91bf-e7d550272254) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123563 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7a7de5a-f988-481c-9b39-11caca16b01a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43832 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43446 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4781 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195546 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40925 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57684 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152336 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46888 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129963 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56192 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55563 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->