### PR TITLE
:target should keep matching a target element that is removed and reinserted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/WEB_FEATURES.yml
@@ -1,4 +1,3 @@
-features:
-- name: target
-  files:
-  - target-pseudo-after-reinsertion.html
+rules:
+- target-pseudo-after-adoption.html: [target]
+- target-pseudo-after-reinsertion.html: [target]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption-expected.txt
@@ -1,0 +1,4 @@
+target
+
+PASS :target should follow the target element back after a round trip through another document.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:annevk@annevk.nl">
+<link rel=help href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#target-element">
+<link rel=help href="https://github.com/whatwg/html/issues/10029">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id=target>target</div>
+
+<script>
+test(() => {
+  const target = document.getElementById('target');
+  window.location.href = '#target';
+  assert_equals(document.querySelector(':target'), target,
+    ':target should match before adoption.');
+
+  const other = document.implementation.createHTMLDocument();
+  other.body.appendChild(other.adoptNode(target));
+  assert_equals(target.ownerDocument, other,
+    'target should have been adopted into the other document.');
+  assert_false(target.matches(':target'),
+    ':target should not match in a document whose target element is null.');
+  assert_equals(other.querySelector(':target'), null,
+    'the other document should have no target element.');
+
+  document.body.appendChild(document.adoptNode(target));
+  assert_equals(target.ownerDocument, document,
+    'target should have been adopted back.');
+  assert_equals(document.querySelector(':target'), target,
+    ':target should match again after being adopted back.');
+}, ':target should follow the target element back after a round trip through another document.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-reinsertion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-reinsertion-expected.txt
@@ -1,4 +1,4 @@
 target
 
-FAIL :target should match the target element even after it is removed and reinserted. assert_equals: :target should match after reinsertion. expected Element node <div id="target">target</div> but got null
+PASS :target should match the target element even after it is removed and reinserted.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/w3c-import.log
@@ -38,4 +38,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-anchor-name.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-id-top.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-top.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-reinsertion.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Autofocus should be skipped when the target element has been removed from the document.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<script>
+'use strict';
+
+promise_test(async () => {
+  const w = window.open('resources/frame-with-anchor.html#anchor1');
+  await waitForLoad(w);
+  const doc = w.document;
+  const anchor = doc.querySelector('#anchor1');
+  assert_equals(doc.querySelector(':target'), anchor);
+
+  // Removing the target element does not set the target element to null.
+  anchor.remove();
+  assert_equals(doc.querySelector(':target'), null);
+
+  const input = doc.createElement('input');
+  input.autofocus = true;
+  doc.body.appendChild(input);
+  await waitUntilStableAutofocusState(w);
+  assert_not_equals(doc.activeElement, input);
+  w.close();
+}, 'Autofocus should be skipped when the target element has been removed from the document.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/w3c-import.log
@@ -21,6 +21,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-on-stable-document.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-empty.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-nonexistent.html
+/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-top.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/first-reconnected.html

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3293,9 +3293,6 @@ void Element::removingSteps(RemovalType removalType, ContainerNode& oldParentOfR
         if (isInTopLayer()) [[unlikely]]
             removeFromTopLayer();
 
-        if (oldDocument->cssTarget() == this)
-            oldDocument->setCSSTarget(nullptr);
-
         if (isDefinedCustomElement()) [[unlikely]]
             CustomElementReactionQueue::enqueueDisconnectedCallbackIfNeeded(*this);
     }


### PR DESCRIPTION
#### cec9d207c1b775717dcdd9b63460b99d7907e661
<pre>
:target should keep matching a target element that is removed and reinserted
<a href="https://bugs.webkit.org/show_bug.cgi?id=322720">https://bugs.webkit.org/show_bug.cgi?id=322720</a>

Reviewed by Tim Nguyen.

A Document&apos;s target element is only set by the scroll to the fragment
algorithm; nothing sets it to null when the element is removed from the
document. WebKit cleared it on removal since 2008 (23144@main) to avoid a
dangling raw pointer, which is no longer a concern now that m_cssTarget
is a WeakPtr. Gecko already behaved this way and Chromium made the same
change in 2024, so this aligns all engines with the HTML Standard.

Tests: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/scroll-to-fragid/target-pseudo-after-adoption.html
       imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-removed-target.html

WPT PR: <a href="https://github.com/web-platform-tests/wpt/pull/62238">https://github.com/web-platform-tests/wpt/pull/62238</a>

Canonical link: <a href="https://commits.webkit.org/320021@main">https://commits.webkit.org/320021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4e95cb1e78b12f08a688acf2a1f03c1e0d26c0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147641 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8012ab0-443f-4c5c-a498-4d0949a58cb2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143120 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99382 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7823976e-3862-4550-8081-7dcf3b79e920) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123539 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0071ae34-08c8-459c-b0f9-c5dd7dd22096) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43801 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43414 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4745 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195510 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57648 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152303 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46859 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129927 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18424 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55766 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->