### PR TITLE
ESPN.com on iPhone: After exiting full screen, video pauses and tapping the resume button doesn’t do anything on espn.com

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4769,12 +4769,14 @@ void HTMLMediaElement::pause()
     if (processingUserGestureForMedia())
         removeBehaviorRestrictionsAfterFirstUserGesture(MediaElementSession::RequireUserGestureToControlControlsManager);
 
-    pauseInternal();
+    bool suppressPauseEvent = m_videoFullscreenMode == VideoFullscreenModeStandard && protect(document())->quirks().needsSuppressedPauseEventOnFullscreenExitQuirk();
+
+    pauseInternal(!suppressPauseEvent);
     // If we have a pending seek, ensure playback doesn't resume.
     m_wasPlayingBeforeSeeking = false;
 }
 
-void HTMLMediaElement::pauseInternal()
+void HTMLMediaElement::pauseInternal(bool dispatchPauseEvent)
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(PauseInternal);
 
@@ -4819,7 +4821,8 @@ void HTMLMediaElement::pauseInternal()
     if (!m_paused && !m_pausedInternal) {
         setPaused(true);
         scheduleTimeupdateEvent(false);
-        scheduleEvent(eventNames().pauseEvent);
+        if (dispatchPauseEvent)
+            scheduleEvent(eventNames().pauseEvent);
         if (!hadInFlightPlayRequest || !m_playPromiseSettlementGuaranteed)
             scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::AbortError));
         if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
@@ -7997,9 +8000,11 @@ void HTMLMediaElement::exitFullscreen()
     if (!videoElement)
         return;
 
+    bool suppressPauseEvent = protect(document())->quirks().needsSuppressedPauseEventOnFullscreenExitQuirk();
+
     if (!paused() && protect(mediaSession())->requiresFullscreenForVideoPlayback()) {
         if (!document().settings().allowsInlineMediaPlaybackAfterFullscreen() || isVideoTooSmallForInlinePlayback())
-            pauseInternal();
+            pauseInternal(!suppressPauseEvent);
         else {
             // Allow inline playback, but set a flag so pausing and starting again (e.g. when scrubbing or looping) won't go back to fullscreen.
             // Also set the controls attribute so the user will be able to control playback.
@@ -8020,9 +8025,6 @@ void HTMLMediaElement::exitFullscreen()
         }
 
         setChangingVideoFullscreenMode(true);
-
-        if (!paused() && protect(document())->quirks().needsPauseBeforeFullscreenExitQuirk())
-            pauseInternal();
 
         if (isInWindowOrStandardFullscreen(oldVideoFullscreenMode)) {
             setFullscreenMode(VideoFullscreenModeNone);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1024,7 +1024,7 @@ private:
 
     // These "internal" functions do not check user gesture restrictions.
     void playInternal();
-    void pauseInternal();
+    void pauseInternal(bool dispatchPauseEvent = true);
     void completePlayInternal();
 
     enum class IsExplicitLoad : bool { No, Yes };

--- a/Source/WebCore/page/QuirkNames.h
+++ b/Source/WebCore/page/QuirkNames.h
@@ -125,7 +125,7 @@ enum class SiteSpecificQuirk {
     NeedsNavigatorUserAgentDataQuirk,
     NeedsNowPlayingFullscreenSwapQuirk,
 #if PLATFORM(IOS_FAMILY)
-    NeedsPauseBeforeFullscreenExitQuirk,
+    NeedsSuppressedPauseEventOnFullscreenExitQuirk,
     NeedsPreloadAutoQuirk,
 #endif
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -257,8 +257,8 @@ static constexpr Quirk table[] = {
     { .match = QuirkMatch::domain("espn.com"_s),
         .behaviors = {
 #if PLATFORM(IOS)
-            // espn.com rdar://154903596
-            NeedsPauseBeforeFullscreenExitQuirk,
+            // espn.com rdar://184169028
+            NeedsSuppressedPauseEventOnFullscreenExitQuirk,
 #endif
 #if PLATFORM(IOS) || PLATFORM(VISION)
             // espn.com rdar://problem/95651814

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1069,13 +1069,13 @@ bool Quirks::needsPreloadAutoQuirk() const
 #endif
 }
 
-// espn.com rdar://154903596
-bool Quirks::needsPauseBeforeFullscreenExitQuirk() const
+// espn.com rdar://184169028
+bool Quirks::needsSuppressedPauseEventOnFullscreenExitQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(SiteSpecificQuirk::NeedsPauseBeforeFullscreenExitQuirk);
+    return m_quirksData.quirkIsEnabled(SiteSpecificQuirk::NeedsSuppressedPauseEventOnFullscreenExitQuirk);
 #else
     return false;
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -167,7 +167,7 @@ public:
 
     bool NODELETE needsPreloadAutoQuirk() const;
 
-    bool NODELETE needsPauseBeforeFullscreenExitQuirk() const;
+    bool NODELETE needsSuppressedPauseEventOnFullscreenExitQuirk() const;
 
     bool shouldBypassBackForwardCache() const;
     bool shouldBypassAsyncScriptDeferring() const;


### PR DESCRIPTION
#### e8032440e4aed34eeb637b153757c03f9ecdeac1
<pre>
ESPN.com on iPhone: After exiting full screen, video pauses and tapping the resume button doesn’t do anything on espn.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=322670">https://bugs.webkit.org/show_bug.cgi?id=322670</a>
<a href="https://rdar.apple.com/184169028">rdar://184169028</a>

Reviewed by Jer Noble.

When exiting video fullscreen on espn.com on iPhone, the video gets stuck in a paused
state. The quirk NeedsPauseBeforeFullscreenExit was added to fix this however it no
longer works with the current configuration of the website.

This patch removes the old quirk and adds a new one NeedsSuppressedPauseEventOnFullscreenExit.
The quirk prevents the pause event from being dispatched while fullscreen is being exited. This
allows the site&apos;s internal state machine to remain in allignment with the real state of the video.

No new tests.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pause):
(WebCore::HTMLMediaElement::pauseInternal):
(WebCore::HTMLMediaElement::exitFullscreen):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/320051@main">https://commits.webkit.org/320051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e9880accfa581ce2225463b94091bd86956b7e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147646 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9428bd17-7b90-4405-a0dd-7adc1cf94157) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143124 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99386 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d92913d-ffc3-4ed0-b7cd-f9f2b7fe38ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163895 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123543 "Found 4 new API test failures: TestWebKit.WebKit.DOMWindowExtensionCrashOnReload, TestWebKit.WebKit.PageLoadDidChangeLocationWithinPage, TestWebKit.WebKit.PageLoadTwiceAndReload, TestWebKit.WebKit.MouseMoveAfterCrash (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efbfee48-268b-4296-a014-3adb5159c3c6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182682 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43805 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5517 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12363 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43419 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4750 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44631 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195515 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182759 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163382 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57653 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152308 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46862 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129932 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126231 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56161 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18429 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->