### PR TITLE
Annotate toWebCoreNode / toWKDOMNode as pointer conversion

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
@@ -88,17 +88,17 @@ DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& NODELETE WKDOMRange
 
 // -- Node and classes derived from Node. --
 
-WebCore::Node* toWebCoreNode(WKDOMNode *);
-WKDOMNode *toWKDOMNode(WebCore::Node*);
+WebCore::Node* CLANG_POINTER_CONVERSION toWebCoreNode(WKDOMNode *);
+WKDOMNode *CLANG_POINTER_CONVERSION toWKDOMNode(WebCore::Node*);
 
-WebCore::Element* toWebCoreElement(WKDOMElement *);
-WKDOMElement *toWKDOMElement(WebCore::Element*);
+WebCore::Element* CLANG_POINTER_CONVERSION toWebCoreElement(WKDOMElement *);
+WKDOMElement *CLANG_POINTER_CONVERSION toWKDOMElement(WebCore::Element*);
 
-WebCore::Document* toWebCoreDocument(WKDOMDocument *);
-WKDOMDocument *toWKDOMDocument(WebCore::Document*);
+WebCore::Document* CLANG_POINTER_CONVERSION toWebCoreDocument(WKDOMDocument *);
+WKDOMDocument *CLANG_POINTER_CONVERSION toWKDOMDocument(WebCore::Document*);
 
-WebCore::Text* toWebCoreText(WKDOMText *);
-WKDOMText *toWKDOMText(WebCore::Text*);
+WebCore::Text* CLANG_POINTER_CONVERSION toWebCoreText(WKDOMText *);
+WKDOMText *CLANG_POINTER_CONVERSION toWKDOMText(WebCore::Text*);
 
 // -- Range. --
 


### PR DESCRIPTION
#### c64092e902106904e3ce2e345a9d71c3a25a5a68
<pre>
Annotate toWebCoreNode / toWKDOMNode as pointer conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=322722">https://bugs.webkit.org/show_bug.cgi?id=322722</a>

Reviewed by Geoffrey Garen.

Annotate these functions and their variants with CLANG_POINTER_CONVERSION.

No new tests since there should be no behavior changes.

* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h:

Canonical link: <a href="https://commits.webkit.org/319987@main">https://commits.webkit.org/319987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c62d4024028c6b6e68b7ac8977538893ace1b5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e78dd84-5273-421c-a796-ed4dd8bbe2a9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143127 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c87d34c-fd96-4111-94c3-9814316721e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6747889-8b08-4649-8fcf-3e87f3203bbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45574 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43421 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195517 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56951 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152622 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57655 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152309 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46866 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129934 "Failed to checkout and rebase branch from PR 72605") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56163 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18431 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->