### PR TITLE
AX: In isolated tree mode, AXStringForTextMarkerRange unexpectedly includes a whitespace at a soft line break

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/empty-final-line-range-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/empty-final-line-range-expected.txt
@@ -1,0 +1,10 @@
+This test ensures the line at a text control's last text position is its empty final line.
+
+PASS: textarea.stringForTextMarkerRange(lineRange) === ''
+PASS: textarea.textMarkerRangeLength(lineRange) === 0
+PASS: lineStart.isEqual(lastMarker) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/empty-final-line-range.html
+++ b/LayoutTests/accessibility/isolated-tree/empty-final-line-range.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+A text control whose value ends in a line break renders an empty final line, which is given a line
+box by a placeholder <br> whose newline is no character of the value. Text runs model rendered text,
+so they do include that newline, which puts the control's last text position past it — one offset
+beyond the position the caret reports on that line (covered by
+accessibility/mac/textarea-line-range-with-trailing-newline.html). The line there is the same empty
+final line, so it must not stretch back over the newline.
+-->
+
+<textarea id="textarea" rows="3" cols="10">one
+</textarea>
+
+<script>
+var output = "This test ensures the line at a text control's last text position is its empty final line.\n\n";
+
+if (window.accessibilityController) {
+    var textarea = accessibilityController.accessibleElementById("textarea");
+    var lastMarker = textarea.endTextMarker;
+    var lineRange = textarea.lineTextMarkerRangeForTextMarker(lastMarker);
+    var lineStart = textarea.startTextMarkerForTextMarkerRange(lineRange);
+
+    output += expect("textarea.stringForTextMarkerRange(lineRange)", "''");
+    output += expect("textarea.textMarkerRangeLength(lineRange)", "0");
+    // Holding no text, the line starts where it ends: at the position asked about.
+    output += expect("lineStart.isEqual(lastMarker)", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space-expected.txt
+++ b/LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space-expected.txt
@@ -1,0 +1,14 @@
+This test ensures a line ended by soft wrapping excludes the space at the wrap point.
+
+PASS: lineText(1) === 'aaa'
+PASS: lineText(2) === 'bbb'
+PASS: webArea.textMarkerRangeLength(lineRange(1)) === 3
+PASS: lineText(3) === 'ccc'
+PASS: lineText(4) === 'ddd'
+PASS: lineText(5) === 'eee'
+PASS: lineText(6) === 'fff'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space.html
+++ b/LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+p { width: 4ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="collapsedSpace">aaa bbb</p>
+<p id="collapsedSpaces">ccc   ddd</p>
+<p id="preservedSpace" style="white-space: pre-wrap;">eee fff</p>
+
+<script>
+var output = "This test ensures a line ended by soft wrapping excludes the space at the wrap point.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    function lineRange(oneBasedLine)
+    {
+        return webArea.textMarkerRangeForLine(oneBasedLine);
+    }
+
+    function lineText(oneBasedLine)
+    {
+        return webArea.stringForTextMarkerRange(lineRange(oneBasedLine));
+    }
+
+    output += expect("lineText(1)", "'aaa'");
+    output += expect("lineText(2)", "'bbb'");
+    // The range ends before the space, so its length matches the text it yields.
+    output += expect("webArea.textMarkerRangeLength(lineRange(1))", "3");
+
+    // Collapsed spaces render as one, and the line ends before that one too.
+    output += expect("lineText(3)", "'ccc'");
+    output += expect("lineText(4)", "'ddd'");
+
+    // This space is preserved rather than collapsed, but still renders on neither line.
+    output += expect("lineText(5)", "'eee'");
+    output += expect("lineText(6)", "'fff'");
+
+    for (var paragraph of document.querySelectorAll("p"))
+        paragraph.style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -829,21 +829,53 @@ static bool hasEmptyFinalLine(AXIsolatedObject& object, const AXTextRuns& textRu
     return previousRuns->toStringView().endsWith('\n');
 }
 
-// |lineRange| ending where the text control's value ends, rather than where its rendered text does.
-// A line that ends with the collapsed trailing newline is one character longer than the line of the
-// value it stands for, and for the empty final line that newline is the whole range. Marker walks are
-// left the unclamped range, so that empty final line remains enumerable as a line of its own.
-static AXTextMarkerRange lineRangeWithoutCollapsedTrailingNewline(const AXTextMarkerRange& lineRange)
+enum class LineRangeTrim : uint8_t {
+    // A text control's value ends before the newline its rendered text ends with.
+    // This option allows explicit trimming of this collapsed newline.
+    CollapsedTrailingNewline = 1 << 0,
+    // The text runs keep the space a line soft-wrapped at, appended to the wrapping line's run, so a
+    // range spanning the wrap reads "foo bar" rather than "foobar". This space renders on no line, so
+    // no line ends with it. This option denotes it should be trimmed.
+    SoftWrapSpace = 1 << 1,
+};
+
+static AXTextMarkerRange lineRangeWithout(const AXTextMarkerRange& lineRange, OptionSet<LineRangeTrim> trims)
 {
     auto endMarker = lineRange.end().toTextRunMarker();
     RefPtr endObject = endMarker.isolatedObject();
-    if (!endObject)
+    const auto* runs = endObject ? endObject->textRuns() : nullptr;
+    if (!runs)
         return lineRange;
 
-    auto indexOfCollapsedNewline = offsetOfCollapsedTrailingNewline(*endObject, endObject->textRuns());
-    if (!indexOfCollapsedNewline || endMarker.offset() <= *indexOfCollapsedNewline)
+    unsigned endOffset = endMarker.offset();
+    if (trims.contains(LineRangeTrim::CollapsedTrailingNewline)) {
+        std::optional offsetOfNewline = offsetOfCollapsedTrailingNewline(*endObject, runs);
+        if (offsetOfNewline && endOffset > *offsetOfNewline)
+            endOffset = *offsetOfNewline;
+    }
+
+    if (trims.contains(LineRangeTrim::SoftWrapSpace)) {
+        // Only a line that ended where this object wrapped has a wrap space, as its end
+        // sits at the end of a run that another follows.
+        //
+        // For example, in this text where _ is a wrap-space and | is the text position:
+        // aaa_|
+        // bbb
+        // We want to trim the space after "aaa" if this option is set.
+        size_t runIndex = runs->indexForOffset(endOffset, Affinity::Upstream);
+        bool endsWhereObjectWrapped = runIndex != notFound && runIndex != runs->lastRunIndex() && runs->runLengthSumTo(runIndex) == endOffset;
+        if (endsWhereObjectWrapped && endOffset && runs->toStringView()[endOffset - 1] == space)
+            --endOffset;
+    }
+
+    if (endOffset == endMarker.offset())
         return lineRange;
-    return { lineRange.start(), AXTextMarker { *endObject, *indexOfCollapsedNewline } };
+
+    if (lineRange.start().objectID() == endMarker.objectID() && lineRange.start().offset() > endOffset) {
+        // Trimming the range would move the end before the start, so early-exit.
+        return lineRange;
+    }
+    return { lineRange.start(), AXTextMarker { *endObject, endOffset } };
 }
 
 // Advances |lineRange| to the following line: the range from the start of the next line through
@@ -898,7 +930,7 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     // the preceding line's range), which is why only block-separated lines were affected.
     unsigned precedingLength = AXTextMarkerRange { textRunMarker, currentLineRange.start() }.length();
 
-    return CharacterRange(precedingLength, lineRangeWithoutCollapsedTrailingNewline(currentLineRange).length());
+    return CharacterRange(precedingLength, lineRangeWithout(currentLineRange, LineRangeTrim::CollapsedTrailingNewline).length());
 }
 
 AXTextMarkerRange AXTextMarker::markerRangeForLineIndex(unsigned lineIndex) const
@@ -916,7 +948,7 @@ AXTextMarkerRange AXTextMarker::markerRangeForLineIndex(unsigned lineIndex) cons
         currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::No, std::nullopt);
         --lineIndex;
     }
-    return lineRangeWithoutCollapsedTrailingNewline(currentLineRange);
+    return lineRangeWithout(currentLineRange, { LineRangeTrim::CollapsedTrailingNewline, LineRangeTrim::SoftWrapSpace });
 }
 
 int AXTextMarker::lineNumberForIndex(unsigned index) const
@@ -938,7 +970,7 @@ int AXTextMarker::lineNumberForIndex(unsigned index) const
     unsigned lineNumber = 0;
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (currentLineRange) {
-        unsigned lineLength = lineRangeWithoutCollapsedTrailingNewline(currentLineRange).length();
+        unsigned lineLength = lineRangeWithout(currentLineRange, LineRangeTrim::CollapsedTrailingNewline).length();
         auto nextRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
         // A line occupies the index space up to the start of the next line, which is not the same as
         // the length of its own range: the newline synthesized at a block boundary belongs to no
@@ -1788,7 +1820,7 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
     if (type == LineRangeType::Current) {
         auto startMarker = atLineStart() ? *this : previousLineStart();
         auto endMarker = atLineEnd() ? *this : nextLineEnd(includeTrailingLineBreak);
-        return lineRangeWithoutCollapsedTrailingNewline({ startMarker, endMarker });
+        return lineRangeWithout({ startMarker, endMarker }, LineRangeTrim::CollapsedTrailingNewline);
     }
 
     if (type == LineRangeType::Left) {
@@ -1798,7 +1830,7 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
             startMarker = startMarker.previousLineStart();
 
         auto endMarker = startMarker.nextLineEnd(includeTrailingLineBreak);
-        return lineRangeWithoutCollapsedTrailingNewline({ WTF::move(startMarker), WTF::move(endMarker) });
+        return lineRangeWithout({ WTF::move(startMarker), WTF::move(endMarker) }, LineRangeTrim::CollapsedTrailingNewline);
     }
 
     AX_ASSERT(type == LineRangeType::Right);
@@ -1809,7 +1841,7 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
         startMarker = startMarker.previousLineStart();
 
     auto endMarker = startMarker.nextLineEnd(includeTrailingLineBreak);
-    return lineRangeWithoutCollapsedTrailingNewline({ WTF::move(startMarker), WTF::move(endMarker) });
+    return lineRangeWithout({ WTF::move(startMarker), WTF::move(endMarker) }, LineRangeTrim::CollapsedTrailingNewline);
 }
 
 AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const


### PR DESCRIPTION
#### befc99869859fc54f2f0931042518f037996252a
<pre>
AX: In isolated tree mode, AXStringForTextMarkerRange unexpectedly includes a whitespace at a soft line break
<a href="https://bugs.webkit.org/show_bug.cgi?id=322442">https://bugs.webkit.org/show_bug.cgi?id=322442</a>
<a href="https://rdar.apple.com/185725689">rdar://185725689</a>

Reviewed by Dominic Mazzoni.

Layout drops the space a line soft-wraps at, but AccessibilityRenderObject::textRuns
re-adds it to the end of the wrapping line&apos;s run, so that a range spanning the wrap
still reads &quot;foo bar&quot; rather than &quot;foobar&quot;. A line&apos;s range therefore ended one
character past the line&apos;s rendered text, and AXStringForTextMarkerRange over the range
AXTextMarkerRangeForLine returned included a space that renders on no line, e.g. for
&lt;p style=&quot;width: 4ch&quot;&gt;aaa bbb&lt;/p&gt;, &quot;aaa &quot; rather than &quot;aaa&quot;.

The live tree ends that range before the space. endOfLine() produces an upstream
position, and AXTextMarker::operator CharacterOffset() maps an upstream marker through
previousCharacterOffset().

With this commit, we do the same in the isolated tree by moving the returned
range&apos;s end marker back over the wrap space, which also brings its length and end
index in line with the live tree&apos;s (3, not 4).

* LayoutTests/accessibility/isolated-tree/empty-final-line-range-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/empty-final-line-range.html: Added.
* LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space-expected.txt: Added.
* LayoutTests/accessibility/mac/line-range-at-soft-break-excludes-space.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::lineRangeWithout):
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::markerRangeForLineIndex const):
(WebCore::AXTextMarker::lineNumberForIndex const):
(WebCore::AXTextMarker::lineRange const):
(WebCore::lineRangeWithoutCollapsedTrailingNewline): Deleted.

Canonical link: <a href="https://commits.webkit.org/320019@main">https://commits.webkit.org/320019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cfafb503087a2060d396ca850b668d1909455a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147649 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe7c06de-cd03-448b-89c8-79b349e24370) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143126 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99388 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb1bafc1-0c64-4398-872e-849d16559c73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3663b63-2afa-4dcc-badc-3c3a85f3fd9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45576 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43807 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43422 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4753 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195518 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40923 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152310 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46865 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129935 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56164 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18432 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->