### PR TITLE
WAKAppKitStubs.h declares duplicate CGRect and CGSize type aliases when building against the public SDK

### DIFF
--- a/Source/WebCore/platform/ios/wak/WAKAppKitStubs.h
+++ b/Source/WebCore/platform/ios/wak/WAKAppKitStubs.h
@@ -92,9 +92,18 @@
 
 #else
 
+// IntRect.h and IntSize.h define NSRect and NSSize as macros on iOS, so an unguarded
+// typedef here expands to a second declaration of CGRect or CGSize that Swift cannot
+// disambiguate from same types in CoreFoundation. The CGPoint guard is defensive.
+#ifndef NSPoint
 typedef CGPoint NSPoint;
+#endif
+#ifndef NSRect
 typedef CGRect NSRect;
+#endif
+#ifndef NSSize
 typedef CGSize NSSize;
+#endif
 
 #ifndef NSZeroPoint
 #define NSZeroPoint CGPointZero


### PR DESCRIPTION
#### 874029ca893872b29e0634e3d7ebd54b1b76579c
<pre>
WAKAppKitStubs.h declares duplicate CGRect and CGSize type aliases when building against the public SDK
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=322725">https://bugs.webkit.org/show_bug.cgi?id=322725</a>&gt;
&lt;<a href="https://rdar.apple.com/185997724">rdar://185997724</a>&gt;

Reviewed by Elliott Williams.

Guard the public-SDK geometry fallbacks so they cannot redeclare
`CGRect` and `CGSize`.  `IntRect.h` and `IntSize.h` define `NSRect` and
`NSSize` as object-like macros for `CGRect` and `CGSize` on iOS, so in
a translation unit that included either header first the fallback
typedefs expand into a second declaration of `CGRect` and of `CGSize`,
and Swift cannot resolve a cross-reference when two candidates carry
the same name.  `WAKAppKitStubs.h` includes neither header, and is
also consumed where those macros are absent, so it cannot assume
either state.

Every other definition in the same block is already `#ifndef`-guarded,
so guarding these three restores the block&apos;s own invariant while
leaving the standalone case intact: a translation unit with no macro
in scope still gets real `NSPoint`, `NSRect` and `NSSize` typedefs.
No `#define NSPoint CGPoint` currently exists, so that guard is
defensive.

No new tests since this change is not directly testable.

* Source/WebCore/platform/ios/wak/WAKAppKitStubs.h:

Canonical link: <a href="https://commits.webkit.org/319976@main">https://commits.webkit.org/319976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed0d3eabdd9eaeee54b08401e11c1782f2cf79a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51103 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57021 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9af9fd4c-b57b-4277-9edf-b9dd1be008d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46874 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43424 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195522 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56956 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57660 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152313 "Found 1 new API test failure: TestWTF.WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46869 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56168 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18434 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->