### PR TITLE
Make InspectorOverlay frame-relative so it can draw in a subframe process

### DIFF
--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -74,6 +74,7 @@ FrameInspectorController::FrameInspectorController(LocalFrame& frame, PageInspec
     , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &parentPageController.backendDispatcher()))
+    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this))
     , m_executionStopwatch(Stopwatch::create())
 {
     if (frame.settings().siteIsolationEnabled())
@@ -93,6 +94,33 @@ void FrameInspectorController::ref() const
 void FrameInspectorController::deref() const
 {
     m_frame->deref();
+}
+
+Page* FrameInspectorController::overlayOwnerPage() const
+{
+    return m_frame->page();
+}
+
+LocalFrame* FrameInspectorController::overlayOwnerFrame() const
+{
+    return m_frame.ptr();
+}
+
+InspectorBackendClient* FrameInspectorController::overlayOwnerBackendClient() const
+{
+    // Not cached: inspectedPageDestroyed() destroys the client before frames detach.
+    RefPtr page = m_frame->page();
+    return page ? page->inspectorController().inspectorBackendClient() : nullptr;
+}
+
+void FrameInspectorController::drawHighlight(GraphicsContext& context) const
+{
+    m_overlay->paint(context);
+}
+
+bool FrameInspectorController::hasOverlayContentToDraw() const
+{
+    return m_overlay->shouldShowOverlay();
 }
 
 FrameAgentContext FrameInspectorController::frameAgentContext()

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -52,6 +52,7 @@ class FrontendRouter;
 
 namespace WebCore {
 
+class GraphicsContext;
 class InspectorBackendClient;
 class InspectorController;
 class InspectorFrontendClient;
@@ -62,7 +63,7 @@ class PageInspectorController;
 class WebInjectedScriptManager;
 struct FrameAgentContext;
 
-class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<FrameInspectorController> {
+class FrameInspectorController final : public Inspector::InspectorEnvironment, public InspectorOverlayOwner, public CanMakeCheckedPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameInspectorController);
@@ -70,15 +71,22 @@ public:
     FrameInspectorController(LocalFrame&, PageInspectorController&);
     ~FrameInspectorController() override;
 
-    // AbstractCanMakeCheckedPtr overrides
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
     WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
+
+    // InspectorOverlayOwner. Anchors on the frame, which owns this controller and so the overlay.
+    void overlayOwnerRef() const final { ref(); }
+    void overlayOwnerDeref() const final { deref(); }
+    Page* NODELETE overlayOwnerPage() const final;
+    LocalFrame* NODELETE overlayOwnerFrame() const final;
+    InspectorBackendClient* NODELETE overlayOwnerBackendClient() const final;
+
+    WEBCORE_EXPORT void drawHighlight(GraphicsContext&) const;
+
+    // True when this frame's own overlay holds the highlight state, not the page overlay.
+    WEBCORE_EXPORT bool hasOverlayContentToDraw() const;
 
     WEBCORE_EXPORT void connectFrontend(Inspector::FrontendChannel&, bool isAutomaticInspection = false, bool immediatelyPause = false);
     WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
@@ -111,6 +119,10 @@ private:
     const Ref<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+
+    // This frame's own overlay, distinct from the page overlay owned by PageInspectorController.
+    const UniqueRef<InspectorOverlay> m_overlay;
+
     const Ref<WTF::Stopwatch> m_executionStopwatch;
     std::unique_ptr<JSC::Debugger> m_debugger;
     Inspector::AgentRegistry m_agents;

--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -62,6 +62,10 @@ public:
     virtual void highlight() = 0;
     virtual void hideHighlight() = 0;
 
+    // Frame-scoped highlight overlays under Site Isolation; default to the page-wide versions.
+    virtual void highlightFrame(LocalFrame&) { highlight(); }
+    virtual void hideHighlightForFrame(LocalFrame&) { hideHighlight(); }
+
     virtual void showInspectorIndication() { }
     virtual void hideInspectorIndication() { }
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -115,19 +115,16 @@ static void truncateWithEllipsis(String& string, size_t length)
         string = makeString(StringView(string).left(length), horizontalEllipsis);
 }
 
-static FloatPoint localPointToRootPoint(const FrameView* view, const FloatPoint& point)
+static void contentsQuadToCoordinateSystem(const FrameView* mainView, const LocalFrameView& view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
 {
-    return view->contentsToRootView(point);
-}
+    // contentsToRootView() stops at this process's local root, which is the space a frame overlay
+    // draws in; convertToRootViewAcrossIsolatedFrames() would map to page space instead.
+    quad.setP1(view.contentsToRootView(quad.p1()));
+    quad.setP2(view.contentsToRootView(quad.p2()));
+    quad.setP3(view.contentsToRootView(quad.p3()));
+    quad.setP4(view.contentsToRootView(quad.p4()));
 
-static void contentsQuadToCoordinateSystem(const FrameView* mainView, const LocalFrameView* view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
-{
-    quad.setP1(localPointToRootPoint(view, quad.p1()));
-    quad.setP2(localPointToRootPoint(view, quad.p2()));
-    quad.setP3(localPointToRootPoint(view, quad.p3()));
-    quad.setP4(localPointToRootPoint(view, quad.p4()));
-
-    if (coordinateSystem == InspectorOverlay::CoordinateSystem::View)
+    if (coordinateSystem == InspectorOverlay::CoordinateSystem::View && mainView)
         quad += toIntSize(mainView->scrollPosition());
 }
 
@@ -154,7 +151,12 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
 
     highlight.setDataFromConfig(highlightConfig);
     RefPtr containingView = containingFrame->view();
-    RefPtr mainView = protect(containingFrame->page())->mainFrame().virtualView();
+    if (!containingView)
+        return;
+
+    // Only read for CoordinateSystem::View, which only the two page-level getHighlight() callers use.
+    RefPtr containingPage = containingFrame->page();
+    RefPtr mainView = containingPage ? containingPage->mainFrame().virtualView() : nullptr;
 
     // (Legacy)RenderSVGRoot should be highlighted through the isBox() code path, all other SVG elements should just dump their absoluteQuads().
     bool isSVGRenderer = renderer->node() && renderer->node()->isSVGElement() && !renderer->isRenderOrLegacyRenderSVGRoot();
@@ -163,7 +165,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
         highlight.type = InspectorOverlay::Highlight::Type::Rects;
         renderer->absoluteQuads(highlight.quads);
         for (auto& quad : highlight.quads)
-            contentsQuadToCoordinateSystem(mainView, containingView, quad, coordinateSystem);
+            contentsQuadToCoordinateSystem(mainView, *containingView, quad, coordinateSystem);
     } else if (isAnyOf<RenderBox, RenderInline>(*renderer)) {
         LayoutRect contentBox;
         LayoutRect paddingBox;
@@ -200,10 +202,10 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
         FloatQuad absBorderQuad = renderer->localToAbsoluteQuad(FloatRect(borderBox));
         FloatQuad absMarginQuad = renderer->localToAbsoluteQuad(FloatRect(marginBox));
 
-        contentsQuadToCoordinateSystem(mainView, containingView, absContentQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absPaddingQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absBorderQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absMarginQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absContentQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absPaddingQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absBorderQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absMarginQuad, coordinateSystem);
 
         highlight.type = InspectorOverlay::Highlight::Type::Node;
         highlight.quads.append(absMarginQuad);
@@ -327,7 +329,12 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
         return;
 
     RefPtr containingView = containingFrame->view();
-    RefPtr mainView = protect(containingFrame->page())->mainFrame().virtualView();
+    if (!containingView)
+        return;
+
+    // See buildRendererHighlight(): only read under CoordinateSystem::View, which frames never reach.
+    RefPtr containingPage = containingFrame->page();
+    RefPtr mainView = containingPage ? containingPage->mainFrame().virtualView() : nullptr;
 
     static constexpr auto shapeHighlightColor = SRGBA<uint8_t> { 96, 82, 127, 204 };
 
@@ -337,7 +344,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     if (paths.shape.isEmpty()) {
         LayoutRect shapeBounds = shapeOutsideInfo->computedShapePhysicalBoundingBox();
         FloatQuad shapeQuad = renderer->localToAbsoluteQuad(FloatRect(shapeBounds));
-        contentsQuadToCoordinateSystem(mainView, containingView, shapeQuad, InspectorOverlay::CoordinateSystem::Document);
+        contentsQuadToCoordinateSystem(mainView, *containingView, shapeQuad, InspectorOverlay::CoordinateSystem::Document);
         drawOutlinedQuad(context, shapeQuad, shapeHighlightColor, Color::transparentBlack, bounds);
         return;
     }
@@ -347,7 +354,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
         path.applyElements([&] (const PathElement& pathElement) {
             const auto localToRoot = [&] (size_t index) {
                 const FloatPoint& point = pathElement.points[index];
-                return localPointToRootPoint(containingView, renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
+                return containingView->contentsToRootView(renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
             };
 
             switch (pathElement.type) {
@@ -395,9 +402,8 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     context.fillPath(shapePath);
 }
 
-InspectorOverlay::InspectorOverlay(PageInspectorController& controller, InspectorBackendClient* client)
-    : m_controller(controller)
-    , m_client(client)
+InspectorOverlay::InspectorOverlay(InspectorOverlayOwner& owner)
+    : m_owner(owner)
     , m_paintRectUpdateTimer(*this, &InspectorOverlay::updatePaintRectsTimerFired)
 {
 }
@@ -406,17 +412,28 @@ InspectorOverlay::~InspectorOverlay() = default;
 
 void InspectorOverlay::ref() const
 {
-    m_controller->ref();
+    m_owner->overlayOwnerRef();
 }
 
 void InspectorOverlay::deref() const
 {
-    m_controller->deref();
+    m_owner->overlayOwnerDeref();
 }
 
-Page& InspectorOverlay::page() const
+Page* InspectorOverlay::page() const
 {
-    return m_controller->inspectedPage();
+    return m_owner->overlayOwnerPage();
+}
+
+LocalFrame* InspectorOverlay::frameForGeometry() const
+{
+    // localMainFrame(), not localMainOrRootFrame(): the page overlay must not draw against a
+    // subframe's geometry, matching PageOverlay::frameForGeometry() that this is named after.
+    if (LocalFrame* ownerFrame = m_owner->overlayOwnerFrame())
+        return ownerFrame;
+
+    RefPtr page = this->page();
+    return page ? page->localMainFrame() : nullptr;
 }
 
 void InspectorOverlay::paint(GraphicsContext& context)
@@ -424,7 +441,13 @@ void InspectorOverlay::paint(GraphicsContext& context)
     if (!shouldShowOverlay())
         return;
 
-    auto viewportSize = protect(page())->mainFrame().virtualView()->sizeForVisibleContent();
+    // Null when the frame has no view, or this process's main frame is remote.
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
+    auto viewportSize = pageView->sizeForVisibleContent();
 
     context.clearRect({ FloatPoint::zero(), viewportSize });
 
@@ -507,7 +530,7 @@ void InspectorOverlay::paint(GraphicsContext& context)
     if (!m_paintRects.isEmpty())
         drawPaintRects(context, m_paintRects);
 
-    if (m_showRulers || m_showRulersForNodeHighlight)
+    if (shouldDrawRulers())
         drawRulers(context, rulerExclusion);
 }
 
@@ -621,8 +644,12 @@ void InspectorOverlay::highlightNode(Node* node, const InspectorOverlay::Highlig
 
 void InspectorOverlay::highlightQuad(std::unique_ptr<FloatQuad> quad, const InspectorOverlay::Highlight::Config& highlightConfig)
 {
-    if (highlightConfig.usePageCoordinates)
-        *quad -= toIntSize(protect(page())->mainFrame().virtualView()->scrollPosition());
+    // Page coordinates are relative to the geometry frame's own scroll position.
+    if (highlightConfig.usePageCoordinates) {
+        RefPtr geometryFrame = frameForGeometry();
+        if (RefPtr geometryView = geometryFrame ? geometryFrame->virtualView() : nullptr)
+            *quad -= toIntSize(geometryView->scrollPosition());
+    }
 
     m_quadHighlightConfig = highlightConfig;
     m_highlightQuad = WTF::move(quad);
@@ -636,7 +663,8 @@ Node* InspectorOverlay::highlightedNode() const
 
 void InspectorOverlay::didSetSearchingForNode(bool enabled)
 {
-    m_client->didSetSearchingForNode(enabled);
+    if (auto* client = m_owner->overlayOwnerBackendClient())
+        client->didSetSearchingForNode(enabled);
 }
 
 void InspectorOverlay::setIndicating(bool indicating)
@@ -649,29 +677,55 @@ void InspectorOverlay::setIndicating(bool indicating)
     update();
 }
 
+bool InspectorOverlay::shouldDrawRulers() const
+{
+    // Rulers are page-wide, so a frame overlay draws neither them nor their guide lines and insets.
+    if (isFrameScoped())
+        return false;
+
+    return m_showRulers || m_showRulersForNodeHighlight;
+}
+
 bool InspectorOverlay::shouldShowOverlay() const
 {
+    // Rulers alone must not install a frame surface that would paint nothing.
+    if (m_showRulers && !isFrameScoped())
+        return true;
+
     return m_highlightNode
         || m_highlightNodeList
         || m_highlightQuad
         || m_activeGridOverlays.size()
         || m_activeFlexOverlays.size()
         || m_indicating
-        || m_showPaintRects
-        || m_showRulers;
+        || m_showPaintRects;
 }
 
 void InspectorOverlay::update()
 {
+    auto* client = m_owner->overlayOwnerBackendClient();
+    if (!client)
+        return;
+
+    RefPtr geometryFrame = frameForGeometry();
+
+    // Dispatch on frame-scoped, not on whether a geometry frame exists, so the page path stays direct.
     if (!shouldShowOverlay()) {
-        m_client->hideHighlight();
+        if (isFrameScoped() && geometryFrame)
+            client->hideHighlightForFrame(*geometryFrame);
+        else
+            client->hideHighlight();
         return;
     }
 
-    if (!protect(page())->mainFrame().virtualView())
+    // Scoped to the geometry frame: the old main-frame check blocked painting in subframe processes.
+    if (!geometryFrame || !geometryFrame->virtualView())
         return;
 
-    m_client->highlight();
+    if (isFrameScoped())
+        client->highlightFrame(*geometryFrame);
+    else
+        client->highlight();
 }
 
 void InspectorOverlay::setShowPaintRects(bool showPaintRects)
@@ -692,7 +746,12 @@ void InspectorOverlay::showPaintRect(const FloatRect& rect)
     if (!m_showPaintRects)
         return;
 
-    auto rootRect = protect(page())->mainFrame().virtualView()->contentsToRootView(enclosingIntRect(rect));
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
+    auto rootRect = pageView->contentsToRootView(enclosingIntRect(rect));
 
     const auto removeDelay = 250_ms;
 
@@ -819,7 +878,7 @@ InspectorOverlay::RulerExclusion InspectorOverlay::drawNodeHighlight(GraphicsCon
     if (m_nodeHighlightConfig.showInfo)
         drawShapeHighlight(context, node, rulerExclusion.bounds);
 
-    if (m_showRulers || m_showRulersForNodeHighlight)
+    if (shouldDrawRulers())
         drawBounds(context, rulerExclusion.bounds);
 
     // Ensure that the title information is drawn after the bounds.
@@ -842,7 +901,7 @@ InspectorOverlay::RulerExclusion InspectorOverlay::drawQuadHighlight(GraphicsCon
     if (highlight.quads.size() >= 1) {
         drawOutlinedQuad(context, highlight.quads[0], highlight.contentColor, highlight.contentOutlineColor, rulerExclusion.bounds);
 
-        if (m_showRulers || m_showRulersForNodeHighlight)
+        if (shouldDrawRulers())
             drawBounds(context, rulerExclusion.bounds);
     }
 
@@ -862,8 +921,11 @@ void InspectorOverlay::drawPaintRects(GraphicsContext& context, const Deque<Time
 
 void InspectorOverlay::drawBounds(GraphicsContext& context, const InspectorOverlay::Highlight::Bounds& bounds)
 {
-    Ref mainFrame = page().mainFrame();
-    RefPtr pageView = mainFrame->virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
 
@@ -917,18 +979,25 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     constexpr auto lightRulerColor = Color::black.colorWithAlphaByte(51);
     constexpr auto darkRulerColor = Color::black.colorWithAlphaByte(128);
 
+    // Rulers are page-wide. Every caller gates on shouldDrawRulers(), which is false when frame scoped.
+    ASSERT(!isFrameScoped());
+
     IntPoint scrollOffset;
-    RefPtr localMainFrame = page().localMainFrame();
+    RefPtr page = this->page();
+    RefPtr localMainFrame = page ? page->localMainFrame() : nullptr;
     if (!localMainFrame)
         return;
 
     RefPtr pageView = localMainFrame->view();
+    if (!pageView)
+        return;
+
     if (!pageView->delegatesScrollingToNativeView())
         scrollOffset = pageView->visibleContentRect().location();
 
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
-    float pageScaleFactor = page().pageScaleFactor();
+    float pageScaleFactor = page->pageScaleFactor();
     float pageZoomFactor = localMainFrame->pageZoomFactor();
 
     float pageFactor = pageZoomFactor * pageScaleFactor;
@@ -993,7 +1062,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw lines.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page->settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(10);
 
         FontCascade font(WTF::move(fontDescription));
@@ -1083,7 +1152,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw viewport size.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page->settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(12);
 
         FontCascade font(WTF::move(fontDescription));
@@ -1198,10 +1267,13 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         elementWidth = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetWidth()), *modelObject));
         elementHeight = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetHeight()), *modelObject));
     } else {
-        RefPtr containingView = node.document().frame()->view();
-        IntRect boundingBox = snappedIntRect(containingView->contentsToRootView(renderer->absoluteBoundingBoxRect()));
-        elementWidth = String::number(boundingBox.width());
-        elementHeight = String::number(boundingBox.height());
+        // A missing view only costs one line of the tooltip; draw the rest.
+        RefPtr containingFrame = node.document().frame();
+        if (RefPtr containingView = containingFrame ? containingFrame->view() : nullptr) {
+            IntRect boundingBox = snappedIntRect(containingView->contentsToRootView(renderer->absoluteBoundingBoxRect()));
+            elementWidth = String::number(boundingBox.width());
+            elementHeight = String::number(boundingBox.height());
+        }
     }
 
     Vector<String> layoutContextBubbleStrings;
@@ -1263,11 +1335,15 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         }
     }
 
-    Ref mainFrame = page().mainFrame();
-    RefPtr pageView = mainFrame->virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return { };
+
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
-    if (m_showRulers || m_showRulersForNodeHighlight) {
+    // Only reserve space for rulers that were actually drawn, or the label is displaced by rulerSize.
+    if (shouldDrawRulers()) {
         obscuredContentInsets.setTop(obscuredContentInsets.top() + rulerSize);
         obscuredContentInsets.setLeft(obscuredContentInsets.left() + rulerSize);
     }
@@ -1558,7 +1634,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
 
     constexpr auto translucentLabelBackgroundColor = Color::white.colorWithAlphaByte(230);
 
-    RefPtr pageView = protect(page())->mainFrame().virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
     if (!pageView)
         return { };
     FloatRect viewportBounds = { { 0, 0 }, pageView->sizeForVisibleContent() };
@@ -1598,6 +1675,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     if (!containingFrame)
         return { };
     RefPtr containingView = containingFrame->view();
+    if (!containingView)
+        return { };
 
     auto computedStyle = node->computedStyle();
     if (!computedStyle)
@@ -1619,8 +1698,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             endPoint = { isWritingModeFlipped ? contentBox.width() - gridEndY : gridEndY, isDirectionFlipped ? contentBox.height() - x : x };
         }
         return {
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(startPoint, nullptr)),
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(endPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(startPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(endPoint, nullptr)),
         };
     };
     auto rowLineAt = [&](float y) -> FloatLine {
@@ -1634,8 +1713,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             endPoint = { isWritingModeFlipped ? contentBox.width() - y : y, isDirectionFlipped ? contentBox.height() - gridEndX : gridEndX };
         }
         return {
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(startPoint, nullptr)),
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(endPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(startPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(endPoint, nullptr)),
         };
     };
 
@@ -1906,8 +1985,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             auto absoluteRect = FloatRect { gridItem->absoluteBoundingBoxRect(true) };
             absoluteRect.expand(gridItem->marginBox());
 
-            auto minCorner = localPointToRootPoint(containingView, absoluteRect.minXMinYCorner());
-            auto maxCorner = localPointToRootPoint(containingView, absoluteRect.maxXMaxYCorner());
+            auto minCorner = containingView->contentsToRootView(absoluteRect.minXMinYCorner());
+            auto maxCorner = containingView->contentsToRootView(absoluteRect.maxXMaxYCorner());
             FloatRect rootRect { minCorner, maxCorner - minCorner };
 
             if (renderGrid->hasStackingAxisRows()) {
@@ -2025,10 +2104,10 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
                 auto margins = gridItem->marginBox();
                 absoluteRect.expand(FloatBoxExtent { margins.top(), margins.right(), margins.bottom(), margins.left() });
                 itemBounds = FloatQuad {
-                    localPointToRootPoint(containingView, absoluteRect.minXMinYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.maxXMinYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.maxXMaxYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.minXMaxYCorner())
+                    containingView->contentsToRootView(absoluteRect.minXMinYCorner()),
+                    containingView->contentsToRootView(absoluteRect.maxXMinYCorner()),
+                    containingView->contentsToRootView(absoluteRect.maxXMaxYCorner()),
+                    containingView->contentsToRootView(absoluteRect.minXMaxYCorner())
                 };
             } else {
                 // For regular grid layouts, compute bounds from the grid area.
@@ -2137,12 +2216,14 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     CheckedRef renderFlex = *downcast<RenderFlexibleBox>(renderer);
 
-    auto itemsAtStartOfLine = m_controller->ensureDOMAgent().flexibleBoxRendererCachedItemsAtStartOfLine(renderFlex);
+    auto itemsAtStartOfLine = m_owner->overlayOwnerFlexLineStarts(renderFlex);
 
     RefPtr containingFrame = node->document().frame();
     if (!containingFrame)
         return { };
     RefPtr containingView = containingFrame->view();
+    if (!containingView)
+        return { };
 
     auto computedStyle = node->computedStyle();
     if (!computedStyle)
@@ -2158,19 +2239,19 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     auto localQuadToRootQuad = [&](const FloatQuad& quad) {
         return FloatQuad(
-            localPointToRootPoint(containingView, quad.p1()),
-            localPointToRootPoint(containingView, quad.p2()),
-            localPointToRootPoint(containingView, quad.p3()),
-            localPointToRootPoint(containingView, quad.p4())
+            containingView->contentsToRootView(quad.p1()),
+            containingView->contentsToRootView(quad.p2()),
+            containingView->contentsToRootView(quad.p3()),
+            containingView->contentsToRootView(quad.p4())
         );
     };
 
     auto childQuadToRootQuad = [&](const FloatQuad& quad) {
         return FloatQuad(
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p1(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p2(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p3(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p4(), nullptr))
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p1(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p2(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p3(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p4(), nullptr))
         );
     };
 

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -37,6 +37,7 @@
 #include <WebCore/InspectorOverlayLabel.h>
 #include <WebCore/Path.h>
 #include <WebCore/Timer.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
@@ -60,10 +61,13 @@ class WeakPtrImplWithEventTargetData;
 class FontCascade;
 class FloatPoint;
 class GraphicsContext;
+class InspectorBackendClient;
+class LocalFrame;
 class Node;
 class NodeList;
 class Page;
 class PageInspectorController;
+class RenderObject;
 
 struct InspectorOverlayHighlight {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(InspectorOverlayHighlight);
@@ -140,10 +144,33 @@ struct InspectorOverlayHighlight {
     using Bounds = FloatRect;
 };
 
+// Owner of an InspectorOverlay: a PageInspectorController (page overlay) or, under Site Isolation,
+// a LocalFrame's FrameInspectorController (frame overlay). ref()/deref() pin the owner, not the
+// overlay, which is not RefCounted; AbstractCanMakeCheckedPtr lets the overlay hold a CheckedRef.
+class InspectorOverlayOwner : public AbstractCanMakeCheckedPtr {
+public:
+    virtual ~InspectorOverlayOwner() = default;
+
+    virtual void overlayOwnerRef() const = 0;
+    virtual void overlayOwnerDeref() const = 0;
+
+    // Null for a frame overlay once its frame is detached.
+    virtual Page* NODELETE overlayOwnerPage() const = 0;
+
+    // Not cached by callers: destroyed by PageInspectorController::inspectedPageDestroyed().
+    virtual InspectorBackendClient* NODELETE overlayOwnerBackendClient() const = 0;
+
+    // The frame the overlay draws in, or null for the page overlay. See frameForGeometry().
+    virtual LocalFrame* NODELETE overlayOwnerFrame() const { return nullptr; }
+
+    // Flex line-wrap positions for line separators; empty for a frame owner, which has no cache yet.
+    virtual Vector<size_t> overlayOwnerFlexLineStarts(const RenderObject&) const { return { }; }
+};
+
 class InspectorOverlay : public CanMakeWeakPtr<InspectorOverlay> {
     WTF_MAKE_TZONE_ALLOCATED(InspectorOverlay);
 public:
-    InspectorOverlay(PageInspectorController&, InspectorBackendClient*);
+    explicit InspectorOverlay(InspectorOverlayOwner&);
     ~InspectorOverlay();
 
     void NODELETE ref() const;
@@ -251,10 +278,19 @@ private:
     bool removeGridOverlayForNode(Node&);
     bool removeFlexOverlayForNode(Node&);
 
-    Page& NODELETE page() const;
+    // Null once the owner is detached from its page; every geometry path must tolerate that.
+    Page* NODELETE page() const;
 
-    const WeakRef<PageInspectorController> m_controller;
-    InspectorBackendClient* m_client;
+    // The frame this overlay draws in: the owner's frame, else the page's local main frame.
+    LocalFrame* NODELETE frameForGeometry() const;
+
+    // True when scoped to one frame rather than the whole page.
+    bool isFrameScoped() const { return !!m_owner->overlayOwnerFrame(); }
+
+    // Single answer to "are rulers being drawn", so the guide lines and tooltip insets agree.
+    bool shouldDrawRulers() const;
+
+    const CheckedRef<const InspectorOverlayOwner> m_owner;
 
     RefPtr<Node> m_highlightNode;
     RefPtr<NodeList> m_highlightNodeList;

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -96,7 +96,7 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
     , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
-    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this, inspectorBackendClient.get()))
+    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this))
     , m_executionStopwatch(Stopwatch::create())
     , m_inspectorBackendClient(WTF::move(inspectorBackendClient))
     , m_identifierRegistry(Inspector::LegacyIdentifierRegistry::create())
@@ -420,6 +420,21 @@ bool PageInspectorController::enabled() const
 Page& PageInspectorController::inspectedPage() const
 {
     return m_page;
+}
+
+Page* PageInspectorController::overlayOwnerPage() const
+{
+    // Always non-null: this controller is owned by the page.
+    return m_page.ptr();
+}
+
+Vector<size_t> PageInspectorController::overlayOwnerFlexLineStarts(const RenderObject& renderer) const
+{
+    // Deliberately does not create the DOM agent: with no agent there is nothing cached to report.
+    CheckedPtr domAgent = m_domAgent;
+    if (!domAgent)
+        return { };
+    return domAgent->flexibleBoxRendererCachedItemsAtStartOfLine(renderer);
 }
 
 void PageInspectorController::dispatchMessageFromFrontend(const String& message)

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -67,7 +67,7 @@ class PageDebugger;
 class WebInjectedScriptManager;
 struct PageAgentContext;
 
-class PageInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<PageInspectorController> {
+class PageInspectorController final : public Inspector::InspectorEnvironment, public InspectorOverlayOwner, public CanMakeCheckedPtr<PageInspectorController> {
     WTF_MAKE_NONCOPYABLE(PageInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(PageInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageInspectorController);
@@ -75,15 +75,17 @@ public:
     PageInspectorController(Page&, std::unique_ptr<InspectorBackendClient>&&);
     ~PageInspectorController() override;
 
-    // AbstractCanMakeCheckedPtr overrides
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
     WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
+
+    // InspectorOverlayOwner. Reports no frame, so the overlay uses the local main frame as before.
+    void overlayOwnerRef() const final { ref(); }
+    void overlayOwnerDeref() const final { deref(); }
+    Page* NODELETE overlayOwnerPage() const final;
+    InspectorBackendClient* NODELETE overlayOwnerBackendClient() const final { return m_inspectorBackendClient.get(); }
+    Vector<size_t> overlayOwnerFlexLineStarts(const RenderObject&) const final;
 
     void inspectedPageDestroyed();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3002,7 +3002,7 @@ void InspectorDOMAgent::flexibleBoxRendererWrappedToNextLine(const RenderObject&
     }).iterator->value.append(lineStartItemIndex);
 }
 
-Vector<size_t> InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject& renderer)
+Vector<size_t> InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject& renderer) const
 {
     return m_flexibleBoxRendererCachedItemsAtStartOfLine.get(renderer);
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -229,7 +229,7 @@ public:
 
     InspectorHistory* history() LIFETIME_BOUND { return m_history.get(); }
     Vector<Document*> documents();
-    Vector<size_t> flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject&);
+    Vector<size_t> flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject&) const;
     void reset();
 
     Node* assertNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -29,6 +29,7 @@
 #include "DrawingArea.h"
 #include "WebInspectorBackend.h"
 #include "WebPage.h"
+#include <WebCore/FrameInspectorController.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerAnimation.h>
 #include <WebCore/GraphicsLayerFactory.h>
@@ -82,23 +83,37 @@ WebInspectorBackendClient::~WebInspectorBackendClient()
     RefPtr page = m_page.get();
     RefPtr corePage = page ? page->corePage() : nullptr;
 
-    // Tear down every per-frame bucket: detach its layers, uninstall its overlay (the controller
-    // holds the only Ref keeping it alive), and drop the controller's per-frame container. The page
-    // may already be gone, in which case the controller torn down with it.
-    for (auto entry : m_paintRectOverlays) {
-        Ref frame = entry.key;
+    // uninstallPageOverlay() re-enters willMoveToPage() synchronously, which mutates these maps.
+    auto paintRectOverlays = std::exchange(m_paintRectOverlays, { });
+    auto frameHighlightOverlays = std::exchange(m_frameHighlightOverlays, { });
+
+    // Paint-rect buckets own graphics layers, so detach those even if the page is already gone.
+    // Highlight overlays hold no layers of their own, so they have nothing to do here.
+    for (auto entry : paintRectOverlays) {
         auto& bucket = entry.value;
         for (auto& layer : bucket.layers)
             protect(layer)->removeFromParent();
         bucket.layers.clear();
-
-        if (corePage) {
-            if (RefPtr overlay = bucket.overlay)
-                corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
-            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
-        }
     }
-    m_paintRectOverlays.clear();
+
+    // Uninstalling needs the page; if it is gone, its overlay controller went with it.
+    if (!corePage)
+        return;
+
+    // Both maps were emptied above, so neither frame's container is still in use by the other.
+    for (auto entry : paintRectOverlays) {
+        Ref frame = entry.key;
+        if (RefPtr overlay = entry.value.overlay)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
+
+    for (auto entry : frameHighlightOverlays) {
+        Ref frame = entry.key;
+        if (RefPtr overlay = entry.value)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
 }
 
 void WebInspectorBackendClient::inspectedPageDestroyed()
@@ -198,6 +213,100 @@ void WebInspectorBackendClient::hideHighlight()
         page->corePage()->pageOverlayController().uninstallPageOverlay(*highlightOverlay, PageOverlay::FadeMode::Fade);
 #else
     page->hideInspectorHighlight();
+#endif
+}
+
+// FIXME: Nothing drives the frame overlays below yet; FrameDOMAgent's highlight commands are stubs.
+RefPtr<PageOverlay> WebInspectorBackendClient::ensureHighlightOverlayForFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return nullptr;
+
+    auto& overlay = m_frameHighlightOverlays.ensure(frame, [&] -> RefPtr<PageOverlay> {
+        // FIXME: <rdar://116202544> Should be OverlayType::View, which needs a per-frame view-overlay
+        // root layer and attachViewOverlayGraphicsLayer() to stop hardcoding the main frame.
+        // DoNotFade matches hideHighlightForFrame(): a Fade uninstall defers the real uninstall.
+        Ref newOverlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
+        newOverlay->setAssociatedFrame(&frame);
+        corePage->pageOverlayController().installPageOverlay(newOverlay.copyRef(), PageOverlay::FadeMode::DoNotFade);
+        return newOverlay.ptr();
+    }).iterator->value;
+
+    return overlay.get();
+}
+
+void WebInspectorBackendClient::highlightFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+    // Only a local root hosts its own compositing tree; a local subframe draws via the page overlay.
+    // FIXME: a nested local subframe's state lives on its own overlay, which nothing consults.
+    if (&frame != corePage->localMainOrRootFrame()) {
+        highlight();
+        return;
+    }
+
+    // The frame must also own the state; update() guarantees it, so this is defence-in-depth.
+    if (!frame.inspectorController().hasOverlayContentToDraw()) {
+        highlight();
+        return;
+    }
+
+    if (!corePage->settings().acceleratedCompositingEnabled()) {
+        highlight();
+        return;
+    }
+
+#if !PLATFORM(IOS_FAMILY)
+    if (RefPtr overlay = ensureHighlightOverlayForFrame(frame)) {
+        overlay->stopFadeOutAnimation();
+        overlay->setNeedsDisplay();
+    }
+#else
+    // iOS highlights go through a page-level singleton with no frame parameter.
+    highlight();
+#endif
+}
+
+void WebInspectorBackendClient::hideHighlightForFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+#if !PLATFORM(IOS_FAMILY)
+    // Only uninstall an overlay this client installed; otherwise this is the page path.
+    if (!m_frameHighlightOverlays.contains(frame)) {
+        hideHighlight();
+        return;
+    }
+
+    // Erase before uninstalling; DoNotFade so the overlay is gone before its entry is.
+    RefPtr overlay = m_frameHighlightOverlays.take(frame);
+    if (overlay)
+        corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+
+    // The container is keyed by frame and shared with the paint-rect overlay; release it only if free.
+    if (!m_paintRectOverlays.contains(frame))
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame);
+
+#if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION) || PLATFORM(WPE)
+    if (!corePage->settings().acceleratedCompositingEnabled()) {
+        // FIXME: It can be optimized by marking only highlighted rect dirty.
+        // setNeedsDisplay always makes whole rect dirty, and could lead to poor performance.
+        // https://bugs.webkit.org/show_bug.cgi?id=195933
+        page->drawingArea()->setNeedsDisplay();
+    }
+#endif
+#else
+    UNUSED_PARAM(frame);
+    hideHighlight();
 #endif
 }
 
@@ -304,9 +413,34 @@ void WebInspectorBackendClient::willDestroyFrameOverlays(WebCore::FrameIdentifie
     RefPtr page = m_page.get();
     RefPtr corePage = page ? page->corePage() : nullptr;
 
+    // Tear highlight overlays down too, or a stale one re-parents under the main frame.
+    // Collect and erase first: uninstalling re-enters willMoveToPage(), which mutates this map.
+    Vector<std::pair<Ref<LocalFrame>, RefPtr<PageOverlay>>> detachedHighlights;
+    m_frameHighlightOverlays.removeIf([&](auto& entry) {
+        Ref frame = entry.key;
+        if (frame->frameID() != frameID)
+            return false;
+
+        detachedHighlights.append({ WTF::move(frame), entry.value });
+        return true;
+    });
+
+    for (auto& [frame, overlay] : detachedHighlights) {
+        if (!corePage)
+            break;
+
+        if (overlay)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+
+        // Shared with the paint-rect overlay; the pass below releases the container otherwise.
+        if (!m_paintRectOverlays.contains(frame.get()))
+            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
+
     // Buckets are keyed by local root frame; a detaching frame owns a bucket only if it is that root.
     // Find it by identity, uninstall its overlay, detach its layers, and drop the controller's
-    // per-frame container so nothing is retained past the frame's lifetime.
+    // per-frame container. Unconditional release is safe only after the highlight pass above; keep
+    // these two passes in this order.
     m_paintRectOverlays.removeIf([frameID, corePage](auto& entry) {
         Ref frame = entry.key;
         if (frame->frameID() != frameID)
@@ -419,24 +553,44 @@ bool WebInspectorBackendClient::setEmulatedConditions(std::optional<int64_t>&& b
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-void WebInspectorBackendClient::willMoveToPage(PageOverlay&, Page* page)
+void WebInspectorBackendClient::willMoveToPage(PageOverlay& overlay, Page* page)
 {
     if (page)
         return;
 
-    // The page overlay is moving away from the web page, reset it.
-    ASSERT(m_highlightOverlay);
-    m_highlightOverlay = nullptr;
+    // Clear only the overlay this call is about; this client serves several.
+    if (m_highlightOverlay.get() == &overlay) {
+        m_highlightOverlay = nullptr;
+        return;
+    }
+
+    // A no-op for our own teardown paths, which erase first; covers an uninstall from elsewhere.
+    m_frameHighlightOverlays.removeIf([&overlay](auto& entry) {
+        return entry.value.get() == &overlay;
+    });
 }
 
 void WebInspectorBackendClient::didMoveToPage(PageOverlay&, Page*)
 {
 }
 
-void WebInspectorBackendClient::drawRect(PageOverlay&, WebCore::GraphicsContext& context, const WebCore::IntRect& /*dirtyRect*/)
+void WebInspectorBackendClient::drawRect(PageOverlay& overlay, WebCore::GraphicsContext& context, const WebCore::IntRect& /*dirtyRect*/)
 {
-    if (RefPtr page = m_page.get())
-        protect(page->corePage()->inspectorController())->drawHighlight(context);
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+    // Map the PageOverlay back to the InspectorOverlay holding its state. Membership, not just
+    // associatedFrame(): paint-rect overlays set one too. Never paint a frame surface with page state.
+    if (RefPtr frame = overlay.associatedFrame(); frame && m_frameHighlightOverlays.contains(*frame)) {
+        Ref frameController = frame->inspectorController();
+        if (frameController->hasOverlayContentToDraw())
+            frameController->drawHighlight(context);
+        return;
+    }
+
+    protect(corePage->inspectorController())->drawHighlight(context);
 }
 
 bool WebInspectorBackendClient::mouseEvent(PageOverlay&, const PlatformMouseEvent&)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
@@ -62,6 +62,8 @@ private:
 
     void highlight() override;
     void hideHighlight() override;
+    void highlightFrame(WebCore::LocalFrame&) override;
+    void hideHighlightForFrame(WebCore::LocalFrame&) override;
 
 #if PLATFORM(IOS_FAMILY)
     void showInspectorIndication() override;
@@ -96,7 +98,14 @@ private:
     void animationEndedForLayer(WebCore::LocalFrame*, const WebCore::GraphicsLayer*);
 
     WeakPtr<WebPage> m_page;
+
+    // The page-level highlight overlay. Kept separate from the per-frame map: it is no frame's overlay.
     WeakPtr<WebCore::PageOverlay> m_highlightOverlay;
+
+    // Frame-scoped highlight overlays, keyed by local root. Separate lifetimes from m_paintRectOverlays.
+    WeakHashMap<WebCore::LocalFrame, RefPtr<WebCore::PageOverlay>> m_frameHighlightOverlays;
+
+    RefPtr<WebCore::PageOverlay> ensureHighlightOverlayForFrame(WebCore::LocalFrame&);
 
     // Paint-rect overlays are per local root frame: under Site Isolation one process can host several
     // local roots, each with its own compositing tree, so each needs its own Document overlay.


### PR DESCRIPTION
#### 9336ddda68a83ce5bc95a2a0b02f556ce4bf1982
<pre>
Make InspectorOverlay frame-relative so it can draw in a subframe process
<a href="https://bugs.webkit.org/show_bug.cgi?id=322726">https://bugs.webkit.org/show_bug.cgi?id=322726</a>
<a href="https://rdar.apple.com/185999163">rdar://185999163</a>

Reviewed by NOBODY (OOPS!).

InspectorOverlay resolved every geometry calculation through the page&apos;s main
frame. In a subframe process that frame is remote and has no view, so the
overlay bailed and drew nothing.

An InspectorOverlayOwner interface replaces the overlay&apos;s direct dependency on
PageInspectorController, so a LocalFrame&apos;s FrameInspectorController can own one
too, and frameForGeometry() replaces every main-frame lookup: a frame overlay
uses its own frame, the page overlay falls back to localMainFrame() as before.
WebInspectorBackendClient gains a per-frame highlight surface keyed by local
root, the same shape the paint-rect overlays already use.

The FrameView dereferences along those paths are now null-checked; two were
reachable on the page path already. Rulers stay page-wide, and one
shouldDrawRulers() now decides that, so the ruler lines, bounds guides, and the
tooltip insets reserving space for them can&apos;t disagree.

Two pre-existing bugs surface once a process holds more than one overlay:
willMoveToPage() nulled the shared page-highlight pointer regardless of which
overlay was moving, so any per-frame paint-rect teardown destroyed it, and
drawRect() ignored the PageOverlay&amp; it was handed and always painted the page
overlay. Both fixed here.

Nothing drives a frame overlay yet since FrameDOMAgent&apos;s highlight commands are
still stubs, so these paths are plumbing for the highlighting work that follows
and aren&apos;t layout-testable in this state; the existing inspector/dom overlay
tests cover the page path against regression. The frame surface is also still
OverlayType::Document while the overlay draws in root-view coordinates; see the
FIXME.

* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::overlayOwnerPage const):
(WebCore::FrameInspectorController::overlayOwnerFrame const):
(WebCore::FrameInspectorController::overlayOwnerBackendClient const):
(WebCore::FrameInspectorController::drawHighlight const):
(WebCore::FrameInspectorController::hasOverlayContentToDraw const):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorBackendClient.h:
(WebCore::InspectorBackendClient::highlightFrame):
(WebCore::InspectorBackendClient::hideHighlightForFrame):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::contentsQuadToCoordinateSystem):
(WebCore::buildRendererHighlight):
(WebCore::drawShapeHighlight):
(WebCore::InspectorOverlay::InspectorOverlay):
(WebCore::InspectorOverlay::ref const):
(WebCore::InspectorOverlay::deref const):
(WebCore::InspectorOverlay::page const):
(WebCore::InspectorOverlay::frameForGeometry const):
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::highlightQuad):
(WebCore::InspectorOverlay::didSetSearchingForNode):
(WebCore::InspectorOverlay::shouldDrawRulers const):
(WebCore::InspectorOverlay::shouldShowOverlay const):
(WebCore::InspectorOverlay::update):
(WebCore::InspectorOverlay::showPaintRect):
(WebCore::InspectorOverlay::drawNodeHighlight):
(WebCore::InspectorOverlay::drawQuadHighlight):
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawRulers):
(WebCore::InspectorOverlay::drawElementTitle):
(WebCore::InspectorOverlay::buildGridOverlay):
(WebCore::InspectorOverlay::buildFlexOverlay):
(WebCore::localPointToRootPoint): Deleted.
* Source/WebCore/inspector/InspectorOverlay.h:
(WebCore::InspectorOverlayOwner::overlayOwnerFrame const):
(WebCore::InspectorOverlayOwner::overlayOwnerFlexLineStarts const):
(WebCore::InspectorOverlay::isFrameScoped const):
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::PageInspectorController):
(WebCore::PageInspectorController::overlayOwnerPage const):
(WebCore::PageInspectorController::overlayOwnerFlexLineStarts const):
* Source/WebCore/inspector/PageInspectorController.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine const):
(WebCore::InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
(WebKit::WebInspectorBackendClient::~WebInspectorBackendClient):
(WebKit::WebInspectorBackendClient::ensureHighlightOverlayForFrame):
(WebKit::WebInspectorBackendClient::highlightFrame):
(WebKit::WebInspectorBackendClient::hideHighlightForFrame):
(WebKit::WebInspectorBackendClient::willDestroyFrameOverlays):
(WebKit::WebInspectorBackendClient::willMoveToPage):
(WebKit::WebInspectorBackendClient::drawRect):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9336ddda68a83ce5bc95a2a0b02f556ce4bf1982

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152086 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146402 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101179 "Exiting early after 60 failures. 25069 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126905 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48844 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46695 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46483 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8780 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199720 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60921 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61638 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155719 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50039 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133769 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60019 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21472 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->