### PR TITLE
[JSC][Wasm] Inline ref.func

### DIFF
--- a/JSTests/wasm/stress/ref-func-wrapper-identity.js
+++ b/JSTests/wasm/stress/ref-func-wrapper-identity.js
@@ -1,0 +1,50 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let producerWat = `
+(module
+    (func $hidden (export "hidden") (result i32) (i32.const 7))
+)
+`
+
+let wat = `
+(module
+    (import "m" "hidden" (func $imported (result i32)))
+    (func $local (result i32) (i32.const 11))
+    (func $exported (export "exported") (result i32) (i32.const 13))
+    (elem declare funcref (ref.func $imported) (ref.func $local) (ref.func $exported))
+    (func (export "importedRef") (result funcref) (ref.func $imported))
+    (func (export "localRef") (result funcref) (ref.func $local))
+    (func (export "exportedRef") (result funcref) (ref.func $exported))
+)
+`
+
+async function test() {
+    const { hidden } = (await instantiate(producerWat)).exports
+    const { importedRef, localRef, exportedRef, exported } = (await instantiate(wat, { m: { hidden } })).exports
+
+    let imported = importedRef()
+    let local = localRef()
+    let exportedFromRef = exportedRef()
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(importedRef(), imported)
+        assert.eq(localRef(), local)
+        assert.eq(exportedRef(), exportedFromRef)
+    }
+
+    assert.eq(imported === local, false)
+    assert.eq(local === exportedFromRef, false)
+    assert.eq(imported, hidden)
+    assert.eq(exportedFromRef, exported)
+    assert.eq(imported(), 7)
+    assert.eq(local(), 11)
+    assert.eq(exportedFromRef(), 13)
+
+    fullGC()
+    assert.eq(importedRef(), imported)
+    assert.eq(localRef(), local)
+    assert.eq(exportedRef(), exported)
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -270,6 +270,7 @@ namespace JSC::B3 {
     macro(JSWebAssemblyInstance_gcObjectStructureIDs) \
     macro(JSWebAssemblyInstance_importFunctionStubs) \
     macro(JSWebAssemblyInstance_tables) \
+    macro(JSWebAssemblyInstance_functionWrappers) \
 
 // This class is meant to be cacheable between compilations, but it doesn't have to be.
 // Doing so saves on creation of nodes. But clearing it will save memory.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3215,16 +3215,27 @@ PartialResult BBQJIT::addI32Extend8S(Value operand, Value& result)
 
 [[nodiscard]] PartialResult BBQJIT::addRefFunc(FunctionSpaceIndex index, Value& result)
 {
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    TypeKind returnType = TypeKind::Ref;
+    GPRReg resultGPR;
+    {
+        ScratchScope<1, 0> scratches(*this);
+        resultGPR = scratches.gpr(0);
 
-    Vector<Value, 8> arguments = {
-        instanceValue(),
-        Value::fromI32(index)
-    };
-    result = topValue(returnType);
-    emitCCall(&operationWasmRefFunc, arguments, result);
+        m_jit.load64(Address(GPRInfo::wasmContextInstancePointer, safeCast<int32_t>(JSWebAssemblyInstance::offsetOfFunctionWrapper(m_info, index))), resultGPR);
 
+        JumpList slowPath = m_jit.branchTest64(ResultCondition::Zero, resultGPR);
+        MacroAssembler::Label done(m_jit);
+        m_slowPaths.append({ origin(), WTF::move(slowPath), WTF::move(done), copyBindings(), [index, resultGPR](BBQJIT&, CCallHelpers& jit) {
+            jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
+            jit.setupArguments<decltype(operationWasmRefFunc)>(GPRInfo::wasmContextInstancePointer, TrustedImm32(static_cast<uint32_t>(index)));
+            jit.callOperation<OperationPtrTag>(operationWasmRefFunc);
+            jit.move(GPRInfo::returnValueGPR, resultGPR);
+        } });
+    }
+
+    result = topValue(TypeKind::Ref);
+    bind(result, Location::fromGPR(resultGPR));
+
+    LOG_INSTRUCTION("RefFunc", index, RESULT(result));
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1786,9 +1786,28 @@ auto OMGIRGenerator::addTableSet(unsigned tableIndex, ExpressionType index, Expr
 
 auto OMGIRGenerator::addRefFunc(FunctionSpaceIndex index, ExpressionType& result) -> PartialResult
 {
-    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    result = push(callWasmOperation(m_currentBlock, wasmRefType(), operationWasmRefFunc,
-        instanceValue(), constant(toB3Type(Types::I32), index)));
+    auto* loaded = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, wasmRefType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfFunctionWrapper(m_info, index)));
+    m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_functionWrappers[index], loaded);
+
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+    auto* phi = continuation->appendNew<Value>(m_proc, Phi, wasmRefType(), origin());
+
+    m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), loaded, phi);
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), loaded,
+        FrequentedBlock(continuation), FrequentedBlock(slowPath, FrequencyClass::Rare));
+    slowPath->addPredecessor(m_currentBlock);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    auto* called = callWasmOperation(m_currentBlock, wasmRefType(), operationWasmRefFunc,
+        instanceValue(), constant(Int32, index));
+    m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), called, phi);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+    result = push(phi);
     TRACE_VALUE(Wasm::Types::Funcref, get(result), "ref_func ", index);
     return { };
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -136,6 +136,7 @@ JSWebAssemblyInstance::JSWebAssemblyInstance(VM& vm, Structure* structure, JSWeb
     }
 
     memset(reinterpret_cast<uint8_t*>(baselineDatas().data()), 0, baselineDatas().size_bytes());
+    zeroSpan(asMutableByteSpan(functionWrappers()));
     if (m_moduleInformation->hasGCObjectTypes()) {
         memset(reinterpret_cast<uint8_t*>(gcObjectStructureIDs().data()), 0, gcObjectStructureIDs().size_bytes());
         CompleteSubspace* subspace = JSWebAssemblyArray::subspaceFor<JSWebAssemblyArray, SubspaceAccess::OnMainThread>(vm);
@@ -222,9 +223,9 @@ void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
             visitor.append(thisObject->gcObjectStructureID(i));
     }
 
-    Locker locker { cell->cellLock() };
     for (auto& wrapper : thisObject->functionWrappers())
-        visitor.appendUnbarriered(wrapper.get());
+        visitor.append(wrapper);
+    Locker locker { cell->cellLock() };
     for (auto& entry : thisObject->m_constantExpressionValues)
         visitor.append(entry.value);
     for (auto& entry : thisObject->m_tagWrappers)
@@ -308,9 +309,7 @@ Identifier JSWebAssemblyInstance::createPrivateModuleKey()
 
 size_t JSWebAssemblyInstance::allocationSize(const Wasm::ModuleInformation& info)
 {
-    if (info.hasGCObjectTypes())
-        return offsetOfAllocatorForGCObject(info, MarkedSpace::numSizeClasses);
-    return offsetOfBaselineData(info, info.internalFunctionCount());
+    return offsetOfFunctionWrapper(info, info.functionIndexSpaceSize());
 }
 
 
@@ -445,18 +444,17 @@ void JSWebAssemblyInstance::setGlobal(unsigned i, JSValue value)
 
 JSValue JSWebAssemblyInstance::getFunctionWrapper(unsigned i) const
 {
-    JSValue value = m_functionWrappers.get(i).get();
-    if (value.isEmpty())
-        return jsNull();
-    return value;
+    ASSERT(i < functionWrappers().size());
+    JSValue value = functionWrappers()[i].get();
+    return value ? value : jsNull();
 }
 
 void JSWebAssemblyInstance::setFunctionWrapper(unsigned i, JSValue value)
 {
+    ASSERT(i < functionWrappers().size());
     ASSERT(value.isCallable());
-    ASSERT(!m_functionWrappers.contains(i));
-    Locker locker { cellLock() };
-    m_functionWrappers.set(i, WriteBarrier<Unknown>(vm(), this, value));
+    ASSERT(!functionWrappers()[i].get());
+    functionWrappers()[i].set(vm(), this, value);
     ASSERT(getFunctionWrapper(i) == value);
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -73,7 +73,7 @@ class BaselineData;
 }
 
 // The layout of a JSWebAssemblyInstance is
-//     { struct JSWebAssemblyInstance }[ WasmMemoryBaseAndSize ][ WasmOrJSImportableFunctionCallLinkInfo ][ Wasm::Table* ][ Global::Value ][ Wasm::BaselineData* ][ WebAssemblyGCStructure* ][ Allocator* ]
+//     { struct JSWebAssemblyInstance }[ WasmMemoryBaseAndSize ][ WasmOrJSImportableFunctionCallLinkInfo ][ Wasm::Table* ][ Global::Value ][ Wasm::BaselineData* ][ WebAssemblyGCStructure* ][ Allocator* ][ WriteBarrier<Unknown> function wrappers ]
 // in a compound TrailingArray-like format.
 class JSWebAssemblyInstance final : public JSNonFinalObject {
     friend class LLIntOffsetsExtractor;
@@ -181,8 +181,6 @@ public:
     static constexpr ptrdiff_t offsetOfJSModule() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_jsModule); }
     static constexpr ptrdiff_t offsetOfVM() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_vm); }
     static constexpr ptrdiff_t offsetOfModuleRecord() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_moduleRecord); }
-
-    using FunctionWrapperMap = UncheckedKeyHashMap<uint32_t, WriteBarrier<Unknown>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
     static constexpr ptrdiff_t offsetOfSoftStackLimit() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_stackMirror) + StackManager::Mirror::offsetOfSoftStackLimit(); }
 
@@ -308,7 +306,6 @@ public:
     const BitVector& globalsToMark() LIFETIME_BOUND { return m_globalsToMark; }
     const BitVector& globalsToBinding() LIFETIME_BOUND { return m_globalsToBinding; }
     JSValue getFunctionWrapper(unsigned) const;
-    typename FunctionWrapperMap::ValuesConstIteratorRange functionWrappers() const { return m_functionWrappers.values(); }
     void setFunctionWrapper(unsigned, JSValue);
     JSValue ensureFunctionWrapper(Wasm::FunctionSpaceIndex);
     void setBuiltinCalleeBits(uint32_t builtinID, CalleeBits calleeBits) { m_builtinCalleeBits[builtinID] = calleeBits; }
@@ -378,6 +375,14 @@ public:
         return roundUpToMultipleOf<alignof(Allocator)>(offsetOfGCObjectStructureID(info, info.typeCount())) + sizeof(Allocator) * index;
     }
 
+    static ptrdiff_t offsetOfFunctionWrapper(const Wasm::ModuleInformation& info, unsigned index)
+    {
+        ptrdiff_t base = info.hasGCObjectTypes()
+            ? offsetOfAllocatorForGCObject(info, MarkedSpace::numSizeClasses)
+            : offsetOfBaselineData(info, info.internalFunctionCount());
+        return roundUpToMultipleOf<alignof(WriteBarrier<Unknown>)>(base) + sizeof(WriteBarrier<Unknown>) * index;
+    }
+
     static size_t offsetOfTargetInstance(const Wasm::ModuleInformation& info, size_t importFunctionNum) { return offsetOfImportFunctionInfo(info, importFunctionNum) + OBJECT_OFFSETOF(Wasm::WasmOrJSImportableFunctionCallLinkInfo, targetInstance); }
     static size_t offsetOfEntrypointLoadLocation(const Wasm::ModuleInformation& info, size_t importFunctionNum) { return offsetOfImportFunctionInfo(info, importFunctionNum) + OBJECT_OFFSETOF(Wasm::WasmOrJSImportableFunctionCallLinkInfo, entrypointLoadLocation); }
     static size_t offsetOfBoxedCallee(const Wasm::ModuleInformation& info, size_t importFunctionNum) { return offsetOfImportFunctionInfo(info, importFunctionNum) + OBJECT_OFFSETOF(Wasm::WasmOrJSImportableFunctionCallLinkInfo, boxedCallee); }
@@ -418,6 +423,16 @@ public:
     std::span<Allocator, MarkedSpace::numSizeClasses> allocators()
     {
         return unsafeMakeSpan<Allocator, MarkedSpace::numSizeClasses>(std::bit_cast<Allocator*>(std::bit_cast<uint8_t*>(this) + offsetOfAllocatorForGCObject(m_moduleInformation, 0)), MarkedSpace::numSizeClasses);
+    }
+
+    std::span<WriteBarrier<Unknown>> functionWrappers()
+    {
+        return std::span { std::bit_cast<WriteBarrier<Unknown>*>(std::bit_cast<uint8_t*>(this) + offsetOfFunctionWrapper(m_moduleInformation, 0)), m_moduleInformation->functionIndexSpaceSize() };
+    }
+
+    std::span<const WriteBarrier<Unknown>> functionWrappers() const
+    {
+        return std::span { std::bit_cast<const WriteBarrier<Unknown>*>(std::bit_cast<const uint8_t*>(this) + offsetOfFunctionWrapper(m_moduleInformation, 0)), m_moduleInformation->functionIndexSpaceSize() };
     }
 
     unsigned numImportFunctions() const { return m_numImportFunctions; }
@@ -485,7 +500,6 @@ private:
 
     RefPtr<Wasm::Memory> m_wasmMemory;
     Wasm::Global::Value* m_globals { nullptr };
-    FunctionWrapperMap m_functionWrappers;
 
     using ConstantExpressionValueMap = UncheckedKeyHashMap<uint64_t, WriteBarrier<Unknown>, IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
     ConstantExpressionValueMap m_constantExpressionValues;


### PR DESCRIPTION
#### 98007ce32048c750eb1a67543055cec022e4eef4
<pre>
[JSC][Wasm] Inline ref.func
<a href="https://bugs.webkit.org/show_bug.cgi?id=322530">https://bugs.webkit.org/show_bug.cgi?id=322530</a>

Reviewed by Yusuke Suzuki.

Store function wrappers in a trailing instance array and load the slot
in BBQ and OMG. Call ensure only when the slot is empty.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* JSTests/wasm/stress/ref-func-wrapper-identity.js: Added.

Canonical link: <a href="https://commits.webkit.org/320054@main">https://commits.webkit.org/320054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78b8ce8d550d8f787517c411d2b16c25e492a34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147664 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143137 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99397 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45586 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43822 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5530 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12377 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43433 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4768 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44649 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56967 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57671 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152325 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46878 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129950 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126249 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18443 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->