### PR TITLE
Implement DOM highlight commands for FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target-expected.txt
@@ -1,0 +1,66 @@
+Tests that a cross-origin iframe's FrameDOMAgent accepts the DOM highlight commands.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameHighlight
+-- Running test case: HighlightNode
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: Should get a nodeId for '#target'.
+PASS: DOM.highlightNode should be accepted by the frame target.
+PASS: DOM.hideHighlight should be accepted by the frame target.
+
+-- Running test case: HighlightNodeScrolled
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: DOM.highlightNode should be accepted while the frame is scrolled.
+
+-- Running test case: HighlightNodeRTL
+PASS: Should find the frame target for highlight-rtl-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: DOM.highlightNode should be accepted in an RTL frame.
+
+-- Running test case: HighlightNodeVerticalWritingMode
+PASS: Should find the frame target for highlight-vertical-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: DOM.highlightNode should be accepted in a vertical-rl frame.
+
+-- Running test case: HighlightNodeList
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: Should get a nodeId for '#target'.
+PASS: Should get a nodeId for '#tail'.
+PASS: DOM.highlightNodeList should be accepted by the frame target.
+
+-- Running test case: HighlightRectAndQuad
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: DOM.highlightRect should be accepted by the frame target.
+PASS: DOM.highlightQuad should be accepted by the frame target.
+
+-- Running test case: HighlightQuadRejectsMalformedQuad
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: DOM.highlightQuad should reject a three-element quad.
+
+-- Running test case: HighlightSelectorNotDispatchable
+PASS: Should find the frame target for highlight-frame.html.
+PASS: Frame target should have a document.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: Frame target should not expose DOM.highlightSelector.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target.html
@@ -1,0 +1,205 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameHighlight");
+
+    // Geometry is deliberately not asserted. internals.inspectorHighlightRects() reads the PAGE
+    // controller's overlay (Internals.cpp: page()->inspectorController()), so it cannot observe a
+    // frame overlay's quads. These cases assert that each command is dispatched to the frame target
+    // and accepted rather than erroring, which is what this patch changes.
+    // FIXME: The contents-to-root-view translation in InspectorOverlay::paint() is not covered here,
+    // and a getHighlight()-style accessor would not cover it either -- getHighlight() builds quads
+    // without a GraphicsContext, so it never sees that CTM. Observing it needs paint() driven into a
+    // recording context, e.g. an Internals hook using DisplayList::RecorderImpl the way
+    // Internals::displayListForElement does.
+
+    async function containerNodeForFrame(resourceName) {
+        let target = await frameTargetForURLContaining(resourceName);
+        InspectorTest.expectNotNull(target, "Should find the frame target for " + resourceName + ".");
+
+        if (target.isProvisional) {
+            let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+            target = committedEvent.data.target;
+        }
+        await target.ensureTargetExecutionContext();
+
+        let frameDoc = WI.domManager.frameTargetDocumentForTarget(target);
+        if (!frameDoc) {
+            let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+            frameDoc = docEvent.data.document;
+        }
+        InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+        let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+        await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+        let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+        InspectorTest.expectNotNull(bodyNode, "Frame document should have a BODY.");
+        await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+        // Bind the container's children so nodes that querySelector returns below are already in the
+        // frontend -- an unbound nodeId resolves to null.
+        let containerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+        InspectorTest.expectNotNull(containerNode, "Frame document should have #container.");
+        await new Promise((resolve) => containerNode.getChildNodes(resolve));
+
+        return {target, containerNode};
+    }
+
+    function highlightConfig() {
+        return {
+            showInfo: true,
+            contentColor: {r: 111, g: 168, b: 220, a: 0.66},
+            paddingColor: {r: 147, g: 196, b: 125, a: 0.66},
+            borderColor: {r: 255, g: 229, b: 153, a: 0.66},
+            marginColor: {r: 246, g: 178, b: 107, a: 0.66},
+        };
+    }
+
+    // Resolves to an error, or null when the command succeeded.
+    async function errorFrom(promise) {
+        try {
+            await promise;
+            return null;
+        } catch (error) {
+            return error;
+        }
+    }
+
+    suite.addTestCase({
+        name: "HighlightNode",
+        description: "DOM.highlightNode and DOM.hideHighlight should be accepted by a frame target.",
+        async test() {
+            let {target, containerNode} = await containerNodeForFrame("highlight-frame.html");
+
+            let nodeId = await containerNode.querySelector("#target");
+            InspectorTest.expectNotNull(nodeId, "Should get a nodeId for '#target'.");
+
+            let highlightError = await errorFrom(target.DOMAgent.highlightNode.invoke({nodeId, highlightConfig: highlightConfig()}));
+            InspectorTest.expectNull(highlightError, "DOM.highlightNode should be accepted by the frame target.");
+
+            let hideError = await errorFrom(target.DOMAgent.hideHighlight());
+            InspectorTest.expectNull(hideError, "DOM.hideHighlight should be accepted by the frame target.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightNodeScrolled",
+        description: "Highlighting should be accepted while the frame is scrolled.",
+        async test() {
+            let {target, containerNode} = await containerNodeForFrame("highlight-frame.html");
+
+            // The overlay surface is contents-sized and offset by the scroll position, so a scrolled
+            // frame is the case the paint() translation exists for.
+            await target.RuntimeAgent.evaluate.invoke({expression: "window.scrollTo(0, 300)"});
+
+            try {
+                let nodeId = await containerNode.querySelector("#target");
+                let error = await errorFrom(target.DOMAgent.highlightNode.invoke({nodeId, highlightConfig: highlightConfig()}));
+                InspectorTest.expectNull(error, "DOM.highlightNode should be accepted while the frame is scrolled.");
+
+                await errorFrom(target.DOMAgent.hideHighlight());
+            } finally {
+                // Later cases share this frame, so do not leave it scrolled if the above throws.
+                await target.RuntimeAgent.evaluate.invoke({expression: "window.scrollTo(0, 0)"});
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightNodeRTL",
+        description: "Highlighting should be accepted in an RTL frame, where scrollOrigin is non-zero.",
+        async test() {
+            let {target, containerNode} = await containerNodeForFrame("highlight-rtl-frame.html");
+
+            let nodeId = await containerNode.querySelector("#target");
+            let error = await errorFrom(target.DOMAgent.highlightNode.invoke({nodeId, highlightConfig: highlightConfig()}));
+            InspectorTest.expectNull(error, "DOM.highlightNode should be accepted in an RTL frame.");
+
+            await errorFrom(target.DOMAgent.hideHighlight());
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightNodeVerticalWritingMode",
+        description: "Highlighting should be accepted in a vertical-rl frame, where scrollOrigin is non-zero.",
+        async test() {
+            let {target, containerNode} = await containerNodeForFrame("highlight-vertical-frame.html");
+
+            let nodeId = await containerNode.querySelector("#target");
+            let error = await errorFrom(target.DOMAgent.highlightNode.invoke({nodeId, highlightConfig: highlightConfig()}));
+            InspectorTest.expectNull(error, "DOM.highlightNode should be accepted in a vertical-rl frame.");
+
+            await errorFrom(target.DOMAgent.hideHighlight());
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightNodeList",
+        description: "DOM.highlightNodeList should be accepted by a frame target.",
+        async test() {
+            let {target, containerNode} = await containerNodeForFrame("highlight-frame.html");
+
+            let targetId = await containerNode.querySelector("#target");
+            let tailId = await containerNode.querySelector("#tail");
+            InspectorTest.expectNotNull(targetId, "Should get a nodeId for '#target'.");
+            InspectorTest.expectNotNull(tailId, "Should get a nodeId for '#tail'.");
+
+            let error = await errorFrom(target.DOMAgent.highlightNodeList.invoke({nodeIds: [targetId, tailId], highlightConfig: highlightConfig()}));
+            InspectorTest.expectNull(error, "DOM.highlightNodeList should be accepted by the frame target.");
+
+            await errorFrom(target.DOMAgent.hideHighlight());
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightRectAndQuad",
+        description: "DOM.highlightRect and DOM.highlightQuad should be accepted by a frame target.",
+        async test() {
+            let {target} = await containerNodeForFrame("highlight-frame.html");
+
+            let rectError = await errorFrom(target.DOMAgent.highlightRect.invoke({x: 10, y: 20, width: 100, height: 50, usePageCoordinates: false}));
+            InspectorTest.expectNull(rectError, "DOM.highlightRect should be accepted by the frame target.");
+
+            let quadError = await errorFrom(target.DOMAgent.highlightQuad.invoke({quad: [10, 20, 110, 20, 110, 70, 10, 70], usePageCoordinates: false}));
+            InspectorTest.expectNull(quadError, "DOM.highlightQuad should be accepted by the frame target.");
+
+            await errorFrom(target.DOMAgent.hideHighlight());
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightQuadRejectsMalformedQuad",
+        description: "DOM.highlightQuad should report an error for a malformed quad.",
+        async test() {
+            let {target} = await containerNodeForFrame("highlight-frame.html");
+
+            let error = await errorFrom(target.DOMAgent.highlightQuad.invoke({quad: [1, 2, 3]}));
+            InspectorTest.expectNotNull(error, "DOM.highlightQuad should reject a three-element quad.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "HighlightSelectorNotDispatchable",
+        description: "DOM.highlightSelector is page-only, so a frame target should not expose it.",
+        async test() {
+            let {target} = await containerNodeForFrame("highlight-frame.html");
+
+            // Unlike the other highlight commands, highlightSelector resolves a frameId through the
+            // page-level identifier registry, so it is still targetTypes ["page"] and still a stub.
+            // Asserted so that implementing it has to update this expectation deliberately.
+            InspectorTest.expectFalse(target.hasCommand("DOM.highlightSelector"), "Frame target should not expose DOM.highlightSelector.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that a cross-origin iframe's FrameDOMAgent accepts the DOM highlight commands.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/highlight-frame.html" width="300" height="200"></iframe>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/highlight-rtl-frame.html" width="300" height="200"></iframe>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/highlight-vertical-frame.html" width="300" height="200"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target-expected.txt
@@ -1,0 +1,27 @@
+Tests that highlighting hands off cleanly between the page target and a cross-origin frame target.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameHighlightTargetHandoff
+-- Running test case: Setup
+PASS: Should find the cross-origin frame target.
+PASS: Frame document should have a BODY.
+PASS: Frame document should have #container.
+PASS: Page target should resolve the iframe element.
+
+-- Running test case: InnerNodeRoutesToFrameTarget
+PASS: Should resolve #target in the frame target.
+PASS: Inner node should report the frame target as its owning target.
+PASS: backendNodeId should be the raw protocol nodeId, not the scoped id.
+PASS: The scoped frontend id should differ from the backend nodeId.
+
+-- Running test case: IframeElementRoutesToPageTarget
+PASS: The iframe element should have no owning frame target.
+PASS: A page-target node's backendNodeId should equal its id.
+
+-- Running test case: BothTargetsAcceptHideHighlight
+PASS: Page and frame targets should be distinct.
+PASS: Page target should support DOM.hideHighlight.
+PASS: Frame target should support DOM.hideHighlight.
+Both targets accepted DOM.hideHighlight.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target.html
@@ -1,0 +1,105 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameHighlightTargetHandoff");
+
+    // Highlight state is per-target. Highlighting a node in one target must clear the others, or the
+    // page target keeps highlighting the owner iframe element while the frame target highlights the
+    // inner node, and both draw at once.
+
+    let frameTarget = null;
+    let frameContainerNode = null;
+    let iframeNode = null;
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Resolve the iframe element in the page target and #container in the frame target.",
+        async test() {
+            frameTarget = await frameTargetForURLContaining("highlight-frame.html");
+            InspectorTest.expectNotNull(frameTarget, "Should find the cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+
+            let frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+
+            let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+            await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+            let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+            InspectorTest.expectNotNull(bodyNode, "Frame document should have a BODY.");
+            await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+            frameContainerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(frameContainerNode, "Frame document should have #container.");
+            await new Promise((resolve) => frameContainerNode.getChildNodes(resolve));
+
+            // The <iframe> element itself lives in the page target.
+            let pageDocument = await new Promise((resolve) => WI.domManager.requestDocument(resolve));
+            let iframeNodeId = await pageDocument.querySelector("iframe");
+            iframeNode = WI.domManager.nodeForId(iframeNodeId);
+            InspectorTest.expectNotNull(iframeNode, "Page target should resolve the iframe element.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "InnerNodeRoutesToFrameTarget",
+        description: "A node inside the frame should carry the frame target and its raw backend nodeId.",
+        async test() {
+            let targetNodeId = await frameContainerNode.querySelector("#target");
+            let targetNode = WI.domManager.nodeForIdInFrameTarget(targetNodeId, frameTarget);
+            InspectorTest.expectNotNull(targetNode, "Should resolve #target in the frame target.");
+
+            InspectorTest.expectEqual(targetNode.owningTarget, frameTarget, "Inner node should report the frame target as its owning target.");
+            InspectorTest.expectEqual(targetNode.backendNodeId, targetNodeId, "backendNodeId should be the raw protocol nodeId, not the scoped id.");
+            InspectorTest.expectThat(targetNode.id !== targetNodeId, "The scoped frontend id should differ from the backend nodeId.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "IframeElementRoutesToPageTarget",
+        description: "The iframe element should belong to the page target and use an unscoped id.",
+        async test() {
+            InspectorTest.expectNull(iframeNode.owningTarget, "The iframe element should have no owning frame target.");
+            InspectorTest.expectEqual(iframeNode.backendNodeId, iframeNode.id, "A page-target node's backendNodeId should equal its id.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "BothTargetsAcceptHideHighlight",
+        description: "Highlighting an inner node must be clearable on both targets, or both keep drawing.",
+        async test() {
+            // Observed through the protocol rather than the backend overlay, which no Internals hook
+            // exposes per frame: hideHighlight must reach the page target when an inner node is
+            // highlighted, otherwise the page keeps drawing the owner iframe element too.
+            let pageTarget = WI.assumingMainTarget();
+            InspectorTest.expectThat(pageTarget !== frameTarget, "Page and frame targets should be distinct.");
+            InspectorTest.expectThat(pageTarget.hasCommand("DOM.hideHighlight"), "Page target should support DOM.hideHighlight.");
+            InspectorTest.expectThat(frameTarget.hasCommand("DOM.hideHighlight"), "Frame target should support DOM.hideHighlight.");
+
+            let targetNodeId = await frameContainerNode.querySelector("#target");
+            let targetNode = WI.domManager.nodeForIdInFrameTarget(targetNodeId, frameTarget);
+            targetNode.highlight();
+
+            await frameTarget.DOMAgent.hideHighlight();
+            await pageTarget.DOMAgent.hideHighlight();
+            InspectorTest.log("Both targets accepted DOM.hideHighlight.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that highlighting hands off cleanly between the page target and a cross-origin frame target.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/highlight-frame.html" width="300" height="200"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Highlight Frame</title>
+    <style>
+        body { margin: 0; }
+        #spacer { height: 400px; }
+        #target { width: 120px; height: 60px; margin: 10px; padding: 8px; border: 4px solid black; background: cyan; }
+        #tail { height: 400px; }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <div id="spacer"></div>
+        <div id="target">Highlight me</div>
+        <div id="tail"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-rtl-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-rtl-frame.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html dir="rtl">
+<head>
+    <title>Cross-Origin RTL Highlight Frame</title>
+    <style>
+        body { margin: 0; }
+        /* Wider than the iframe so the RTL scroll origin is non-zero. */
+        #container { width: 1200px; }
+        #target { width: 120px; height: 60px; margin: 10px; padding: 8px; border: 4px solid black; background: cyan; }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <div id="target">Highlight me</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-vertical-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-vertical-frame.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Vertical Writing Mode Highlight Frame</title>
+    <style>
+        /* vertical-rl also puts the scroll origin on the right, like RTL. */
+        html { writing-mode: vertical-rl; }
+        body { margin: 0; }
+        #container { width: 1200px; }
+        #target { width: 120px; height: 60px; margin: 10px; padding: 8px; border: 4px solid black; background: cyan; }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <div id="target">Highlight me</div>
+    </div>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -587,8 +587,8 @@
         },
         {
             "name": "highlightRect",
-            "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.",
-            "targetTypes": ["page"],
+            "description": "Highlights given rectangle. Coordinates are absolute with respect to the target's viewport: the main frame viewport for a page target, or the frame's own viewport for a frame target.",
+            "targetTypes": ["itml", "frame", "page"],
             "parameters": [
                 { "name": "x", "type": "integer", "description": "X coordinate" },
                 { "name": "y", "type": "integer", "description": "Y coordinate" },
@@ -601,8 +601,8 @@
         },
         {
             "name": "highlightQuad",
-            "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport.",
-            "targetTypes": ["page"],
+            "description": "Highlights given quad. Coordinates are absolute with respect to the target's viewport: the main frame viewport for a page target, or the frame's own viewport for a frame target.",
+            "targetTypes": ["itml", "frame", "page"],
             "parameters": [
                 { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
                 { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1992,6 +1992,7 @@ inspector/InspectorInstrumentationWebKit.cpp
 inspector/InspectorNetworkIntercept.cpp
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp @header:RenderStyleGetters
+inspector/InspectorOverlayConfigParser.cpp
 inspector/InspectorOverlayLabel.cpp
 inspector/InspectorResourceUtilities.cpp
 inspector/InspectorShaderProgram.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -15267,6 +15267,8 @@
 		7C5222971E1DAE16002CB8F7 /* ActiveDOMCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActiveDOMCallback.cpp; sourceTree = "<group>"; };
 		7C5222981E1DAE16002CB8F7 /* ActiveDOMCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActiveDOMCallback.h; sourceTree = "<group>"; };
 		7C522D4915B477E8009B7C95 /* InspectorOverlay.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorOverlay.cpp; sourceTree = "<group>"; };
+		7C522D5015B477E8009B7C96 /* InspectorOverlayConfigParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorOverlayConfigParser.cpp; sourceTree = "<group>"; };
+		7C522D5115B477E8009B7C97 /* InspectorOverlayConfigParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorOverlayConfigParser.h; sourceTree = "<group>"; };
 		7C522D4A15B478B2009B7C95 /* InspectorOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorOverlay.h; sourceTree = "<group>"; };
 		7C5266961F1B02FC000F068B /* StringAdaptors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringAdaptors.h; sourceTree = "<group>"; };
 		7C57BFE61EDE2F5B00534A48 /* JSDOMAbstractOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMAbstractOperations.h; sourceTree = "<group>"; };
@@ -26434,6 +26436,8 @@
 				504AACCC1834455900E3D9BC /* InspectorNodeFinder.h */,
 				7C522D4915B477E8009B7C95 /* InspectorOverlay.cpp */,
 				7C522D4A15B478B2009B7C95 /* InspectorOverlay.h */,
+				7C522D5015B477E8009B7C96 /* InspectorOverlayConfigParser.cpp */,
+				7C522D5115B477E8009B7C97 /* InspectorOverlayConfigParser.h */,
 				2EDDAF4527920EC3005D18E4 /* InspectorOverlayLabel.cpp */,
 				2EDDAF4327920EB4005D18E4 /* InspectorOverlayLabel.h */,
 				9940EAFA2E8DBD6E007F64DD /* InspectorResourceType.h */,

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -179,7 +179,7 @@ void FrameInspectorController::createLazyAgents()
 
     auto context = frameAgentContext();
     m_agents.append(makeUniqueRef<FrameDebuggerAgent>(context));
-    m_agents.append(makeUniqueRef<FrameDOMAgent>(context));
+    m_agents.append(makeUniqueRef<FrameDOMAgent>(context, m_overlay.get()));
     m_agents.append(makeUniqueRef<FrameDOMStorageAgent>(context));
     m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
     m_agents.append(makeUniqueRef<FrameCSSAgent>(context));

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -74,6 +74,7 @@ FrameInspectorController::FrameInspectorController(LocalFrame& frame, PageInspec
     , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &parentPageController.backendDispatcher()))
+    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this))
     , m_executionStopwatch(Stopwatch::create())
 {
     if (frame.settings().siteIsolationEnabled())
@@ -93,6 +94,33 @@ void FrameInspectorController::ref() const
 void FrameInspectorController::deref() const
 {
     m_frame->deref();
+}
+
+Page* FrameInspectorController::overlayOwnerPage() const
+{
+    return m_frame->page();
+}
+
+LocalFrame* FrameInspectorController::overlayOwnerFrame() const
+{
+    return m_frame.ptr();
+}
+
+InspectorBackendClient* FrameInspectorController::overlayOwnerBackendClient() const
+{
+    // Not cached: inspectedPageDestroyed() destroys the client before frames detach.
+    RefPtr page = m_frame->page();
+    return page ? page->inspectorController().inspectorBackendClient() : nullptr;
+}
+
+void FrameInspectorController::drawHighlight(GraphicsContext& context) const
+{
+    m_overlay->paint(context);
+}
+
+bool FrameInspectorController::hasOverlayContentToDraw() const
+{
+    return m_overlay->shouldShowOverlay();
 }
 
 FrameAgentContext FrameInspectorController::frameAgentContext()

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -52,6 +52,7 @@ class FrontendRouter;
 
 namespace WebCore {
 
+class GraphicsContext;
 class InspectorBackendClient;
 class InspectorController;
 class InspectorFrontendClient;
@@ -62,7 +63,7 @@ class PageInspectorController;
 class WebInjectedScriptManager;
 struct FrameAgentContext;
 
-class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<FrameInspectorController> {
+class FrameInspectorController final : public Inspector::InspectorEnvironment, public InspectorOverlayOwner, public CanMakeCheckedPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameInspectorController);
@@ -70,15 +71,22 @@ public:
     FrameInspectorController(LocalFrame&, PageInspectorController&);
     ~FrameInspectorController() override;
 
-    // AbstractCanMakeCheckedPtr overrides
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
     WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
+
+    // InspectorOverlayOwner. Anchors on the frame, which owns this controller and so the overlay.
+    void overlayOwnerRef() const final { ref(); }
+    void overlayOwnerDeref() const final { deref(); }
+    Page* NODELETE overlayOwnerPage() const final;
+    LocalFrame* NODELETE overlayOwnerFrame() const final;
+    InspectorBackendClient* NODELETE overlayOwnerBackendClient() const final;
+
+    WEBCORE_EXPORT void drawHighlight(GraphicsContext&) const;
+
+    // True when this frame's own overlay holds the highlight state, not the page overlay.
+    WEBCORE_EXPORT bool hasOverlayContentToDraw() const;
 
     WEBCORE_EXPORT void connectFrontend(Inspector::FrontendChannel&, bool isAutomaticInspection = false, bool immediatelyPause = false);
     WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
@@ -111,6 +119,10 @@ private:
     const Ref<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+
+    // This frame's own overlay, distinct from the page overlay owned by PageInspectorController.
+    const UniqueRef<InspectorOverlay> m_overlay;
+
     const Ref<WTF::Stopwatch> m_executionStopwatch;
     std::unique_ptr<JSC::Debugger> m_debugger;
     Inspector::AgentRegistry m_agents;

--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -62,6 +62,10 @@ public:
     virtual void highlight() = 0;
     virtual void hideHighlight() = 0;
 
+    // Frame-scoped highlight overlays under Site Isolation; default to the page-wide versions.
+    virtual void highlightFrame(LocalFrame&) { highlight(); }
+    virtual void hideHighlightForFrame(LocalFrame&) { hideHighlight(); }
+
     virtual void showInspectorIndication() { }
     virtual void hideInspectorIndication() { }
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -449,6 +449,19 @@ void InspectorOverlay::paint(GraphicsContext& context)
 
     auto viewportSize = pageView->sizeForVisibleContent();
 
+    // Everything below emits root-view coordinates, but a frame overlay paints into an
+    // OverlayType::Document surface positioned at the contents origin, so it receives contents
+    // coordinates. Undo contentsToView(), which subtracts documentScrollPositionRelativeToViewOrigin()
+    // -- and is a no-op when scrolling is delegated, so this must be too. PageOverlay::drawRect() has
+    // already translated by scrollOrigin(), which is part of that same conversion and must not be
+    // re-applied here. Must precede the clearRect below, which is also viewport-relative.
+    // FIXME: <rdar://116202544> Remove once frame overlays can use OverlayType::View, which needs a
+    // per-frame view-overlay root layer and attachViewOverlayGraphicsLayer() to stop hardcoding the
+    // main frame.
+    GraphicsContextStateSaver documentSurfaceStateSaver(context);
+    if (isFrameScoped() && !pageView->delegatesScrollingToNativeView())
+        context.translate(pageView->documentScrollPositionRelativeToViewOrigin() - pageView->scrollOrigin());
+
     context.clearRect({ FloatPoint::zero(), viewportSize });
 
     GraphicsContextStateSaver stateSaver(context);
@@ -1347,6 +1360,11 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         obscuredContentInsets.setTop(obscuredContentInsets.top() + rulerSize);
         obscuredContentInsets.setLeft(obscuredContentInsets.left() + rulerSize);
     }
+
+    // FIXME: For a frame overlay these clamps are against the frame's own viewport, so a tooltip for a
+    // node near an iframe edge is confined to the iframe instead of the window. Fixing it needs the
+    // label drawn into a surface that can extend past the frame, which a per-frame overlay cannot do
+    // today -- it is the same constraint as <rdar://116202544>'s OverlayType::View work.
 
     auto expectedLabelSize = InspectorOverlayLabel::expectedSize(labelContents, InspectorOverlayLabel::Arrow::Direction::Up);
     auto boundsCenterX = bounds.center().x();

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -115,19 +115,16 @@ static void truncateWithEllipsis(String& string, size_t length)
         string = makeString(StringView(string).left(length), horizontalEllipsis);
 }
 
-static FloatPoint localPointToRootPoint(const FrameView* view, const FloatPoint& point)
+static void contentsQuadToCoordinateSystem(const FrameView* mainView, const LocalFrameView& view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
 {
-    return view->contentsToRootView(point);
-}
+    // contentsToRootView() stops at this process's local root, which is the space a frame overlay
+    // draws in; convertToRootViewAcrossIsolatedFrames() would map to page space instead.
+    quad.setP1(view.contentsToRootView(quad.p1()));
+    quad.setP2(view.contentsToRootView(quad.p2()));
+    quad.setP3(view.contentsToRootView(quad.p3()));
+    quad.setP4(view.contentsToRootView(quad.p4()));
 
-static void contentsQuadToCoordinateSystem(const FrameView* mainView, const LocalFrameView* view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
-{
-    quad.setP1(localPointToRootPoint(view, quad.p1()));
-    quad.setP2(localPointToRootPoint(view, quad.p2()));
-    quad.setP3(localPointToRootPoint(view, quad.p3()));
-    quad.setP4(localPointToRootPoint(view, quad.p4()));
-
-    if (coordinateSystem == InspectorOverlay::CoordinateSystem::View)
+    if (coordinateSystem == InspectorOverlay::CoordinateSystem::View && mainView)
         quad += toIntSize(mainView->scrollPosition());
 }
 
@@ -154,7 +151,12 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
 
     highlight.setDataFromConfig(highlightConfig);
     RefPtr containingView = containingFrame->view();
-    RefPtr mainView = protect(containingFrame->page())->mainFrame().virtualView();
+    if (!containingView)
+        return;
+
+    // Only read for CoordinateSystem::View, which only the two page-level getHighlight() callers use.
+    RefPtr containingPage = containingFrame->page();
+    RefPtr mainView = containingPage ? containingPage->mainFrame().virtualView() : nullptr;
 
     // (Legacy)RenderSVGRoot should be highlighted through the isBox() code path, all other SVG elements should just dump their absoluteQuads().
     bool isSVGRenderer = renderer->node() && renderer->node()->isSVGElement() && !renderer->isRenderOrLegacyRenderSVGRoot();
@@ -163,7 +165,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
         highlight.type = InspectorOverlay::Highlight::Type::Rects;
         renderer->absoluteQuads(highlight.quads);
         for (auto& quad : highlight.quads)
-            contentsQuadToCoordinateSystem(mainView, containingView, quad, coordinateSystem);
+            contentsQuadToCoordinateSystem(mainView, *containingView, quad, coordinateSystem);
     } else if (isAnyOf<RenderBox, RenderInline>(*renderer)) {
         LayoutRect contentBox;
         LayoutRect paddingBox;
@@ -200,10 +202,10 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
         FloatQuad absBorderQuad = renderer->localToAbsoluteQuad(FloatRect(borderBox));
         FloatQuad absMarginQuad = renderer->localToAbsoluteQuad(FloatRect(marginBox));
 
-        contentsQuadToCoordinateSystem(mainView, containingView, absContentQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absPaddingQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absBorderQuad, coordinateSystem);
-        contentsQuadToCoordinateSystem(mainView, containingView, absMarginQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absContentQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absPaddingQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absBorderQuad, coordinateSystem);
+        contentsQuadToCoordinateSystem(mainView, *containingView, absMarginQuad, coordinateSystem);
 
         highlight.type = InspectorOverlay::Highlight::Type::Node;
         highlight.quads.append(absMarginQuad);
@@ -327,7 +329,12 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
         return;
 
     RefPtr containingView = containingFrame->view();
-    RefPtr mainView = protect(containingFrame->page())->mainFrame().virtualView();
+    if (!containingView)
+        return;
+
+    // See buildRendererHighlight(): only read under CoordinateSystem::View, which frames never reach.
+    RefPtr containingPage = containingFrame->page();
+    RefPtr mainView = containingPage ? containingPage->mainFrame().virtualView() : nullptr;
 
     static constexpr auto shapeHighlightColor = SRGBA<uint8_t> { 96, 82, 127, 204 };
 
@@ -337,7 +344,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     if (paths.shape.isEmpty()) {
         LayoutRect shapeBounds = shapeOutsideInfo->computedShapePhysicalBoundingBox();
         FloatQuad shapeQuad = renderer->localToAbsoluteQuad(FloatRect(shapeBounds));
-        contentsQuadToCoordinateSystem(mainView, containingView, shapeQuad, InspectorOverlay::CoordinateSystem::Document);
+        contentsQuadToCoordinateSystem(mainView, *containingView, shapeQuad, InspectorOverlay::CoordinateSystem::Document);
         drawOutlinedQuad(context, shapeQuad, shapeHighlightColor, Color::transparentBlack, bounds);
         return;
     }
@@ -347,7 +354,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
         path.applyElements([&] (const PathElement& pathElement) {
             const auto localToRoot = [&] (size_t index) {
                 const FloatPoint& point = pathElement.points[index];
-                return localPointToRootPoint(containingView, renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
+                return containingView->contentsToRootView(renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
             };
 
             switch (pathElement.type) {
@@ -395,9 +402,8 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     context.fillPath(shapePath);
 }
 
-InspectorOverlay::InspectorOverlay(PageInspectorController& controller, InspectorBackendClient* client)
-    : m_controller(controller)
-    , m_client(client)
+InspectorOverlay::InspectorOverlay(InspectorOverlayOwner& owner)
+    : m_owner(owner)
     , m_paintRectUpdateTimer(*this, &InspectorOverlay::updatePaintRectsTimerFired)
 {
 }
@@ -406,17 +412,28 @@ InspectorOverlay::~InspectorOverlay() = default;
 
 void InspectorOverlay::ref() const
 {
-    m_controller->ref();
+    m_owner->overlayOwnerRef();
 }
 
 void InspectorOverlay::deref() const
 {
-    m_controller->deref();
+    m_owner->overlayOwnerDeref();
 }
 
-Page& InspectorOverlay::page() const
+Page* InspectorOverlay::page() const
 {
-    return m_controller->inspectedPage();
+    return m_owner->overlayOwnerPage();
+}
+
+LocalFrame* InspectorOverlay::frameForGeometry() const
+{
+    // localMainFrame(), not localMainOrRootFrame(): the page overlay must not draw against a
+    // subframe's geometry, matching PageOverlay::frameForGeometry() that this is named after.
+    if (LocalFrame* ownerFrame = m_owner->overlayOwnerFrame())
+        return ownerFrame;
+
+    RefPtr page = this->page();
+    return page ? page->localMainFrame() : nullptr;
 }
 
 void InspectorOverlay::paint(GraphicsContext& context)
@@ -424,7 +441,13 @@ void InspectorOverlay::paint(GraphicsContext& context)
     if (!shouldShowOverlay())
         return;
 
-    auto viewportSize = protect(page())->mainFrame().virtualView()->sizeForVisibleContent();
+    // Null when the frame has no view, or this process's main frame is remote.
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
+    auto viewportSize = pageView->sizeForVisibleContent();
 
     context.clearRect({ FloatPoint::zero(), viewportSize });
 
@@ -507,7 +530,7 @@ void InspectorOverlay::paint(GraphicsContext& context)
     if (!m_paintRects.isEmpty())
         drawPaintRects(context, m_paintRects);
 
-    if (m_showRulers || m_showRulersForNodeHighlight)
+    if (shouldDrawRulers())
         drawRulers(context, rulerExclusion);
 }
 
@@ -621,8 +644,12 @@ void InspectorOverlay::highlightNode(Node* node, const InspectorOverlay::Highlig
 
 void InspectorOverlay::highlightQuad(std::unique_ptr<FloatQuad> quad, const InspectorOverlay::Highlight::Config& highlightConfig)
 {
-    if (highlightConfig.usePageCoordinates)
-        *quad -= toIntSize(protect(page())->mainFrame().virtualView()->scrollPosition());
+    // Page coordinates are relative to the geometry frame's own scroll position.
+    if (highlightConfig.usePageCoordinates) {
+        RefPtr geometryFrame = frameForGeometry();
+        if (RefPtr geometryView = geometryFrame ? geometryFrame->virtualView() : nullptr)
+            *quad -= toIntSize(geometryView->scrollPosition());
+    }
 
     m_quadHighlightConfig = highlightConfig;
     m_highlightQuad = WTF::move(quad);
@@ -636,7 +663,8 @@ Node* InspectorOverlay::highlightedNode() const
 
 void InspectorOverlay::didSetSearchingForNode(bool enabled)
 {
-    m_client->didSetSearchingForNode(enabled);
+    if (auto* client = m_owner->overlayOwnerBackendClient())
+        client->didSetSearchingForNode(enabled);
 }
 
 void InspectorOverlay::setIndicating(bool indicating)
@@ -649,29 +677,55 @@ void InspectorOverlay::setIndicating(bool indicating)
     update();
 }
 
+bool InspectorOverlay::shouldDrawRulers() const
+{
+    // Rulers are page-wide, so a frame overlay draws neither them nor their guide lines and insets.
+    if (isFrameScoped())
+        return false;
+
+    return m_showRulers || m_showRulersForNodeHighlight;
+}
+
 bool InspectorOverlay::shouldShowOverlay() const
 {
+    // Rulers alone must not install a frame surface that would paint nothing.
+    if (m_showRulers && !isFrameScoped())
+        return true;
+
     return m_highlightNode
         || m_highlightNodeList
         || m_highlightQuad
         || m_activeGridOverlays.size()
         || m_activeFlexOverlays.size()
         || m_indicating
-        || m_showPaintRects
-        || m_showRulers;
+        || m_showPaintRects;
 }
 
 void InspectorOverlay::update()
 {
+    auto* client = m_owner->overlayOwnerBackendClient();
+    if (!client)
+        return;
+
+    RefPtr geometryFrame = frameForGeometry();
+
+    // Dispatch on frame-scoped, not on whether a geometry frame exists, so the page path stays direct.
     if (!shouldShowOverlay()) {
-        m_client->hideHighlight();
+        if (isFrameScoped() && geometryFrame)
+            client->hideHighlightForFrame(*geometryFrame);
+        else
+            client->hideHighlight();
         return;
     }
 
-    if (!protect(page())->mainFrame().virtualView())
+    // Scoped to the geometry frame: the old main-frame check blocked painting in subframe processes.
+    if (!geometryFrame || !geometryFrame->virtualView())
         return;
 
-    m_client->highlight();
+    if (isFrameScoped())
+        client->highlightFrame(*geometryFrame);
+    else
+        client->highlight();
 }
 
 void InspectorOverlay::setShowPaintRects(bool showPaintRects)
@@ -692,7 +746,12 @@ void InspectorOverlay::showPaintRect(const FloatRect& rect)
     if (!m_showPaintRects)
         return;
 
-    auto rootRect = protect(page())->mainFrame().virtualView()->contentsToRootView(enclosingIntRect(rect));
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
+    auto rootRect = pageView->contentsToRootView(enclosingIntRect(rect));
 
     const auto removeDelay = 250_ms;
 
@@ -819,7 +878,7 @@ InspectorOverlay::RulerExclusion InspectorOverlay::drawNodeHighlight(GraphicsCon
     if (m_nodeHighlightConfig.showInfo)
         drawShapeHighlight(context, node, rulerExclusion.bounds);
 
-    if (m_showRulers || m_showRulersForNodeHighlight)
+    if (shouldDrawRulers())
         drawBounds(context, rulerExclusion.bounds);
 
     // Ensure that the title information is drawn after the bounds.
@@ -842,7 +901,7 @@ InspectorOverlay::RulerExclusion InspectorOverlay::drawQuadHighlight(GraphicsCon
     if (highlight.quads.size() >= 1) {
         drawOutlinedQuad(context, highlight.quads[0], highlight.contentColor, highlight.contentOutlineColor, rulerExclusion.bounds);
 
-        if (m_showRulers || m_showRulersForNodeHighlight)
+        if (shouldDrawRulers())
             drawBounds(context, rulerExclusion.bounds);
     }
 
@@ -862,8 +921,11 @@ void InspectorOverlay::drawPaintRects(GraphicsContext& context, const Deque<Time
 
 void InspectorOverlay::drawBounds(GraphicsContext& context, const InspectorOverlay::Highlight::Bounds& bounds)
 {
-    Ref mainFrame = page().mainFrame();
-    RefPtr pageView = mainFrame->virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return;
+
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
 
@@ -917,18 +979,25 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     constexpr auto lightRulerColor = Color::black.colorWithAlphaByte(51);
     constexpr auto darkRulerColor = Color::black.colorWithAlphaByte(128);
 
+    // Rulers are page-wide. Every caller gates on shouldDrawRulers(), which is false when frame scoped.
+    ASSERT(!isFrameScoped());
+
     IntPoint scrollOffset;
-    RefPtr localMainFrame = page().localMainFrame();
+    RefPtr page = this->page();
+    RefPtr localMainFrame = page ? page->localMainFrame() : nullptr;
     if (!localMainFrame)
         return;
 
     RefPtr pageView = localMainFrame->view();
+    if (!pageView)
+        return;
+
     if (!pageView->delegatesScrollingToNativeView())
         scrollOffset = pageView->visibleContentRect().location();
 
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
-    float pageScaleFactor = page().pageScaleFactor();
+    float pageScaleFactor = page->pageScaleFactor();
     float pageZoomFactor = localMainFrame->pageZoomFactor();
 
     float pageFactor = pageZoomFactor * pageScaleFactor;
@@ -993,7 +1062,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw lines.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page->settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(10);
 
         FontCascade font(WTF::move(fontDescription));
@@ -1083,7 +1152,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw viewport size.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page->settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(12);
 
         FontCascade font(WTF::move(fontDescription));
@@ -1198,10 +1267,13 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         elementWidth = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetWidth()), *modelObject));
         elementHeight = String::number(Style::adjustForAbsoluteZoom(roundToInt(modelObject->offsetHeight()), *modelObject));
     } else {
-        RefPtr containingView = node.document().frame()->view();
-        IntRect boundingBox = snappedIntRect(containingView->contentsToRootView(renderer->absoluteBoundingBoxRect()));
-        elementWidth = String::number(boundingBox.width());
-        elementHeight = String::number(boundingBox.height());
+        // A missing view only costs one line of the tooltip; draw the rest.
+        RefPtr containingFrame = node.document().frame();
+        if (RefPtr containingView = containingFrame ? containingFrame->view() : nullptr) {
+            IntRect boundingBox = snappedIntRect(containingView->contentsToRootView(renderer->absoluteBoundingBoxRect()));
+            elementWidth = String::number(boundingBox.width());
+            elementHeight = String::number(boundingBox.height());
+        }
     }
 
     Vector<String> layoutContextBubbleStrings;
@@ -1263,11 +1335,15 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         }
     }
 
-    Ref mainFrame = page().mainFrame();
-    RefPtr pageView = mainFrame->virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
+    if (!pageView)
+        return { };
+
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     auto obscuredContentInsets = pageView->obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
-    if (m_showRulers || m_showRulersForNodeHighlight) {
+    // Only reserve space for rulers that were actually drawn, or the label is displaced by rulerSize.
+    if (shouldDrawRulers()) {
         obscuredContentInsets.setTop(obscuredContentInsets.top() + rulerSize);
         obscuredContentInsets.setLeft(obscuredContentInsets.left() + rulerSize);
     }
@@ -1558,7 +1634,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
 
     constexpr auto translucentLabelBackgroundColor = Color::white.colorWithAlphaByte(230);
 
-    RefPtr pageView = protect(page())->mainFrame().virtualView();
+    RefPtr geometryFrame = frameForGeometry();
+    RefPtr pageView = geometryFrame ? geometryFrame->virtualView() : nullptr;
     if (!pageView)
         return { };
     FloatRect viewportBounds = { { 0, 0 }, pageView->sizeForVisibleContent() };
@@ -1598,6 +1675,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     if (!containingFrame)
         return { };
     RefPtr containingView = containingFrame->view();
+    if (!containingView)
+        return { };
 
     auto computedStyle = node->computedStyle();
     if (!computedStyle)
@@ -1619,8 +1698,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             endPoint = { isWritingModeFlipped ? contentBox.width() - gridEndY : gridEndY, isDirectionFlipped ? contentBox.height() - x : x };
         }
         return {
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(startPoint, nullptr)),
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(endPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(startPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(endPoint, nullptr)),
         };
     };
     auto rowLineAt = [&](float y) -> FloatLine {
@@ -1634,8 +1713,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             endPoint = { isWritingModeFlipped ? contentBox.width() - y : y, isDirectionFlipped ? contentBox.height() - gridEndX : gridEndX };
         }
         return {
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(startPoint, nullptr)),
-            localPointToRootPoint(containingView, renderGrid->localToContainerPoint(endPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(startPoint, nullptr)),
+            containingView->contentsToRootView(renderGrid->localToContainerPoint(endPoint, nullptr)),
         };
     };
 
@@ -1906,8 +1985,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             auto absoluteRect = FloatRect { gridItem->absoluteBoundingBoxRect(true) };
             absoluteRect.expand(gridItem->marginBox());
 
-            auto minCorner = localPointToRootPoint(containingView, absoluteRect.minXMinYCorner());
-            auto maxCorner = localPointToRootPoint(containingView, absoluteRect.maxXMaxYCorner());
+            auto minCorner = containingView->contentsToRootView(absoluteRect.minXMinYCorner());
+            auto maxCorner = containingView->contentsToRootView(absoluteRect.maxXMaxYCorner());
             FloatRect rootRect { minCorner, maxCorner - minCorner };
 
             if (renderGrid->hasStackingAxisRows()) {
@@ -2025,10 +2104,10 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
                 auto margins = gridItem->marginBox();
                 absoluteRect.expand(FloatBoxExtent { margins.top(), margins.right(), margins.bottom(), margins.left() });
                 itemBounds = FloatQuad {
-                    localPointToRootPoint(containingView, absoluteRect.minXMinYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.maxXMinYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.maxXMaxYCorner()),
-                    localPointToRootPoint(containingView, absoluteRect.minXMaxYCorner())
+                    containingView->contentsToRootView(absoluteRect.minXMinYCorner()),
+                    containingView->contentsToRootView(absoluteRect.maxXMinYCorner()),
+                    containingView->contentsToRootView(absoluteRect.maxXMaxYCorner()),
+                    containingView->contentsToRootView(absoluteRect.minXMaxYCorner())
                 };
             } else {
                 // For regular grid layouts, compute bounds from the grid area.
@@ -2137,12 +2216,14 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     CheckedRef renderFlex = *downcast<RenderFlexibleBox>(renderer);
 
-    auto itemsAtStartOfLine = m_controller->ensureDOMAgent().flexibleBoxRendererCachedItemsAtStartOfLine(renderFlex);
+    auto itemsAtStartOfLine = m_owner->overlayOwnerFlexLineStarts(renderFlex);
 
     RefPtr containingFrame = node->document().frame();
     if (!containingFrame)
         return { };
     RefPtr containingView = containingFrame->view();
+    if (!containingView)
+        return { };
 
     auto computedStyle = node->computedStyle();
     if (!computedStyle)
@@ -2158,19 +2239,19 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     auto localQuadToRootQuad = [&](const FloatQuad& quad) {
         return FloatQuad(
-            localPointToRootPoint(containingView, quad.p1()),
-            localPointToRootPoint(containingView, quad.p2()),
-            localPointToRootPoint(containingView, quad.p3()),
-            localPointToRootPoint(containingView, quad.p4())
+            containingView->contentsToRootView(quad.p1()),
+            containingView->contentsToRootView(quad.p2()),
+            containingView->contentsToRootView(quad.p3()),
+            containingView->contentsToRootView(quad.p4())
         );
     };
 
     auto childQuadToRootQuad = [&](const FloatQuad& quad) {
         return FloatQuad(
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p1(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p2(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p3(), nullptr)),
-            localPointToRootPoint(containingView, renderFlex->localToContainerPoint(quad.p4(), nullptr))
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p1(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p2(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p3(), nullptr)),
+            containingView->contentsToRootView(renderFlex->localToContainerPoint(quad.p4(), nullptr))
         );
     };
 

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -37,6 +37,7 @@
 #include <WebCore/InspectorOverlayLabel.h>
 #include <WebCore/Path.h>
 #include <WebCore/Timer.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
@@ -60,10 +61,13 @@ class WeakPtrImplWithEventTargetData;
 class FontCascade;
 class FloatPoint;
 class GraphicsContext;
+class InspectorBackendClient;
+class LocalFrame;
 class Node;
 class NodeList;
 class Page;
 class PageInspectorController;
+class RenderObject;
 
 struct InspectorOverlayHighlight {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(InspectorOverlayHighlight);
@@ -140,10 +144,33 @@ struct InspectorOverlayHighlight {
     using Bounds = FloatRect;
 };
 
+// Owner of an InspectorOverlay: a PageInspectorController (page overlay) or, under Site Isolation,
+// a LocalFrame's FrameInspectorController (frame overlay). ref()/deref() pin the owner, not the
+// overlay, which is not RefCounted; AbstractCanMakeCheckedPtr lets the overlay hold a CheckedRef.
+class InspectorOverlayOwner : public AbstractCanMakeCheckedPtr {
+public:
+    virtual ~InspectorOverlayOwner() = default;
+
+    virtual void overlayOwnerRef() const = 0;
+    virtual void overlayOwnerDeref() const = 0;
+
+    // Null for a frame overlay once its frame is detached.
+    virtual Page* NODELETE overlayOwnerPage() const = 0;
+
+    // Not cached by callers: destroyed by PageInspectorController::inspectedPageDestroyed().
+    virtual InspectorBackendClient* NODELETE overlayOwnerBackendClient() const = 0;
+
+    // The frame the overlay draws in, or null for the page overlay. See frameForGeometry().
+    virtual LocalFrame* NODELETE overlayOwnerFrame() const { return nullptr; }
+
+    // Flex line-wrap positions for line separators; empty for a frame owner, which has no cache yet.
+    virtual Vector<size_t> overlayOwnerFlexLineStarts(const RenderObject&) const { return { }; }
+};
+
 class InspectorOverlay : public CanMakeWeakPtr<InspectorOverlay> {
     WTF_MAKE_TZONE_ALLOCATED(InspectorOverlay);
 public:
-    InspectorOverlay(PageInspectorController&, InspectorBackendClient*);
+    explicit InspectorOverlay(InspectorOverlayOwner&);
     ~InspectorOverlay();
 
     void NODELETE ref() const;
@@ -251,10 +278,19 @@ private:
     bool removeGridOverlayForNode(Node&);
     bool removeFlexOverlayForNode(Node&);
 
-    Page& NODELETE page() const;
+    // Null once the owner is detached from its page; every geometry path must tolerate that.
+    Page* NODELETE page() const;
 
-    const WeakRef<PageInspectorController> m_controller;
-    InspectorBackendClient* m_client;
+    // The frame this overlay draws in: the owner's frame, else the page's local main frame.
+    LocalFrame* NODELETE frameForGeometry() const;
+
+    // True when scoped to one frame rather than the whole page.
+    bool isFrameScoped() const { return !!m_owner->overlayOwnerFrame(); }
+
+    // Single answer to "are rulers being drawn", so the guide lines and tooltip insets agree.
+    bool shouldDrawRulers() const;
+
+    const CheckedRef<const InspectorOverlayOwner> m_owner;
 
     RefPtr<Node> m_highlightNode;
     RefPtr<NodeList> m_highlightNodeList;

--- a/Source/WebCore/inspector/InspectorOverlayConfigParser.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayConfigParser.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorOverlayConfigParser.h"
+
+#include "ColorTypes.h"
+#include "FloatQuad.h"
+#include <wtf/JSONValues.h>
+
+namespace WebCore {
+
+std::optional<Color> parseInspectorColor(RefPtr<JSON::Object>&& colorObject)
+{
+    if (!colorObject)
+        return std::nullopt;
+
+    auto r = colorObject->getInteger("r"_s);
+    auto g = colorObject->getInteger("g"_s);
+    auto b = colorObject->getInteger("b"_s);
+    if (!r || !g || !b)
+        return std::nullopt;
+
+    auto a = colorObject->getDouble("a"_s);
+    if (!a)
+        return { makeFromComponentsClamping<SRGBA<uint8_t>>(*r, *g, *b) };
+    return { makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(*r, *g, *b, convertFloatAlphaTo<uint8_t>(*a)) };
+}
+
+static std::optional<Color> parseRequiredConfigColor(const String& fieldName, JSON::Object& configObject)
+{
+    return parseInspectorColor(configObject.getObject(fieldName));
+}
+
+static Color parseOptionalConfigColor(const String& fieldName, JSON::Object& configObject)
+{
+    return parseRequiredConfigColor(fieldName, configObject).value_or(Color::transparentBlack);
+}
+
+bool parseInspectorQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
+{
+    std::array<double, 8> coordinates { };
+    if (quadArray->length() != coordinates.size())
+        return false;
+    for (size_t i = 0; i < coordinates.size(); ++i) {
+        auto coordinate = quadArray->get(i)->asDouble();
+        if (!coordinate)
+            return false;
+        coordinates[i] = *coordinate;
+    }
+    quad->setP1(FloatPoint(coordinates[0], coordinates[1]));
+    quad->setP2(FloatPoint(coordinates[2], coordinates[3]));
+    quad->setP3(FloatPoint(coordinates[4], coordinates[5]));
+    quad->setP4(FloatPoint(coordinates[6], coordinates[7]));
+
+    return true;
+}
+
+std::unique_ptr<InspectorOverlay::Highlight::Config> highlightConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&& highlightInspectorObject)
+{
+    if (!highlightInspectorObject) {
+        errorString = "Internal error: highlight configuration parameter is missing"_s;
+        return nullptr;
+    }
+
+    auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
+    highlightConfig->showInfo = highlightInspectorObject->getBoolean("showInfo"_s).value_or(false);
+    highlightConfig->content = parseOptionalConfigColor("contentColor"_s, *highlightInspectorObject);
+    highlightConfig->padding = parseOptionalConfigColor("paddingColor"_s, *highlightInspectorObject);
+    highlightConfig->border = parseOptionalConfigColor("borderColor"_s, *highlightInspectorObject);
+    highlightConfig->margin = parseOptionalConfigColor("marginColor"_s, *highlightInspectorObject);
+    return highlightConfig;
+}
+
+std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&& gridOverlayInspectorObject)
+{
+    if (!gridOverlayInspectorObject)
+        return std::nullopt;
+
+    auto gridColor = parseRequiredConfigColor("gridColor"_s, *gridOverlayInspectorObject);
+    if (!gridColor) {
+        errorString = "Internal error: grid color property of grid overlay configuration parameter is missing"_s;
+        return std::nullopt;
+    }
+
+    InspectorOverlay::Grid::Config gridOverlayConfig;
+    gridOverlayConfig.gridColor = *gridColor;
+    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean("showLineNames"_s).value_or(false);
+    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean("showLineNumbers"_s).value_or(false);
+    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean("showExtendedGridLines"_s).value_or(false);
+    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean("showTrackSizes"_s).value_or(false);
+    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean("showAreaNames"_s).value_or(false);
+    gridOverlayConfig.showOrderNumbers = gridOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
+    return gridOverlayConfig;
+}
+
+std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+{
+    if (!flexOverlayInspectorObject)
+        return std::nullopt;
+
+    auto flexColor = parseRequiredConfigColor("flexColor"_s, *flexOverlayInspectorObject);
+    if (!flexColor) {
+        errorString = "Internal error: flex color property of flex overlay configuration parameter is missing"_s;
+        return std::nullopt;
+    }
+
+    InspectorOverlay::Flex::Config flexOverlayConfig;
+    flexOverlayConfig.flexColor = *flexColor;
+    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
+    return flexOverlayConfig;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/InspectorOverlayConfigParser.h
+++ b/Source/WebCore/inspector/InspectorOverlayConfigParser.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorOverlay.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+// Shared by InspectorDOMAgent and FrameDOMAgent: converting the protocol's highlight configuration
+// objects into the overlay's config structs. Depends on InspectorOverlay.h, so WebCore-internal.
+
+std::optional<Color> parseInspectorColor(RefPtr<JSON::Object>&&);
+bool parseInspectorQuad(Ref<JSON::Array>&&, FloatQuad*);
+
+std::unique_ptr<InspectorOverlay::Highlight::Config> highlightConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&&);
+std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&&);
+std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(String& errorString, RefPtr<JSON::Object>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -96,7 +96,7 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
     , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
-    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this, inspectorBackendClient.get()))
+    , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this))
     , m_executionStopwatch(Stopwatch::create())
     , m_inspectorBackendClient(WTF::move(inspectorBackendClient))
     , m_identifierRegistry(Inspector::LegacyIdentifierRegistry::create())
@@ -420,6 +420,21 @@ bool PageInspectorController::enabled() const
 Page& PageInspectorController::inspectedPage() const
 {
     return m_page;
+}
+
+Page* PageInspectorController::overlayOwnerPage() const
+{
+    // Always non-null: this controller is owned by the page.
+    return m_page.ptr();
+}
+
+Vector<size_t> PageInspectorController::overlayOwnerFlexLineStarts(const RenderObject& renderer) const
+{
+    // Deliberately does not create the DOM agent: with no agent there is nothing cached to report.
+    CheckedPtr domAgent = m_domAgent;
+    if (!domAgent)
+        return { };
+    return domAgent->flexibleBoxRendererCachedItemsAtStartOfLine(renderer);
 }
 
 void PageInspectorController::dispatchMessageFromFrontend(const String& message)

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -67,7 +67,7 @@ class PageDebugger;
 class WebInjectedScriptManager;
 struct PageAgentContext;
 
-class PageInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<PageInspectorController> {
+class PageInspectorController final : public Inspector::InspectorEnvironment, public InspectorOverlayOwner, public CanMakeCheckedPtr<PageInspectorController> {
     WTF_MAKE_NONCOPYABLE(PageInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(PageInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageInspectorController);
@@ -75,15 +75,17 @@ public:
     PageInspectorController(Page&, std::unique_ptr<InspectorBackendClient>&&);
     ~PageInspectorController() override;
 
-    // AbstractCanMakeCheckedPtr overrides
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
     WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
+
+    // InspectorOverlayOwner. Reports no frame, so the overlay uses the local main frame as before.
+    void overlayOwnerRef() const final { ref(); }
+    void overlayOwnerDeref() const final { deref(); }
+    Page* NODELETE overlayOwnerPage() const final;
+    InspectorBackendClient* NODELETE overlayOwnerBackendClient() const final { return m_inspectorBackendClient.get(); }
+    Vector<size_t> overlayOwnerFlexLineStarts(const RenderObject&) const final;
 
     void inspectedPageDestroyed();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3002,7 +3002,7 @@ void InspectorDOMAgent::flexibleBoxRendererWrappedToNextLine(const RenderObject&
     }).iterator->value.append(lineStartItemIndex);
 }
 
-Vector<size_t> InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject& renderer)
+Vector<size_t> InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject& renderer) const
 {
     return m_flexibleBoxRendererCachedItemsAtStartOfLine.get(renderer);
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -83,6 +83,7 @@
 #include "InspectorHistory.h"
 #include "InspectorIdentifierRegistry.h"
 #include "InspectorNodeFinder.h"
+#include "InspectorOverlayConfigParser.h"
 #include "InspectorPageAgent.h"
 #include "InstrumentingAgents.h"
 #include "IntRect.h"
@@ -155,52 +156,6 @@ using namespace HTMLNames;
 
 static const size_t maxTextSize = 10000;
 static const char16_t horizontalEllipsisUTF16[] = { horizontalEllipsis, 0 };
-
-static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
-{
-    if (!colorObject)
-        return std::nullopt;
-
-    auto r = colorObject->getInteger("r"_s);
-    auto g = colorObject->getInteger("g"_s);
-    auto b = colorObject->getInteger("b"_s);
-    if (!r || !g || !b)
-        return std::nullopt;
-
-    auto a = colorObject->getDouble("a"_s);
-    if (!a)
-        return { makeFromComponentsClamping<SRGBA<uint8_t>>(*r, *g, *b) };
-    return { makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(*r, *g, *b, convertFloatAlphaTo<uint8_t>(*a)) };
-}
-
-static std::optional<Color> parseRequiredConfigColor(const String& fieldName, JSON::Object& configObject)
-{
-    return parseColor(configObject.getObject(fieldName));
-}
-
-static Color parseOptionalConfigColor(const String& fieldName, JSON::Object& configObject)
-{
-    return parseRequiredConfigColor(fieldName, configObject).value_or(Color::transparentBlack);
-}
-
-static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
-{
-    std::array<double, 8> coordinates;
-    if (quadArray->length() != coordinates.size())
-        return false;
-    for (size_t i = 0; i < coordinates.size(); ++i) {
-        auto coordinate = quadArray->get(i)->asDouble();
-        if (!coordinate)
-            return false;
-        coordinates[i] = *coordinate;
-    }
-    quad->setP1(FloatPoint(coordinates[0], coordinates[1]));
-    quad->setP2(FloatPoint(coordinates[2], coordinates[3]));
-    quad->setP3(FloatPoint(coordinates[4], coordinates[5]));
-    quad->setP4(FloatPoint(coordinates[6], coordinates[7]));
-
-    return true;
-}
 
 class RevalidateStyleAttributeTask final : public CanMakeCheckedPtr<RevalidateStyleAttributeTask> {
     WTF_MAKE_TZONE_ALLOCATED(RevalidateStyleAttributeTask);
@@ -1377,61 +1332,6 @@ void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& er
         client->elementSelectionChanged(m_searchingForNode);
 }
 
-std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& highlightInspectorObject)
-{
-    if (!highlightInspectorObject) {
-        errorString = "Internal error: highlight configuration parameter is missing"_s;
-        return nullptr;
-    }
-
-    auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
-    highlightConfig->showInfo = highlightInspectorObject->getBoolean("showInfo"_s).value_or(false);
-    highlightConfig->content = parseOptionalConfigColor("contentColor"_s, *highlightInspectorObject);
-    highlightConfig->padding = parseOptionalConfigColor("paddingColor"_s, *highlightInspectorObject);
-    highlightConfig->border = parseOptionalConfigColor("borderColor"_s, *highlightInspectorObject);
-    highlightConfig->margin = parseOptionalConfigColor("marginColor"_s, *highlightInspectorObject);
-    return highlightConfig;
-}
-
-std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& gridOverlayInspectorObject)
-{
-    if (!gridOverlayInspectorObject)
-        return std::nullopt;
-
-    auto gridColor = parseRequiredConfigColor("gridColor"_s, *gridOverlayInspectorObject);
-    if (!gridColor) {
-        errorString = "Internal error: grid color property of grid overlay configuration parameter is missing"_s;
-        return std::nullopt;
-    }
-
-    InspectorOverlay::Grid::Config gridOverlayConfig;
-    gridOverlayConfig.gridColor = *gridColor;
-    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean("showLineNames"_s).value_or(false);
-    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean("showLineNumbers"_s).value_or(false);
-    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean("showExtendedGridLines"_s).value_or(false);
-    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean("showTrackSizes"_s).value_or(false);
-    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean("showAreaNames"_s).value_or(false);
-    gridOverlayConfig.showOrderNumbers = gridOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
-    return gridOverlayConfig;
-}
-
-std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
-{
-    if (!flexOverlayInspectorObject)
-        return std::nullopt;
-
-    auto flexColor = parseRequiredConfigColor("flexColor"_s, *flexOverlayInspectorObject);
-    if (!flexColor) {
-        errorString = "Internal error: flex color property of flex overlay configuration parameter is missing"_s;
-        return std::nullopt;
-    }
-
-    InspectorOverlay::Flex::Config flexOverlayConfig;
-    flexOverlayConfig.flexColor = *flexColor;
-    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
-    return flexOverlayConfig;
-}
-
 #if PLATFORM(IOS_FAMILY)
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig)
 {
@@ -1469,7 +1369,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightRect(int x,
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightQuad(Ref<JSON::Array>&& quadObject, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
 {
     auto quad = makeUnique<FloatQuad>();
-    if (!parseQuad(WTF::move(quadObject), quad.get()))
+    if (!parseInspectorQuad(WTF::move(quadObject), quad.get()))
         return makeUnexpected("Unexpected invalid quad"_s);
 
     innerHighlightQuad(WTF::move(quad), WTF::move(color), WTF::move(outlineColor), WTF::move(usePageCoordinates));
@@ -1480,8 +1380,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightQuad(Ref<JS
 void InspectorDOMAgent::innerHighlightQuad(std::unique_ptr<FloatQuad> quad, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
 {
     auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
-    highlightConfig->content = parseColor(WTF::move(color)).value_or(Color::transparentBlack);
-    highlightConfig->contentOutline = parseColor(WTF::move(outlineColor)).value_or(Color::transparentBlack);
+    highlightConfig->content = parseInspectorColor(WTF::move(color)).value_or(Color::transparentBlack);
+    highlightConfig->contentOutline = parseInspectorColor(WTF::move(outlineColor)).value_or(Color::transparentBlack);
     highlightConfig->usePageCoordinates = usePageCoordinates ? *usePageCoordinates : false;
     protect(overlay())->highlightQuad(WTF::move(quad), *highlightConfig);
 }
@@ -1694,8 +1594,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
     if (RefPtr ownerElement = frame->ownerElement()) {
         auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
         highlightConfig->showInfo = true; // Always show tooltips for frames.
-        highlightConfig->content = parseColor(WTF::move(color)).value_or(Color::transparentBlack);
-        highlightConfig->contentOutline = parseColor(WTF::move(outlineColor)).value_or(Color::transparentBlack);
+        highlightConfig->content = parseInspectorColor(WTF::move(color)).value_or(Color::transparentBlack);
+        highlightConfig->contentOutline = parseInspectorColor(WTF::move(outlineColor)).value_or(Color::transparentBlack);
         protect(overlay())->highlightNode(ownerElement.get(), *highlightConfig);
     }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -229,7 +229,7 @@ public:
 
     InspectorHistory* history() LIFETIME_BOUND { return m_history.get(); }
     Vector<Document*> documents();
-    Vector<size_t> flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject&);
+    Vector<size_t> flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject&) const;
     void reset();
 
     Node* assertNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -246,9 +246,6 @@ private:
 
     void highlightMousedOverNode();
     void setSearchingForNode(Inspector::Protocol::ErrorString&, bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, bool showRulers);
-    std::unique_ptr<InspectorOverlay::Highlight::Config> highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& highlightInspectorObject);
-    std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& gridOverlayInspectorObject);
-    std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& flexOverlayInspectorObject);
 
     // Node-related methods.
     Inspector::Protocol::DOM::NodeId bind(Node&);

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -54,6 +54,7 @@
 #include "InspectorDOMAgent.h"
 #include "InspectorHistory.h"
 #include "InspectorNodeFinder.h"
+#include "InspectorOverlayConfigParser.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMWindowCustom.h"
@@ -67,6 +68,7 @@
 #include "RegisteredEventListener.h"
 #include "ScriptController.h"
 #include "ShadowRoot.h"
+#include "StaticNodeList.h"
 #include "Text.h"
 #include "TextNodeTraversal.h"
 #include "WebInjectedScriptManager.h"
@@ -92,6 +94,9 @@ using namespace Inspector;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameDOMAgent);
 
 // FIXME: <https://webkit.org/b/298980> Extract shared tree-building and node-binding logic into a base class shared with InspectorDOMAgent.
+// The highlight commands below (innerHighlightNode, innerHighlightNodeList, innerHighlightQuad,
+// highlightRect, highlightQuad) are also near-verbatim clones of the page agent's, and belong in that
+// same base class. The config parsing they share already moved to InspectorOverlayConfigParser.
 
 static const size_t frameMaxTextSize = 10000;
 static const char16_t frameHorizontalEllipsisUTF16[] = { horizontalEllipsis, 0 };
@@ -155,12 +160,13 @@ static String frameComputeContentSecurityPolicySHA256Hash(const Element& element
 
 // MARK: - FrameDOMAgent
 
-FrameDOMAgent::FrameDOMAgent(FrameAgentContext& context)
+FrameDOMAgent::FrameDOMAgent(FrameAgentContext& context, InspectorOverlay& overlay)
     : InspectorAgentBase("DOM"_s, context)
     , m_frontendDispatcher(makeUniqueRef<Inspector::DOMFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::DOMBackendDispatcher::create(Ref { context.backendDispatcher }, this))
     , m_instrumentingAgents(context.instrumentingAgents)
     , m_inspectedFrame(context.inspectedFrame)
+    , m_overlay(overlay)
     , m_injectedScriptManager(context.injectedScriptManager)
     , m_destroyedNodesTimer(*this, &FrameDOMAgent::destroyedNodesTimerFired)
 {
@@ -180,6 +186,9 @@ void FrameDOMAgent::didCreateFrontendAndBackend()
         m_document = frame->document();
 }
 
+// Deliberately does not touch the overlay. InspectorDOMAgent does `Ref overlay = m_overlay.get()` here,
+// which on the frame path would ref a LocalFrame whose refcount has already reached zero -- the frame
+// destructor is what calls into this controller.
 void FrameDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
     m_domEditor.reset();
@@ -1561,6 +1570,150 @@ Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int nodeId)
 
     if (RefPtr commandLineAPIHost = downcast<WebInjectedScriptManager>(m_injectedScriptManager.get()).commandLineAPIHost())
         commandLineAPIHost->addInspectedObject(makeUnique<InspectableFrameNode>(node.get()));
+
+    return { };
+}
+
+// MARK: - Highlighting
+
+void FrameDOMAgent::innerHighlightQuad(std::unique_ptr<FloatQuad> quad, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
+{
+    auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
+    highlightConfig->content = parseInspectorColor(WTF::move(color)).value_or(Color::transparentBlack);
+    highlightConfig->contentOutline = parseInspectorColor(WTF::move(outlineColor)).value_or(Color::transparentBlack);
+    highlightConfig->usePageCoordinates = usePageCoordinates ? *usePageCoordinates : false;
+    protect(overlay())->highlightQuad(WTF::move(quad), *highlightConfig);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightRect(int x, int y, int width, int height, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
+{
+    auto quad = makeUnique<FloatQuad>(FloatRect(x, y, width, height));
+    innerHighlightQuad(WTF::move(quad), WTF::move(color), WTF::move(outlineColor), WTF::move(usePageCoordinates));
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightQuad(Ref<JSON::Array>&& quadObject, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
+{
+    auto quad = makeUnique<FloatQuad>();
+    if (!parseInspectorQuad(WTF::move(quadObject), quad.get()))
+        return makeUnexpected("Unexpected invalid quad"_s);
+
+    innerHighlightQuad(WTF::move(quad), WTF::move(color), WTF::move(outlineColor), WTF::move(usePageCoordinates));
+
+    return { };
+}
+
+#if PLATFORM(IOS_FAMILY)
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+{
+    return innerHighlightNode(WTF::move(nodeId), objectId, WTF::move(highlightInspectorObject), WTF::move(gridOverlayInspectorObject), WTF::move(flexOverlayInspectorObject), std::nullopt);
+}
+
+#else
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+{
+    return innerHighlightNode(WTF::move(nodeId), objectId, WTF::move(highlightInspectorObject), WTF::move(gridOverlayInspectorObject), WTF::move(flexOverlayInspectorObject), WTF::move(showRulers));
+}
+
+#endif // PLATFORM(IOS_FAMILY)
+
+Inspector::CommandResult<void> FrameDOMAgent::innerHighlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr<Node> node;
+    if (nodeId)
+        node = assertNode(errorString, *nodeId);
+    else if (!objectId.isEmpty()) {
+        node = nodeForObjectId(objectId);
+        if (!node)
+            errorString = "Missing node for given objectId"_s;
+    } else
+        errorString = "Either nodeId or objectId must be specified"_s;
+
+    if (!node)
+        return makeUnexpected(errorString);
+
+    auto highlightConfig = highlightConfigFromInspectorObject(errorString, WTF::move(highlightInspectorObject));
+    if (!highlightConfig)
+        return makeUnexpected(errorString);
+
+    bool providedGridOverlayConfig = gridOverlayInspectorObject;
+    auto gridOverlayConfig = gridOverlayConfigFromInspectorObject(errorString, WTF::move(gridOverlayInspectorObject));
+    if (providedGridOverlayConfig && !gridOverlayConfig)
+        return makeUnexpected(errorString);
+
+    bool providedFlexOverlayConfig = flexOverlayInspectorObject;
+    auto flexOverlayConfig = flexOverlayConfigFromInspectorObject(errorString, WTF::move(flexOverlayInspectorObject));
+    if (providedFlexOverlayConfig && !flexOverlayConfig)
+        return makeUnexpected(errorString);
+
+    protect(overlay())->highlightNode(node.get(), *highlightConfig, WTF::move(gridOverlayConfig), WTF::move(flexOverlayConfig), showRulers && *showRulers);
+
+    return { };
+}
+
+#if PLATFORM(IOS_FAMILY)
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+{
+    return innerHighlightNodeList(WTF::move(nodeIds), WTF::move(highlightInspectorObject), WTF::move(gridOverlayInspectorObject), WTF::move(flexOverlayInspectorObject), std::nullopt);
+}
+
+#else
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+{
+    return innerHighlightNodeList(WTF::move(nodeIds), WTF::move(highlightInspectorObject), WTF::move(gridOverlayInspectorObject), WTF::move(flexOverlayInspectorObject), WTF::move(showRulers));
+}
+
+#endif // PLATFORM(IOS_FAMILY)
+
+Inspector::CommandResult<void> FrameDOMAgent::innerHighlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    Vector<Ref<Node>> nodes;
+    for (auto& nodeIdValue : nodeIds.get()) {
+        auto nodeId = nodeIdValue->asInteger();
+        if (!nodeId)
+            return makeUnexpected("Unexpected non-integer item in given nodeIds"_s);
+
+        // A node may have been removed between the frontend sending this and the backend running it.
+        // Highlight as many as still resolve rather than failing the whole command.
+        Inspector::Protocol::ErrorString ignored;
+        RefPtr node = assertNode(ignored, *nodeId);
+        if (!node)
+            continue;
+
+        nodes.append(*node);
+    }
+
+    auto highlightConfig = highlightConfigFromInspectorObject(errorString, WTF::move(highlightInspectorObject));
+    if (!highlightConfig)
+        return makeUnexpected(errorString);
+
+    bool providedGridOverlayConfig = gridOverlayInspectorObject;
+    auto gridOverlayConfig = gridOverlayConfigFromInspectorObject(errorString, WTF::move(gridOverlayInspectorObject));
+    if (providedGridOverlayConfig && !gridOverlayConfig)
+        return makeUnexpected(errorString);
+
+    bool providedFlexOverlayConfig = flexOverlayInspectorObject;
+    auto flexOverlayConfig = flexOverlayConfigFromInspectorObject(errorString, WTF::move(flexOverlayInspectorObject));
+    if (providedFlexOverlayConfig && !flexOverlayConfig)
+        return makeUnexpected(errorString);
+
+    protect(overlay())->highlightNodeList(StaticNodeList::create(WTF::move(nodes)), *highlightConfig, WTF::move(gridOverlayConfig), WTF::move(flexOverlayConfig), showRulers && *showRulers);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::hideHighlight()
+{
+    protect(overlay())->hideHighlight();
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "InspectorOverlay.h"
 #include "InspectorWebAgentBase.h"
 #include "Timer.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
@@ -59,7 +60,7 @@ class FrameDOMAgent final : public InspectorAgentBase, public Inspector::DOMBack
     WTF_MAKE_TZONE_ALLOCATED(FrameDOMAgent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameDOMAgent);
 public:
-    FrameDOMAgent(FrameAgentContext&);
+    FrameDOMAgent(FrameAgentContext&, InspectorOverlay&);
     ~FrameDOMAgent();
 
     // InspectorAgentBase
@@ -183,6 +184,12 @@ private:
 
     RefPtr<Node> nodeForPath(const String& path);
 
+    void innerHighlightQuad(std::unique_ptr<FloatQuad>, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates);
+    Inspector::CommandResult<void> innerHighlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers);
+    Inspector::CommandResult<void> innerHighlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers);
+
+    InspectorOverlay& overlay() const { return m_overlay.get(); }
+
     struct InspectorEventListener {
         Inspector::Protocol::DOM::EventListenerId identifier { 1 };
         RefPtr<EventTarget> eventTarget;
@@ -222,6 +229,7 @@ private:
     const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
     WeakRef<LocalFrame> m_inspectedFrame;
+    WeakRef<InspectorOverlay> m_overlay;
     const CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
 
     WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -64,28 +64,8 @@ Inspector::CommandResult<void> FrameDOMAgent::setInspectModeEnabled(bool, RefPtr
 }
 #endif
 
-Inspector::CommandResult<void> FrameDOMAgent::highlightRect(int, int, int, int, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::highlightQuad(Ref<JSON::Array>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
 #if PLATFORM(IOS_FAMILY)
 Inspector::CommandResult<void> FrameDOMAgent::highlightSelector(const String&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
 {
     return makeUnexpected("Not supported for frame targets"_s);
 }
@@ -94,22 +74,7 @@ Inspector::CommandResult<void> FrameDOMAgent::highlightSelector(const String&, c
 {
     return makeUnexpected("Not supported for frame targets"_s);
 }
-
-Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
 #endif
-
-Inspector::CommandResult<void> FrameDOMAgent::hideHighlight()
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
 
 Inspector::CommandResult<void> FrameDOMAgent::highlightFrame(const String&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
 {

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -2084,7 +2084,7 @@ WI._domStorageWasInspected = function(event)
 
 WI._domNodeWasInspected = function(event)
 {
-    WI.domManager.highlightDOMNodeForTwoSeconds(event.data.node.id);
+    WI.domManager.highlightDOMNodeForTwoSeconds(event.data.node);
 
     InspectorFrontendHost.bringToFront();
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -1114,33 +1114,40 @@ WI.DOMManager = class DOMManager extends WI.Object
 
     highlightDOMNodeList(nodes, mode)
     {
-        if (this._hideDOMNodeHighlightTimeout) {
-            clearTimeout(this._hideDOMNodeHighlightTimeout);
-            this._hideDOMNodeHighlightTimeout = undefined;
-        }
+        this.cancelPendingHighlightHide();
 
-        let nodeIds = [];
+        // A single highlightNodeList carries IDs for one target only, so group by owning target and
+        // send one command each. Frame-target nodes need their raw backend ID, not the scoped one.
+        let nodeIdsByTarget = new Map();
         for (let node of nodes) {
             console.assert(node instanceof WI.DOMNode, node);
             console.assert(!node.destroyed, node);
             if (node.destroyed)
                 continue;
-            nodeIds.push(node.id);
+
+            let target = node.owningTarget || WI.assumingMainTarget();
+            let nodeIds = nodeIdsByTarget.get(target);
+            if (!nodeIds) {
+                nodeIds = [];
+                nodeIdsByTarget.set(target, nodeIds);
+            }
+            nodeIds.push(node.backendNodeId);
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.highlightNodeList.invoke({
-            nodeIds,
-            ...WI.DOMManager.buildHighlightConfigs(mode),
-        });
+        // Clear targets not receiving a list, so a stale highlight elsewhere does not draw alongside.
+        this.hideDOMNodeHighlight({exceptTargets: new Set(nodeIdsByTarget.keys())});
+
+        for (let [target, nodeIds] of nodeIdsByTarget) {
+            target.DOMAgent.highlightNodeList.invoke({
+                nodeIds,
+                ...WI.DOMManager.buildHighlightConfigs(mode),
+            });
+        }
     }
 
     highlightSelector(selectorString, frameId, mode)
     {
-        if (this._hideDOMNodeHighlightTimeout) {
-            clearTimeout(this._hideDOMNodeHighlightTimeout);
-            this._hideDOMNodeHighlightTimeout = undefined;
-        }
+        this.cancelPendingHighlightHide();
 
         let target = WI.assumingMainTarget();
         target.DOMAgent.highlightSelector.invoke({
@@ -1164,25 +1171,35 @@ WI.DOMManager = class DOMManager extends WI.Object
         });
     }
 
-    hideDOMNodeHighlight()
+    cancelPendingHighlightHide()
+    {
+        if (!this._hideDOMNodeHighlightTimeout)
+            return;
+
+        clearTimeout(this._hideDOMNodeHighlightTimeout);
+        this._hideDOMNodeHighlightTimeout = undefined;
+    }
+
+    hideDOMNodeHighlight({exceptTargets} = {})
     {
         for (let target of WI.targets) {
-            if (target instanceof WI.FrameTarget)
+            if (exceptTargets && exceptTargets.has(target))
                 continue;
             if (target.hasCommand("DOM.hideHighlight"))
                 target.DOMAgent.hideHighlight();
         }
     }
 
-    highlightDOMNodeForTwoSeconds(nodeId)
+    highlightDOMNodeForTwoSeconds(node)
     {
-        let node = this._idToDOMNode[nodeId];
-        if (!node)
+        console.assert(!node || node instanceof WI.DOMNode, node);
+        if (!node || node.destroyed)
             return;
 
         node.highlight();
 
-        this._hideDOMNodeHighlightTimeout = setTimeout(this.hideDOMNodeHighlight.bind(this), 2000);
+        // Bind an empty options object: setTimeout would otherwise pass the timer id as the first argument.
+        this._hideDOMNodeHighlightTimeout = setTimeout(this.hideDOMNodeHighlight.bind(this, {}), 2000);
     }
 
     get inspectModeEnabled()

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -650,18 +650,18 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._destroyed)
             return;
 
-        // FIXME: <https://webkit.org/b/298980> Highlighting cross-origin frame nodes requires page-level coordination.
-        if (this.owningTarget)
-            return;
+        // The two-second auto-hide timeout lives on DOMManager, not here.
+        WI.domManager.cancelPendingHighlightHide();
 
-        if (this._hideDOMNodeHighlightTimeout) {
-            clearTimeout(this._hideDOMNodeHighlightTimeout);
-            this._hideDOMNodeHighlightTimeout = undefined;
-        }
+        let target = this.owningTarget || WI.assumingMainTarget();
 
-        let target = WI.assumingMainTarget();
+        // Each target holds its own highlight state, so clear the others. Otherwise highlighting a
+        // node inside a frame leaves the page target still highlighting the owner iframe element,
+        // and both draw at once.
+        WI.domManager.hideDOMNodeHighlight({exceptTargets: new Set([target])});
+
         target.DOMAgent.highlightNode.invoke({
-            nodeId: this.id,
+            nodeId: this.backendNodeId,
             ...WI.DOMManager.buildHighlightConfigs(mode),
         });
     }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -216,7 +216,6 @@ void WebInspectorBackendClient::hideHighlight()
 #endif
 }
 
-// FIXME: Nothing drives the frame overlays below yet; FrameDOMAgent's highlight commands are stubs.
 RefPtr<PageOverlay> WebInspectorBackendClient::ensureHighlightOverlayForFrame(LocalFrame& frame)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -29,6 +29,7 @@
 #include "DrawingArea.h"
 #include "WebInspectorBackend.h"
 #include "WebPage.h"
+#include <WebCore/FrameInspectorController.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerAnimation.h>
 #include <WebCore/GraphicsLayerFactory.h>
@@ -82,23 +83,37 @@ WebInspectorBackendClient::~WebInspectorBackendClient()
     RefPtr page = m_page.get();
     RefPtr corePage = page ? page->corePage() : nullptr;
 
-    // Tear down every per-frame bucket: detach its layers, uninstall its overlay (the controller
-    // holds the only Ref keeping it alive), and drop the controller's per-frame container. The page
-    // may already be gone, in which case the controller torn down with it.
-    for (auto entry : m_paintRectOverlays) {
-        Ref frame = entry.key;
+    // uninstallPageOverlay() re-enters willMoveToPage() synchronously, which mutates these maps.
+    auto paintRectOverlays = std::exchange(m_paintRectOverlays, { });
+    auto frameHighlightOverlays = std::exchange(m_frameHighlightOverlays, { });
+
+    // Paint-rect buckets own graphics layers, so detach those even if the page is already gone.
+    // Highlight overlays hold no layers of their own, so they have nothing to do here.
+    for (auto entry : paintRectOverlays) {
         auto& bucket = entry.value;
         for (auto& layer : bucket.layers)
             protect(layer)->removeFromParent();
         bucket.layers.clear();
-
-        if (corePage) {
-            if (RefPtr overlay = bucket.overlay)
-                corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
-            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
-        }
     }
-    m_paintRectOverlays.clear();
+
+    // Uninstalling needs the page; if it is gone, its overlay controller went with it.
+    if (!corePage)
+        return;
+
+    // Both maps were emptied above, so neither frame's container is still in use by the other.
+    for (auto entry : paintRectOverlays) {
+        Ref frame = entry.key;
+        if (RefPtr overlay = entry.value.overlay)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
+
+    for (auto entry : frameHighlightOverlays) {
+        Ref frame = entry.key;
+        if (RefPtr overlay = entry.value)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
 }
 
 void WebInspectorBackendClient::inspectedPageDestroyed()
@@ -198,6 +213,100 @@ void WebInspectorBackendClient::hideHighlight()
         page->corePage()->pageOverlayController().uninstallPageOverlay(*highlightOverlay, PageOverlay::FadeMode::Fade);
 #else
     page->hideInspectorHighlight();
+#endif
+}
+
+// FIXME: Nothing drives the frame overlays below yet; FrameDOMAgent's highlight commands are stubs.
+RefPtr<PageOverlay> WebInspectorBackendClient::ensureHighlightOverlayForFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return nullptr;
+
+    auto& overlay = m_frameHighlightOverlays.ensure(frame, [&] -> RefPtr<PageOverlay> {
+        // FIXME: <rdar://116202544> Should be OverlayType::View, which needs a per-frame view-overlay
+        // root layer and attachViewOverlayGraphicsLayer() to stop hardcoding the main frame.
+        // DoNotFade matches hideHighlightForFrame(): a Fade uninstall defers the real uninstall.
+        Ref newOverlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
+        newOverlay->setAssociatedFrame(&frame);
+        corePage->pageOverlayController().installPageOverlay(newOverlay.copyRef(), PageOverlay::FadeMode::DoNotFade);
+        return newOverlay.ptr();
+    }).iterator->value;
+
+    return overlay.get();
+}
+
+void WebInspectorBackendClient::highlightFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+    // Only a local root hosts its own compositing tree; a local subframe draws via the page overlay.
+    // FIXME: a nested local subframe's state lives on its own overlay, which nothing consults.
+    if (&frame != corePage->localMainOrRootFrame()) {
+        highlight();
+        return;
+    }
+
+    // The frame must also own the state; update() guarantees it, so this is defence-in-depth.
+    if (!frame.inspectorController().hasOverlayContentToDraw()) {
+        highlight();
+        return;
+    }
+
+    if (!corePage->settings().acceleratedCompositingEnabled()) {
+        highlight();
+        return;
+    }
+
+#if !PLATFORM(IOS_FAMILY)
+    if (RefPtr overlay = ensureHighlightOverlayForFrame(frame)) {
+        overlay->stopFadeOutAnimation();
+        overlay->setNeedsDisplay();
+    }
+#else
+    // iOS highlights go through a page-level singleton with no frame parameter.
+    highlight();
+#endif
+}
+
+void WebInspectorBackendClient::hideHighlightForFrame(LocalFrame& frame)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+#if !PLATFORM(IOS_FAMILY)
+    // Only uninstall an overlay this client installed; otherwise this is the page path.
+    if (!m_frameHighlightOverlays.contains(frame)) {
+        hideHighlight();
+        return;
+    }
+
+    // Erase before uninstalling; DoNotFade so the overlay is gone before its entry is.
+    RefPtr overlay = m_frameHighlightOverlays.take(frame);
+    if (overlay)
+        corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+
+    // The container is keyed by frame and shared with the paint-rect overlay; release it only if free.
+    if (!m_paintRectOverlays.contains(frame))
+        corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame);
+
+#if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION) || PLATFORM(WPE)
+    if (!corePage->settings().acceleratedCompositingEnabled()) {
+        // FIXME: It can be optimized by marking only highlighted rect dirty.
+        // setNeedsDisplay always makes whole rect dirty, and could lead to poor performance.
+        // https://bugs.webkit.org/show_bug.cgi?id=195933
+        page->drawingArea()->setNeedsDisplay();
+    }
+#endif
+#else
+    UNUSED_PARAM(frame);
+    hideHighlight();
 #endif
 }
 
@@ -304,9 +413,34 @@ void WebInspectorBackendClient::willDestroyFrameOverlays(WebCore::FrameIdentifie
     RefPtr page = m_page.get();
     RefPtr corePage = page ? page->corePage() : nullptr;
 
+    // Tear highlight overlays down too, or a stale one re-parents under the main frame.
+    // Collect and erase first: uninstalling re-enters willMoveToPage(), which mutates this map.
+    Vector<std::pair<Ref<LocalFrame>, RefPtr<PageOverlay>>> detachedHighlights;
+    m_frameHighlightOverlays.removeIf([&](auto& entry) {
+        Ref frame = entry.key;
+        if (frame->frameID() != frameID)
+            return false;
+
+        detachedHighlights.append({ WTF::move(frame), entry.value });
+        return true;
+    });
+
+    for (auto& [frame, overlay] : detachedHighlights) {
+        if (!corePage)
+            break;
+
+        if (overlay)
+            corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+
+        // Shared with the paint-rect overlay; the pass below releases the container otherwise.
+        if (!m_paintRectOverlays.contains(frame.get()))
+            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+    }
+
     // Buckets are keyed by local root frame; a detaching frame owns a bucket only if it is that root.
     // Find it by identity, uninstall its overlay, detach its layers, and drop the controller's
-    // per-frame container so nothing is retained past the frame's lifetime.
+    // per-frame container. Unconditional release is safe only after the highlight pass above; keep
+    // these two passes in this order.
     m_paintRectOverlays.removeIf([frameID, corePage](auto& entry) {
         Ref frame = entry.key;
         if (frame->frameID() != frameID)
@@ -419,24 +553,44 @@ bool WebInspectorBackendClient::setEmulatedConditions(std::optional<int64_t>&& b
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-void WebInspectorBackendClient::willMoveToPage(PageOverlay&, Page* page)
+void WebInspectorBackendClient::willMoveToPage(PageOverlay& overlay, Page* page)
 {
     if (page)
         return;
 
-    // The page overlay is moving away from the web page, reset it.
-    ASSERT(m_highlightOverlay);
-    m_highlightOverlay = nullptr;
+    // Clear only the overlay this call is about; this client serves several.
+    if (m_highlightOverlay.get() == &overlay) {
+        m_highlightOverlay = nullptr;
+        return;
+    }
+
+    // A no-op for our own teardown paths, which erase first; covers an uninstall from elsewhere.
+    m_frameHighlightOverlays.removeIf([&overlay](auto& entry) {
+        return entry.value.get() == &overlay;
+    });
 }
 
 void WebInspectorBackendClient::didMoveToPage(PageOverlay&, Page*)
 {
 }
 
-void WebInspectorBackendClient::drawRect(PageOverlay&, WebCore::GraphicsContext& context, const WebCore::IntRect& /*dirtyRect*/)
+void WebInspectorBackendClient::drawRect(PageOverlay& overlay, WebCore::GraphicsContext& context, const WebCore::IntRect& /*dirtyRect*/)
 {
-    if (RefPtr page = m_page.get())
-        protect(page->corePage()->inspectorController())->drawHighlight(context);
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage)
+        return;
+
+    // Map the PageOverlay back to the InspectorOverlay holding its state. Membership, not just
+    // associatedFrame(): paint-rect overlays set one too. Never paint a frame surface with page state.
+    if (RefPtr frame = overlay.associatedFrame(); frame && m_frameHighlightOverlays.contains(*frame)) {
+        Ref frameController = frame->inspectorController();
+        if (frameController->hasOverlayContentToDraw())
+            frameController->drawHighlight(context);
+        return;
+    }
+
+    protect(corePage->inspectorController())->drawHighlight(context);
 }
 
 bool WebInspectorBackendClient::mouseEvent(PageOverlay&, const PlatformMouseEvent&)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
@@ -62,6 +62,8 @@ private:
 
     void highlight() override;
     void hideHighlight() override;
+    void highlightFrame(WebCore::LocalFrame&) override;
+    void hideHighlightForFrame(WebCore::LocalFrame&) override;
 
 #if PLATFORM(IOS_FAMILY)
     void showInspectorIndication() override;
@@ -96,7 +98,14 @@ private:
     void animationEndedForLayer(WebCore::LocalFrame*, const WebCore::GraphicsLayer*);
 
     WeakPtr<WebPage> m_page;
+
+    // The page-level highlight overlay. Kept separate from the per-frame map: it is no frame's overlay.
     WeakPtr<WebCore::PageOverlay> m_highlightOverlay;
+
+    // Frame-scoped highlight overlays, keyed by local root. Separate lifetimes from m_paintRectOverlays.
+    WeakHashMap<WebCore::LocalFrame, RefPtr<WebCore::PageOverlay>> m_frameHighlightOverlays;
+
+    RefPtr<WebCore::PageOverlay> ensureHighlightOverlayForFrame(WebCore::LocalFrame&);
 
     // Paint-rect overlays are per local root frame: under Site Isolation one process can host several
     // local roots, each with its own compositing tree, so each needs its own Document overlay.


### PR DESCRIPTION
#### 9ea6dc20096938167d562a5d6a58484833f074ac
<pre>
Implement DOM highlight commands for FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=316139">https://bugs.webkit.org/show_bug.cgi?id=316139</a>
<a href="https://rdar.apple.com/178562987">rdar://178562987</a>

Reviewed by NOBODY (OOPS!).

Implements highlightNode, highlightNodeList, highlightRect, highlightQuad and
hideHighlight for FrameDOMAgent, replacing the stubs that returned &quot;Not
supported for frame targets&quot;, so nodes inside a cross-origin iframe can be
highlighted.

The three *FromInspectorObject config parsers and their color and quad helpers
move out of InspectorDOMAgent into a shared InspectorOverlayConfigParser so both
agents use one implementation. The command bodies themselves are still
duplicated.

highlightRect and highlightQuad drop their [&quot;page&quot;] targetTypes override so they
match the other highlight commands, and their descriptions no longer claim
coordinates are relative to the main frame viewport, since for a frame target
they are relative to that frame.

paint() has to undo contentsToView() for a frame overlay: the surface is
OverlayType::Document and so receives contents coordinates, while everything
paint() emits is in root-view coordinates. The translation skips scrollOrigin(),
which PageOverlay::drawRect() has already applied, and is a no-op when scrolling
is delegated, matching contentsToView() itself.

Two frontend behavior changes are worth calling out. hideDOMNodeHighlight() no
longer skips frame targets, so its ~20 callers now send DOM.hideHighlight to each
frame target as well. highlighting clears every other target via
hideDOMNodeHighlight({exceptTargets}), and highlightDOMNodeList groups nodes by
owning target, because one command carries IDs for one target only.

highlightDOMNodeForTwoSeconds() briefly flashes a highlight on a node that was
just revealed in the inspector. It looked the node up by ID in the page target&apos;s
node map, so a node inside a frame target was never found and never flashed. It
now takes the node itself.

The new tests check that the commands reach the frame target and are accepted,
including frames that are scrolled, right-to-left, and vertical writing mode.
They do not check where the highlight actually lands on screen, because no test
hook can observe what the overlay paints. The coordinate math above is verified
by manual testing only.

highlightSelector, highlightFrame, focus and getMediaStats stay stubbed and
page-only.

Tests: http/tests/site-isolation/inspector/dom/highlight-frame-target.html
       http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/highlight-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/highlight-target-handoff-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-rtl-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/highlight-vertical-frame.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::drawElementTitle):
* Source/WebCore/inspector/InspectorOverlayConfigParser.cpp: Added.
(WebCore::parseInspectorColor):
(WebCore::parseRequiredConfigColor):
(WebCore::parseOptionalConfigColor):
(WebCore::parseInspectorQuad):
(WebCore::highlightConfigFromInspectorObject):
(WebCore::gridOverlayConfigFromInspectorObject):
(WebCore::flexOverlayConfigFromInspectorObject):
* Source/WebCore/inspector/InspectorOverlayConfigParser.h: Added.
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::highlightQuad):
(WebCore::InspectorDOMAgent::innerHighlightQuad):
(WebCore::InspectorDOMAgent::highlightFrame):
(WebCore::parseColor): Deleted.
(WebCore::parseRequiredConfigColor): Deleted.
(WebCore::parseOptionalConfigColor): Deleted.
(WebCore::parseQuad): Deleted.
(WebCore::InspectorDOMAgent::highlightConfigFromInspectorObject): Deleted.
(WebCore::InspectorDOMAgent::gridOverlayConfigFromInspectorObject): Deleted.
(WebCore::InspectorDOMAgent::flexOverlayConfigFromInspectorObject): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::FrameDOMAgent):
(WebCore::FrameDOMAgent::innerHighlightQuad):
(WebCore::FrameDOMAgent::highlightRect):
(WebCore::FrameDOMAgent::highlightQuad):
(WebCore::FrameDOMAgent::highlightNode):
(WebCore::FrameDOMAgent::innerHighlightNode):
(WebCore::FrameDOMAgent::highlightNodeList):
(WebCore::FrameDOMAgent::innerHighlightNodeList):
(WebCore::FrameDOMAgent::hideHighlight):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::highlightSelector):
(WebCore::FrameDOMAgent::highlightRect): Deleted.
(WebCore::FrameDOMAgent::highlightQuad): Deleted.
(WebCore::FrameDOMAgent::highlightNode): Deleted.
(WebCore::FrameDOMAgent::highlightNodeList): Deleted.
(WebCore::FrameDOMAgent::hideHighlight): Deleted.
* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.highlightDOMNodeList):
(WI.DOMManager.prototype.highlightSelector):
(WI.DOMManager.prototype.cancelPendingHighlightHide):
(WI.DOMManager.prototype.hideDOMNodeHighlight):
(WI.DOMManager.prototype.highlightDOMNodeForTwoSeconds):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.highlight):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
</pre>
----------------------------------------------------------------------
#### 9336ddda68a83ce5bc95a2a0b02f556ce4bf1982
<pre>
Make InspectorOverlay frame-relative so it can draw in a subframe process
<a href="https://bugs.webkit.org/show_bug.cgi?id=322726">https://bugs.webkit.org/show_bug.cgi?id=322726</a>
<a href="https://rdar.apple.com/185999163">rdar://185999163</a>

Reviewed by NOBODY (OOPS!).

InspectorOverlay resolved every geometry calculation through the page&apos;s main
frame. In a subframe process that frame is remote and has no view, so the
overlay bailed and drew nothing.

An InspectorOverlayOwner interface replaces the overlay&apos;s direct dependency on
PageInspectorController, so a LocalFrame&apos;s FrameInspectorController can own one
too, and frameForGeometry() replaces every main-frame lookup: a frame overlay
uses its own frame, the page overlay falls back to localMainFrame() as before.
WebInspectorBackendClient gains a per-frame highlight surface keyed by local
root, the same shape the paint-rect overlays already use.

The FrameView dereferences along those paths are now null-checked; two were
reachable on the page path already. Rulers stay page-wide, and one
shouldDrawRulers() now decides that, so the ruler lines, bounds guides, and the
tooltip insets reserving space for them can&apos;t disagree.

Two pre-existing bugs surface once a process holds more than one overlay:
willMoveToPage() nulled the shared page-highlight pointer regardless of which
overlay was moving, so any per-frame paint-rect teardown destroyed it, and
drawRect() ignored the PageOverlay&amp; it was handed and always painted the page
overlay. Both fixed here.

Nothing drives a frame overlay yet since FrameDOMAgent&apos;s highlight commands are
still stubs, so these paths are plumbing for the highlighting work that follows
and aren&apos;t layout-testable in this state; the existing inspector/dom overlay
tests cover the page path against regression. The frame surface is also still
OverlayType::Document while the overlay draws in root-view coordinates; see the
FIXME.

* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::overlayOwnerPage const):
(WebCore::FrameInspectorController::overlayOwnerFrame const):
(WebCore::FrameInspectorController::overlayOwnerBackendClient const):
(WebCore::FrameInspectorController::drawHighlight const):
(WebCore::FrameInspectorController::hasOverlayContentToDraw const):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorBackendClient.h:
(WebCore::InspectorBackendClient::highlightFrame):
(WebCore::InspectorBackendClient::hideHighlightForFrame):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::contentsQuadToCoordinateSystem):
(WebCore::buildRendererHighlight):
(WebCore::drawShapeHighlight):
(WebCore::InspectorOverlay::InspectorOverlay):
(WebCore::InspectorOverlay::ref const):
(WebCore::InspectorOverlay::deref const):
(WebCore::InspectorOverlay::page const):
(WebCore::InspectorOverlay::frameForGeometry const):
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::highlightQuad):
(WebCore::InspectorOverlay::didSetSearchingForNode):
(WebCore::InspectorOverlay::shouldDrawRulers const):
(WebCore::InspectorOverlay::shouldShowOverlay const):
(WebCore::InspectorOverlay::update):
(WebCore::InspectorOverlay::showPaintRect):
(WebCore::InspectorOverlay::drawNodeHighlight):
(WebCore::InspectorOverlay::drawQuadHighlight):
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawRulers):
(WebCore::InspectorOverlay::drawElementTitle):
(WebCore::InspectorOverlay::buildGridOverlay):
(WebCore::InspectorOverlay::buildFlexOverlay):
(WebCore::localPointToRootPoint): Deleted.
* Source/WebCore/inspector/InspectorOverlay.h:
(WebCore::InspectorOverlayOwner::overlayOwnerFrame const):
(WebCore::InspectorOverlayOwner::overlayOwnerFlexLineStarts const):
(WebCore::InspectorOverlay::isFrameScoped const):
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::PageInspectorController):
(WebCore::PageInspectorController::overlayOwnerPage const):
(WebCore::PageInspectorController::overlayOwnerFlexLineStarts const):
* Source/WebCore/inspector/PageInspectorController.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine const):
(WebCore::InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
(WebKit::WebInspectorBackendClient::~WebInspectorBackendClient):
(WebKit::WebInspectorBackendClient::ensureHighlightOverlayForFrame):
(WebKit::WebInspectorBackendClient::highlightFrame):
(WebKit::WebInspectorBackendClient::hideHighlightForFrame):
(WebKit::WebInspectorBackendClient::willDestroyFrameOverlays):
(WebKit::WebInspectorBackendClient::willMoveToPage):
(WebKit::WebInspectorBackendClient::drawRect):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ea6dc20096938167d562a5d6a58484833f074ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152097 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146412 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101186 "1 flakes 36 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126915 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46708 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8579 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/15426 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46496 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8798 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/48644 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199738 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/166428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61654 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155734 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50054 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133782 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59639 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->