### PR TITLE
AX: AXReplaceRangeWithText inserts text at the wrong index

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary-expected.txt
@@ -1,0 +1,100 @@
+Asserts that AXReplaceRangeWithText writes at the character index it is given, including the
+index that starts a block, and clamps a range running past the end of the value to the end
+rather than writing at the current selection.
+
+block ending in <br>, index starting the next block: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+block without a trailing <br>: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+<br>-separated lines: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+one line, index starting the blank second line: value "alpha\n\n", replacing {6, 0}
+PASS: axField.replaceTextInRange("Y", 6, 0) === true
+PASS: textOf(field) === "alpha\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+two blocks ending in <br>: value "alpha\nbravo\ncharlie\n\n", replacing {20, 0}
+PASS: axField.replaceTextInRange("Y", 20, 0) === true
+PASS: textOf(field) === "alpha\nbravo\ncharlie\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+interior index: value "alpha\nbravo\n\n", replacing {6, 0}
+PASS: axField.replaceTextInRange("Y", 6, 0) === true
+PASS: textOf(field) === "alpha\nYbravo\n\n"
+PASS: textOf(bystander) === "bystander"
+
+replacing a run of characters: value "alpha\nbravo\n\n", replacing {6, 5}
+PASS: axField.replaceTextInRange("Y", 6, 5) === true
+PASS: textOf(field) === "alpha\nY\n\n"
+PASS: textOf(bystander) === "bystander"
+
+field with no text: value "", replacing {0, 0}
+PASS: axField.replaceTextInRange("Y", 0, 0) === true
+PASS: textOf(field) === "Y"
+PASS: textOf(bystander) === "bystander"
+
+textarea, index starting the blank final line: value "alpha\nbravo\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY"
+PASS: textOf(bystander) === "bystander"
+
+location one past the end of the value: value "alpha\nbravo\n\n", replacing {14, 0}
+PASS: axField.replaceTextInRange("Y", 14, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+location far past the end of the value: value "alpha\nbravo\n\n", replacing {99, 0}
+PASS: axField.replaceTextInRange("Y", 99, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+length running past the end of the value: value "alpha\nbravo\n\n", replacing {6, 99}
+PASS: axField.replaceTextInRange("Y", 6, 99) === true
+PASS: textOf(field) === "alpha\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+Y
+alpha
+bravo
+charlie
+Y
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+Y
+alpha
+Ybravo
+
+alpha
+Y
+
+Y
+
+bystander

--- a/LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary.html
@@ -1,0 +1,123 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- AXReplaceRangeWithText resolved the character range it was handed by walking CharacterOffsets. A
+     CharacterOffset names a node and a side of it, so at a block boundary one character index belongs
+     to two of them: the position after the <br> that ends the preceding block, and the position
+     starting the next block. The walk picked the former, which is not a caret position -- a <br>
+     ending a block is collapsed out by rendering -- so it canonicalized back over the <br> and the
+     text landed one character early, swallowing a line break.
+
+     This is the shape pressing Return in a contenteditable produces, because the default paragraph
+     separator is a <div> and the block holding the typed text also carries a trailing <br>. It takes
+     three lines to see: the first Return leaves no preceding block to land in. -->
+<div id="typed" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- The same rendered text in shapes that already worked, so a fix that only handles one is visible. -->
+<div id="blocks" contenteditable style="width: 200px">alpha<div>bravo</div><div><br></div></div>
+<div id="brs" contenteditable style="width: 200px">alpha<br>bravo<br><br></div>
+<!-- One line shorter. This is the shape a two-line attempt reaches, and it was always correct. -->
+<div id="short" contenteditable style="width: 200px">alpha<div><br></div></div>
+<!-- Longer, to show the answer does not drift with distance into the content. -->
+<div id="longer" contenteditable style="width: 200px">alpha<div>bravo<br></div><div>charlie<br></div><div><br></div></div>
+<!-- Ranges naming characters the value does not have. Each case gets its own element, so no
+     measurement runs against a value an earlier edit has already changed. -->
+<div id="pastEnd" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="farPastEnd" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="pastEndByLength" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- Interior indices, correct throughout. -->
+<div id="interior" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="replacing" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- A field with no text still has the one position an insertion can name. -->
+<div id="empty" contenteditable style="width: 200px"></div>
+<!-- A native text control takes HTMLTextFormControlElement::setRangeText instead. -->
+<textarea id="textarea" style="width: 200px; height: 60px">alpha
+bravo
+</textarea>
+<!-- Left alone. A request that ignored its range would land wherever the caret is, which is here. -->
+<div id="bystander" contenteditable style="width: 200px">bystander</div>
+
+<script>
+var output = "Asserts that AXReplaceRangeWithText writes at the character index it is given, including the\n"
+    + "index that starts a block, and clamps a range running past the end of the value to the end\n"
+    + "rather than writing at the current selection.\n\n";
+
+// `at`/`length` are the requested range, `want` the element's innerText afterwards. `returns` defaults
+// to true.
+var cases = [
+    { id: "typed", label: "block ending in <br>, index starting the next block", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "blocks", label: "block without a trailing <br>", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "brs", label: "<br>-separated lines", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "short", label: "one line, index starting the blank second line", at: 6, want: "alpha\nY\n" },
+    { id: "longer", label: "two blocks ending in <br>", at: 20, want: "alpha\nbravo\ncharlie\nY\n" },
+    { id: "interior", label: "interior index", at: 6, want: "alpha\nYbravo\n\n" },
+    { id: "replacing", label: "replacing a run of characters", at: 6, length: 5, want: "alpha\nY\n\n" },
+    { id: "empty", label: "field with no text", at: 0, want: "Y" },
+    { id: "textarea", label: "textarea, index starting the blank final line", at: 12, want: "alpha\nbravo\nY" },
+    // A range naming characters the value does not have is clamped to the end of the value rather
+    // than refused, the way setRangeText clamps for a native control. The caller gets its text
+    // somewhere sensible in the field it addressed instead of losing it.
+    { id: "pastEnd", label: "location one past the end of the value", at: 14, want: "alpha\nbravo\nY\n" },
+    { id: "farPastEnd", label: "location far past the end of the value", at: 99, want: "alpha\nbravo\nY\n" },
+    // Replacing through the end leaves the block's own trailing line break, the same way the
+    // interior replacement above does.
+    { id: "pastEndByLength", label: "length running past the end of the value", at: 6, length: 99, want: "alpha\nY\n" },
+];
+
+var axField, field, bystander;
+
+// The editor applies an accessibility edit asynchronously, so give it a turn to land before reading
+// the DOM back. A refused request changes nothing, so there is nothing to wait for; wait a turn
+// either way and assert on the resulting text.
+function editSettled() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function textOf(element) {
+    return element.isContentEditable ? element.innerText : element.value;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        bystander = document.getElementById("bystander");
+
+        // Park the caret outside every measured field, so a request that ignored its range would
+        // corrupt the bystander rather than land plausibly in the field it named.
+        bystander.focus();
+        var selection = window.getSelection();
+        selection.removeAllRanges();
+        var caret = document.createRange();
+        caret.selectNodeContents(bystander);
+        caret.collapse(false);
+        selection.addRange(caret);
+
+        for (var testCase of cases) {
+            field = document.getElementById(testCase.id);
+            axField = await waitForElementById(testCase.id);
+            if (!axField) {
+                output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n\n`;
+                continue;
+            }
+
+            var length = testCase.length || 0;
+            output += `${testCase.label}: value ${JSON.stringify(axField.stringAttributeValue("AXValue"))}, replacing {${testCase.at}, ${length}}\n`;
+            output += expect(`axField.replaceTextInRange("Y", ${testCase.at}, ${length})`, testCase.returns === false ? "false" : "true");
+            await editSettled();
+            output += expect("textOf(field)", JSON.stringify(testCase.want));
+            output += expect("textOf(bystander)", JSON.stringify("bystander"));
+            output += "\n";
+        }
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/replace-range-at-block-boundary-expected.txt
+++ b/LayoutTests/accessibility/mac/replace-range-at-block-boundary-expected.txt
@@ -1,0 +1,100 @@
+Asserts that AXReplaceRangeWithText writes at the character index it is given, including the
+index that starts a block, and clamps a range running past the end of the value to the end
+rather than writing at the current selection.
+
+block ending in <br>, index starting the next block: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+block without a trailing <br>: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+<br>-separated lines: value "alpha\nbravo\n\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+one line, index starting the blank second line: value "alpha\n\n", replacing {6, 0}
+PASS: axField.replaceTextInRange("Y", 6, 0) === true
+PASS: textOf(field) === "alpha\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+two blocks ending in <br>: value "alpha\nbravo\ncharlie\n\n", replacing {20, 0}
+PASS: axField.replaceTextInRange("Y", 20, 0) === true
+PASS: textOf(field) === "alpha\nbravo\ncharlie\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+interior index: value "alpha\nbravo\n\n", replacing {6, 0}
+PASS: axField.replaceTextInRange("Y", 6, 0) === true
+PASS: textOf(field) === "alpha\nYbravo\n\n"
+PASS: textOf(bystander) === "bystander"
+
+replacing a run of characters: value "alpha\nbravo\n\n", replacing {6, 5}
+PASS: axField.replaceTextInRange("Y", 6, 5) === true
+PASS: textOf(field) === "alpha\nY\n\n"
+PASS: textOf(bystander) === "bystander"
+
+field with no text: value "", replacing {0, 0}
+PASS: axField.replaceTextInRange("Y", 0, 0) === true
+PASS: textOf(field) === "Y"
+PASS: textOf(bystander) === "bystander"
+
+textarea, index starting the blank final line: value "alpha\nbravo\n", replacing {12, 0}
+PASS: axField.replaceTextInRange("Y", 12, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY"
+PASS: textOf(bystander) === "bystander"
+
+location one past the end of the value: value "alpha\nbravo\n\n", replacing {14, 0}
+PASS: axField.replaceTextInRange("Y", 14, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+location far past the end of the value: value "alpha\nbravo\n\n", replacing {99, 0}
+PASS: axField.replaceTextInRange("Y", 99, 0) === true
+PASS: textOf(field) === "alpha\nbravo\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+length running past the end of the value: value "alpha\nbravo\n\n", replacing {6, 99}
+PASS: axField.replaceTextInRange("Y", 6, 99) === true
+PASS: textOf(field) === "alpha\nY\n"
+PASS: textOf(bystander) === "bystander"
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+Y
+alpha
+bravo
+charlie
+Y
+alpha
+bravo
+Y
+alpha
+bravo
+Y
+alpha
+Y
+alpha
+Ybravo
+
+alpha
+Y
+
+Y
+
+bystander

--- a/LayoutTests/accessibility/mac/replace-range-at-block-boundary.html
+++ b/LayoutTests/accessibility/mac/replace-range-at-block-boundary.html
@@ -1,0 +1,123 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- AXReplaceRangeWithText resolved the character range it was handed by walking CharacterOffsets. A
+     CharacterOffset names a node and a side of it, so at a block boundary one character index belongs
+     to two of them: the position after the <br> that ends the preceding block, and the position
+     starting the next block. The walk picked the former, which is not a caret position -- a <br>
+     ending a block is collapsed out by rendering -- so it canonicalized back over the <br> and the
+     text landed one character early, swallowing a line break.
+
+     This is the shape pressing Return in a contenteditable produces, because the default paragraph
+     separator is a <div> and the block holding the typed text also carries a trailing <br>. It takes
+     three lines to see: the first Return leaves no preceding block to land in. -->
+<div id="typed" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- The same rendered text in shapes that already worked, so a fix that only handles one is visible. -->
+<div id="blocks" contenteditable style="width: 200px">alpha<div>bravo</div><div><br></div></div>
+<div id="brs" contenteditable style="width: 200px">alpha<br>bravo<br><br></div>
+<!-- One line shorter. This is the shape a two-line attempt reaches, and it was always correct. -->
+<div id="short" contenteditable style="width: 200px">alpha<div><br></div></div>
+<!-- Longer, to show the answer does not drift with distance into the content. -->
+<div id="longer" contenteditable style="width: 200px">alpha<div>bravo<br></div><div>charlie<br></div><div><br></div></div>
+<!-- Ranges naming characters the value does not have. Each case gets its own element, so no
+     measurement runs against a value an earlier edit has already changed. -->
+<div id="pastEnd" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="farPastEnd" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="pastEndByLength" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- Interior indices, correct throughout. -->
+<div id="interior" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<div id="replacing" contenteditable style="width: 200px">alpha<div>bravo<br></div><div><br></div></div>
+<!-- A field with no text still has the one position an insertion can name. -->
+<div id="empty" contenteditable style="width: 200px"></div>
+<!-- A native text control takes HTMLTextFormControlElement::setRangeText instead. -->
+<textarea id="textarea" style="width: 200px; height: 60px">alpha
+bravo
+</textarea>
+<!-- Left alone. A request that ignored its range would land wherever the caret is, which is here. -->
+<div id="bystander" contenteditable style="width: 200px">bystander</div>
+
+<script>
+var output = "Asserts that AXReplaceRangeWithText writes at the character index it is given, including the\n"
+    + "index that starts a block, and clamps a range running past the end of the value to the end\n"
+    + "rather than writing at the current selection.\n\n";
+
+// `at`/`length` are the requested range, `want` the element's innerText afterwards. `returns` defaults
+// to true.
+var cases = [
+    { id: "typed", label: "block ending in <br>, index starting the next block", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "blocks", label: "block without a trailing <br>", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "brs", label: "<br>-separated lines", at: 12, want: "alpha\nbravo\nY\n" },
+    { id: "short", label: "one line, index starting the blank second line", at: 6, want: "alpha\nY\n" },
+    { id: "longer", label: "two blocks ending in <br>", at: 20, want: "alpha\nbravo\ncharlie\nY\n" },
+    { id: "interior", label: "interior index", at: 6, want: "alpha\nYbravo\n\n" },
+    { id: "replacing", label: "replacing a run of characters", at: 6, length: 5, want: "alpha\nY\n\n" },
+    { id: "empty", label: "field with no text", at: 0, want: "Y" },
+    { id: "textarea", label: "textarea, index starting the blank final line", at: 12, want: "alpha\nbravo\nY" },
+    // A range naming characters the value does not have is clamped to the end of the value rather
+    // than refused, the way setRangeText clamps for a native control. The caller gets its text
+    // somewhere sensible in the field it addressed instead of losing it.
+    { id: "pastEnd", label: "location one past the end of the value", at: 14, want: "alpha\nbravo\nY\n" },
+    { id: "farPastEnd", label: "location far past the end of the value", at: 99, want: "alpha\nbravo\nY\n" },
+    // Replacing through the end leaves the block's own trailing line break, the same way the
+    // interior replacement above does.
+    { id: "pastEndByLength", label: "length running past the end of the value", at: 6, length: 99, want: "alpha\nY\n" },
+];
+
+var axField, field, bystander;
+
+// The editor applies an accessibility edit asynchronously, so give it a turn to land before reading
+// the DOM back. A refused request changes nothing, so there is nothing to wait for; wait a turn
+// either way and assert on the resulting text.
+function editSettled() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function textOf(element) {
+    return element.isContentEditable ? element.innerText : element.value;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        bystander = document.getElementById("bystander");
+
+        // Park the caret outside every measured field, so a request that ignored its range would
+        // corrupt the bystander rather than land plausibly in the field it named.
+        bystander.focus();
+        var selection = window.getSelection();
+        selection.removeAllRanges();
+        var caret = document.createRange();
+        caret.selectNodeContents(bystander);
+        caret.collapse(false);
+        selection.addRange(caret);
+
+        for (var testCase of cases) {
+            field = document.getElementById(testCase.id);
+            axField = await waitForElementById(testCase.id);
+            if (!axField) {
+                output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n\n`;
+                continue;
+            }
+
+            var length = testCase.length || 0;
+            output += `${testCase.label}: value ${JSON.stringify(axField.stringAttributeValue("AXValue"))}, replacing {${testCase.at}, ${length}}\n`;
+            output += expect(`axField.replaceTextInRange("Y", ${testCase.at}, ${length})`, testCase.returns === false ? "false" : "true");
+            await editSettled();
+            output += expect("textOf(field)", JSON.stringify(testCase.want));
+            output += expect("textOf(bystander)", JSON.stringify("bystander"));
+            output += "\n";
+        }
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2961,7 +2961,19 @@ bool AccessibilityObject::replaceTextInRange(const String& replacementString, co
     // Also only do this when the field is in editing mode.
     Ref frame = renderer()->frame();
     if (element->shouldUseInputMethod()) {
-        frame->selection().setSelectedRange(rangeForCharacterRange(range), Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes);
+        uint64_t textLength = getLengthForTextRange();
+        uint64_t startIndex = std::min(range.location, textLength);
+        uint64_t endIndex = startIndex + std::min(range.length, textLength - startIndex);
+
+        auto start = visiblePositionForIndex(static_cast<int>(startIndex));
+        std::optional insertionRange = makeSimpleRange(start, endIndex == startIndex ? start : visiblePositionForIndex(static_cast<int>(endIndex)));
+        if (!insertionRange)
+            return false;
+
+        // Fail if the selection can't be set, otherwise the wrong text would be replaced.
+        if (!frame->selection().setSelectedRange(*insertionRange, Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes))
+            return false;
+
         protect(frame->editor())->replaceSelectionWithText(replacementString, Editor::SelectReplacement::No, Editor::SmartReplace::No);
         return true;
     }


### PR DESCRIPTION
#### b2177e4ae385e3c4d991a2dc4a61ba96bd783e8e
<pre>
AX: AXReplaceRangeWithText inserts text at the wrong index
<a href="https://rdar.apple.com/186004521">rdar://186004521</a>

Reviewed by Tyler Wilcock.

AccessibilityObject::replaceTextInRange resolved the character range
through rangeForCharacterRange, which walks CharacterOffsets. A
CharacterOffset names a node and a side of it, so at a block boundary
a single character index belongs to two of them: the position after
the &lt;br&gt; that ends the preceding block, and the position starting the
next block. The walk picked the former. That is not a caret position
-- a &lt;br&gt; ending a block is collapsed out by rendering and has nothing
after it -- so it canonicalized back over the &lt;br&gt;, one character
early. Resolving the same index through visiblePositionForIndex lands
on the position that renders where the caller means, so
replaceTextInRange now uses that.

Tests: accessibility/isolated-tree/mac/replace-range-at-block-boundary.html
       accessibility/mac/replace-range-at-block-boundary.html

* LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/replace-range-at-block-boundary.html: Added.
* LayoutTests/accessibility/mac/replace-range-at-block-boundary-expected.txt: Added.
* LayoutTests/accessibility/mac/replace-range-at-block-boundary.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::replaceTextInRange):

Canonical link: <a href="https://commits.webkit.org/320013@main">https://commits.webkit.org/320013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64135d38b1439054fdf610b6f20e85aa326307d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cba8dfd6-639f-409b-9c9f-ee245df1184a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143152 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb255db2-40cf-44b8-80e0-f569301cbcb0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123571 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7c6a01b-d596-4a98-8343-7f2a75b9e70c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45613 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43840 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43448 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4793 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195558 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152661 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40920 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57696 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152345 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46903 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129975 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56204 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18458 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->