### PR TITLE
background-size: cover paints nothing for an SVG image with an extreme natural aspect ratio

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5166,13 +5166,6 @@ webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/backgrou
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-clipping-image-6.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-3.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-4.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-008.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-014.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--cover--height.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--cover--width.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/wide--contain--percent-width-nonpercent-height.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/wide--cover--height.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/wide--cover--width.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/first-letter-space-not-selected.html [ ImageOnlyFailure ]
 
 webkit.org/b/206579 [ Debug ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/zero-height-ratio-auto-5px.html [ Skip ]

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -833,6 +833,26 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
         FloatSize localImageIntrinsicSize = imageIntrinsicSize;
         FloatSize localPositioningAreaSize = positioningAreaSize;
 
+        if (image && localImageIntrinsicSize.isEmpty()) {
+            float intrinsicWidth = 0;
+            float intrinsicHeight = 0;
+            FloatSize intrinsicRatio;
+            image->computeIntrinsicDimensions(&renderer, intrinsicWidth, intrinsicHeight, intrinsicRatio);
+            if (!intrinsicRatio.isEmpty()) {
+                float heightAtFullWidth = localPositioningAreaSize.width() * intrinsicRatio.height() / intrinsicRatio.width();
+                bool fitToWidth = keyword.value == CSSValueContain
+                    ? heightAtFullWidth <= localPositioningAreaSize.height()
+                    : heightAtFullWidth >= localPositioningAreaSize.height();
+                auto concreteSize = fitToWidth
+                    ? FloatSize(localPositioningAreaSize.width(), heightAtFullWidth)
+                    : FloatSize(localPositioningAreaSize.height() * intrinsicRatio.width() / intrinsicRatio.height(), localPositioningAreaSize.height());
+                LayoutSize tileSize(concreteSize);
+                if (tileSize.isEmpty())
+                    return { };
+                return tileSize.expandedTo({ devicePixelSize, devicePixelSize });
+            }
+        }
+
         float horizontalScaleFactor = localImageIntrinsicSize.width() ? (localPositioningAreaSize.width() / localImageIntrinsicSize.width()) : 1;
         float verticalScaleFactor = localImageIntrinsicSize.height() ? (localPositioningAreaSize.height() / localImageIntrinsicSize.height()) : 1;
         float scaleFactor = keyword.value == CSSValueContain ? std::min(horizontalScaleFactor, verticalScaleFactor) : std::max(horizontalScaleFactor, verticalScaleFactor);


### PR DESCRIPTION
#### 6b879687ee9429781c5dacc0d123e73105f06511
<pre>
background-size: cover paints nothing for an SVG image with an extreme natural aspect ratio
<a href="https://bugs.webkit.org/show_bug.cgi?id=322736">https://bugs.webkit.org/show_bug.cgi?id=322736</a>
<a href="https://rdar.apple.com/186006463">rdar://186006463</a>

Reviewed by Simon Fraser.

An SVG image whose natural aspect ratio is extreme e.g. a viewBox of
&quot;0 0 1 2147483647&quot; with one specified dimension, rounds the derived
dimension of its resolved intrinsic size down to zero in
RenderBoxModelObject::calculateImageIntrinsicDimensions() (8 * 1 / 2147483647
floors to 0 as a LayoutUnit). BackgroundPainter::calculateFillTileSize()&apos;s
cover/contain handling then scales that intrinsic size by a single factor,
which can never recover the lost dimension: it hits the isEmpty() guard and
returns an empty tile, so nothing is painted. cover on such an image is
supposed to fill the positioning area.

The cover and contain concrete object size depends only on the natural aspect
ratio and the constraint rectangle, not on the (possibly sub-pixel, rounded)
intrinsic pixel size. When the resolved intrinsic size has collapsed to empty
but the image still reports a non-empty natural ratio, derive the concrete
size from the ratio and the positioning area directly:

  &quot;A contain constraint is resolved by setting the concrete object size to the
   largest rectangle that has the object&apos;s natural aspect ratio and
   additionally has neither width nor height larger than the constraint
   rectangle&apos;s [...]. A cover constraint is resolved by setting the concrete
   object size to the smallest rectangle that has the object&apos;s natural aspect
   ratio and additionally has neither width nor height smaller than the
   constraint rectangle&apos;s [...].&quot; [1]

For an extreme ratio contain collapses the tiny axis to zero (empty, matching
the -empty references) while cover expands it to fill the area (matching the
-lime references). The new path only runs when the resolved intrinsic size is
empty and a natural ratio exists, so ordinary cover/contain sizing is
unchanged.

This is CSS box code shared by both the legacy and layer-based SVG engines;
the SVG image&apos;s natural ratio comes from SVGImage::computeIntrinsicDimensions.

[1] <a href="https://drafts.csswg.org/css-images-3/#cover-contain">https://drafts.csswg.org/css-images-3/#cover-contain</a>

* LayoutTests/TestExpectations: Unskip now passing tests
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateFillTileSize):

Canonical link: <a href="https://commits.webkit.org/320008@main">https://commits.webkit.org/320008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd890516244a493d22eca15595211ce8d72fa412

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147673 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f815b201-d485-4985-a8b1-0e644e4c0f32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143145 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/721697d1-fead-4bd9-ad10-a111bce043e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/998aa61a-3a1c-4369-adee-5783853cb1b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43828 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43441 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4777 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195542 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40915 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152331 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46884 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129959 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56188 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18451 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->