### PR TITLE
[scroll-animations] keep track of style scope for `animation-timeline` and `{scroll|view}-timeline-name` properties

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -217,7 +217,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
         [&](const CSS::Keyword::None&) {
             setTimeline(nullptr);
         },
-        [&](const Style::CustomIdent&) {
+        [&](const Style::ScopedName&) {
             CheckedRef styleOriginatedTimelinesController = document->ensureStyleOriginatedTimelinesController();
             styleOriginatedTimelinesController->attachAnimation(*this);
         },
@@ -235,7 +235,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
                 if (existingViewTimeline->matchesAnonymousViewFunctionForSubject(viewFunction, m_backingStyleZoomForLength, *owningElement()))
                     return;
             }
-            auto viewTimeline = ViewTimeline::create(nullAtom(), viewFunction->axis, viewFunction->insets, m_backingStyleZoomForLength);
+            auto viewTimeline = ViewTimeline::create({ nullAtom() }, viewFunction->axis, viewFunction->insets, m_backingStyleZoomForLength);
             viewTimeline->setSubject(*owningElement());
             setTimeline(WTF::move(viewTimeline));
         }
@@ -243,7 +243,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
 
     // If we're not dealing with a named timeline, we should make sure we have no
     // pending attachment operation for this timeline name.
-    if (!m_backingStyleAnimation.timeline().isCustomIdent()) {
+    if (!m_backingStyleAnimation.timeline().isScopedName()) {
         CheckedRef styleOriginatedTimelinesController = document->ensureStyleOriginatedTimelinesController();
         styleOriginatedTimelinesController->removePendingOperationsForCSSAnimation(*this);
     }

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -83,7 +83,7 @@ Ref<ScrollTimeline> ScrollTimeline::create(Document& document, ScrollTimelineOpt
     return timeline;
 }
 
-Ref<ScrollTimeline> ScrollTimeline::create(const AtomString& name, ScrollAxis axis)
+Ref<ScrollTimeline> ScrollTimeline::create(const Style::ScopedName& name, ScrollAxis axis)
 {
     return adoptRef(*new ScrollTimeline(name, axis));
 }
@@ -95,7 +95,7 @@ Ref<ScrollTimeline> ScrollTimeline::create(Scroller scroller, ScrollAxis axis)
 
 Ref<ScrollTimeline> ScrollTimeline::createInactiveStyleOriginatedTimeline(const AtomString& name)
 {
-    auto timeline = adoptRef(*new ScrollTimeline(name, ScrollAxis::Block));
+    Ref timeline = adoptRef(*new ScrollTimeline({ name }, ScrollAxis::Block));
     timeline->m_isInactiveStyleOriginatedTimeline = true;
     return timeline;
 }
@@ -110,7 +110,7 @@ ScrollTimeline::ScrollTimeline()
 {
 }
 
-ScrollTimeline::ScrollTimeline(const AtomString& name, ScrollAxis axis)
+ScrollTimeline::ScrollTimeline(const Style::ScopedName& name, ScrollAxis axis)
     : ScrollTimeline()
 {
     m_axis = axis;
@@ -416,7 +416,7 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
 
 bool ScrollTimeline::matchesAnonymousScrollFunctionForSource(const Style::ScrollFunction& scrollFunction, const Styleable& source) const
 {
-    return m_isStyleOriginated && m_name.isEmpty() && m_scroller == scrollFunction->scroller && m_axis == scrollFunction->axis && m_source.styleable() == source;
+    return m_isStyleOriginated && m_name.name.isEmpty() && m_scroller == scrollFunction->scroller && m_axis == scrollFunction->axis && m_source.styleable() == source;
 }
 
 #if ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -28,6 +28,7 @@
 #include <WebCore/AnimationTimeline.h>
 #include <WebCore/Element.h>
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/ScopedName.h>
 #include <WebCore/ScrollAxis.h>
 #include <WebCore/ScrollTimelineOptions.h>
 #include <WebCore/StyleScrollFunction.h>
@@ -51,7 +52,7 @@ class ComputedStyle;
 class ScrollTimeline : public AnimationTimeline {
 public:
     static Ref<ScrollTimeline> create(Document&, ScrollTimelineOptions&& = { });
-    static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
+    static Ref<ScrollTimeline> create(const Style::ScopedName&, ScrollAxis);
     static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
     static Ref<ScrollTimeline> createInactiveStyleOriginatedTimeline(const AtomString& name);
 
@@ -64,8 +65,8 @@ public:
     ScrollAxis axis() const { return m_axis; }
     void setAxis(ScrollAxis axis) { m_axis = axis; }
 
-    const AtomString& name() const LIFETIME_BOUND { return m_name; }
-    void setName(const AtomString& name) { m_name = name; }
+    const Style::ScopedName& name() const LIFETIME_BOUND { return m_name; }
+    void setName(const Style::ScopedName& name) { m_name = name; }
 
     bool isInactiveStyleOriginatedTimeline() const { return m_isInactiveStyleOriginatedTimeline; }
 
@@ -98,7 +99,7 @@ public:
 #endif
 
 protected:
-    explicit ScrollTimeline(const AtomString&, ScrollAxis);
+    explicit ScrollTimeline(const Style::ScopedName&, ScrollAxis);
 
     struct Data {
         float scrollOffset { 0 };
@@ -140,7 +141,7 @@ private:
 
     WeakStyleable m_source;
     ScrollAxis m_axis { ScrollAxis::Block };
-    AtomString m_name;
+    Style::ScopedName m_name;
     Scroller m_scroller { Scroller::Self };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_timelineScopeElement;
     CurrentTimeData m_cachedCurrentTimeData { };

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -183,11 +183,11 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
     }
 }
 
-void StyleOriginatedTimelinesController::registerNamedScrollTimeline(const AtomString& name, const Styleable& source, ScrollAxis axis)
+void StyleOriginatedTimelinesController::registerNamedScrollTimeline(const Style::ScopedName& scopedName, const Styleable& source, ScrollAxis axis)
 {
-    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::registerNamedScrollTimeline: " << name << " source: " << source);
+    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::registerNamedScrollTimeline: " << scopedName.name << " source: " << source);
 
-    auto& timelines = timelinesForName(name);
+    auto& timelines = timelinesForName(scopedName.name);
 
     auto existingTimelineIndex = timelines.findIf([&](auto& timeline) {
         return !is<ViewTimeline>(timeline) && timeline->sourceStyleable() == source;
@@ -197,11 +197,11 @@ void StyleOriginatedTimelinesController::registerNamedScrollTimeline(const AtomS
         auto& existingScrollTimeline = timelines[existingTimelineIndex].get();
         existingScrollTimeline.setAxis(axis);
     } else {
-        auto newScrollTimeline = ScrollTimeline::create(name, axis);
+        auto newScrollTimeline = ScrollTimeline::create(scopedName, axis);
         newScrollTimeline->setSource(source);
-        updateTimelineForTimelineScope(newScrollTimeline, name);
+        updateTimelineForTimelineScope(newScrollTimeline, scopedName.name);
         timelines.append(WTF::move(newScrollTimeline));
-        updateCSSAnimationsAssociatedWithNamedTimeline(name);
+        updateCSSAnimationsAssociatedWithNamedTimeline(scopedName.name);
     }
 }
 
@@ -216,8 +216,8 @@ void StyleOriginatedTimelinesController::updateCSSAnimationsAssociatedWithNamedT
             if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation.get())) {
                 if (!cssAnimation->owningElement())
                     continue;
-                if (auto timelineName = cssAnimation->backingStyleAnimation().timeline().tryCustomIdent()) {
-                    if (timelineName->value == name)
+                if (auto timelineName = cssAnimation->backingStyleAnimation().timeline().tryScopedName()) {
+                    if (timelineName->name == name)
                         cssAnimationsWithMatchingTimelineName.add(*cssAnimation);
                 }
             }
@@ -255,11 +255,11 @@ void StyleOriginatedTimelinesController::documentDidResolveStyle()
     m_removedTimelines.clear();
 }
 
-void StyleOriginatedTimelinesController::registerNamedViewTimeline(const AtomString& name, const Styleable& subject, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
+void StyleOriginatedTimelinesController::registerNamedViewTimeline(const Style::ScopedName& scopedName, const Styleable& subject, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
 {
-    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::registerNamedViewTimeline: " << name << " subject: " << subject);
+    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::registerNamedViewTimeline: " << scopedName.name << " subject: " << subject);
 
-    auto& timelines = timelinesForName(name);
+    auto& timelines = timelinesForName(scopedName.name);
 
     auto existingTimelineIndex = timelines.findIf([&](auto& timeline) {
         if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(timeline))
@@ -274,14 +274,14 @@ void StyleOriginatedTimelinesController::registerNamedViewTimeline(const AtomStr
         existingViewTimeline->setAxis(axis);
         existingViewTimeline->setInsets(ResolvableViewTimelineInsets { insets, usedZoomForLength });
     } else {
-        auto newViewTimeline = ViewTimeline::create(name, axis, insets, usedZoomForLength);
+        auto newViewTimeline = ViewTimeline::create(scopedName, axis, insets, usedZoomForLength);
         newViewTimeline->setSubject(subject);
-        updateTimelineForTimelineScope(newViewTimeline, name);
+        updateTimelineForTimelineScope(newViewTimeline, scopedName.name);
         timelines.append(WTF::move(newViewTimeline));
     }
 
     if (!hasExistingTimeline)
-        updateCSSAnimationsAssociatedWithNamedTimeline(name);
+        updateCSSAnimationsAssociatedWithNamedTimeline(scopedName.name);
 }
 
 void StyleOriginatedTimelinesController::unregisterNamedTimeline(const AtomString& name, const Styleable& styleable)
@@ -336,14 +336,14 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
     if (!target)
         return;
 
-    auto timelineName = protectedAnimation->backingStyleAnimation().timeline().tryCustomIdent();
+    auto timelineName = protectedAnimation->backingStyleAnimation().timeline().tryScopedName();
     if (!timelineName)
         return;
 
-    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->value << " target: " << *target);
+    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->name << " target: " << *target);
 
     auto relevantTimelineScopeElement = [&] -> RefPtr<Element> {
-        auto timelineScopeElements = relatedTimelineScopeElements(*timelineName);
+        auto timelineScopeElements = relatedTimelineScopeElements(Style::CustomIdent { timelineName->name });
         if (timelineScopeElements.isEmpty())
             return nullptr;
         // Find the nearest parent within timelineScopeElements.
@@ -356,7 +356,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
         return nullptr;
     }();
 
-    auto it = m_nameToTimelineMap.find(timelineName->value);
+    auto it = m_nameToTimelineMap.find(timelineName->name);
     auto hasNamedTimeline = it != m_nameToTimelineMap.end() && it->value.containsIf([&](auto& timeline) {
         auto timelineScope = timeline->timelineScopeDeclaredElement();
         if (timelineScope && timelineScope.get() != relevantTimelineScopeElement.get())
@@ -380,13 +380,13 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
         //        scroll timeline, or,
         //     2. the name is not within scope and the timeline is null.
         if (relevantTimelineScopeElement)
-            protectedAnimation->setTimeline(&inactiveNamedTimeline(timelineName->value));
+            protectedAnimation->setTimeline(&inactiveNamedTimeline(timelineName->name));
         else
             protectedAnimation->setTimeline(nullptr);
     } else {
         auto& timelines = it->value;
         RefPtr timeline = determineTimelineForElement(timelines, *target, relevantTimelineScopeElement.get());
-        LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->value << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
+        LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->name << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
         // A deferred inactive timeline means there was a conflict with multiple timelines existing within
         // a parent element with a "timeline-scope" property. In that case, we must reconsider timeline attachment
         // once style resolution completes as further updates may occur that would yield a different timeline
@@ -441,7 +441,7 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
         // We need to unregister all timelines that are no longer within this scope.
         for (auto& timeline : namedTimelinesToUnregister) {
             if (auto associatedElement = originatingElement(timeline).styleable())
-                unregisterNamedTimeline(timeline->name(), *associatedElement);
+                unregisterNamedTimeline(timeline->name().name, *associatedElement);
         }
         break;
     }

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSAnimation.h"
+#include "ScopedName.h"
 #include "ScrollAxis.h"
 #include "StyleNameScope.h"
 #include "Styleable.h"
@@ -64,8 +65,8 @@ public:
     explicit StyleOriginatedTimelinesController() = default;
     ~StyleOriginatedTimelinesController() = default;
 
-    void registerNamedScrollTimeline(const AtomString&, const Styleable&, ScrollAxis);
-    void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
+    void registerNamedScrollTimeline(const Style::ScopedName&, const Styleable&, ScrollAxis);
+    void registerNamedViewTimeline(const Style::ScopedName&, const Styleable&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
     void unregisterNamedTimeline(const AtomString&, const Styleable&);
     void attachAnimation(CSSAnimation&);
     void updateNamedTimelineMapForTimelineScope(const Style::NameScope&, const Styleable&);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -58,7 +58,7 @@ ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTime
     if (!insets)
         return Exception { ExceptionCode::TypeError };
 
-    auto viewTimeline = ViewTimeline::create(nullAtom(), options.axis, WTF::move(*insets), Style::ZoomFactor::none());
+    auto viewTimeline = ViewTimeline::create({ nullAtom() }, options.axis, WTF::move(*insets), Style::ZoomFactor::none());
 
     viewTimeline->setSubject(options.subject.get());
     if (auto subject = options.subject)
@@ -68,13 +68,13 @@ ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTime
     return viewTimeline;
 }
 
-Ref<ViewTimeline> ViewTimeline::create(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
+Ref<ViewTimeline> ViewTimeline::create(const Style::ScopedName& scopedName, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
 {
-    return adoptRef(*new ViewTimeline(name, axis, insets, usedZoomForLength));
+    return adoptRef(*new ViewTimeline(scopedName, axis, insets, usedZoomForLength));
 }
 
-ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
-    : ScrollTimeline(name, axis)
+ViewTimeline::ViewTimeline(const Style::ScopedName& scopedName, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
+    : ScrollTimeline(scopedName, axis)
     , m_insets({ .insets = insets, .zoom = usedZoomForLength })
 {
 }
@@ -552,7 +552,7 @@ Ref<CSSNumericValue> ViewTimeline::endOffset() const
 bool ViewTimeline::matchesAnonymousViewFunctionForSubject(const Style::ViewFunction& viewFunction, const Style::ZoomFactor& usedZoomForLength, const Styleable& subject) const
 {
     return isStyleOriginated()
-        && name().isEmpty()
+        && name().name.isEmpty()
         && m_insets.insets == viewFunction->insets
         && m_insets.zoom == usedZoomForLength
         && axis() == viewFunction->axis

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -28,6 +28,7 @@
 #include <WebCore/CSSNumericValue.h>
 #include <WebCore/CSSPrimitiveValue.h>
 #include <WebCore/ResolvableViewTimelineInsets.h>
+#include <WebCore/ScopedName.h>
 #include <WebCore/ScrollTimeline.h>
 #include <WebCore/StyleViewFunction.h>
 #include <WebCore/Styleable.h>
@@ -72,7 +73,7 @@ struct StickinessAdjustmentData {
 class ViewTimeline final : public ScrollTimeline {
 public:
     static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&&);
-    static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
+    static Ref<ViewTimeline> create(const Style::ScopedName&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     const Element* NODELETE subject() const;
     const WeakStyleable subjectStyleable() const { return m_subject; }
@@ -102,7 +103,7 @@ public:
     WebAnimationTime NODELETE epsilon() const;
 
 private:
-    ViewTimeline(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
+    ViewTimeline(const Style::ScopedName&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     ScrollTimeline::Data computeTimelineData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const final;
     std::pair<double, double> intervalForTimelineRangeName(const ScrollTimeline::Data&, Style::SingleAnimationRangeName) const;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -874,9 +874,9 @@ void Styleable::updateCSSScrollTimelines(const Style::ComputedStyle* currentStyl
             [](CSS::Keyword::None) {
                 // Nothing to register.
             },
-            [&](const Style::CustomIdent& identifier) {
-                styleOriginatedTimelinesController->registerNamedScrollTimeline(identifier.value, *this, scrollTimeline.axis());
-                registeredScrollTimelineNames.add(identifier.value);
+            [&](const Style::ScopedName& scopedName) {
+                styleOriginatedTimelinesController->registerNamedScrollTimeline(scopedName, *this, scrollTimeline.axis());
+                registeredScrollTimelineNames.add(scopedName.name);
             }
         );
     }
@@ -889,9 +889,9 @@ void Styleable::updateCSSScrollTimelines(const Style::ComputedStyle* currentStyl
             [](CSS::Keyword::None) {
                 // Nothing to unregister.
             },
-            [&](const Style::CustomIdent& identifier) {
-                if (!registeredScrollTimelineNames.contains(identifier.value))
-                    styleOriginatedTimelinesController->unregisterNamedTimeline(identifier.value, *this);
+            [&](const Style::ScopedName& scopedName) {
+                if (!registeredScrollTimelineNames.contains(scopedName.name))
+                    styleOriginatedTimelinesController->unregisterNamedTimeline(scopedName.name, *this);
             }
         );
     }
@@ -911,9 +911,9 @@ void Styleable::updateCSSViewTimelines(const Style::ComputedStyle* currentStyle,
             [](CSS::Keyword::None) {
                 // Nothing to register.
             },
-            [&](const Style::CustomIdent& identifier) {
-                styleOriginatedTimelinesController->registerNamedViewTimeline(identifier.value, *this, viewTimeline.axis(), viewTimeline.inset(), afterChangeStyle.usedZoomForLength());
-                registeredViewTimelineNames.add(identifier.value);
+            [&](const Style::ScopedName& scopedName) {
+                styleOriginatedTimelinesController->registerNamedViewTimeline(scopedName, *this, viewTimeline.axis(), viewTimeline.inset(), afterChangeStyle.usedZoomForLength());
+                registeredViewTimelineNames.add(scopedName.name);
             }
         );
     }
@@ -926,9 +926,9 @@ void Styleable::updateCSSViewTimelines(const Style::ComputedStyle* currentStyle,
             [](CSS::Keyword::None) {
                 // Nothing to unregister.
             },
-            [&](const Style::CustomIdent& identifier) {
-                if (!registeredViewTimelineNames.contains(identifier.value))
-                    styleOriginatedTimelinesController->unregisterNamedTimeline(identifier.value, *this);
+            [&](const Style::ScopedName& scopedName) {
+                if (!registeredViewTimelineNames.contains(scopedName.name))
+                    styleOriginatedTimelinesController->unregisterNamedTimeline(scopedName.name, *this);
             }
         );
     }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp
@@ -59,7 +59,7 @@ auto CSSValueConversion<SingleAnimationTimeline>::operator()(BuilderState& state
     if (RefPtr viewValue = dynamicDowncast<CSSViewValue>(value))
         return toStyleFromCSSValue<ViewFunction>(state, *viewValue);
 
-    return toStyleFromCSSValue<CustomIdent>(state, value);
+    return toStyleFromCSSValue<ScopedName>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StyleCustomIdent.h>
+#include <WebCore/ScopedName.h>
 #include <WebCore/StyleScrollFunction.h>
 #include <WebCore/StyleValueTypes.h>
 #include <WebCore/StyleViewFunction.h>
@@ -45,8 +45,8 @@ struct SingleAnimationTimeline {
     {
     }
 
-    SingleAnimationTimeline(CustomIdent&& identifier)
-        : m_value { identifier }
+    SingleAnimationTimeline(ScopedName&& name)
+        : m_value { name }
     {
     }
 
@@ -62,8 +62,8 @@ struct SingleAnimationTimeline {
 
     bool isAuto() const { return std::holds_alternative<CSS::Keyword::Auto>(m_value); }
     bool isNone() const { return std::holds_alternative<CSS::Keyword::None>(m_value); }
-    bool isCustomIdent() const { return std::holds_alternative<CustomIdent>(m_value); }
-    std::optional<CustomIdent> tryCustomIdent() const { return isCustomIdent() ? std::make_optional(std::get<CustomIdent>(m_value)) : std::nullopt; }
+    bool isScopedName() const { return std::holds_alternative<ScopedName>(m_value); }
+    std::optional<ScopedName> tryScopedName() const { return isScopedName() ? std::make_optional(std::get<ScopedName>(m_value)) : std::nullopt; }
     bool isScrollFunction() const { return std::holds_alternative<ScrollFunction>(m_value); }
     std::optional<ScrollFunction> tryScrollFunction() const { return isScrollFunction() ? std::make_optional(std::get<ScrollFunction>(m_value)) : std::nullopt; }
     bool isViewFunction() const { return std::holds_alternative<ViewFunction>(m_value); }
@@ -77,7 +77,7 @@ struct SingleAnimationTimeline {
     bool operator==(const SingleAnimationTimeline&) const = default;
 
 private:
-    Variant<CSS::Keyword::Auto, CSS::Keyword::None, CustomIdent, ScrollFunction, ViewFunction> m_value;
+    Variant<CSS::Keyword::Auto, CSS::Keyword::None, ScopedName, ScrollFunction, ViewFunction> m_value;
 };
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StyleCustomIdent.h>
+#include <WebCore/ScopedName.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -32,7 +32,7 @@ namespace Style {
 
 // <single-progress-timeline-name> = none | <dashed-ident>
 // https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-name
-struct ProgressTimelineName : ValueOrKeyword<CustomIdent, CSS::Keyword::None> {
+struct ProgressTimelineName : ValueOrKeyword<ScopedName, CSS::Keyword::None> {
     using Base::Base;
 
     bool isNone() const { return isKeyword(); }


### PR DESCRIPTION
#### f54d0579631ecf491974f33c46fcae9e47cee8bc
<pre>
[scroll-animations] keep track of style scope for `animation-timeline` and `{scroll|view}-timeline-name` properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=322739">https://bugs.webkit.org/show_bug.cgi?id=322739</a>
<a href="https://rdar.apple.com/186008235">rdar://186008235</a>

Reviewed by Anne van Kesteren.

Track the style scope when parsing the `animation-timeline`, `scroll-timeline-name` and
`view-timeline-name` properties such that in a future patch we may correctly look up
progress-based timelines across style scopes and address bug 322013.

We simply change `Style::CustomIdent` to `Style::ScopedName` in `Style::SingleAnimationTimeline`
and `Style::ProgressTimelineName` and additionally switch from `AtomString` to `Style::ScopedName`
to represent a progress-based timeline&apos;s name.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::create):
(WebCore::ScrollTimeline::createInactiveStyleOriginatedTimeline):
(WebCore::ScrollTimeline::ScrollTimeline):
(WebCore::ScrollTimeline::matchesAnonymousScrollFunctionForSource const):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::setName):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::registerNamedScrollTimeline):
(WebCore::StyleOriginatedTimelinesController::updateCSSAnimationsAssociatedWithNamedTimeline):
(WebCore::StyleOriginatedTimelinesController::registerNamedViewTimeline):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
(WebCore::StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope):
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::create):
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::matchesAnonymousViewFunctionForSubject const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSScrollTimelines const):
(WebCore::Styleable::updateCSSViewTimelines const):
* Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp:
(WebCore::Style::CSSValueConversion&lt;SingleAnimationTimeline&gt;::operator):
* Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h:
(WebCore::Style::SingleAnimationTimeline::SingleAnimationTimeline):
(WebCore::Style::SingleAnimationTimeline::isScopedName const):
(WebCore::Style::SingleAnimationTimeline::tryScopedName const):
(WebCore::Style::SingleAnimationTimeline::isCustomIdent const): Deleted.
(WebCore::Style::SingleAnimationTimeline::tryCustomIdent const): Deleted.
* Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h:

Canonical link: <a href="https://commits.webkit.org/320026@main">https://commits.webkit.org/320026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/301308b048142012da57fdd10a2b2a410efe7e8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147732 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6356855e-af82-4a3e-95d0-49c2102f5e40) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143182 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99421 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4c8d76e-e450-4dda-b296-afa4e4fcd518) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e25c814-67f9-4872-b13a-77c9a59bc4da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43874 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43474 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4836 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195601 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57035 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152381 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46930 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130018 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56247 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18483 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55618 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55857 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->