### PR TITLE
text-decoration-skip-ink should draw through pictographic characters

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure that underlines drawn across pictographic characters (e.g. symbols and emoji) do not skip over them as though they were low-hanging descenders. See webkit.org/b/322735.
+<div style="text-decoration: underline; text-decoration-skip-ink: none; font-size: 48px;">text &#x263B; text &#x1F600; text</div>
+</body>
+</html>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure that underlines drawn across pictographic characters (e.g. symbols and emoji) do not skip over them as though they were low-hanging descenders. See webkit.org/b/322735.
+<div style="text-decoration: underline; font-size: 48px;">text &#x263B; text &#x1F600; text</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1374,6 +1374,10 @@ static GlyphUnderlineType computeUnderlineType(const TextRun& textRun, const Gly
         auto characters = textRun.span16();
         U16_GET(characters, 0, static_cast<unsigned>(offsetInString.value()), characters.size(), baseCharacter);
     }
+    // Draw underlines through pictographic characters instead of skipping their ink (webkit.org/b/322735).
+    if (isEmojiGroupCandidate(baseCharacter))
+        return GlyphUnderlineType::DrawOverGlyph;
+
     // u_getIntPropertyValue with UCHAR_IDEOGRAPHIC doesn't return true for Japanese or Korean codepoints.
     // Instead, we can use the "Unicode allocation block" for the character.
     UBlockCode blockCode = ublock_getCode(baseCharacter);


### PR DESCRIPTION
#### d614ce230f5120558e1f14b094e8d3c7917d335b
<pre>
text-decoration-skip-ink should draw through pictographic characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=322735">https://bugs.webkit.org/show_bug.cgi?id=322735</a>
<a href="https://rdar.apple.com/60409304">rdar://60409304</a>

Reviewed by NOBODY (OOPS!).

computeUnderlineType only special-cases CJK, Kana, and Hangul blocks to draw straight through a glyph instead of skipping around its ink, because those scripts have wide filled strokes that get misread as descenders. Pictographic and emoji glyphs have the same wide outlines and hit the same misclassification, so the underline drops or gaps under them instead of drawing through.

Test: fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic.html

* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-pictographic.html: Added.
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::computeUnderlineType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d614ce230f5120558e1f14b094e8d3c7917d335b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147683 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65aea1a6-31e7-4e68-aa7b-1d2d22a52d3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143148 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99404 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da6030ff-269f-41c6-9413-36b15d82849f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16829a97-0b2f-417d-89ba-ae669b03579b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43838 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43445 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4787 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195552 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57690 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152339 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46893 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129969 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126268 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56198 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18455 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->