### PR TITLE
[css-text-decor] Negative text-decoration-inset is clipped when the decoration propagates to a descendant inline box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSTextDecorationInsetEnabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Text Decoration: a decoration propagated to a descendant inline box is measured with the originating box's style (reference)</title>
+<style>
+body { margin: 30px; }
+div { font: 24px/2 monospace; width: max-content; will-change: transform; }
+.thick { text-decoration: underline; text-decoration-thickness: 24px; }
+.wavy { text-decoration: underline wavy; text-decoration-thickness: 8px; }
+.inset { text-decoration: underline 3px blue; text-underline-offset: 6px; text-decoration-inset: -40px; }
+</style>
+
+<!-- Bare text, so the text box's parent is the box that originates the decoration. -->
+
+<div class="thick">thickness</div>
+<div class="wavy">wavyline</div>
+<div class="inset">negative inset</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSTextDecorationInsetEnabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Text Decoration: a decoration propagated to a descendant inline box is measured with the originating box's style</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#line-decoration">
+<link rel="match" href="text-decoration-propagated-ink-overflow-expected.html">
+<meta name="assert" content="The text decoration properties are not inherited, so a decoration that propagates to a descendant is drawn with the originating box's style. Its ink overflow must be measured from that same style, or the parts of the decoration that fall outside the text box are clipped.">
+<style>
+body { margin: 30px; }
+div { font: 24px/2 monospace; width: max-content; will-change: transform; }
+.thick { text-decoration: underline; text-decoration-thickness: 24px; }
+.wavy { text-decoration: underline wavy; text-decoration-thickness: 8px; }
+.inset { text-decoration: underline 3px blue; text-underline-offset: 6px; text-decoration-inset: -40px; }
+</style>
+
+<!-- Each decoration originates on the div and propagates to the text inside the span, so the text
+     box's immediate parent is not the box carrying the decoration properties. The composited layer
+     is sized from the ink overflow, so any part measured against the span's initial values - a
+     24px-thick underline, a wavy underline's control points, a negative inset's overhang - is
+     clipped instead of painted. The reference has the same declarations on bare text. -->
+
+<div class="thick"><span>thickness</span></div>
+<div class="wavy"><span>wavyline</span></div>
+<div class="inset"><span>negative inset</span></div>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1223,20 +1223,34 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(std::span
         if (!displayBox.isText())
             continue;
 
-        CheckedRef parentStyle = displayBox.layoutBox().parent().style();
-        auto textDecorations = parentStyle->textDecorationLineInEffect();
-        if (!textDecorations)
-            continue;
-
+        // Note that decoration properties are not inherited but propagated
         auto decorationOverflow = [&] {
-            if (!textDecorations.hasUnderline())
-                return inkOverflowForDecorations(parentStyle);
+            auto overflowForDecoratingBox = [&](auto& decoratingBoxStyle) {
+                if (!decoratingBoxStyle.textDecorationLineInEffect().hasUnderline())
+                    return inkOverflowForDecorations(decoratingBoxStyle);
 
-            if (!logicalBottomForTextDecoration)
-                logicalBottomForTextDecoration = logicalBottomForTextDecorationContent(boxes, isHorizontalWritingMode);
-            auto textRunLogicalOffsetFromLineBottom = *logicalBottomForTextDecoration - (isHorizontalWritingMode ? displayBox.bottom() : displayBox.right());
-            auto textRunLogicalHeight = isHorizontalWritingMode ? displayBox.height() : displayBox.width();
-            return inkOverflowForDecorations(parentStyle, { textRunLogicalHeight, textRunLogicalOffsetFromLineBottom });
+                if (!logicalBottomForTextDecoration)
+                    logicalBottomForTextDecoration = logicalBottomForTextDecorationContent(boxes, isHorizontalWritingMode);
+                auto textRunLogicalOffsetFromLineBottom = *logicalBottomForTextDecoration - (isHorizontalWritingMode ? displayBox.bottom() : displayBox.right());
+                auto textRunLogicalHeight = isHorizontalWritingMode ? displayBox.height() : displayBox.width();
+                return inkOverflowForDecorations(decoratingBoxStyle, { textRunLogicalHeight, textRunLogicalOffsetFromLineBottom });
+            };
+
+            // Several ancestors may each decorate this text box, which then has to accommodate whichever of them overflows it the most on each side.
+            auto maximumOverflow = InkOverflowForDecorations { };
+            for (CheckedPtr box = &displayBox.layoutBox().parent(); box; box = &box->parent()) {
+                CheckedRef style = isFirstFormattedLine() ? box->firstLineStyle() : box->style();
+                if (style->textDecorationLine()) {
+                    auto overflow = overflowForDecoratingBox(style.get());
+                    maximumOverflow.top() = std::max(maximumOverflow.top(), overflow.top());
+                    maximumOverflow.right() = std::max(maximumOverflow.right(), overflow.right());
+                    maximumOverflow.bottom() = std::max(maximumOverflow.bottom(), overflow.bottom());
+                    maximumOverflow.left() = std::max(maximumOverflow.left(), overflow.left());
+                }
+                if (box == &root())
+                    break;
+            }
+            return maximumOverflow;
         }();
 
         if (!decorationOverflow.isZero()) {


### PR DESCRIPTION
#### 845882297cd22aeb22135aecf95aebbe4638842a
<pre>
[css-text-decor] Negative text-decoration-inset is clipped when the decoration propagates to a descendant inline box
<a href="https://bugs.webkit.org/show_bug.cgi?id=322718">https://bugs.webkit.org/show_bug.cgi?id=322718</a>
&lt;<a href="https://rdar.apple.com/problem/185985708">rdar://problem/185985708</a>&gt;

Reviewed by Antti Koivisto.

collectInkOverflowForTextDecorations() measured each text box&apos;s decoration overflow
from displayBox.layoutBox().parent().style(). The decoration properties are not
inherited, so when a decoration propagates from an ancestor to a descendant inline box
that immediate parent carries the initial values, and the overflow came out too small.
The decoration was still painted in the right place - TextBoxPainter walks up to the
originating box - so it got clipped to the undersized overflow instead.

Test: imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagated-ink-overflow-expected.html: Added.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::collectInkOverflowForTextDecorations):

Canonical link: <a href="https://commits.webkit.org/320044@main">https://commits.webkit.org/320044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d106917f7e35ef0bc9692ba00b503a862404b28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147888 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48a6b2cc-0355-4fb6-88a2-a452c6d6b54a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143294 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99488 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d656bd50-54bf-4383-8676-2e0b2a0198e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123717 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/249b097d-4b27-4960-8b93-45f27f9def55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43992 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43578 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4997 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40937 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57895 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152511 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47051 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130174 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126481 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56403 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18588 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55774 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->