### PR TITLE
Make CSSTokenizer work efficiently with StringViews

### DIFF
--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -80,7 +80,7 @@ auto CSSCustomPropertySyntax::parseComponent(std::span<const CharacterType> span
         ++buffer;
 
     auto ident = [&] {
-        auto tokenizer = CSSTokenizer::tryCreate(StringView(begin.first(buffer.position() - begin.data())).toStringWithoutCopying());
+        auto tokenizer = CSSTokenizer::tryCreate(StringView(begin.first(buffer.position() - begin.data())));
         if (!tokenizer)
             return nullAtom();
 

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -128,7 +128,7 @@ public:
 
     static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
 
-    CSSTokenizer* tokenizer() const LIFETIME_BOUND { return m_tokenizer.get(); }
+    const CSSTokenizer* tokenizer() const LIFETIME_BOUND { return m_tokenizer.get(); }
 
 private:
     struct NestingContext {

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -35,6 +35,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSTokenizerInputStream.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/CodePointIterator.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -42,19 +43,60 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizer);
 
 // https://drafts.csswg.org/css-syntax/#input-preprocessing
-String CSSTokenizer::preprocessString(const String& string)
+StringView CSSTokenizer::preprocessString(StringView string)
 {
     // We don't replace '\r' and '\f' with '\n' as the specification suggests, instead
     // we treat them all the same in the isCSSNewline() function from CSSParserIdioms.h.
-    StringImpl* oldImpl = string.impl();
-    String replaced = makeStringByReplacingAll(string, '\0', replacementCharacter);
-    replaced = replaceUnpairedSurrogatesWithReplacementCharacter(WTF::move(replaced));
-    if (replaced.impl() != oldImpl)
-        registerString(replaced);
-    return replaced;
+
+    auto preprocessSpan8 = [&](auto characters) -> StringView {
+        // Latin-1 strings only need to replace any null characters.
+
+        size_t indexOfNullCharacter = WTF::find(characters, '\0');
+        if (indexOfNullCharacter == notFound)
+            return string;
+
+        return registerString(String { StringImpl::createByReplacingInCharacters(characters, '\0', replacementCharacter, indexOfNullCharacter) });
+    };
+
+    auto preprocessSpan16 = [&](auto characters) -> StringView {
+        // UTF-16 string need to replace any null characters and any unpaired surrogates.
+
+        bool hasUnpairedSurrogate = [&] {
+            for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
+                if (U_IS_SURROGATE(*iterator))
+                    return true;
+            }
+            return false;
+        }();
+
+        if (!hasUnpairedSurrogate) {
+            // When there are no unpaired surrogates, we can treat this just like the Latin-1 case.
+
+            size_t indexOfNullCharacter = WTF::find(characters, '\0');
+            if (indexOfNullCharacter == notFound)
+                return string;
+
+            return registerString(String { StringImpl::createByReplacingInCharacters(characters, '\0', replacementCharacter, indexOfNullCharacter) });
+        } else {
+            StringBuilder result;
+            result.reserveCapacity(string.length());
+            for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
+                auto codePoint = *iterator;
+                if (!codePoint || U_IS_SURROGATE(codePoint))
+                    result.append(replacementCharacter);
+                else
+                    result.append(codePoint);
+            }
+            return registerString(result.toString());
+        }
+    };
+
+    if (string.is8Bit())
+        return preprocessSpan8(string.span8());
+    return preprocessSpan16(string.span16());
 }
 
-std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string)
+std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(StringView string)
 {
     bool success = true;
     // We can't use makeUnique here because it does not have access to this private constructor.
@@ -64,7 +106,7 @@ std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string)
     return tokenizer;
 }
 
-std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string, CSSParserObserverWrapper& wrapper)
+std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(StringView string, CSSParserObserverWrapper& wrapper)
 {
     bool success = true;
     // We can't use makeUnique here because it does not have access to this private constructor.
@@ -74,17 +116,17 @@ std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string, CSSP
     return tokenizer;
 }
 
-CSSTokenizer::CSSTokenizer(const String& string)
+CSSTokenizer::CSSTokenizer(StringView string)
     : CSSTokenizer(string, nullptr, nullptr)
 {
 }
 
-CSSTokenizer::CSSTokenizer(const String& string, CSSParserObserverWrapper& wrapper)
+CSSTokenizer::CSSTokenizer(StringView string, CSSParserObserverWrapper& wrapper)
     : CSSTokenizer(string, &wrapper, nullptr)
 {
 }
 
-CSSTokenizer::CSSTokenizer(const String& string, CSSParserObserverWrapper* wrapper, bool* constructionSuccessPtr)
+CSSTokenizer::CSSTokenizer(StringView string, CSSParserObserverWrapper* wrapper, bool* constructionSuccessPtr)
     : m_input(preprocessString(string))
 {
     if (constructionSuccessPtr)
@@ -134,7 +176,7 @@ CSSParserTokenRange CSSTokenizer::tokenRange() const LIFETIME_BOUND
     return m_tokens;
 }
 
-unsigned CSSTokenizer::tokenCount()
+unsigned CSSTokenizer::tokenCount() const
 {
     return m_tokens.size();
 }
@@ -863,6 +905,12 @@ bool CSSTokenizer::nextCharsAreIdentifier()
     bool areIdentifier = nextCharsAreIdentifier(first);
     reconsume(first);
     return areIdentifier;
+}
+
+StringView CSSTokenizer::registerString(String&& string)
+{
+    m_stringPool.append(WTF::move(string));
+    return m_stringPool.last();
 }
 
 StringView CSSTokenizer::registerString(const String& string)

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -33,7 +33,6 @@
 #include <WebCore/CSSTokenizerInputStream.h>
 #include <climits>
 #include <wtf/text/StringView.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -46,28 +45,28 @@ class CSSTokenizer {
     WTF_MAKE_NONCOPYABLE(CSSTokenizer);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSTokenizer, CSSTokenizer);
 public:
-    static std::unique_ptr<CSSTokenizer> tryCreate(const String&);
-    static std::unique_ptr<CSSTokenizer> tryCreate(const String&, CSSParserObserverWrapper&); // For the inspector
+    static std::unique_ptr<CSSTokenizer> tryCreate(StringView string LIFETIME_BOUND);
+    static std::unique_ptr<CSSTokenizer> tryCreate(StringView string LIFETIME_BOUND, CSSParserObserverWrapper&); // For the inspector
 
-    WEBCORE_EXPORT explicit CSSTokenizer(const String&);
-    CSSTokenizer(const String&, CSSParserObserverWrapper&); // For the inspector
+    WEBCORE_EXPORT explicit CSSTokenizer(StringView string LIFETIME_BOUND);
+    CSSTokenizer(StringView string LIFETIME_BOUND, CSSParserObserverWrapper&); // For the inspector
 
     WEBCORE_EXPORT CSSParserTokenRange NODELETE tokenRange() const LIFETIME_BOUND;
-    unsigned NODELETE tokenCount();
+    unsigned NODELETE tokenCount() const;
 
     static bool NODELETE isWhitespace(CSSParserTokenType);
 
     Vector<String>&& escapedStringsForAdoption() { return WTF::move(m_stringPool); }
 
 private:
-    CSSTokenizer(const String&, CSSParserObserverWrapper*, bool* constructionSuccess);
+    CSSTokenizer(StringView string LIFETIME_BOUND, CSSParserObserverWrapper*, bool* constructionSuccess);
 
     CSSParserToken nextToken();
 
     char16_t NODELETE consume();
     void NODELETE reconsume(char16_t);
 
-    String preprocessString(const String&);
+    StringView preprocessString(StringView);
 
     CSSParserToken consumeNumericToken();
     CSSParserToken consumeIdentLikeToken();
@@ -122,6 +121,7 @@ private:
     CSSParserToken stringStart(char16_t);
     CSSParserToken endOfFile(char16_t);
 
+    StringView registerString(String&&);
     StringView registerString(const String&);
 
     using CodePoint = CSSParserToken (CSSTokenizer::*)(char16_t);

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -37,10 +37,10 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream);
 
-CSSTokenizerInputStream::CSSTokenizerInputStream(const String& input)
+CSSTokenizerInputStream::CSSTokenizerInputStream(StringView string)
     : m_offset(0)
-    , m_stringLength(input.length())
-    , m_string(input.impl())
+    , m_stringLength(string.length())
+    , m_string(string)
 {
 }
 
@@ -52,10 +52,10 @@ void CSSTokenizerInputStream::advanceUntilNonWhitespace()
             ++m_offset;
     };
 
-    if (m_string->is8Bit())
-        advance(m_string->span8());
+    if (m_string.is8Bit())
+        advance(m_string.span8());
     else
-        advance(m_string->span16());
+        advance(m_string.span16());
 }
 
 void CSSTokenizerInputStream::advanceUntilNewlineOrNonWhitespace()
@@ -68,10 +68,10 @@ void CSSTokenizerInputStream::advanceUntilNewlineOrNonWhitespace()
         }
     };
 
-    if (m_string->is8Bit())
-        advance(m_string->span8());
+    if (m_string.is8Bit())
+        advance(m_string.span8());
     else
-        advance(m_string->span16());
+        advance(m_string.span16());
 }
 
 double CSSTokenizerInputStream::getDouble(unsigned start, unsigned end) const
@@ -80,10 +80,10 @@ double CSSTokenizerInputStream::getDouble(unsigned start, unsigned end) const
     bool isResultOK = false;
     double result = 0.0;
     if (start < end) {
-        if (m_string->is8Bit())
-            result = charactersToDouble(m_string->span8().subspan(m_offset + start, end - start), &isResultOK);
+        if (m_string.is8Bit())
+            result = charactersToDouble(m_string.span8().subspan(m_offset + start, end - start), &isResultOK);
         else
-            result = charactersToDouble(m_string->span16().subspan(m_offset + start, end - start), &isResultOK);
+            result = charactersToDouble(m_string.span16().subspan(m_offset + start, end - start), &isResultOK);
     }
     // FIXME: It looks like callers ensure we have a valid number
     return isResultOK ? result : 0.0;

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -40,7 +40,7 @@ class CSSTokenizerInputStream {
     WTF_MAKE_NONCOPYABLE(CSSTokenizerInputStream);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream, CSSTokenizerInputStream);
 public:
-    explicit CSSTokenizerInputStream(const String& input);
+    explicit CSSTokenizerInputStream(StringView string LIFETIME_BOUND);
 
     // Gets the char in the stream. Will return (NUL) kEndOfFileMarker when at the
     // end of the stream.
@@ -48,7 +48,7 @@ public:
     {
         if (m_offset >= m_stringLength)
             return kEndOfFileMarker;
-        return (*m_string)[m_offset];
+        return m_string[m_offset];
     }
 
     // Gets the char at lookaheadOffset from the current stream position. Will
@@ -57,7 +57,7 @@ public:
     {
         if ((m_offset + lookaheadOffset) >= m_stringLength)
             return kEndOfFileMarker;
-        return (*m_string)[m_offset + lookaheadOffset];
+        return m_string[m_offset + lookaheadOffset];
     }
 
     void advance(unsigned offset = 1) { m_offset += offset; }
@@ -72,12 +72,12 @@ public:
     template<bool characterPredicate(char16_t)>
     unsigned skipWhilePredicate(unsigned offset)
     {
-        if (m_string->is8Bit()) {
-            auto characters8 = m_string->span8();
+        if (m_string.is8Bit()) {
+            auto characters8 = m_string.span8();
             while ((m_offset + offset) < m_stringLength && characterPredicate(characters8[m_offset + offset]))
                 ++offset;
         } else {
-            auto characters16 = m_string->span16();
+            auto characters16 = m_string.span16();
             while ((m_offset + offset) < m_stringLength && characterPredicate(characters16[m_offset + offset]))
                 ++offset;
         }
@@ -93,13 +93,13 @@ public:
     StringView rangeAt(unsigned start, unsigned length) const
     {
         ASSERT(start + length <= m_stringLength);
-        return StringView(m_string.get()).substring(start, length); // FIXME: Should make a constructor on StringView for this.
+        return m_string.substring(start, length);
     }
 
 private:
     size_t m_offset;
     const size_t m_stringLength;
-    RefPtr<StringImpl> m_string;
+    StringView m_string;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -168,7 +168,8 @@ ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnpar
 
 RefPtr<CSSValue> CSSUnparsedValue::toCSSValue() const
 {
-    CSSTokenizer tokenizer(toString());
+    auto serialization = toString();
+    CSSTokenizer tokenizer(serialization);
     return CSSSubstitutionValue::create(tokenizer.tokenRange(), { }, strictCSSParserContext());
 }
 

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -233,7 +233,8 @@ const Vector<CSSParserToken>& CustomProperty::tokens() const
         },
         [&](auto&) -> const Vector<CSSParserToken>& {
             if (!m_cachedTokens) {
-                CSSTokenizer tokenizer { propertyValueSerializationForTokenization(CSS::defaultSerializationContext(), Style::ComputedStyle::defaultStyleSingleton()) };
+                auto serialization = propertyValueSerializationForTokenization(CSS::defaultSerializationContext(), Style::ComputedStyle::defaultStyleSingleton());
+                CSSTokenizer tokenizer { serialization };
                 m_cachedTokens = CSSVariableData::create(tokenizer.tokenRange(), m_isAttrTainted);
             }
             return m_cachedTokens->tokens();

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -382,7 +382,7 @@ ExceptionOr<void> SVGLengthValue::setValueAsString(StringView string)
         .context = parserContext
     };
 
-    CSSTokenizer tokenizer(trimmedString.toString());
+    CSSTokenizer tokenizer(trimmedString);
     auto tokenRange = tokenizer.tokenRange();
 
     auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<>, CSS::LengthPercentage<>>::consume(tokenRange, parserState, { });


### PR DESCRIPTION
#### 66e2e265cfeecef8ddee8ba16e16acbf35644a7b
<pre>
Make CSSTokenizer work efficiently with StringViews
<a href="https://bugs.webkit.org/show_bug.cgi?id=322730">https://bugs.webkit.org/show_bug.cgi?id=322730</a>

Reviewed by Darin Adler.

Makes CSSTokenizer and CSSTokenizerInputStream operate on StringView rather
than String and StringImpl.

Biggest change is in CSSTokenizer::preprocessString where we now check the
string for null characters and unpair surrogates before allocating a
replacement, making sure to do the minimum required based on character type.

* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSTokenizer.cpp:
* Source/WebCore/css/parser/CSSTokenizer.h:
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
* Source/WebCore/css/parser/CSSTokenizerInputStream.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
* Source/WebCore/style/StyleCustomProperty.cpp:
* Source/WebCore/svg/SVGLengthValue.cpp:

Canonical link: <a href="https://commits.webkit.org/320094@main">https://commits.webkit.org/320094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abba043b689e6d50f372bdf95671f467d9eabbbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183724 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99570 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45867 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43680 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5128 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50303 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 26981 issues") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195884 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57318 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152933 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40968 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58022 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152617 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47157 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130302 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126620 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56530 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18690 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->