### PR TITLE
[CMake] A leftover WebKitBuild/cmake-mac tree makes Xcode builds ask xcodebuild for arm64

### DIFF
--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -93,15 +93,16 @@ if (checkForArgumentAndRemoveFromARGV("-h") || checkForArgumentAndRemoveFromARGV
 }
 
 my $baseProductDir = baseProductDir();
-if (isAppleCocoaWebKit() && !isCMakeBuild()) {
+if (isAppleCocoaWebKit()) {
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();
-    if ($workspace) {
-        open WORKSPACE, ">", "$baseProductDir/Workspace";
-        print WORKSPACE realpath($workspace);
-        close WORKSPACE;
-    }
 } else {
     make_path($baseProductDir);
+}
+
+if ($workspace) {
+    open WORKSPACE, ">", "$baseProductDir/Workspace";
+    print WORKSPACE realpath($workspace);
+    close WORKSPACE;
 }
 
 if (checkForArgumentAndRemoveFromARGV("--reset")) {

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -548,6 +548,19 @@ sub determineNativeArchitecture($)
     $nativeArchitectureMap{@{$remotes}} = $output;
 }
 
+sub defaultArchitectureForXcodeSDK
+{
+    my $arch = nativeArchitecture([]);
+    if (isAppleCocoaWebKit() && $arch eq "arm64") {
+        determineXcodeSDK();
+        if ($xcodeSDK =~ /\.internal$/ && $xcodeSDK !~ /simulator/) {
+            # Device SDKs (macosx.internal, iphoneos.internal, etc.) default to arm64e.
+            $arch = "arm64e";
+        }
+    }
+    return $arch;
+}
+
 sub determineArchitecture
 {
     return if defined $architecture;
@@ -560,14 +573,7 @@ sub determineArchitecture
         return;
     }
 
-    $architecture = nativeArchitecture([]);
-    if (isAppleCocoaWebKit() && $architecture eq "arm64") {
-        determineXcodeSDK();
-        if ($xcodeSDK =~ /\.internal$/ && $xcodeSDK !~ /simulator/) {
-            # Device SDKs (macosx.internal, iphoneos.internal, etc.) default to arm64e.
-            $architecture = "arm64e";
-        }
-    }
+    $architecture = defaultArchitectureForXcodeSDK();
 
     if (isCMakeBuild()) {
         if (isCrossCompilation()) {
@@ -630,7 +636,7 @@ sub determineXcodeDestination
     # Use a generic destination ("Any Mac", etc.) when there are multiple architectures, or when building to
     # a device.
 
-    my @architectures = split(' ', $architecture);
+    my @architectures = split(' ', xcodeArchitecture());
     my $generic = $xcodeSDKPlatformName =~ /os$/ || (scalar @architectures) > 1;
 
     if (willUseIOSDeviceSDK()) {
@@ -1564,6 +1570,14 @@ sub architecture()
 {
     determineArchitecture();
     return $architecture;
+}
+
+# Not architecture(): that reports what a cmake-mac tree builds, and xcodebuild must target the SDK's slice regardless.
+sub xcodeArchitecture()
+{
+    determineArchitecture();
+    return $architecture if $didUserSpecifyArchitecture;
+    return defaultArchitectureForXcodeSDK();
 }
 
 sub xcodeDestination()

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureIgnoresCMake.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureIgnoresCMake.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::xcodeArchitecture. Both functions cache their answer
+# in a script-global, so the --architecture scenario lives in
+# xcodeArchitectureUserSpecified.pl (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 2);
+
+# webkitperl runs on non-Cocoa bots too, so fake a Cocoa port with a cmake-mac tree.
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+*webkitdirs::isCMakeBuild = sub () { 1 };
+*webkitdirs::defaultArchitectureForXcodeSDK = sub { "arm64e" };
+# determineArchitecture()'s cross-compilation branch reads $CC instead of shelling out to `cmake --system-information`.
+*webkitdirs::isCrossCompilation = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $stubCompiler = File::Spec->catfile(tempdir(CLEANUP => 1), "cc");
+open my $fh, ">", $stubCompiler or die "Can't write stub compiler: $!";
+print $fh "#!/bin/sh\necho arm64-apple-darwin\n";
+close $fh;
+chmod 0755, $stubCompiler or die "Can't make stub compiler executable: $!";
+$ENV{'CC'} = $stubCompiler;
+
+@ARGV = ();
+
+is(architecture(), "arm64", "architecture() reports what the CMake build targets");
+is(webkitdirs::xcodeArchitecture(), "arm64e", "xcodeArchitecture() reports the SDK's default slice");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureUserSpecified.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureUserSpecified.pl
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::xcodeArchitecture with an explicit --architecture.
+use strict;
+use warnings;
+use Test::More;
+use webkitdirs;
+
+plan(tests => 2);
+
+# webkitperl runs on non-Cocoa bots too, so fake a Cocoa port.
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+*webkitdirs::defaultArchitectureForXcodeSDK = sub { "arm64e" };
+use warnings qw(redefine prototype);
+
+@ARGV = ("--architecture=x86_64");
+
+is(architecture(), "x86_64", "architecture() honors --architecture");
+is(webkitdirs::xcodeArchitecture(), "x86_64", "xcodeArchitecture() honors --architecture");


### PR DESCRIPTION
#### 72cfe5e52e88e0e18cea0b8d2934237005ea2526
<pre>
[CMake] A leftover WebKitBuild/cmake-mac tree makes Xcode builds ask xcodebuild for arm64
<a href="https://bugs.webkit.org/show_bug.cgi?id=322740">https://bugs.webkit.org/show_bug.cgi?id=322740</a>
<a href="https://rdar.apple.com/186008344">rdar://186008344</a>

Reviewed by NOBODY (OOPS!).

Both build systems share WebKitBuild/, so deleting WebKitBuild/&lt;Configuration&gt;
while a CMake macOS build is left behind makes determineIsCMakeBuild() report a
CMake build. Callers that are unconditionally driving xcodebuild then get CMake&apos;s
answers: `make release` died instantly with &quot;Unable to find a destination matching
{ platform:macOS, arch:arm64 }&quot; because determineArchitecture() replaced the
internal SDK&apos;s arm64e with `cmake --system-information`&apos;s CMAKE_SYSTEM_PROCESSOR,
and the Xcode schemes only support arm64e/x86_64.

Pinning the build system inside XcodeOptions() is not an option: build-webkit
calls it for every Apple Cocoa build before branching on isCMakeBuild(), so that
would turn `build-webkit --cmake` into an Xcode build. architecture() also has to
keep reporting what CMake targets -- the mac presets don&apos;t set
CMAKE_OSX_ARCHITECTURES, so a cmake-mac tree really does build the host arm64,
and run-safari needs that to pick `arch -arm64`. So give the Xcode destination its
own resolver instead, leaving architecture() alone.

set-webkit-configuration had the same confusion. Makefile.shared runs it before
every xcodebuild invocation, but a CMake verdict skipped the Xcode setup, so the
com.apple.xcode.CreatedByBuildSystem marker was never set on WebKitBuild and
--workspace was never recorded. Building Safari after an OpenSource build then
passed -workspace WebKit.xcworkspace to Safari&apos;s schemes. Both behaviours now key
off facts the script actually knows: the port, and whether --workspace was passed.

* Tools/Scripts/set-webkit-configuration:
* Tools/Scripts/webkitdirs.pm:
(defaultArchitectureForXcodeSDK): Extracted from determineArchitecture(), so the
Xcode resolver can reach it without the CMake probe.
(determineArchitecture):
(determineXcodeDestination):
(xcodeArchitecture):
* Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureIgnoresCMake.pl: Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/xcodeArchitectureUserSpecified.pl: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72cfe5e52e88e0e18cea0b8d2934237005ea2526

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147687 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5bd238d-18da-41c0-955f-2aa0a1230a3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143151 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99406 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b73661f-8e52-4f6f-8886-301de5a1b101) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123570 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc081aef-7f58-4e0f-842e-34dd62bd9042) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45609 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43839 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5544 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12396 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43452 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4791 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44672 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195556 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56990 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152680 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57694 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46897 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126272 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56202 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18462 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55573 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55640 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->