### PR TITLE
[libpas] Inline PAS_MTE_HANDLEs which resolve to PAS_MTE_CLEAR*

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.c
@@ -40,9 +40,6 @@ pas_allocation_result pas_allocation_result_zero_large_slow(pas_allocation_resul
     uintptr_t page_aligned_begin;
     uintptr_t page_aligned_end;
 
-    PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
-    PAS_MTE_HANDLE(ZERO_ALLOCATION_RESULT, result.begin);
-
     page_size = pas_page_malloc_alignment();
     begin = result.begin;
     end = begin + size;

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
@@ -95,11 +95,6 @@ pas_allocation_result_zero(pas_allocation_result result,
     if (size >= (1ULL << PAS_VA_BASED_ZERO_MEMORY_SHIFT))
         return pas_allocation_result_zero_large_slow(result, size);
 
-    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
-    PAS_MTE_HANDLE(ZERO_ALLOCATION_RESULT, result.begin);
-    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
-
     void* memory = (void*)result.begin;
     pas_zero_memory(memory, size);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
@@ -134,7 +134,7 @@ static inline pas_fast_megapage_kind pas_fast_megapage_table_get(
     uintptr_t begin)
 {
     PAS_PROFILE(MEGAPAGE_GET, begin);
-    PAS_MTE_HANDLE(MEGAPAGE_GET, begin);
+    PAS_MTE_CLEAR(begin);
     return pas_fast_megapage_table_get_by_index(table, begin >> PAS_FAST_MEGAPAGE_SHIFT);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_map.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_map.c
@@ -78,7 +78,7 @@ pas_large_map_entry pas_large_map_find(uintptr_t begin)
     unsigned variant_index;
 
     PAS_PROFILE(LARGE_MAP_FIND, begin);
-    PAS_MTE_HANDLE(LARGE_MAP_FIND, begin);
+    PAS_MTE_CLEAR(begin);
 
     pas_heap_lock_assert_held();
 
@@ -99,7 +99,7 @@ void pas_large_map_add(pas_large_map* map, pas_large_map_entry entry)
     pas_heap_lock_assert_held();
 
     PAS_PROFILE(LARGE_MAP_ADD, entry.begin, entry.end);
-    PAS_MTE_HANDLE(LARGE_MAP_ADD, entry.begin, entry.end);
+    PAS_MTE_CLEAR(entry.begin);
 
     if (verbose)
         pas_log("large map adding %p...%p, heap = %p.\n", (void*)entry.begin, (void*)entry.end, entry.heap);
@@ -227,7 +227,7 @@ pas_large_map_entry pas_large_map_take(uintptr_t begin)
     unsigned variant_index;
 
     PAS_PROFILE(LARGE_MAP_TAKE, begin);
-    PAS_MTE_HANDLE(LARGE_MAP_TAKE, begin);
+    PAS_MTE_CLEAR(begin);
 
     pas_heap_lock_assert_held();
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -1051,7 +1051,7 @@ void pas_large_sharing_pool_boot_free(
     size_t page_size;
 
     PAS_PROFILE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
-    PAS_MTE_HANDLE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
+    PAS_MTE_CLEAR_PAIR(range.begin, range.end);
 
     page_size = pas_page_malloc_alignment();
     PAS_ASSERT(pas_is_aligned(range.begin, page_size));
@@ -1080,7 +1080,7 @@ void pas_large_sharing_pool_free(pas_range range,
     uint64_t epoch;
 
     PAS_PROFILE(LARGE_SHARING_POOL_FREE, range.begin, range.end);
-    PAS_MTE_HANDLE(LARGE_SHARING_POOL_FREE, range.begin, range.end);
+    PAS_MTE_CLEAR_PAIR(range.begin, range.end);
 
     if (!pas_large_sharing_pool_enabled)
         return;
@@ -1099,7 +1099,7 @@ bool pas_large_sharing_pool_allocate_and_commit(
     static const bool verbose = false;
 
     PAS_PROFILE(LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT, range.begin, range.end);
-    PAS_MTE_HANDLE(LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT, range.begin, range.end);
+    PAS_MTE_CLEAR_PAIR(range.begin, range.end);
     
     pas_large_free_heap_deferred_commit_log commit_log;
     uint64_t epoch;
@@ -1248,7 +1248,7 @@ pas_large_sharing_pool_compute_summary(
     pas_heap_summary result;
 
     PAS_PROFILE(LARGE_SHARING_POOL_COMPUTE_SUMMARY, range.begin, range.end);
-    PAS_MTE_HANDLE(LARGE_SHARING_POOL_COMPUTE_SUMMARY, range.begin, range.end);
+    PAS_MTE_CLEAR_PAIR(range.begin, range.end);
 
     pas_zero_memory(&result, sizeof(result));
     

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -121,7 +121,7 @@ static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size
     
     begin = (uintptr_t)base_before_exclusion;
     PAS_PROFILE(MEGAPAGE_SET, begin);
-    PAS_MTE_HANDLE(MEGAPAGE_SET, begin);
+    PAS_MTE_CLEAR(begin);
 
     end = begin + new_size;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Apple Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,33 +37,44 @@
 #include <mach/vm_statistics.h>
 #endif // PAS_USE_APPLE_INTERNAL_SDK
 #endif // PAS_OS(DARWIN)
+#include "pas_allocation_mode.h"
+#include "pas_internal_config.h"
+#include "pas_page_base_config.h"
+#include "pas_stats.h"
+#include "pas_utils.h"
 #include "stdint.h"
 #include "stdio.h"
 #include "stdlib.h"
 #if !PAS_OS(WINDOWS)
 #include "unistd.h"
 #endif
+#if __has_include(<malloc_private.h>)
+#include <malloc_private.h>
+#endif
 
-#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
-#if PAS_ENABLE_MTE
-
-#include "pas_utils.h"
-#include "pas_page_base_config.h"
-#include "pas_allocation_mode.h"
-#include "pas_internal_config.h"
-#include "pas_stats.h"
-
-PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #define PAS_MTE_TAG_SHIFT 56
 #define PAS_MTE_TAG_MASK (0x0full << PAS_MTE_TAG_SHIFT)
 #define PAS_MTE_CANONICAL_MASK ((0x1ull << 48) - 1)
-
 #define PAS_MTE_GRANULE_SIZE 16
 
-#if __has_include(<malloc_private.h>)
-#include <malloc_private.h>
-#endif
+/*
+ * Clear is used to canonicalize (zero out) the tag bits of a pointer.
+ * We generally use this when we want to treat the address itself as
+ * an integer or key, and don't intend to load from it directly.
+ * We don't check for PAS_MTE enablement in these cases, since on non-PAS_MTE
+ * hardware, the tag should be zero anyway, and masking off the bits
+ * should be faster than branching on g_config.
+ */
+#define PAS_MTE_CLEAR(a) do { \
+        a &= ~PAS_MTE_TAG_MASK; \
+    } while (0)
+
+#define PAS_MTE_CLEAR_PAIR(a, b) do { \
+        a &= ~PAS_MTE_TAG_MASK; \
+        b &= ~PAS_MTE_TAG_MASK; \
+    } while (0)
 
 #define PAS_MTE_SMALL_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_SMALL_PAGE_DEFAULT_SHIFT) - 1ull))
 #define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_PAGE_DEFAULT_SHIFT) - 1ull))
@@ -71,6 +82,8 @@ PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
 #define PAS_MTE_SMALL_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_SMALL_PAGE_NO_MASK)
 #define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK)
 #define PAS_MTE_MEDIUM_BITFIT_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_BITFIT_PAGE_NO_MASK)
+
+#if PAS_ENABLE_MTE
 
 #define PAS_MTE_GET_MTAG(ptr) do { \
         __asm__ volatile( \
@@ -530,23 +543,6 @@ pas_mte_tag_region_from_pointer(
         } \
     } while (0)
 
-/*
- * Clear is used to canonicalize (zero out) the tag bits of a pointer.
- * We generally use this when we want to treat the address itself as
- * an integer or key, and don't intend to load from it directly.
- * We don't check for PAS_MTE enablement in these cases, since on non-PAS_MTE
- * hardware, the tag should be zero anyway, and masking off the bits
- * should be faster than branching on g_config.
- */
-#define PAS_MTE_CLEAR(a) do { \
-        a &= ~PAS_MTE_TAG_MASK; \
-    } while (0)
-
-#define PAS_MTE_CLEAR_PAIR(a, b) do { \
-        a &= ~PAS_MTE_TAG_MASK; \
-        b &= ~PAS_MTE_TAG_MASK; \
-    } while (0)
-
 #define PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator) (allocator)->is_mte_tagged
 #define PAS_MTE_DECIDE_PAGE_CONFIG_TAGGEDNESS(size_category) \
     (size_category == pas_page_config_size_category_small || size_category == pas_page_config_size_category_medium)
@@ -811,16 +807,9 @@ pas_mte_retag_freed_region_if_tagged(
       } while (false)
 #endif // PAS_OS(DARWIN)
 
-// This is no longer needed as the pointer is already tagged in preparation for
-// being returned to the caller of the allocation function.
-#define PAS_MTE_HANDLE_ZERO_ALLOCATION_RESULT(a) do { (void)a; } while (false)
-
 // Used to zero an existing page allocation without clearing the tagged-memory
 // bit in its page-table entries.
 #define PAS_MTE_HANDLE_ZERO_FILL_PAGE(ptr, size, flags, tag) PAS_MTE_ZERO_FILL_PAGE(ptr, size, flags, tag)
-
-// Used to clear the tag before we look up the address in the megapage table when reallocating.
-#define PAS_MTE_HANDLE_REALLOCATE(a) PAS_MTE_CLEAR(a)
 
 // Used to restore the correct tag on the pointer when realloc reuses the existing allocation.
 #define PAS_MTE_HANDLE_REALLOCATE_IN_PLACE(a) PAS_MTE_PURIFY(a)
@@ -840,24 +829,10 @@ pas_mte_retag_freed_region_if_tagged(
         } \
     } while (false)
 
-// Used to clear the tag from a pointer into a page, since the page header should
-// be zero-tagged.
+// Get the right tag for a pointer to a page header.
+// Currently this just clears any stray tag, since page headers are always
+// zero-tagged.
 #define PAS_MTE_HANDLE_PAGE_BASE_FROM_BOUNDARY(a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits before looking it up in the page header table.
-#define PAS_MTE_HANDLE_PAGE_HEADER_TABLE_GET(a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits before adding it to the page header table.
-#define PAS_MTE_HANDLE_PAGE_HEADER_TABLE_ADD(a) PAS_MTE_CLEAR(a)
-
-// Used to clear key tag bits before looking up a pointer in the large map.
-#define PAS_MTE_HANDLE_LARGE_MAP_FIND(a) PAS_MTE_CLEAR(a)
-
-// Used to clear key tag bits before inserting a pointer range into the large map.
-#define PAS_MTE_HANDLE_LARGE_MAP_ADD(a, b) PAS_MTE_CLEAR(a)
-
-// Used to clear key tag bits before taking a pointer from the large map.
-#define PAS_MTE_HANDLE_LARGE_MAP_TAKE(a) PAS_MTE_CLEAR(a)
 
 // Used to restore the correct tag of a large map entry key after looking it up.
 // Takes a pas_heap_config*
@@ -866,31 +841,6 @@ pas_mte_retag_freed_region_if_tagged(
 // Used to restore the correct tag of a large map entry key after taking it from the map.
 // Takes a pas_heap_config*
 #define PAS_MTE_HANDLE_LARGE_MAP_TOOK_ENTRY(config, a, b) PAS_MTE_PURIFY(a)
-
-// Used to clear pointer tag bits before taking a pointer from the large map.
-// Takes a pas_heap_config*
-#define PAS_MTE_HANDLE_PGM_ALLOCATE(config, a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits before taking a pointer from the large map.
-#define PAS_MTE_HANDLE_PGM_DEALLOCATE(a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits before putting a pointer to the megapage table.
-#define PAS_MTE_HANDLE_MEGAPAGE_SET(a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits before getting a pointer from the megapage table.
-#define PAS_MTE_HANDLE_MEGAPAGE_GET(a) PAS_MTE_CLEAR(a)
-
-// Used to clear pointer tag bits freeing a range in the large sharing pool.
-#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_BOOT_FREE(a, b) PAS_MTE_CLEAR_PAIR(a, b)
-
-// Used to clear pointer tag bits freeing a range in the large sharing pool.
-#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_FREE(a, b) PAS_MTE_CLEAR_PAIR(a, b)
-
-// Used to clear pointer tag bits allocating a range in the large sharing pool.
-#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT(a, b) PAS_MTE_CLEAR_PAIR(a, b)
-
-// Used to clear pointer tag bits when summarizing a range in the large sharing pool.
-#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_COMPUTE_SUMMARY(a, b) PAS_MTE_CLEAR_PAIR(a, b)
 
 struct __pas_heap;
 
@@ -1093,12 +1043,10 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
 #define PAS_MTE_HANDLE(kind, ...) \
     PAS_MTE_HANDLE_ ## kind(__VA_ARGS__)
 
-PAS_IGNORE_WARNINGS_END
-
 #else // !PAS_ENABLE_MTE
 #define PAS_MTE_HANDLE(kind, ...) PAS_UNUSED_V(__VA_ARGS__)
 #endif // PAS_ENABLE_MTE
-#else // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
-#define PAS_MTE_HANDLE(kind, ...) PAS_UNUSED_V(__VA_ARGS__)
-#endif // PAS_ENABLE_MTE
+
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 #endif // PAS_MTE_H

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
@@ -43,7 +43,7 @@ pas_page_base* pas_page_header_table_add(pas_page_header_table* table,
 
     uintptr_t boundary_int = (uintptr_t)boundary;
     PAS_PROFILE(PAGE_HEADER_TABLE_ADD, boundary_int);
-    PAS_MTE_HANDLE(PAGE_HEADER_TABLE_ADD, boundary_int);
+    PAS_MTE_CLEAR(boundary_int);
     boundary = (void*)boundary_int;
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
@@ -97,7 +97,7 @@ pas_page_header_table_get_for_boundary(pas_page_header_table* table,
                        == begin);
 
     PAS_PROFILE(PAGE_HEADER_TABLE_GET, begin);
-    PAS_MTE_HANDLE(PAGE_HEADER_TABLE_GET, begin);
+    PAS_MTE_CLEAR(begin);
     boundary = (void*)begin;
     return (pas_page_base*)pas_lock_free_read_ptr_ptr_hashtable_find(
         &table->hashtable, pas_page_header_table_hash, (void*)page_size, boundary);

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -211,7 +211,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
 #endif
 
     PAS_PROFILE(PGM_ALLOCATE, heap_config, key);
-    PAS_MTE_HANDLE(PGM_ALLOCATE, heap_config, key);
+    PAS_MTE_CLEAR(key);
 
     /* create struct to hold hash map value */
     pas_pgm_storage* value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");
@@ -262,7 +262,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
 
     uintptr_t key = (uintptr_t)mem;
     PAS_PROFILE(PGM_DEALLOCATE, key);
-    PAS_MTE_HANDLE(PGM_DEALLOCATE, key);
+    PAS_MTE_CLEAR(key);
 
     pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*)key);
     if (!entry || !entry->value)


### PR DESCRIPTION
#### f918fec1e1d9dfe1dfe2d7e8a5466af0f47e5acb
<pre>
[libpas] Inline PAS_MTE_HANDLEs which resolve to PAS_MTE_CLEAR*
<a href="https://bugs.webkit.org/show_bug.cgi?id=321197">https://bugs.webkit.org/show_bug.cgi?id=321197</a>
<a href="https://rdar.apple.com/184255766">rdar://184255766</a>

Reviewed by Yusuke Suzuki.

This provides no extra semantic information, so there&apos;s no need for an
indirection. Remove in line with our general push to de-macroify libpas&apos;
MTE implementation.

No new tests because this is a purely syntactic change.

* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h:
(pas_fast_megapage_table_get):
* Source/bmalloc/libpas/src/libpas/pas_large_map.c:
(pas_large_map_find):
(pas_large_map_add):
(pas_large_map_take):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(pas_large_sharing_pool_boot_free):
(pas_large_sharing_pool_free):
(pas_large_sharing_pool_allocate_and_commit):
(pas_large_sharing_pool_compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c:
(megapage_cache_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_mte.h:
* Source/bmalloc/libpas/src/libpas/pas_page_header_table.c:
(pas_page_header_table_add):
* Source/bmalloc/libpas/src/libpas/pas_page_header_table.h:
(pas_page_header_table_get_for_boundary):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_allocation_result.h:
(pas_allocation_result_zero):

* Source/bmalloc/libpas/src/libpas/pas_allocation_result.c:
(pas_allocation_result_zero_large_slow):

Canonical link: <a href="https://commits.webkit.org/320000@main">https://commits.webkit.org/320000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e359c48e5b01c6e9d47aa303f3fbabbe7c5baf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193641 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5358a1b0-07ef-457f-a300-00c72823b115) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57079 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/947516b4-fb12-4ba2-801d-0505c73a1179) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123583 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5500d97c-9943-41a4-8d43-706d6830a9d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45622 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5557 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12408 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43465 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4815 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44696 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195580 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57014 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57718 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152359 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46913 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56226 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18474 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->