### PR TITLE
[Quirks] Add parameterized quirks to the table

### DIFF
--- a/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
@@ -41,7 +41,7 @@ https://www.codepen.io/
 https://www.bankofamerica.com/
     MaybeBypassBackForwardCache
 https://www.bestbuy.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.bing.com/
     MaybeBypassBackForwardCache
     NeedsMediaRewriteRangeRequestQuirk
@@ -159,14 +159,14 @@ https://www.hulu.com/
 https://www.icloud.com/
     (none)
 https://www.iheart.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.imdb.com/
     NeedsChromeMediaControlsPseudoElementQuirk
     NeedsZeroMaxTouchPointsQuirk
 https://www.instagram.com/
     NeedsInstagramResizingReelsQuirk
 https://invideo.io/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.linkedin.com/
     (none)
 https://outlook.live.com/
@@ -249,11 +249,11 @@ https://open.spotify.com/
 https://www.spotify.com/
     (none)
 https://ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://sub.ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://www.state.gov/
     (none)
 https://www.theguardian.com/

--- a/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
@@ -41,7 +41,7 @@ https://www.codepen.io/
 https://www.bankofamerica.com/
     MaybeBypassBackForwardCache
 https://www.bestbuy.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.bing.com/
     MaybeBypassBackForwardCache
     NeedsMediaRewriteRangeRequestQuirk
@@ -157,14 +157,14 @@ https://www.hulu.com/
 https://www.icloud.com/
     (none)
 https://www.iheart.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.imdb.com/
     NeedsChromeMediaControlsPseudoElementQuirk
     NeedsZeroMaxTouchPointsQuirk
 https://www.instagram.com/
     NeedsInstagramResizingReelsQuirk
 https://invideo.io/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.linkedin.com/
     (none)
 https://outlook.live.com/
@@ -247,9 +247,9 @@ https://open.spotify.com/
 https://www.spotify.com/
     (none)
 https://ceac.state.gov/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://sub.ceac.state.gov/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.state.gov/
     (none)
 https://www.theguardian.com/

--- a/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
@@ -42,7 +42,7 @@ https://www.codepen.io/
 https://www.bankofamerica.com/
     MaybeBypassBackForwardCache
 https://www.bestbuy.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.bing.com/
     MaybeBypassBackForwardCache
     NeedsMediaRewriteRangeRequestQuirk
@@ -72,8 +72,8 @@ https://www.t-mobile.com/
 https://www.descript.com/
     ShouldDisableDOMAudioSession
 https://www.dictionary.com/
+    EvaluateScriptBeforeRunningScript
     NeedsAnchorToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://www.disneyplus.com/
     ShouldHideCoarsePointerCharacteristicsQuirk
 https://www.ea.com/
@@ -117,9 +117,9 @@ https://docs.google.com/
     MaybeBypassBackForwardCache
     ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk
 https://translate.google.com/
+    EvaluateScriptBeforeRunningScript
     MaybeBypassBackForwardCache
     NeedsGoogleTranslateScrollingQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://mail.google.com/
     MaybeBypassBackForwardCache
     NeedsGMailOverflowScrollQuirk
@@ -172,7 +172,7 @@ https://www.hulu.com/
 https://www.icloud.com/
     (none)
 https://www.iheart.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.imdb.com/
     NeedsChromeMediaControlsPseudoElementQuirk
     NeedsZeroMaxTouchPointsQuirk
@@ -181,7 +181,7 @@ https://www.instagram.com/
     ShouldDisableElementFullscreenQuirk
     ShouldSendFakeTouchForceChangeEvent
 https://invideo.io/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.linkedin.com/
     (none)
 https://outlook.live.com/
@@ -226,7 +226,7 @@ https://www.netflix.com/
     NeedsNetflixVolumeSliderQuirk
     NeedsSeekingSupportDisabledQuirk
 https://www.nba.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
     ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen
 https://www.nfl.com/
     ShouldSuppressHLSSubtitles
@@ -273,16 +273,16 @@ https://open.spotify.com/
 https://www.spotify.com/
     (none)
 https://ceac.state.gov/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://sub.ceac.state.gov/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.state.gov/
     (none)
 https://www.theguardian.com/
     ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk
 https://www.thesaurus.com/
+    EvaluateScriptBeforeRunningScript
     NeedsAnchorToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://www.tiktok.com/
     NeedsTikTokOverflowingContentQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk

--- a/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
@@ -41,7 +41,7 @@ https://www.codepen.io/
 https://www.bankofamerica.com/
     MaybeBypassBackForwardCache
 https://www.bestbuy.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.bing.com/
     MaybeBypassBackForwardCache
     NeedsMediaRewriteRangeRequestQuirk
@@ -156,14 +156,14 @@ https://www.hulu.com/
 https://www.icloud.com/
     (none)
 https://www.iheart.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.imdb.com/
     NeedsChromeMediaControlsPseudoElementQuirk
     NeedsZeroMaxTouchPointsQuirk
 https://www.instagram.com/
     NeedsInstagramResizingReelsQuirk
 https://invideo.io/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.linkedin.com/
     (none)
 https://outlook.live.com/
@@ -245,11 +245,11 @@ https://open.spotify.com/
 https://www.spotify.com/
     (none)
 https://ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://sub.ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://www.state.gov/
     (none)
 https://www.theguardian.com/

--- a/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
@@ -41,7 +41,7 @@ https://www.codepen.io/
 https://www.bankofamerica.com/
     MaybeBypassBackForwardCache
 https://www.bestbuy.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.bing.com/
     MaybeBypassBackForwardCache
     NeedsMediaRewriteRangeRequestQuirk
@@ -156,14 +156,14 @@ https://www.hulu.com/
 https://www.icloud.com/
     (none)
 https://www.iheart.com/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.imdb.com/
     NeedsChromeMediaControlsPseudoElementQuirk
     NeedsZeroMaxTouchPointsQuirk
 https://www.instagram.com/
     NeedsInstagramResizingReelsQuirk
 https://invideo.io/
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+    EvaluateScriptBeforeRunningScript
 https://www.linkedin.com/
     (none)
 https://outlook.live.com/
@@ -245,11 +245,11 @@ https://open.spotify.com/
 https://www.spotify.com/
     (none)
 https://ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://sub.ceac.state.gov/
+    EvaluateScriptBeforeRunningScript
     NeedsFormControlToBeMouseFocusableQuirk
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
 https://www.state.gov/
     (none)
 https://www.theguardian.com/

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2080,6 +2080,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/PrewarmInformation.h
     page/PrintContext.h
     page/ProcessWarming.h
+    page/QuirkBehavior.h
     page/QuirkMatch.h
     page/QuirkNames.h
     page/QuirkTable.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3159,6 +3159,7 @@
 		7ABA251028B40FE7005D4F6D /* ReportingScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA250C28ADA68D005D4F6D /* ReportingScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABA251128B41C64005D4F6D /* Report.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA24E528A5C8D1005D4F6D /* Report.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABA251228B4457C005D4F6D /* ReportBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA24E728A5C90A005D4F6D /* ReportBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7ABB0F612CE7C170009A837E /* QuirkBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5E2CE7C170009A837E /* QuirkBehavior.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		05D4770CFFB4C18C6BA6928C /* QuirkTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 05D4770BFFB4C18C6BA6928C /* QuirkTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABB0F622CE7C170009A837F /* QuirkNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5D2CE7C170009A837F /* QuirkNames.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABB0F602CE7C170009A837D /* QuirksData.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5F2CE7C170009A837D /* QuirksData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14988,6 +14989,7 @@
 		7ABA250D28AEF4FC005D4F6D /* ReportBody.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReportBody.cpp; sourceTree = "<group>"; };
 		7ABA250E28B40370005D4F6D /* ReportingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportingClient.h; sourceTree = "<group>"; };
 		7ABB0F5D2CE7C170009A837F /* QuirkNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirkNames.h; sourceTree = "<group>"; };
+		7ABB0F5E2CE7C170009A837E /* QuirkBehavior.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirkBehavior.h; sourceTree = "<group>"; };
 		7ABB0F5F2CE7C170009A837D /* QuirksData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirksData.h; sourceTree = "<group>"; };
 		05D47709FFB4C18C6BA6928A /* QuirkMatch.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = QuirkMatch.cpp; sourceTree = "<group>"; };
 		05D4770AFFB4C18C6BA6928B /* QuirkTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = QuirkTable.cpp; sourceTree = "<group>"; };
@@ -31520,6 +31522,7 @@
 				B776D43A1104525D00BEB0EC /* PrintContext.h */,
 				E42050162141901B0066EF3B /* ProcessWarming.cpp */,
 				E42050142141901A0066EF3B /* ProcessWarming.h */,
+				7ABB0F5E2CE7C170009A837E /* QuirkBehavior.h */,
 				05D47709FFB4C18C6BA6928A /* QuirkMatch.cpp */,
 				05D47707FFB4C18C6BA6928A /* QuirkMatch.h */,
 				7ABB0F5D2CE7C170009A837F /* QuirkNames.h */,
@@ -48274,6 +48277,7 @@
 				A70B77D62A9EE40B003D8566 /* Quaternion.h in Headers */,
 				CD20ED3C27878FFB0038BE44 /* QueuedVideoOutput.h in Headers */,
 				A15E31F41E0CB0B5004B371C /* QuickLook.h in Headers */,
+				7ABB0F612CE7C170009A837E /* QuirkBehavior.h in Headers */,
 				05D47708FFB4C18C6BA6928A /* QuirkMatch.h in Headers */,
 				7ABB0F622CE7C170009A837F /* QuirkNames.h in Headers */,
 				9BAEE92C22388A7D004157A9 /* Quirks.h in Headers */,

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -173,7 +173,7 @@ ValueOrException ScriptController::evaluateInWorld(const ScriptSourceCode& sourc
     SetForScope sourceURLScope(m_sourceURL, &sourceURL);
 
     if (RefPtr document = m_frame->document()) {
-        if (auto script = document->quirks().scriptToEvaluateBeforeRunningScriptFromURL(sourceURL); !script.isEmpty())
+        for (auto& script : document->quirks().scriptsToEvaluateBeforeRunningScriptFromURL(sourceURL))
             evaluateIgnoringException({ WTF::move(script), JSC::SourceTaintedOrigin::Untainted });
     }
 

--- a/Source/WebCore/page/QuirkBehavior.h
+++ b/Source/WebCore/page/QuirkBehavior.h
@@ -25,32 +25,51 @@
 
 #pragma once
 
-#include <WebCore/QuirkBehavior.h>
 #include <WebCore/QuirkMatch.h>
 #include <WebCore/QuirkNames.h>
-#include <WebCore/QuirksData.h>
+#include <concepts>
 #include <optional>
-#include <wtf/Vector.h>
+#include <wtf/Assertions.h>
+#include <wtf/EnumTraits.h>
+#include <wtf/Variant.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/StringView.h>
 
 namespace WebCore {
 
-enum class IsTopDocument : bool { No, Yes };
+namespace ParameterizedQuirk {
 
-struct Quirk {
-    std::optional<QuirkMatch> topMatch { };
-    std::optional<QuirkMatch> documentMatch { };
-    Vector<QuirkBehavior> behaviors { };
-    std::optional<QuirkSite> site { };
+struct EvaluateScriptBeforeRunningScript {
+    static constexpr auto name = "EvaluateScriptBeforeRunningScript"_s;
 
-    constexpr bool namesAURL() const { return topMatch || documentMatch; }
+    ASCIILiteral script;
+    std::optional<QuirkMatch> gate;
 
-    bool matches(const QuirkMatchContext& page, const std::optional<QuirkMatchContext>& embeddedDocument) const;
+    bool appliesTo(const URL& scriptURL) const { return !gate || gate->matches(scriptURL); }
 
-    void apply(QuirksData&) const;
+    static EvaluateScriptBeforeRunningScript create(ASCIILiteral script, std::optional<QuirkMatch> gate = std::nullopt)
+    {
+        RELEASE_ASSERT(!script.isNull());
+        return { script, gate };
+    }
 };
 
-WEBCORE_EXPORT QuirksData resolveSiteSpecificQuirks(const URL& topURL, const URL& documentURL, IsTopDocument);
+} // namespace ParameterizedQuirk
 
-WEBCORE_EXPORT void validateQuirkTable();
+template<typename T> concept IsParameterizedQuirk = requires {
+    { T::name } -> std::convertible_to<ASCIILiteral>;
+};
+
+using QuirkBehavior = Variant<
+    SiteSpecificQuirk,
+    ParameterizedQuirk::EvaluateScriptBeforeRunningScript
+>;
+
+inline StringView quirkBehaviorName(const QuirkBehavior& behavior)
+{
+    return WTF::switchOn(behavior,
+        [](SiteSpecificQuirk quirk) -> StringView { return WTF::enumName(quirk); },
+        [](const IsParameterizedQuirk auto& payload) -> StringView { return payload.name; });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/QuirkBehaviors.h
+++ b/Source/WebCore/page/QuirkBehaviors.h
@@ -25,26 +25,24 @@
 
 #pragma once
 
+#include <WebCore/URLMatch.h>
 #include <wtf/BitSet.h>
+#include <wtf/OptionSet.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
 
 enum class QuirkSite : uint8_t {
     Amazon,
     BankOfAmerica,
-    BestBuy,
     Bing,
     CBSSports,
-    CEAC,
-    Dictionary,
     EA,
     Facebook,
     GoogleDocs,
     GoogleProperty,
     GoogleMaps,
     GoogleSearch,
-    IHeart,
-    InVideo,
     LinkedIn,
     MyBinder,
     NBA,
@@ -52,11 +50,9 @@ enum class QuirkSite : uint8_t {
     Outlook,
     Reddit,
     SoundCloud,
-    Thesaurus,
     TikTok,
     Vimeo,
     Walmart,
-    WebEx,
 
     NumberOfSites
 };
@@ -336,9 +332,41 @@ enum class QuirkBehaviorID {
 
 using QuirkBitSet = WTF::BitSet<static_cast<size_t>(QuirkBehaviorID::NumberOfIDs)>;
 
+struct QuirkParameters {
+    ASCIILiteral script;
+
+    static consteval QuirkParameters fromScript(ASCIILiteral script)
+    {
+        return QuirkParameters {
+            .script = script
+        };
+    }
+};
+
+enum class QuirkParametersNeeded : uint8_t {
+    NeedsScript = 1 << 0,
+};
+
 struct QuirkBehavior {
     QuirkBehaviorID id;
     bool isAvailable { false };
+    OptionSet<QuirkParametersNeeded> quirkParametersNeeded { };
+    std::optional<URLMatch> urlCondition { std::nullopt };
+    std::optional<QuirkParameters> parameters { std::nullopt };
+
+    consteval QuirkBehavior operator()(QuirkParameters params) const
+    {
+        auto copy = *this;
+        copy.parameters = params;
+        return copy;
+    }
+
+    consteval QuirkBehavior when(const URLMatch& urlCondition) const
+    {
+        auto copy = *this;
+        copy.urlCondition = urlCondition;
+        return copy;
+    }
 };
 
 // One QuirkBehavior per QuirkBehaviorID, for use in the quirk table.
@@ -391,7 +419,7 @@ inline constexpr QuirkBehavior needsSuppressedPauseEventOnFullscreenExitQuirk { 
 inline constexpr QuirkBehavior needsPreloadAutoQuirk { WebCore::QuirkBehaviorID::NeedsPreloadAutoQuirk, BuildCondition::iOSFamily };
 inline constexpr QuirkBehavior needsResettingTransitionCancelsRunningTransitionQuirk { WebCore::QuirkBehaviorID::NeedsResettingTransitionCancelsRunningTransitionQuirk, BuildCondition::always };
 inline constexpr QuirkBehavior needsReuseLiveRangeForSelectionUpdateQuirk { WebCore::QuirkBehaviorID::NeedsReuseLiveRangeForSelectionUpdateQuirk, BuildCondition::always };
-inline constexpr QuirkBehavior needsScriptToEvaluateBeforeRunningScriptFromURLQuirk { WebCore::QuirkBehaviorID::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk, BuildCondition::always };
+inline constexpr QuirkBehavior needsScriptToEvaluateBeforeRunningScriptFromURLQuirk { WebCore::QuirkBehaviorID::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk, BuildCondition::always, QuirkParametersNeeded::NeedsScript };
 inline constexpr QuirkBehavior needsScrollbarWidthThinDisabledQuirk { WebCore::QuirkBehaviorID::NeedsScrollbarWidthThinDisabledQuirk, BuildCondition::always };
 inline constexpr QuirkBehavior needsSeekingSupportDisabledQuirk { WebCore::QuirkBehaviorID::NeedsSeekingSupportDisabledQuirk, BuildCondition::always };
 inline constexpr QuirkBehavior needsSupportsProgressMonitoringQuirk { WebCore::QuirkBehaviorID::NeedsSupportsProgressMonitoringQuirk, BuildCondition::mediaSource };

--- a/Source/WebCore/page/QuirkMatch.cpp
+++ b/Source/WebCore/page/QuirkMatch.cpp
@@ -31,36 +31,35 @@
 
 namespace WebCore {
 
-const String& QuirkMatchContext::topRegistrableDomain() const
+const String& QuirkMatchContext::registrableDomain() const
 {
-    if (!m_topRegistrableDomain)
-        m_topRegistrableDomain = RegistrableDomain { m_topURL }.string();
-    return *m_topRegistrableDomain;
+    if (!m_registrableDomain)
+        m_registrableDomain = RegistrableDomain { m_url }.string();
+    return *m_registrableDomain;
 }
 
-const String& QuirkMatchContext::topDomainWithoutPublicSuffix() const
+const String& QuirkMatchContext::domainWithoutPublicSuffix() const
 {
-    if (!m_topDomainWithoutPublicSuffix)
-        m_topDomainWithoutPublicSuffix = PublicSuffixStore::singleton().domainWithoutPublicSuffix(topRegistrableDomain());
-    return *m_topDomainWithoutPublicSuffix;
+    if (!m_domainWithoutPublicSuffix)
+        m_domainWithoutPublicSuffix = PublicSuffixStore::singleton().domainWithoutPublicSuffix(registrableDomain());
+    return *m_domainWithoutPublicSuffix;
 }
 
-const String& QuirkMatchContext::documentRegistrableDomain() const
-{
-    if (!m_documentRegistrableDomain)
-        m_documentRegistrableDomain = RegistrableDomain { m_documentURL }.string();
-    return *m_documentRegistrableDomain;
-}
-
-bool QuirkMatch::RefinementSet::matchesPathPattern(const URL& topURL) const
+bool QuirkMatch::RefinementSet::matchesPathPattern(const URL& url) const
 {
     switch (pathComparison) {
     case PathComparison::PathContains:
-        return topURL.path().contains(pathPattern);
+        return url.path().contains(pathPattern);
     case PathComparison::PathStartsWith:
-        return startsWithLettersIgnoringASCIICase(topURL.path(), pathPattern);
+        return startsWithLettersIgnoringASCIICase(url.path(), pathPattern);
     case PathComparison::PathOrFragmentContains:
-        return topURL.path().contains(pathPattern) || topURL.fragmentIdentifier().contains(pathPattern);
+        return url.path().contains(pathPattern) || url.fragmentIdentifier().contains(pathPattern);
+    case PathComparison::LastPathComponentIs:
+        return url.lastPathComponent() == pathPattern;
+    case PathComparison::LastPathComponentStartsWith:
+        return url.lastPathComponent().startsWith(pathPattern);
+    case PathComparison::LastPathComponentEndsWith:
+        return url.lastPathComponent().endsWith(pathPattern);
     }
 
     ASSERT_NOT_REACHED();
@@ -69,38 +68,32 @@ bool QuirkMatch::RefinementSet::matchesPathPattern(const URL& topURL) const
 
 bool QuirkMatch::RefinementSet::matches(const QuirkMatchContext& context) const
 {
-    if (!pathPattern.isNull() && !matchesPathPattern(context.topURL()))
+    if (!pathPattern.isNull() && !matchesPathPattern(context.url()))
+        return false;
+
+    if (!hosts.isEmpty() && !hosts.contains(context.host()))
         return false;
 
     if (environment && !evaluateQuirkEnvironment(*environment))
         return false;
 
-    if (requiresEmbeddedDocument && context.isTopDocument())
-        return false;
-
-    if (!documentDomains.isEmpty() && !documentDomains.contains(context.documentRegistrableDomain()))
-        return false;
-
-    if (!hosts.isEmpty() && !hosts.contains(context.topHost()))
-        return false;
-
     return true;
 }
 
-bool QuirkMatch::matchesSite(const QuirkMatchContext& context) const
+bool QuirkMatch::matchesIdentity(const QuirkMatchContext& context) const
 {
     switch (m_kind) {
     case Kind::Domain:
-        return m_patterns.contains(context.topRegistrableDomain());
+        return m_patterns.contains(context.registrableDomain());
     case Kind::Host:
-        return m_patterns.contains(context.topHost());
+        return m_patterns.contains(context.host());
     case Kind::HostOrSubdomainOf:
-        return m_patterns.containsMatching([&](ASCIILiteral pattern) { return context.topURL().isMatchingDomain(pattern); });
+        return m_patterns.containsMatching([&](ASCIILiteral pattern) { return context.url().isMatchingDomain(pattern); });
     case Kind::AnyTopLevelDomain:
-        return m_patterns.contains(context.topDomainWithoutPublicSuffix());
-    case Kind::AnySite:
+        return m_patterns.contains(context.domainWithoutPublicSuffix());
+    case Kind::Any:
         // about:, data:, and other URLs without a host are not sites.
-        return !context.topHost().isEmpty();
+        return !context.host().isEmpty();
     }
 
     ASSERT_NOT_REACHED();
@@ -109,7 +102,7 @@ bool QuirkMatch::matchesSite(const QuirkMatchContext& context) const
 
 bool QuirkMatch::matches(const QuirkMatchContext& context) const
 {
-    if (!matchesSite(context)) [[likely]]
+    if (!matchesIdentity(context)) [[likely]]
         return false;
 
     if (!m_refinements.matches(context))

--- a/Source/WebCore/page/QuirkMatch.h
+++ b/Source/WebCore/page/QuirkMatch.h
@@ -45,36 +45,25 @@ enum class QuirkEnvironment : uint8_t {
 
 WEBCORE_EXPORT bool evaluateQuirkEnvironment(QuirkEnvironment);
 
-enum class IsTopDocument : bool { No, Yes };
-
 class QuirkMatchContext {
 public:
-    QuirkMatchContext(URL topURL, URL documentURL, IsTopDocument isTopDocument)
-        : m_topURL(WTF::move(topURL))
-        , m_documentURL(WTF::move(documentURL))
-        , m_isTopDocument(isTopDocument)
+    explicit QuirkMatchContext(URL url)
+        : m_url(WTF::move(url))
     {
     }
 
-    const URL& topURL() const LIFETIME_BOUND { return m_topURL; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
 
-    bool isTopDocument() const { return m_isTopDocument == IsTopDocument::Yes; }
+    StringView host() const LIFETIME_BOUND { return m_url.host(); }
 
-    StringView topHost() const LIFETIME_BOUND { return m_topURL.host(); }
+    WEBCORE_EXPORT const String& registrableDomain() const LIFETIME_BOUND;
 
-    WEBCORE_EXPORT const String& topRegistrableDomain() const LIFETIME_BOUND;
-
-    WEBCORE_EXPORT const String& topDomainWithoutPublicSuffix() const LIFETIME_BOUND;
-
-    WEBCORE_EXPORT const String& documentRegistrableDomain() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const String& domainWithoutPublicSuffix() const LIFETIME_BOUND;
 
 private:
-    const URL m_topURL;
-    const URL m_documentURL;
-    const IsTopDocument m_isTopDocument;
-    mutable std::optional<String> m_topRegistrableDomain;
-    mutable std::optional<String> m_topDomainWithoutPublicSuffix;
-    mutable std::optional<String> m_documentRegistrableDomain;
+    const URL m_url;
+    mutable std::optional<String> m_registrableDomain;
+    mutable std::optional<String> m_domainWithoutPublicSuffix;
 };
 
 class QuirkPatternList {
@@ -137,8 +126,16 @@ struct PathOrFragmentContains {
     ASCIILiteral substring;
 };
 
-struct DocumentDomainIs {
-    QuirkPatternList domains;
+struct LastPathComponentIs {
+    ASCIILiteral name;
+};
+
+struct LastPathComponentStartsWith {
+    ASCIILiteral prefix;
+};
+
+struct LastPathComponentEndsWith {
+    ASCIILiteral suffix;
 };
 
 struct HostIs {
@@ -149,59 +146,62 @@ struct EnvironmentIs {
     QuirkEnvironment environment;
 };
 
-struct Embedded { };
-
 constexpr PathContains pathContains(ASCIILiteral substring)
 {
-    return { substring };
+    return { .substring = substring };
 }
 
 constexpr PathStartsWith pathStartsWith(ASCIILiteral prefix)
 {
-    return { prefix };
+    return { .prefix = prefix };
 }
 
 constexpr PathOrFragmentContains pathOrFragmentContains(ASCIILiteral substring)
 {
-    return { substring };
+    return { .substring = substring };
 }
 
-constexpr DocumentDomainIs documentDomainIs(QuirkPatternList domains)
+constexpr LastPathComponentIs lastPathComponentIs(ASCIILiteral name)
 {
-    return { domains };
+    return { .name = name };
+}
+
+constexpr LastPathComponentStartsWith lastPathComponentStartsWith(ASCIILiteral prefix)
+{
+    return { .prefix = prefix };
+}
+
+constexpr LastPathComponentEndsWith lastPathComponentEndsWith(ASCIILiteral suffix)
+{
+    return { .suffix = suffix };
 }
 
 constexpr HostIs hostIs(QuirkPatternList hosts)
 {
-    return { hosts };
-}
-
-constexpr Embedded embedded()
-{
-    return { };
+    return { .hosts = hosts };
 }
 
 constexpr EnvironmentIs smallScreen()
 {
-    return { QuirkEnvironment::SmallScreen };
+    return { .environment = QuirkEnvironment::SmallScreen };
 }
 
 constexpr EnvironmentIs tubularApp()
 {
-    return { QuirkEnvironment::TubularApp };
+    return { .environment = QuirkEnvironment::TubularApp };
 }
 
 constexpr EnvironmentIs lensApp()
 {
-    return { QuirkEnvironment::LensApp };
+    return { .environment = QuirkEnvironment::LensApp };
 }
 
 } // namespace QuirkRefinement
 
-// QuirkMatch represents a declarative description of which pages a quirk applies to
+// QuirkMatch is a declarative description of a set of URLs.
 //
-// Every match starts with exactly one static factory, which picks how the site is
-// identified. Each takes a single pattern or a list of them:
+// Every match starts with exactly one static factory, which picks how the URL is identified.
+// Each takes a single pattern or a list of them:
 //
 //     domain()             the registrable domain, so "youtube.com" also covers
 //                          player.youtube.com but not youtube.co.uk
@@ -210,15 +210,15 @@ constexpr EnvironmentIs lensApp()
 //                          for HTTP-family URLs only
 //     anyTopLevelDomain()  the domain under every public suffix, so "amazon" covers
 //                          amazon.com and amazon.co.uk
-//     anySite()            every page with a host, for quirks keyed only on refinements
+//     anyURL()             every URL with a host, for matches keyed only on refinements
 //
 // when() then narrows the match with QuirkRefinement refinements, all of which are ANDed
 // together:
 //
 //     QuirkMatch::anyTopLevelDomain("apple"_s).when(pathStartsWith("/store"_s))
 //
-// exceptWhen() takes the same refinements to carve matching pages back out, so a
-// refinement reads identically in either position and its scope is bounded by the call:
+// exceptWhen() takes the same refinements to carve matching URLs back out, so a refinement
+// reads identically in either position and its scope is bounded by the call:
 //
 //     QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s))
 //
@@ -244,9 +244,9 @@ public:
         return QuirkMatch { Kind::AnyTopLevelDomain, names };
     }
 
-    static constexpr QuirkMatch anySite()
+    static constexpr QuirkMatch anyURL()
     {
-        return QuirkMatch { Kind::AnySite };
+        return QuirkMatch { Kind::Any };
     }
 
     template<typename... Refinements> constexpr QuirkMatch when(Refinements... refinements) &&
@@ -270,37 +270,41 @@ public:
 
     WEBCORE_EXPORT bool matches(const QuirkMatchContext&) const;
 
+    bool matches(const URL& url) const { return matches(QuirkMatchContext { url }); }
+
 private:
     enum class Kind : uint8_t {
         Domain,
         Host,
         HostOrSubdomainOf,
         AnyTopLevelDomain,
-        AnySite,
+        Any,
     };
 
     enum class PathComparison : uint8_t {
         PathContains,
         PathStartsWith,
         PathOrFragmentContains,
+        LastPathComponentIs,
+        LastPathComponentStartsWith,
+        LastPathComponentEndsWith,
     };
 
     struct RefinementSet {
         PathComparison pathComparison { PathComparison::PathContains };
         ASCIILiteral pathPattern;
-        std::optional<QuirkEnvironment> environment;
-        QuirkPatternList documentDomains;
         QuirkPatternList hosts;
-        bool requiresEmbeddedDocument { false };
+        std::optional<QuirkEnvironment> environment;
 
         bool matches(const QuirkMatchContext&) const;
 
     private:
-        bool matchesPathPattern(const URL& topURL) const;
+        bool matchesPathPattern(const URL&) const;
     };
 
     static constexpr void setPathPattern(RefinementSet& set, PathComparison comparison, ASCIILiteral pattern)
     {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!pattern.isNull());
         RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(set.pathPattern.isNull());
         set.pathComparison = comparison;
         set.pathPattern = pattern;
@@ -321,10 +325,19 @@ private:
         setPathPattern(set, PathComparison::PathOrFragmentContains, refinement.substring);
     }
 
-    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::DocumentDomainIs refinement)
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::LastPathComponentIs refinement)
     {
-        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(set.documentDomains.isEmpty());
-        set.documentDomains = refinement.domains;
+        setPathPattern(set, PathComparison::LastPathComponentIs, refinement.name);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::LastPathComponentStartsWith refinement)
+    {
+        setPathPattern(set, PathComparison::LastPathComponentStartsWith, refinement.prefix);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::LastPathComponentEndsWith refinement)
+    {
+        setPathPattern(set, PathComparison::LastPathComponentEndsWith, refinement.suffix);
     }
 
     static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::HostIs refinement)
@@ -339,12 +352,6 @@ private:
         set.environment = refinement.environment;
     }
 
-    static constexpr void applyRefinement(RefinementSet& set, QuirkRefinement::Embedded)
-    {
-        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!set.requiresEmbeddedDocument);
-        set.requiresEmbeddedDocument = true;
-    }
-
     constexpr explicit QuirkMatch(Kind kind)
         : m_kind(kind)
     {
@@ -356,7 +363,7 @@ private:
     {
     }
 
-    bool matchesSite(const QuirkMatchContext&) const;
+    bool matchesIdentity(const QuirkMatchContext&) const;
 
     Kind m_kind;
     QuirkPatternList m_patterns;

--- a/Source/WebCore/page/QuirkNames.h
+++ b/Source/WebCore/page/QuirkNames.h
@@ -33,18 +33,13 @@ namespace WebCore {
 enum class QuirkSite : uint8_t {
     Amazon,
     BankOfAmerica,
-    BestBuy,
     Bing,
     CBSSports,
-    CEAC,
-    Dictionary,
     EA,
     Facebook,
     GoogleDocs,
     GoogleProperty,
     GoogleMaps,
-    IHeart,
-    InVideo,
     LinkedIn,
     MyBinder,
     NBA,
@@ -52,11 +47,9 @@ enum class QuirkSite : uint8_t {
     Outlook,
     Reddit,
     SoundCloud,
-    Thesaurus,
     TikTok,
     Vimeo,
     Walmart,
-    WebEx,
 
     NumberOfSites
 };
@@ -133,7 +126,6 @@ enum class SiteSpecificQuirk {
 #endif
     NeedsResettingTransitionCancelsRunningTransitionQuirk,
     NeedsReuseLiveRangeForSelectionUpdateQuirk,
-    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
     NeedsScrollbarWidthThinDisabledQuirk,
     NeedsSeekingSupportDisabledQuirk,
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -27,8 +27,58 @@
 #include "QuirkTable.h"
 
 #include <array>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
+
+#if PLATFORM(IOS_FAMILY)
+// nba.com rdar://147429596
+static constexpr auto nbaSeekBarFixScript = R"js(if (!window.__nbaSeekFix) {
+    window.__nbaSeekFix = true;
+    document.addEventListener('touchmove', function({ target, touches }) {
+        if (!target?.getAttribute
+            || target.getAttribute('data-id') !== 'video-player:scrub-bar:controls'
+            || !touches?.[0])
+            return;
+        const touch = touches[0];
+        const rect = target.getBoundingClientRect();
+        const event = new MouseEvent('mousemove', {
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+            screenX: touch.screenX,
+            screenY: touch.screenY,
+            bubbles: true,
+            cancelable: true
+        });
+        Object.defineProperty(event, 'offsetX', { value: touch.clientX - rect.left, configurable: true });
+        Object.defineProperty(event, 'offsetY', { value: touch.clientY - rect.top, configurable: true });
+        target.dispatchEvent(event);
+    }, false);
+})js"_s;
+#endif
+
+// ceac.state.gov rdar://170258502
+static constexpr auto ceacBeforeUnloadFixScript = R"js((function() {
+    if (window.__ceacBeforeUnloadFix) return;
+    window.__ceacBeforeUnloadFix = true;
+    var origAEL = window.addEventListener;
+    window.addEventListener = function(type, fn, opts) {
+        if (type === 'beforeunload') {
+            return origAEL.call(this, type, function(e) {
+                var ae = document.activeElement;
+                if (ae && ae.tagName === 'INPUT') {
+                    var t = (ae.type || '').toLowerCase();
+                    if (t === 'radio' || t === 'checkbox' || t === 'submit' || t === 'button')
+                        return;
+                }
+                if (typeof fn === 'function') fn.call(this, e);
+            }, opts);
+        }
+        return origAEL.apply(this, arguments);
+    };
+})();)js"_s;
 
 static constexpr std::array bbcDomains { "bbc.co.uk"_s, "bbc.com"_s };
 static constexpr std::array expediaGroupDomains {
@@ -48,33 +98,46 @@ static constexpr std::array claudeDomains { "claude.ai"_s, "claude.com"_s };
 
 namespace SiteSpecificQuirks {
 using enum SiteSpecificQuirk;
+using namespace ParameterizedQuirk;
 using namespace QuirkRefinement;
 
-static constexpr Quirk table[] = {
+#if PLATFORM(IOS_FAMILY)
+// The AnyClip player only needs the quirk for the script that sniffs the user agent.
+static constexpr auto anyClipPlayerScript = QuirkMatch::host("player.anyclip.com"_s).when(lastPathComponentEndsWith("lre.js"_s));
+
+static constexpr auto chromeUserAgentScript = "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
+
+// dictionary.com and thesaurus.com both embed the AnyClip player. player.anyclip.com rdar://138789765
+// nba.com rdar://147429596
+#endif
+
+static Vector<Quirk> makeTable()
+{
+    return {
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // 365scores.com rdar://116491386
-    { .match = QuirkMatch::domain("365scores.com"_s),
+    { .topMatch = QuirkMatch::domain("365scores.com"_s),
         .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 
 #if ENABLE(MEDIA_STREAM)
     // actesting.org rdar://124017544
-    { .match = QuirkMatch::domain("actesting.org"_s),
+    { .topMatch = QuirkMatch::domain("actesting.org"_s),
         .behaviors = { ShouldEnableLegacyGetUserMediaQuirk } },
 #endif
 
     // airindiaexpress.com https://webkit.org/b/317375
-    { .match = QuirkMatch::domain("airindiaexpress.com"_s),
+    { .topMatch = QuirkMatch::domain("airindiaexpress.com"_s),
         .behaviors = { NeedsAirIndiaExpressLayeringQuirk } },
 
     // Note: There is a userAgent override for rdar://117771731, see needsCustomUserAgentOverride()
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // airtable.com rdar://49124313
-    { .match = QuirkMatch::domain("airtable.com"_s),
+    { .topMatch = QuirkMatch::domain("airtable.com"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
-    { .match = QuirkMatch::anyTopLevelDomain("amazon"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("amazon"_s),
         .behaviors = {
             // amazon.com rdar://49124529
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
@@ -90,31 +153,31 @@ static constexpr Quirk table[] = {
         .site = QuirkSite::Amazon },
 
 #if PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::domain("amazon.design"_s),
+    { .topMatch = QuirkMatch::domain("amazon.design"_s),
         .behaviors = { NeedsAmazonDesignMenuViewportUnitQuirk } },
 #endif
 
     // apple.com rdar://154434137
     // FIXME: Maybe EnsureCaptionVisibilityInFullscreenAndPictureInPicture should apply to apple.com.cn too?
-    { .match = QuirkMatch::domain("apple.com"_s),
+    { .topMatch = QuirkMatch::domain("apple.com"_s),
         .behaviors = { EnsureCaptionVisibilityInFullscreenAndPictureInPicture } },
 
     // Quirk added for rdar://181007316, remove when rdar://182134549 is fixed.
-    { .match = QuirkMatch::anyTopLevelDomain("apple"_s).when(pathContains("/retail"_s)),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("apple"_s).when(pathContains("/retail"_s)),
         .behaviors = { ShouldDisableScrollAnchoringQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // as.com: rdar://121014613
-    { .match = QuirkMatch::domain("as.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("as.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // att.com rdar://55185021
-    { .match = QuirkMatch::domain("att.com"_s),
+    { .topMatch = QuirkMatch::domain("att.com"_s),
         .behaviors = { ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk } },
 #endif
 
     // Login issue on bankofamerica.com (rdar://104938789).
-    { .match = QuirkMatch::domain("bankofamerica.com"_s),
+    { .topMatch = QuirkMatch::domain("bankofamerica.com"_s),
         .behaviors = {
             MaybeBypassBackForwardCache,
         },
@@ -122,17 +185,16 @@ static constexpr Quirk table[] = {
 
     // bbc.co.uk rdar://126494734
     // bbc.com rdar://157499149
-    { .match = QuirkMatch::domain(bbcDomains),
+    { .topMatch = QuirkMatch::domain(bbcDomains),
         .behaviors = { ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk } },
 
     // bestbuy.com rdar://136235936
-    { .match = QuirkMatch::domain("bestbuy.com"_s),
+    { .topMatch = QuirkMatch::domain("bestbuy.com"_s),
         .behaviors = {
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::BestBuy },
+            EvaluateScriptBeforeRunningScript::create("Object.defineProperty(navigator,'language',{get:function(){return'en-US'}});Object.defineProperty(navigator,'languages',{get:function(){return['en-US','en']}});"_s),
+        } },
 
-    { .match = QuirkMatch::domain("bing.com"_s),
+    { .topMatch = QuirkMatch::domain("bing.com"_s),
         .behaviors = {
             // bing.com rdar://133223599
             MaybeBypassBackForwardCache,
@@ -142,36 +204,35 @@ static constexpr Quirk table[] = {
         .site = QuirkSite::Bing },
 
     // bungalow.com rdar://61658940
-    { .match = QuirkMatch::domain("bungalow.com"_s),
+    { .topMatch = QuirkMatch::domain("bungalow.com"_s),
         .behaviors = { ShouldBypassAsyncScriptDeferring } },
 
-    { .match = QuirkMatch::domain("capitalgroup.com"_s),
+    { .topMatch = QuirkMatch::domain("capitalgroup.com"_s),
         .behaviors = { ShouldDelayReloadWhenRegisteringServiceWorker } },
 
 #if PLATFORM(IOS_FAMILY)
     // Remove this once rdar://139478801 is resolved.
-    { .match = QuirkMatch::domain("cbssports.com"_s),
+    { .topMatch = QuirkMatch::domain("cbssports.com"_s),
         .behaviors = {
             ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk,
         },
         .site = QuirkSite::CBSSports },
 #endif
 
-    { .match = QuirkMatch::hostOrSubdomainOf("ceac.state.gov"_s),
+    { .topMatch = QuirkMatch::hostOrSubdomainOf("ceac.state.gov"_s),
         .behaviors = {
 #if PLATFORM(MAC)
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
             NeedsFormControlToBeMouseFocusableQuirk,
 #endif
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=311383
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::CEAC },
+            EvaluateScriptBeforeRunningScript::create(ceacBeforeUnloadFixScript, QuirkMatch::anyURL().when(lastPathComponentIs("CheckBrowserClose.js"_s))),
+        } },
 #if PLATFORM(IOS)
-    { .match = QuirkMatch::domain("chess.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("chess.com"_s).when(smallScreen()),
         .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
 #endif
-    { .match = QuirkMatch::domain("claude.ai"_s),
+    { .topMatch = QuirkMatch::domain("claude.ai"_s),
         .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             NeedsClaudeSidebarViewportUnitQuirk,
@@ -183,12 +244,12 @@ static constexpr Quirk table[] = {
         } },
 
 #if PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::domain(claudeDomains),
+    { .topMatch = QuirkMatch::domain(claudeDomains),
         .behaviors = { NeedsHideSelectionDuringOverflowScrollQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::domain("cnn.com"_s),
+    { .topMatch = QuirkMatch::domain("cnn.com"_s),
         .behaviors = {
             // cnn.com rdar://119640248
             NeedsFullscreenObjectFitQuirk,
@@ -203,44 +264,43 @@ static constexpr Quirk table[] = {
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    { .match = QuirkMatch::host("codepen.io"_s),
+    { .topMatch = QuirkMatch::host("codepen.io"_s),
         .behaviors = { ShouldEnableSpeakerSelectionPermissionsPolicyQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("crunchyroll.com"_s),
+    { .topMatch = QuirkMatch::domain("crunchyroll.com"_s),
         .behaviors = { NeedsSuppressPostLayoutBoundaryEventsQuirk } },
 
-    { .match = QuirkMatch::domain("dailymail.co.uk"_s),
+    { .topMatch = QuirkMatch::domain("dailymail.co.uk"_s),
         .behaviors = { ShouldUnloadHeavyFrames } },
 
-    { .match = QuirkMatch::host("digits.t-mobile.com"_s),
+    { .topMatch = QuirkMatch::host("digits.t-mobile.com"_s),
         .behaviors = { NeedsNavigatorUserAgentDataQuirk, NeedsCustomUserAgentData } },
 
     // descript.com rdar://156024693
-    { .match = QuirkMatch::domain("descript.com"_s),
+    { .topMatch = QuirkMatch::domain("descript.com"_s),
         .behaviors = { ShouldDisableDOMAudioSession } },
 
-    { .match = QuirkMatch::domain("dictionary.com"_s),
+    { .topMatch = QuirkMatch::domain("dictionary.com"_s),
         .behaviors = {
 #if PLATFORM(IOS_FAMILY)
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            EvaluateScriptBeforeRunningScript::create(chromeUserAgentScript, anyClipPlayerScript),
 #endif
 #if PLATFORM(COCOA)
             NeedsAnchorToBeMouseFocusableQuirk,
 #endif
-        },
-        .site = QuirkSite::Dictionary },
+        } },
 
 #if PLATFORM(IOS_FAMILY)
     // digitaltrends.com rdar://121014613
-    { .match = QuirkMatch::domain("digitaltrends.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("digitaltrends.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // discord.com rdar://162719481
-    { .match = QuirkMatch::domain("discord.com"_s),
+    { .topMatch = QuirkMatch::domain("discord.com"_s),
         .behaviors = { ShouldUseLayoutViewportForClientRectsQuirk } },
 
-    { .match = QuirkMatch::domain("disneyplus.com"_s),
+    { .topMatch = QuirkMatch::domain("disneyplus.com"_s),
         .behaviors = {
             // disneyplus rdar://137613110
             ShouldHideCoarsePointerCharacteristicsQuirk,
@@ -251,10 +311,10 @@ static constexpr Quirk table[] = {
         } },
 #endif
 
-    { .match = QuirkMatch::domain("ea.com"_s),
+    { .topMatch = QuirkMatch::domain("ea.com"_s),
         .site = QuirkSite::EA },
 
-    { .match = QuirkMatch::domain("espn.com"_s),
+    { .topMatch = QuirkMatch::domain("espn.com"_s),
         .behaviors = {
 #if PLATFORM(IOS)
             // espn.com rdar://154903596
@@ -271,14 +331,14 @@ static constexpr Quirk table[] = {
         } },
 
     // Expedia Group rdar://126631968
-    { .match = QuirkMatch::domain(expediaGroupDomains),
+    { .topMatch = QuirkMatch::domain(expediaGroupDomains),
         .behaviors = { NeedsExpediaGroupAnimationQuirk } },
-    { .match = QuirkMatch::anyTopLevelDomain("ebookers"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("ebookers"_s),
         .behaviors = { NeedsExpediaGroupAnimationQuirk } },
-    { .match = QuirkMatch::anyTopLevelDomain("expedia"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("expedia"_s),
         .behaviors = { NeedsExpediaGroupAnimationQuirk } },
 
-    { .match = QuirkMatch::domain("facebook.com"_s),
+    { .topMatch = QuirkMatch::domain("facebook.com"_s),
         .behaviors = {
             // facebook.com rdar://100871402
             NeedsFacebookRemoveNotSupportedQuirk,
@@ -310,33 +370,33 @@ static constexpr Quirk table[] = {
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // flipkart.com rdar://49648520
-    { .match = QuirkMatch::domain("flipkart.com"_s),
+    { .topMatch = QuirkMatch::domain("flipkart.com"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // forbes.com rdar://67273166
-    { .match = QuirkMatch::domain("forbes.com"_s),
+    { .topMatch = QuirkMatch::domain("forbes.com"_s),
         .behaviors = { RequiresUserGestureToPauseInPictureInPictureQuirk } },
 #endif
 
-    { .match = QuirkMatch::host("play.geforcenow.com"_s),
+    { .topMatch = QuirkMatch::host("play.geforcenow.com"_s),
         .behaviors = { NeedsGeforcenowWarningDisplayNoneQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // gizmodo.com rdar://102227302
-    { .match = QuirkMatch::domain("gizmodo.com"_s),
+    { .topMatch = QuirkMatch::domain("gizmodo.com"_s),
         .behaviors = { NeedsFullscreenDisplayNoneQuirk } },
 #endif
 
-    { .match = QuirkMatch::anyTopLevelDomain("google"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("google"_s),
         .behaviors = {
             // docs.google.com rdar://59893415
             MaybeBypassBackForwardCache,
         },
         .site = QuirkSite::GoogleProperty },
 
-    { .match = QuirkMatch::anyTopLevelDomain("google"_s).when(pathStartsWith("/maps/"_s)),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("google"_s).when(pathStartsWith("/maps/"_s)),
         .behaviors = {
 #if ENABLE(TWO_PHASE_CLICKS)
             // maps.google.com rdar://152194074
@@ -355,7 +415,7 @@ static constexpr Quirk table[] = {
         },
         .site = QuirkSite::GoogleMaps },
 
-    { .match = QuirkMatch::host("docs.google.com"_s),
+    { .topMatch = QuirkMatch::host("docs.google.com"_s),
         .behaviors = {
             InputMethodUsesCorrectKeyEventOrder,
 #if PLATFORM(MAC)
@@ -372,40 +432,40 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
-    { .match = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/spreadsheets/"_s)),
+    { .topMatch = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/spreadsheets/"_s)),
         .behaviors = { NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk } },
 
-    { .match = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/presentation/"_s)),
+    { .topMatch = QuirkMatch::host("docs.google.com"_s).when(pathStartsWith("/presentation/"_s)),
         .behaviors = { ShouldIgnoreInputModeNone } },
 
     // mail.google.com rdar://49403416
-    { .match = QuirkMatch::host("mail.google.com"_s),
+    { .topMatch = QuirkMatch::host("mail.google.com"_s),
         .behaviors = { NeedsGMailOverflowScrollQuirk } },
 
-    { .match = QuirkMatch::host("translate.google.com"_s),
+    { .topMatch = QuirkMatch::host("translate.google.com"_s),
         .behaviors = {
             // translate.google.com rdar://106539018
             NeedsGoogleTranslateScrollingQuirk,
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            EvaluateScriptBeforeRunningScript::create("(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s),
         } },
 #endif
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // sites.google.com rdar://58653069
-    { .match = QuirkMatch::host("sites.google.com"_s),
+    { .topMatch = QuirkMatch::host("sites.google.com"_s),
         .behaviors = { ShouldPreventDispatchOfTouchEventQuirk } },
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    { .match = QuirkMatch::host("meet.google.com"_s),
+    { .topMatch = QuirkMatch::host("meet.google.com"_s),
         .behaviors = { ShouldEnableCameraBackgroundPlayback } },
 #endif
 
     // hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
-    { .match = QuirkMatch::domain("hbomax.com"_s),
+    { .topMatch = QuirkMatch::domain("hbomax.com"_s),
         .behaviors = { ShouldEnableFontLoadingAPIQuirk } },
 
-    { .match = QuirkMatch::host("play.hbomax.com"_s),
+    { .topMatch = QuirkMatch::host("play.hbomax.com"_s),
         .behaviors = {
 #if HAVE(PIP_SKIP_PREROLL)
             // play.hbomax.com rdar://158430821
@@ -419,7 +479,7 @@ static constexpr Quirk table[] = {
 #endif
         } },
 
-    { .match = QuirkMatch::domain("hulu.com"_s),
+    { .topMatch = QuirkMatch::domain("hulu.com"_s),
         .behaviors = {
             // hulu.com rdar://55041979
             NeedsCanPlayAfterSeekedQuirk,
@@ -431,22 +491,22 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // icloud.com rdar://131836301
-    { .match = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s)),
+    { .topMatch = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s)),
         .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 #if PLATFORM(MAC)
     // icloud.com rdar://26013388
-    { .match = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("notes"_s)),
+    { .topMatch = QuirkMatch::domain("icloud.com"_s).when(pathOrFragmentContains("notes"_s)),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("iheart.com"_s),
+    // iheart.com rdar://171198911
+    { .topMatch = QuirkMatch::domain("iheart.com"_s),
         .behaviors = {
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::IHeart },
+            EvaluateScriptBeforeRunningScript::create("document.cookie = 'app=listen:60; path=/; domain=.iheart.com';"_s),
+        } },
 
-    { .match = QuirkMatch::domain("imdb.com"_s),
+    { .topMatch = QuirkMatch::domain("imdb.com"_s),
         .behaviors = {
             // imdb.com: rdar://137991466
             NeedsChromeMediaControlsPseudoElementQuirk,
@@ -454,7 +514,7 @@ static constexpr Quirk table[] = {
             NeedsZeroMaxTouchPointsQuirk,
         } },
 
-    { .match = QuirkMatch::domain("instagram.com"_s),
+    { .topMatch = QuirkMatch::domain("instagram.com"_s),
         .behaviors = {
             // rdar://166400170
             NeedsInstagramResizingReelsQuirk,
@@ -466,21 +526,20 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // instagram.com rdar://121014613
-    { .match = QuirkMatch::domain("instagram.com"_s),
+    { .topMatch = QuirkMatch::domain("instagram.com"_s),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 #endif
 
     // invideo.io rdar://171741842 https://webkit.org/b/311602
-    { .match = QuirkMatch::domain("invideo.io"_s),
+    { .topMatch = QuirkMatch::domain("invideo.io"_s),
         .behaviors = {
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::InVideo },
+            EvaluateScriptBeforeRunningScript::create("if(!window.chrome)window.chrome={};"_s),
+        } },
 
-    { .match = QuirkMatch::domain("linkedin.com"_s),
+    { .topMatch = QuirkMatch::domain("linkedin.com"_s),
         .site = QuirkSite::LinkedIn },
 
-    { .match = QuirkMatch::domain("live.com"_s),
+    { .topMatch = QuirkMatch::domain("live.com"_s),
         .behaviors = {
 #if PLATFORM(IOS_FAMILY)
             // live.com: rdar://167489768
@@ -490,7 +549,7 @@ static constexpr Quirk table[] = {
             ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
         } },
 
-    { .match = QuirkMatch::host("outlook.live.com"_s),
+    { .topMatch = QuirkMatch::host("outlook.live.com"_s),
         .behaviors = {
             // outlook.live.com: rdar://136624720
             NeedsMozillaFileTypeForDataTransferQuirk,
@@ -506,28 +565,28 @@ static constexpr Quirk table[] = {
         .site = QuirkSite::Outlook },
 
     // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
-    { .match = QuirkMatch::hostOrSubdomainOf("officeapps.live.com"_s),
+    { .topMatch = QuirkMatch::hostOrSubdomainOf("officeapps.live.com"_s),
         .behaviors = { ShouldDisableDataURLPaddingValidation } },
-    { .match = QuirkMatch::hostOrSubdomainOf("onedrive.live.com"_s),
+    { .topMatch = QuirkMatch::hostOrSubdomainOf("onedrive.live.com"_s),
         .behaviors = { ShouldDisableDataURLPaddingValidation } },
 
 #if PLATFORM(MAC)
     // onedrive.live.com rdar://26013388
-    { .match = QuirkMatch::host("onedrive.live.com"_s),
+    { .topMatch = QuirkMatch::host("onedrive.live.com"_s),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 
     // madisoncity.k12.al.us https://bugs.webkit.org/show_bug.cgi?id=296989
-    { .match = QuirkMatch::domain("madisoncity.k12.al.us"_s),
+    { .topMatch = QuirkMatch::domain("madisoncity.k12.al.us"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     // mailchimp.com rdar://47868965
-    { .match = QuirkMatch::domain("mailchimp.com"_s),
+    { .topMatch = QuirkMatch::domain("mailchimp.com"_s),
         .behaviors = { ShouldDisablePointerEventsQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("marcus.com"_s),
+    { .topMatch = QuirkMatch::domain("marcus.com"_s),
         .behaviors = {
             // Marcus: <rdar://101086391>.
             ShouldExposeShowModalDialog,
@@ -538,20 +597,20 @@ static constexpr Quirk table[] = {
         } },
 
     // medium.com rdar://50457837
-    { .match = QuirkMatch::domain("medium.com"_s),
+    { .topMatch = QuirkMatch::domain("medium.com"_s),
         .behaviors = { ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk } },
 
 #if PLATFORM(IOS_FAMILY)
     // m365.cloud.microsoft rdar://157794706
-    { .match = QuirkMatch::hostOrSubdomainOf("m365.cloud.microsoft"_s),
+    { .topMatch = QuirkMatch::hostOrSubdomainOf("m365.cloud.microsoft"_s),
         .behaviors = { ShouldAllowPopupFromMicrosoftOfficeToOneDrive } },
 #endif
 
     // safe.menlosecurity.com rdar://135114489
-    { .match = QuirkMatch::host("safe.menlosecurity.com"_s),
+    { .topMatch = QuirkMatch::host("safe.menlosecurity.com"_s),
         .behaviors = { ShouldDisableWritingSuggestionsByDefaultQuirk } },
 
-    { .match = QuirkMatch::domain("messenger.com"_s),
+    { .topMatch = QuirkMatch::domain("messenger.com"_s),
         .behaviors = {
 #if ENABLE(MEDIA_STREAM)
             // facebook.com rdar://158736355
@@ -568,29 +627,29 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // rdar://147429596
-    { .match = QuirkMatch::domain("nba.com"_s),
+    { .topMatch = QuirkMatch::domain("nba.com"_s),
         .behaviors = {
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            EvaluateScriptBeforeRunningScript::create(nbaSeekBarFixScript),
         },
         .site = QuirkSite::NBA },
 #if PLATFORM(IOS)
-    { .match = QuirkMatch::domain("nba.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("nba.com"_s).when(smallScreen()),
         .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
 #endif
 #endif
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // mybinder.org rdar://51770057
-    { .match = QuirkMatch::domain("mybinder.org"_s),
+    { .topMatch = QuirkMatch::domain("mybinder.org"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk },
         .site = QuirkSite::MyBinder },
 
     // naver.com rdar://48068610
-    { .match = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs(naverHostsWithoutSimulatedMouseEvents)),
+    { .topMatch = QuirkMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs(naverHostsWithoutSimulatedMouseEvents)),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("netflix.com"_s),
+    { .topMatch = QuirkMatch::domain("netflix.com"_s),
         .behaviors = {
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
             NeedsSeekingSupportDisabledQuirk,
@@ -608,28 +667,28 @@ static constexpr Quirk table[] = {
         },
         .site = QuirkSite::Netflix },
 
-    { .match = QuirkMatch::domain("nfl.com"_s),
+    { .topMatch = QuirkMatch::domain("nfl.com"_s),
         .behaviors = { ShouldSuppressHLSSubtitles } },
 
-    { .match = QuirkMatch::domain("nhl.com"_s),
+    { .topMatch = QuirkMatch::domain("nhl.com"_s),
         .behaviors = { NeedsWebKitMediaTextTrackDisplayQuirk } },
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // nytimes.com: rdar://problem/5976384
-    { .match = QuirkMatch::domain("nytimes.com"_s),
+    { .topMatch = QuirkMatch::domain("nytimes.com"_s),
         .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
 #endif
 
     // Pandora: <rdar://100243111>.
-    { .match = QuirkMatch::domain("pandora.com"_s),
+    { .topMatch = QuirkMatch::domain("pandora.com"_s),
         .behaviors = { ShouldExposeShowModalDialog } },
 
     // pinterest.com rdar://104979314
     // FIXME: Remove this Quirk if Pinterest decides to trigger this notification from an user gesture (rdar://165745719)
-    { .match = QuirkMatch::domain("pinterest.com"_s),
+    { .topMatch = QuirkMatch::domain("pinterest.com"_s),
         .behaviors = { ShouldAllowNotificationPermissionWithoutUserGesture } },
 
-    { .match = QuirkMatch::domain("premierleague.com"_s),
+    { .topMatch = QuirkMatch::domain("premierleague.com"_s),
         .behaviors = {
             // premierleague.com: rdar://123721211
             ShouldIgnorePlaysInlineRequirementQuirk,
@@ -641,12 +700,12 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // ralphlauren.com rdar://55629493
-    { .match = QuirkMatch::domain("ralphlauren.com"_s),
+    { .topMatch = QuirkMatch::domain("ralphlauren.com"_s),
         .behaviors = { ShouldIgnoreAriaForFastPathContentObservationCheckQuirk } },
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE) || PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::domain("reddit.com"_s),
+    { .topMatch = QuirkMatch::domain("reddit.com"_s),
         .behaviors = {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
             // reddit.com: rdar://80550715
@@ -660,19 +719,19 @@ static constexpr Quirk table[] = {
         .site = QuirkSite::Reddit },
 #endif
 
-    { .match = QuirkMatch::domain("scribd.com"_s),
+    { .topMatch = QuirkMatch::domain("scribd.com"_s),
         .behaviors = { NeedsReuseLiveRangeForSelectionUpdateQuirk } },
 
     // sfusd.edu: rdar://116292738
-    { .match = QuirkMatch::domain("sfusd.edu"_s),
+    { .topMatch = QuirkMatch::domain("sfusd.edu"_s),
         .behaviors = { ShouldBypassAsyncScriptDeferring } },
 
     // sharepoint.com rdar://52116170
-    { .match = QuirkMatch::domain("sharepoint.com"_s),
+    { .topMatch = QuirkMatch::domain("sharepoint.com"_s),
         .behaviors = { ShouldAvoidResizingWhenInputViewBoundsChangeQuirk } },
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(META_VIEWPORT)
-    { .match = QuirkMatch::domain("slack.com"_s),
+    { .topMatch = QuirkMatch::domain("slack.com"_s),
         .behaviors = {
             // slack.com: rdar://138614711
             ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk,
@@ -681,7 +740,7 @@ static constexpr Quirk table[] = {
         } },
 #endif
 
-    { .match = QuirkMatch::domain("soundcloud.com"_s),
+    { .topMatch = QuirkMatch::domain("soundcloud.com"_s),
         .behaviors = {
             // soundcloud.com rdar://52915981
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
@@ -696,12 +755,12 @@ static constexpr Quirk table[] = {
 
 #if ENABLE(TOUCH_EVENTS)
     // soylent.*: rdar://113314067
-    { .match = QuirkMatch::anyTopLevelDomain("soylent"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("soylent"_s),
         .behaviors = { ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick } },
 #endif
 
     // spotify.com rdar://138918575
-    { .match = QuirkMatch::host("open.spotify.com"_s),
+    { .topMatch = QuirkMatch::host("open.spotify.com"_s),
         .behaviors = {
             NeedsBodyScrollbarWidthNoneDisabledQuirk,
             ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
@@ -716,31 +775,31 @@ static constexpr Quirk table[] = {
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     // Remove this once rdar://142573562 is resolved.
-    { .match = QuirkMatch::domain("steampowered.com"_s),
+    { .topMatch = QuirkMatch::domain("steampowered.com"_s),
         .behaviors = { ShouldTreatAddingMouseOutEventListenerAsContentChange } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    { .match = QuirkMatch::anyTopLevelDomain("theguardian"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("theguardian"_s),
         .behaviors = { ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk } },
 
     // theguardian.com rdar://166727225
-    { .match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(documentDomainIs(youTubeEmbedDomains)),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("theguardian"_s),
+        .documentMatch = QuirkMatch::domain(youTubeEmbedDomains),
         .behaviors = { NeedsYouTubeEmbedAutoplayQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("thesaurus.com"_s),
+    { .topMatch = QuirkMatch::domain("thesaurus.com"_s),
         .behaviors = {
 #if PLATFORM(IOS_FAMILY)
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            EvaluateScriptBeforeRunningScript::create(chromeUserAgentScript, anyClipPlayerScript),
 #endif
 #if PLATFORM(COCOA)
             NeedsAnchorToBeMouseFocusableQuirk,
 #endif
-        },
-        .site = QuirkSite::Thesaurus },
+        } },
 
-    { .match = QuirkMatch::domain("tiktok.com"_s),
+    { .topMatch = QuirkMatch::domain("tiktok.com"_s),
         .behaviors = {
             NeedsTikTokOverflowingContentQuirk,
             // tiktok.com rdar://174179805
@@ -754,31 +813,31 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(MAC)
     // trix-editor.org rdar://28242210
-    { .match = QuirkMatch::domain("trix-editor.org"_s),
+    { .topMatch = QuirkMatch::domain("trix-editor.org"_s),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
     // twitch.tv rdar://102420527
-    { .match = QuirkMatch::domain("twitch.tv"_s),
+    { .topMatch = QuirkMatch::domain("twitch.tv"_s),
         .behaviors = { ShouldReportDocumentAsVisibleIfActivePIPQuirk } },
 #endif
 
     // https://tympanus.net/Tutorials/WebGPUFluid/ does not load (rdar://143839620).
-    { .match = QuirkMatch::domain("tympanus.net"_s),
+    { .topMatch = QuirkMatch::domain("tympanus.net"_s),
         .behaviors = { ShouldBlockFetchWithNewlineAndLessThan } },
 
 #if ENABLE(MEDIA_SOURCE)
     // unifi.ui.com rdar://180411019
-    { .match = QuirkMatch::domain("ui.com"_s),
+    { .topMatch = QuirkMatch::domain("ui.com"_s),
         .behaviors = { NeedsSupportsProgressMonitoringQuirk } },
 #endif
 
     // Breaks express checkout on victoriassecret.com (rdar://104818312).
-    { .match = QuirkMatch::domain("victoriassecret.com"_s),
+    { .topMatch = QuirkMatch::domain("victoriassecret.com"_s),
         .behaviors = { ShouldDisableFetchMetadata } },
 
-    { .match = QuirkMatch::domain("vimeo.com"_s),
+    { .topMatch = QuirkMatch::domain("vimeo.com"_s),
         .behaviors = {
             // vimeo.com rdar://56996057
             MaybeBypassBackForwardCache,
@@ -801,13 +860,13 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(IOS_FAMILY)
     // rdar://116531089
-    { .match = QuirkMatch::domain("vimeo.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("vimeo.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
     // walmart.com: rdar://123734840
-    { .match = QuirkMatch::domain("walmart.com"_s),
+    { .topMatch = QuirkMatch::domain("walmart.com"_s),
         .behaviors = {
             MayNeedToIgnoreContentObservation,
         },
@@ -816,23 +875,25 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(MAC)
     // weather.com rdar://139689157
-    { .match = QuirkMatch::domain("weather.com"_s),
+    { .topMatch = QuirkMatch::domain("weather.com"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    { .match = QuirkMatch::domain("webex.com"_s),
+    { .topMatch = QuirkMatch::domain("webex.com"_s),
         .behaviors = {
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::WebEx },
+            EvaluateScriptBeforeRunningScript::create(
+                "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s,
+                QuirkMatch::anyURL().when(lastPathComponentStartsWith("pushdownload."_s))
+            ),
+        } },
 #endif
 
     // weebly.com rdar://48003980
-    { .match = QuirkMatch::domain("weebly.com"_s),
+    { .topMatch = QuirkMatch::domain("weebly.com"_s),
         .behaviors = { ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk } },
 
-    { .match = QuirkMatch::domain("wikipedia.org"_s),
+    { .topMatch = QuirkMatch::domain("wikipedia.org"_s),
         .behaviors = {
             // wikipedia.org rdar://54856323
             ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk,
@@ -845,20 +906,20 @@ static constexpr Quirk table[] = {
     // rdar://170412045, https://bugs.webkit.org/show_bug.cgi?id=307933
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // wix.com rdar://49124313, except while picking a template.
-    { .match = QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s)),
+    { .topMatch = QuirkMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s)),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("workspaces.xyz"_s),
+    { .topMatch = QuirkMatch::domain("workspaces.xyz"_s),
         .behaviors = { ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions } },
 
 #if PLATFORM(MAC)
     // wpdevelopment.ca rdar://156109518
-    { .match = QuirkMatch::domain("wpdevelopment.ca"_s),
+    { .topMatch = QuirkMatch::domain("wpdevelopment.ca"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("x.com"_s),
+    { .topMatch = QuirkMatch::domain("x.com"_s),
         .behaviors = {
 #if PLATFORM(VISION)
             // x.com: rdar://132850672
@@ -880,7 +941,7 @@ static constexpr Quirk table[] = {
 #endif
         } },
 
-    { .match = QuirkMatch::anyTopLevelDomain("yahoo"_s),
+    { .topMatch = QuirkMatch::anyTopLevelDomain("yahoo"_s),
         .behaviors = {
             // yahoo.com: rdar://170502516
             NeedsYahooVolumeSliderQuirk,
@@ -894,11 +955,11 @@ static constexpr Quirk table[] = {
 
 #if ENABLE(TEXT_AUTOSIZING)
     // news.ycombinator.com: rdar://127246368
-    { .match = QuirkMatch::host("news.ycombinator.com"_s),
+    { .topMatch = QuirkMatch::host("news.ycombinator.com"_s),
         .behaviors = { ShouldIgnoreTextAutoSizingQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("youtube.com"_s),
+    { .topMatch = QuirkMatch::domain("youtube.com"_s),
         .behaviors = {
             // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
             HasBrokenEncryptedMediaAPISupportQuirk,
@@ -915,65 +976,65 @@ static constexpr Quirk table[] = {
 
 #if PLATFORM(COCOA)
     // Embedded youtube.com players need the caption quirk regardless of the embedding site.
-    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains)),
+    { .documentMatch = QuirkMatch::domain(youTubeEmbedDomains),
         .behaviors = { NeedsYouTubeCaptionQuirk } },
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
-    { .match = QuirkMatch::domain("youtube.com"_s).when(smallScreen()),
+    { .topMatch = QuirkMatch::domain("youtube.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // tiny. (Ref: rdar://121471373, rdar://121473410)
-    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains), smallScreen()),
+    { .documentMatch = QuirkMatch::domain(youTubeEmbedDomains).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
-    { .match = QuirkMatch::anySite().when(embedded(), documentDomainIs("x.com"_s)),
+    { .documentMatch = QuirkMatch::domain("x.com"_s),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // youtube.com rdar://49582231
-    { .match = QuirkMatch::host("www.youtube.com"_s),
+    { .topMatch = QuirkMatch::host("www.youtube.com"_s),
         .behaviors = { NeedsYouTubeOverflowScrollQuirk } },
 
-    { .match = QuirkMatch::domain("youtube.com"_s).when(tubularApp()),
+    { .topMatch = QuirkMatch::domain("youtube.com"_s).when(tubularApp()),
         .behaviors = { ShouldSuppressMediaSessionPauseActionOnInterruption } },
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
     // www.youtube.com rdar://52361019
-    { .match = QuirkMatch::host("www.youtube.com"_s),
+    { .topMatch = QuirkMatch::host("www.youtube.com"_s),
         .behaviors = { NeedsYouTubeMouseOutQuirk } },
 #endif
 
 #if PLATFORM(VISION) && ENABLE(FULLSCREEN_API)
     // Lens.app rdar://178769976
-    { .match = QuirkMatch::domain("youtube.com"_s).when(lensApp()),
+    { .topMatch = QuirkMatch::domain("youtube.com"_s).when(lensApp()),
         .behaviors = { RequiresUserGestureToPlayInFullscreenQuirk } },
 #endif
 
 #if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
     // zencastr.com rdar://143087016
-    { .match = QuirkMatch::domain("zencastr.com"_s),
+    { .topMatch = QuirkMatch::domain("zencastr.com"_s),
         .behaviors = { NeedsLimitedMatroskaSupportQuirk } },
 #endif
 
     // zillow.com rdar://53103732
-    { .match = QuirkMatch::host("www.zillow.com"_s),
+    { .topMatch = QuirkMatch::host("www.zillow.com"_s),
         .behaviors = { ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk } },
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     // zillow.com rdar://110097836
-    { .match = QuirkMatch::domain("zillow.com"_s),
+    { .topMatch = QuirkMatch::domain("zillow.com"_s),
         .behaviors = { ShouldSilenceResizeObservers } },
 #endif
 
 #if PLATFORM(MAC)
-    { .match = QuirkMatch::domain("zomato.com"_s),
+    { .topMatch = QuirkMatch::domain("zomato.com"_s),
         .behaviors = { NeedsZomatoEmailLoginLabelQuirk } },
 #endif
 
-    { .match = QuirkMatch::domain("zoom.us"_s),
+    { .topMatch = QuirkMatch::domain("zoom.us"_s),
         .behaviors = {
             // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
             ShouldAutoplayWebAudioForArbitraryUserGestureQuirk,
@@ -984,22 +1045,81 @@ static constexpr Quirk table[] = {
 #endif
         } },
 };
+}
+
+static void validateTable(const Vector<Quirk>& table)
+{
+    for (auto& quirk : table) {
+        RELEASE_ASSERT_WITH_MESSAGE(quirk.namesAURL(), "Every quirk must name the page URL, the embedded document URL, or both.");
+
+        unsigned scriptCount = 0;
+        for (auto& behavior : quirk.behaviors) {
+            if (auto* script = std::get_if<EvaluateScriptBeforeRunningScript>(&behavior)) {
+                RELEASE_ASSERT_WITH_MESSAGE(!script->script.isNull(), "A script behavior must name a script.");
+                ++scriptCount;
+            }
+        }
+
+        RELEASE_ASSERT_WITH_MESSAGE(scriptCount <= 1, "A quirk must not name more than one script to evaluate.");
+    }
+}
+
+static const Vector<Quirk>& table()
+{
+    static NeverDestroyed<Vector<Quirk>> table = [] {
+        auto entries = makeTable();
+        validateTable(entries);
+        return entries;
+    }();
+    return table.get();
+}
 
 } // namespace SiteSpecificQuirks
 
+void validateQuirkTable()
+{
+    // Building the table validates it.
+    SiteSpecificQuirks::table();
+}
+
 void Quirk::apply(QuirksData& quirksData) const
 {
-    quirksData.activeQuirks.merge(behaviors.bits());
+    for (auto& behavior : behaviors) {
+        WTF::switchOn(behavior,
+            [&](SiteSpecificQuirk quirk) {
+                quirksData.enableQuirk(quirk);
+            },
+            [&](const IsParameterizedQuirk auto& payload) {
+                quirksData.behaviors.append(payload);
+            });
+    }
 
     if (site)
         quirksData.addSite(*site);
 }
 
-QuirksData resolveSiteSpecificQuirks(const QuirkMatchContext& context)
+bool Quirk::matches(const QuirkMatchContext& page, const std::optional<QuirkMatchContext>& embeddedDocument) const
 {
+    if (topMatch && !topMatch->matches(page)) [[likely]]
+        return false;
+
+    if (documentMatch && (!embeddedDocument || !documentMatch->matches(*embeddedDocument)))
+        return false;
+
+    return true;
+}
+
+QuirksData resolveSiteSpecificQuirks(const URL& topURL, const URL& documentURL, IsTopDocument isTopDocument)
+{
+    QuirkMatchContext page { topURL };
+
+    std::optional<QuirkMatchContext> embeddedDocument;
+    if (isTopDocument == IsTopDocument::No)
+        embeddedDocument.emplace(documentURL);
+
     QuirksData quirksData;
-    for (auto& quirk : SiteSpecificQuirks::table) {
-        if (quirk.match.matches(context))
+    for (auto& quirk : SiteSpecificQuirks::table()) {
+        if (quirk.matches(page, embeddedDocument))
             quirk.apply(quirksData);
     }
     return quirksData;

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -25,9 +25,11 @@
 
 #include "config.h"
 #include "QuirkTable.h"
+#include "QuirkBehaviors.h"
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <span>
 #include <utility>
 
@@ -44,10 +46,67 @@ static constexpr std::array naverHostsWithoutSimulatedMouseEvents { "tv.naver.co
 static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
 static constexpr std::array claudeDomains { "claude.ai"_s, "claude.com"_s };
 
+static constexpr auto bestBuyLanguageScript = "Object.defineProperty(navigator,'language',{get:function(){return'en-US'}});Object.defineProperty(navigator,'languages',{get:function(){return['en-US','en']}});"_s;
+
+static constexpr auto chromeUserAgentScript = "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
+
+static constexpr auto iHeartListenCookieScript = "document.cookie = 'app=listen:60; path=/; domain=.iheart.com';"_s;
+
+static constexpr auto inVideoChromeObjectScript = "if(!window.chrome)window.chrome={};"_s;
+
+static constexpr auto webExUndefinedTouchScript = "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
+
+static constexpr auto nbaSeekBarFixScript = R"js(if (!window.__nbaSeekFix) {
+    window.__nbaSeekFix = true;
+    document.addEventListener('touchmove', function({ target, touches }) {
+        if (!target?.getAttribute
+            || target.getAttribute('data-id') !== 'video-player:scrub-bar:controls'
+            || !touches?.[0])
+            return;
+        const touch = touches[0];
+        const rect = target.getBoundingClientRect();
+        const event = new MouseEvent('mousemove', {
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+            screenX: touch.screenX,
+            screenY: touch.screenY,
+            bubbles: true,
+            cancelable: true
+        });
+        Object.defineProperty(event, 'offsetX', { value: touch.clientX - rect.left, configurable: true });
+        Object.defineProperty(event, 'offsetY', { value: touch.clientY - rect.top, configurable: true });
+        target.dispatchEvent(event);
+    }, false);
+})js"_s;
+
+static constexpr auto ceacBeforeUnloadFixScript = R"js((function() {
+    if (window.__ceacBeforeUnloadFix) return;
+    window.__ceacBeforeUnloadFix = true;
+    var origAEL = window.addEventListener;
+    window.addEventListener = function(type, fn, opts) {
+        if (type === 'beforeunload') {
+            return origAEL.call(this, type, function(e) {
+                var ae = document.activeElement;
+                if (ae && ae.tagName === 'INPUT') {
+                    var t = (ae.type || '').toLowerCase();
+                    if (t === 'radio' || t === 'checkbox' || t === 'submit' || t === 'button')
+                        return;
+                }
+                if (typeof fn === 'function') fn.call(this, e);
+            }, opts);
+        }
+        return origAEL.apply(this, arguments);
+    };
+})();)js"_s;
+
 namespace SiteSpecificQuirks {
 using namespace QuirkBehaviors;
 using namespace URLRefinement;
 using namespace BuildCondition;
+
+static constexpr auto anyclipPlayerScriptURL = URLMatch::host("player.anyclip.com"_s).when(lastPathComponentEndsWith("lre.js"_s));
+static constexpr auto ceacBrowserCloseScriptURL = URLMatch::anyURL().when(lastPathComponentIs("CheckBrowserClose.js"_s));
+static constexpr auto webExPushDownloadScriptURL = URLMatch::anyURL().when(lastPathComponentStartsWith("pushdownload."_s));
 
 static constexpr Quirk fullTable[] = {
     // 365scores.com rdar://116491386
@@ -113,9 +172,8 @@ static constexpr Quirk fullTable[] = {
     // bestbuy.com rdar://136235936
     { .match = URLMatch::domain("bestbuy.com"_s),
         .behaviors = {
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::BestBuy },
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(bestBuyLanguageScript)),
+        } },
 
     // billpaysite.com rdar://141328971
     { .match = URLMatch::hostOrSubdomainOf("billpaysite.com"_s),
@@ -154,9 +212,8 @@ static constexpr Quirk fullTable[] = {
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
             needsFormControlToBeMouseFocusableQuirk,
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=311383
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::CEAC },
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(ceacBeforeUnloadFixScript)).when(ceacBrowserCloseScriptURL),
+        } },
 
     // secure.chase.com rdar://126715227
     { .match = URLMatch::host("secure.chase.com"_s),
@@ -206,11 +263,11 @@ static constexpr Quirk fullTable[] = {
         .behaviors = { shouldDisableDOMAudioSession } },
 
     { .match = URLMatch::domain("dictionary.com"_s),
-        .behaviors = { needsAnchorToBeMouseFocusableQuirk },
-        .site = QuirkSite::Dictionary },
+        .behaviors = { needsAnchorToBeMouseFocusableQuirk } },
 
+    // player.anyclip.com rdar://138789765
     { .match = URLMatch::domain("dictionary.com"_s),
-        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(chromeUserAgentScript)).when(anyclipPlayerScriptURL) },
         .isAvailable = iOSFamily },
 
     // digitaltrends.com rdar://121014613
@@ -340,7 +397,7 @@ static constexpr Quirk fullTable[] = {
         .behaviors = { needsGoogleTranslateScrollingQuirk } },
 
     { .match = URLMatch::host("translate.google.com"_s),
-        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(chromeUserAgentScript)) },
         .isAvailable = iOSFamily },
 
     // sites.google.com rdar://58653069
@@ -386,9 +443,8 @@ static constexpr Quirk fullTable[] = {
 
     { .match = URLMatch::domain("iheart.com"_s),
         .behaviors = {
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::IHeart },
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(iHeartListenCookieScript)),
+        } },
 
     { .match = URLMatch::domain("imdb.com"_s),
         .behaviors = {
@@ -417,9 +473,8 @@ static constexpr Quirk fullTable[] = {
     // invideo.io rdar://171741842 https://webkit.org/b/311602
     { .match = URLMatch::domain("invideo.io"_s),
         .behaviors = {
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        },
-        .site = QuirkSite::InVideo },
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(inVideoChromeObjectScript)),
+        } },
 
     { .match = URLMatch::domain("linkedin.com"_s),
         .site = QuirkSite::LinkedIn },
@@ -498,7 +553,7 @@ static constexpr Quirk fullTable[] = {
     // rdar://147429596
     { .match = URLMatch::domain("nba.com"_s),
         .behaviors = {
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(nbaSeekBarFixScript)),
         },
         .site = QuirkSite::NBA,
         .isAvailable = iOSFamily },
@@ -653,11 +708,11 @@ static constexpr Quirk fullTable[] = {
         .behaviors = { isMicrosoftTeamsRedirectURLQuirk } },
 
     { .match = URLMatch::domain("thesaurus.com"_s),
-        .behaviors = { needsAnchorToBeMouseFocusableQuirk },
-        .site = QuirkSite::Thesaurus },
+        .behaviors = { needsAnchorToBeMouseFocusableQuirk } },
 
+    // player.anyclip.com rdar://138789765
     { .match = URLMatch::domain("thesaurus.com"_s),
-        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .behaviors = { needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(chromeUserAgentScript)).when(anyclipPlayerScriptURL) },
         .isAvailable = iOSFamily },
 
     { .match = URLMatch::domain("tiktok.com"_s),
@@ -727,11 +782,10 @@ static constexpr Quirk fullTable[] = {
 
     { .match = URLMatch::domain("webex.com"_s),
         .behaviors = {
-            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
+            needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirkParameters::fromScript(webExUndefinedTouchScript)).when(webExPushDownloadScriptURL),
             // webex.com rdar://143715630
             needsWebExScrollabilityQuirk,
         },
-        .site = QuirkSite::WebEx,
         .isAvailable = iOSFamily && desktopContentModeQuirks },
 
     // weebly.com rdar://48003980
@@ -873,6 +927,31 @@ static constexpr Quirk fullTable[] = {
         } },
 };
 
+consteval bool everyQuirkHasValidParameters()
+{
+    for (auto& quirk : fullTable) {
+        for (auto& behavior : quirk.behaviors.span()) {
+            auto parametersNeeded = behavior.quirkParametersNeeded;
+            if (parametersNeeded.isEmpty()) {
+                if (behavior.parameters)
+                    return false;
+                continue;
+            }
+
+            if (!behavior.parameters)
+                return false;
+
+            // FIXME: ASCIILiteral::isEmpty() is not constexpr, but length() is.
+            if (parametersNeeded.contains(QuirkParametersNeeded::NeedsScript) && !behavior.parameters->script.length())
+                return false;
+        }
+    }
+
+    return true;
+}
+
+static_assert(everyQuirkHasValidParameters(), "A quirk in fullTable declares QuirkParametersNeeded but does not supply them, or supplies parameters it does not declare");
+
 consteval bool shouldEmit(const Quirk& quirk)
 {
     if (!quirk.isAvailable)
@@ -936,7 +1015,7 @@ bool QuirkURLMatch::matches(const URLMatchContext& topContext, const URLMatchCon
 
 void Quirk::apply(QuirksData& quirksData) const
 {
-    quirksData.enableQuirks(behaviors.span());
+    quirksData.applyTableRow(behaviors.span());
 
     if (site)
         quirksData.addSite(*site);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -126,55 +126,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Quirks);
 
-#if PLATFORM(IOS_FAMILY)
-static constexpr auto chromeUserAgentScript = "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
-
-// nba.com rdar://147429596
-static constexpr auto nbaSeekBarFixScript = R"js(if (!window.__nbaSeekFix) {
-    window.__nbaSeekFix = true;
-    document.addEventListener('touchmove', function({ target, touches }) {
-        if (!target?.getAttribute
-            || target.getAttribute('data-id') !== 'video-player:scrub-bar:controls'
-            || !touches?.[0])
-            return;
-        const touch = touches[0];
-        const rect = target.getBoundingClientRect();
-        const event = new MouseEvent('mousemove', {
-            clientX: touch.clientX,
-            clientY: touch.clientY,
-            screenX: touch.screenX,
-            screenY: touch.screenY,
-            bubbles: true,
-            cancelable: true
-        });
-        Object.defineProperty(event, 'offsetX', { value: touch.clientX - rect.left, configurable: true });
-        Object.defineProperty(event, 'offsetY', { value: touch.clientY - rect.top, configurable: true });
-        target.dispatchEvent(event);
-    }, false);
-})js"_s;
-#endif
-
-// ceac.state.gov rdar://170258502
-static constexpr auto ceacBeforeUnloadFixScript = R"js((function() {
-    if (window.__ceacBeforeUnloadFix) return;
-    window.__ceacBeforeUnloadFix = true;
-    var origAEL = window.addEventListener;
-    window.addEventListener = function(type, fn, opts) {
-        if (type === 'beforeunload') {
-            return origAEL.call(this, type, function(e) {
-                var ae = document.activeElement;
-                if (ae && ae.tagName === 'INPUT') {
-                    var t = (ae.type || '').toLowerCase();
-                    if (t === 'radio' || t === 'checkbox' || t === 'submit' || t === 'button')
-                        return;
-                }
-                if (typeof fn === 'function') fn.call(this, e);
-            }, opts);
-        }
-        return origAEL.apply(this, arguments);
-    };
-})();)js"_s;
-
 static inline OptionSet<AutoplayQuirk> NODELETE allowedAutoplayQuirks(Document& document)
 {
     auto* loader = document.loader();
@@ -2118,49 +2069,10 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE({ });
 
-    if (!m_quirksData.quirkIsEnabled(SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk))
-        return { };
-
     if (scriptURL.isEmpty())
         return { };
 
-    // iheart.com rdar://171198911
-    if (m_quirksData.isSite(QuirkSite::IHeart))
-        return "document.cookie = 'app=listen:60; path=/; domain=.iheart.com';"_s;
-
-    // bestbuy.com rdar://136235936
-    if (m_quirksData.isSite(QuirkSite::BestBuy)) [[unlikely]]
-        return "Object.defineProperty(navigator,'language',{get:function(){return'en-US'}});Object.defineProperty(navigator,'languages',{get:function(){return['en-US','en']}});"_s;
-
-#if PLATFORM(IOS_FAMILY)
-    // player.anyclip.com rdar://138789765
-    if ((m_quirksData.isSite(QuirkSite::Dictionary) || m_quirksData.isSite(QuirkSite::Thesaurus)) && scriptURL.lastPathComponent().endsWith("lre.js"_s)) [[unlikely]] {
-        if (scriptURL.host() == "player.anyclip.com"_s)
-            return chromeUserAgentScript;
-    }
-
-    if (m_quirksData.quirkIsEnabled(SiteSpecificQuirk::NeedsGoogleTranslateScrollingQuirk)) [[unlikely]]
-        return chromeUserAgentScript;
-
-    // nba.com rdar://147429596
-    if (m_quirksData.isSite(QuirkSite::NBA) && !scriptURL.isEmpty()) [[unlikely]]
-        return nbaSeekBarFixScript;
-
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (m_quirksData.isSite(QuirkSite::WebEx) && scriptURL.lastPathComponent().startsWith("pushdownload."_s)) [[unlikely]]
-        return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
-#endif
-#endif
-
-    // ceac.state.gov rdar://170258502
-    if (m_quirksData.isSite(QuirkSite::CEAC) && scriptURL.lastPathComponent() == "CheckBrowserClose.js"_s) [[unlikely]]
-        return ceacBeforeUnloadFixScript;
-
-    // invideo.io https://webkit.org/b/311602
-    if (m_quirksData.isSite(QuirkSite::InVideo)) [[unlikely]]
-        return "if(!window.chrome)window.chrome={};"_s;
-
-    return { };
+    return m_quirksData.scriptsToEvaluateBeforeRunningScript(scriptURL);
 }
 
 // disneyplus: rdar://137613110
@@ -2884,7 +2796,7 @@ void Quirks::determineRelevantQuirks()
         return;
 
     Ref document = *protect(m_document);
-    m_quirksData.merge(resolveSiteSpecificQuirks({ quirksURL, document->url(), document->isTopDocument() ? IsTopDocument::Yes : IsTopDocument::No }));
+    m_quirksData.merge(resolveSiteSpecificQuirks(quirksURL, document->url(), document->isTopDocument() ? IsTopDocument::Yes : IsTopDocument::No));
 
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
     // rdar://133423460
@@ -2913,10 +2825,9 @@ void Quirks::logQuirksToConsoleIfNecessary() const
 
 Vector<String> Quirks::activeQuirks() const
 {
-    Vector<String> result;
-
-    for (auto quirk : m_quirksData.activeQuirks)
-        result.append(String { WTF::enumName(static_cast<SiteSpecificQuirk>(quirk)) });
+    auto result = m_quirksData.behaviors.map([](auto& behavior) {
+        return quirkBehaviorName(behavior).toString();
+    });
 
     std::ranges::sort(result, codePointCompareLessThan);
     return result;
@@ -2924,7 +2835,7 @@ Vector<String> Quirks::activeQuirks() const
 
 bool Quirks::hasRelevantQuirks() const
 {
-    return !m_quirksData.activeQuirks.isEmpty();
+    return !m_quirksData.behaviors.isEmpty();
 }
 
 }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -121,55 +121,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Quirks);
 
-#if PLATFORM(IOS_FAMILY)
-static constexpr auto chromeUserAgentScript = "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
-
-// nba.com rdar://147429596
-static constexpr auto nbaSeekBarFixScript = R"js(if (!window.__nbaSeekFix) {
-    window.__nbaSeekFix = true;
-    document.addEventListener('touchmove', function({ target, touches }) {
-        if (!target?.getAttribute
-            || target.getAttribute('data-id') !== 'video-player:scrub-bar:controls'
-            || !touches?.[0])
-            return;
-        const touch = touches[0];
-        const rect = target.getBoundingClientRect();
-        const event = new MouseEvent('mousemove', {
-            clientX: touch.clientX,
-            clientY: touch.clientY,
-            screenX: touch.screenX,
-            screenY: touch.screenY,
-            bubbles: true,
-            cancelable: true
-        });
-        Object.defineProperty(event, 'offsetX', { value: touch.clientX - rect.left, configurable: true });
-        Object.defineProperty(event, 'offsetY', { value: touch.clientY - rect.top, configurable: true });
-        target.dispatchEvent(event);
-    }, false);
-})js"_s;
-#endif
-
-// ceac.state.gov rdar://170258502
-static constexpr auto ceacBeforeUnloadFixScript = R"js((function() {
-    if (window.__ceacBeforeUnloadFix) return;
-    window.__ceacBeforeUnloadFix = true;
-    var origAEL = window.addEventListener;
-    window.addEventListener = function(type, fn, opts) {
-        if (type === 'beforeunload') {
-            return origAEL.call(this, type, function(e) {
-                var ae = document.activeElement;
-                if (ae && ae.tagName === 'INPUT') {
-                    var t = (ae.type || '').toLowerCase();
-                    if (t === 'radio' || t === 'checkbox' || t === 'submit' || t === 'button')
-                        return;
-                }
-                if (typeof fn === 'function') fn.call(this, e);
-            }, opts);
-        }
-        return origAEL.apply(this, arguments);
-    };
-})();)js"_s;
-
 static inline OptionSet<AutoplayQuirk> NODELETE allowedAutoplayQuirks(Document& document)
 {
     auto* loader = document.loader();
@@ -208,7 +159,7 @@ static inline String NODELETE standardUserAgentWithApplicationNameIncludingCompa
 
 static bool urlHasQuirk(const URL& url, const QuirkBehavior& quirk)
 {
-    return resolveTopURLQuirks(url).quirkIsEnabled(quirk);
+    return resolveTopURLQuirks(url).isBehaviorEnabled(quirk);
 }
 
 Quirks::Quirks(Document& document)
@@ -240,7 +191,7 @@ bool Quirks::needsAnchorToBeMouseFocusable(const Element& anchor) const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsAnchorToBeMouseFocusableQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsAnchorToBeMouseFocusableQuirk))
         return false;
 
     // On a Google search page only the links inside the "Where to watch" panel need
@@ -271,14 +222,14 @@ bool Quirks::needsFormControlToBeMouseFocusable() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsFormControlToBeMouseFocusableQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsFormControlToBeMouseFocusableQuirk);
 }
 
 bool Quirks::needsAutoplayPlayPauseEvents() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDispatchPlayPauseEventsOnResume))
+    if (m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDispatchPlayPauseEventsOnResume))
         return true;
 
     Ref document = *m_document;
@@ -297,7 +248,7 @@ bool Quirks::needsSeekingSupportDisabled() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsSeekingSupportDisabledQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsSeekingSupportDisabledQuirk);
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=193301
@@ -319,7 +270,7 @@ bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAutoplayWebAudioForArbitraryUserGestureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAutoplayWebAudioForArbitraryUserGestureQuirk);
 }
 
 // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
@@ -330,7 +281,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 #else
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::hasBrokenEncryptedMediaAPISupportQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::hasBrokenEncryptedMediaAPISupportQuirk);
 #endif
 }
 
@@ -339,7 +290,7 @@ bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::isTouchBarUpdateSuppressedForHiddenContentEditableQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::isTouchBarUpdateSuppressedForHiddenContentEditableQuirk);
 }
 
 // icloud.com rdar://26013388
@@ -350,7 +301,7 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::isNeverRichlyEditableForTouchBarQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::isNeverRichlyEditableForTouchBarQuirk);
 }
 
 // docs.google.com rdar://49864669
@@ -359,7 +310,7 @@ bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAr
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk);
 }
 
 // weebly.com rdar://48003980
@@ -371,7 +322,7 @@ bool Quirks::shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const
 
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk);
 }
 
 // www.youtube.com rdar://52361019
@@ -382,21 +333,21 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
 
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsYouTubeMouseOutQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsYouTubeMouseOutQuirk);
 }
 
 bool Quirks::needsYouTubeCaptionsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsYouTubeCaptionQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsYouTubeCaptionQuirk);
 }
 
 bool Quirks::needsCNNCaptionQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsCNNCaptionQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsCNNCaptionQuirk);
 }
 
 // The sites whose in-page captions WebKit mirrors into a text track rdar://174708144
@@ -410,7 +361,7 @@ bool Quirks::needsYouTubeEmbedAutoplayQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsYouTubeEmbedAutoplayQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsYouTubeEmbedAutoplayQuirk);
 }
 
 // safe.menlosecurity.com rdar://135114489
@@ -419,7 +370,7 @@ bool Quirks::shouldDisableWritingSuggestionsByDefault() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableWritingSuggestionsByDefaultQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableWritingSuggestionsByDefaultQuirk);
 }
 
 void Quirks::updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&& userAgentStringQuirks)
@@ -448,7 +399,7 @@ String Quirks::storageAccessUserAgentStringQuirkForDomain(const URL& url)
 bool Quirks::ensureCaptionVisibilityInFullscreenAndPictureInPicture() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::ensureCaptionVisibilityInFullscreenAndPictureInPicture);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::ensureCaptionVisibilityInFullscreenAndPictureInPicture);
 }
 
 bool Quirks::shouldDisableElementFullscreenQuirk() const
@@ -465,7 +416,7 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     // (Ref: rdar://121473410)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableElementFullscreenQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableElementFullscreenQuirk);
 }
 
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
@@ -491,7 +442,7 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
 
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDispatchSimulatedMouseEventsQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDispatchSimulatedMouseEventsQuirk))
         return false;
 
     auto* loader = m_document->loader();
@@ -520,7 +471,7 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldPreventDispatchOfTouchEventQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldPreventDispatchOfTouchEventQuirk))
         return false;
 
     // yahoo.com : rdar://142894603
@@ -561,7 +512,7 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
     if (!shouldDispatchSimulatedMouseEvents(target))
         return false;
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk))
         return false;
 
     RefPtr element = dynamicDowncast<Element>(target);
@@ -616,7 +567,7 @@ bool Quirks::shouldAvoidResizingWhenInputViewBoundsChange() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAvoidResizingWhenInputViewBoundsChangeQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAvoidResizingWhenInputViewBoundsChangeQuirk);
 }
 
 // mailchimp.com rdar://47868965
@@ -624,7 +575,7 @@ bool Quirks::shouldDisablePointerEventsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisablePointerEventsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisablePointerEventsQuirk);
 }
 
 // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
@@ -648,14 +599,14 @@ bool Quirks::inputMethodMustUseCompositionEvents() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::inputMethodMustUseCompositionEvents);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::inputMethodMustUseCompositionEvents);
 }
 
 bool Quirks::shouldIgnoreInputModeNone() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnoreInputModeNone);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnoreInputModeNone);
 }
 
 // rdar://176981763
@@ -674,7 +625,7 @@ bool Quirks::needsGMailOverflowScrollQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsGMailOverflowScrollQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsGMailOverflowScrollQuirk);
 }
 
 // FIXME: Remove after the site is fixed, <rdar://problem/50374311>
@@ -683,7 +634,7 @@ bool Quirks::needsYouTubeOverflowScrollQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsYouTubeOverflowScrollQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsYouTubeOverflowScrollQuirk);
 }
 
 // webex.com rdar://143715630
@@ -691,7 +642,7 @@ bool Quirks::needsWebExScrollabilityQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsWebExScrollabilityQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsWebExScrollabilityQuirk);
 }
 // facebook.com https://webkit.org/b/295071
 // FIXME: https://webkit.org/b/295318
@@ -699,7 +650,7 @@ bool Quirks::needsFacebookRemoveNotSupportedQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsFacebookRemoveNotSupportedQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsFacebookRemoveNotSupportedQuirk);
 }
 
 // youtube.com rdar://135886305
@@ -708,7 +659,7 @@ bool Quirks::needsScrollbarWidthThinDisabledQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsScrollbarWidthThinDisabledQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsScrollbarWidthThinDisabledQuirk);
 }
 
 // spotify.com rdar://138918575
@@ -716,7 +667,7 @@ bool Quirks::needsBodyScrollbarWidthNoneDisabledQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsBodyScrollbarWidthNoneDisabledQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsBodyScrollbarWidthNoneDisabledQuirk);
 }
 
 // airindiaexpress.com https://webkit.org/b/317375
@@ -724,7 +675,7 @@ bool Quirks::needsAirIndiaExpressLayeringQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsAirIndiaExpressLayeringQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsAirIndiaExpressLayeringQuirk);
 }
 
 // gizmodo.com rdar://102227302
@@ -732,7 +683,7 @@ bool Quirks::needsFullscreenDisplayNoneQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsFullscreenDisplayNoneQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsFullscreenDisplayNoneQuirk);
 }
 
 // cnn.com rdar://119640248
@@ -740,7 +691,7 @@ bool Quirks::needsFullscreenObjectFitQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsFullscreenObjectFitQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsFullscreenObjectFitQuirk);
 }
 
 // zomato.com <rdar://problem/128962778>
@@ -748,7 +699,7 @@ bool Quirks::needsZomatoEmailLoginLabelQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsZomatoEmailLoginLabelQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsZomatoEmailLoginLabelQuirk);
 }
 
 // maps.google.com rdar://67358928
@@ -756,7 +707,7 @@ bool Quirks::needsGoogleMapsScrollingQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsGoogleMapsScrollingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsGoogleMapsScrollingQuirk);
 }
 
 // translate.google.com rdar://106539018
@@ -764,7 +715,7 @@ bool Quirks::needsGoogleTranslateScrollingQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsGoogleTranslateScrollingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsGoogleTranslateScrollingQuirk);
 }
 
 // netflix.com rdar://178545839
@@ -772,7 +723,7 @@ bool Quirks::needsNetflixVolumeSliderQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsNetflixVolumeSliderQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsNetflixVolumeSliderQuirk);
 }
 
 // play.geforcenow.com https://webkit.org/b/303622
@@ -781,7 +732,7 @@ bool Quirks::needsGeforcenowWarningDisplayNoneQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsGeforcenowWarningDisplayNoneQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsGeforcenowWarningDisplayNoneQuirk);
 }
 
 // yahoo.com rdar://170502516
@@ -789,7 +740,7 @@ bool Quirks::needsYahooVolumeSliderQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsYahooVolumeSliderQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsYahooVolumeSliderQuirk);
 }
 
 // Kugou Music rdar://74602294
@@ -815,14 +766,14 @@ bool Quirks::shouldSilenceResizeObservers() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSilenceResizeObservers);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSilenceResizeObservers);
 }
 
 bool Quirks::shouldSilenceWindowResizeEventsDuringApplicationSnapshotting() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSilenceWindowResizeEventsDuringApplicationSnapshotting))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSilenceWindowResizeEventsDuringApplicationSnapshotting))
         return false;
 
     // We silence window resize events during the 'homing out' snapshot sequence when on icloud.com/mail
@@ -839,14 +790,14 @@ bool Quirks::shouldDeferIntersectionObserversDuringResize() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDeferIntersectionObserversDuringResize);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDeferIntersectionObserversDuringResize);
 }
 
 bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSilenceMediaQueryListChangeEvents))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSilenceMediaQueryListChangeEvents))
         return false;
 
     // We silence MediaQueryList's change events during the 'homing out' snapshot sequence when on x.com (twitter)
@@ -863,7 +814,7 @@ bool Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk);
 }
 
 // discord.com rdar://162719481
@@ -871,7 +822,7 @@ bool Quirks::shouldUseLayoutViewportForClientRects() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldUseLayoutViewportForClientRectsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldUseLayoutViewportForClientRectsQuirk);
 }
 
 // Some input only specify image/* as an acceptable type, which is failing sometimes for certains domain names
@@ -886,7 +837,7 @@ bool Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() con
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk);
 }
 
 // ralphlauren.com rdar://55629493
@@ -894,7 +845,7 @@ bool Quirks::shouldIgnoreAriaForFastPathContentObservationCheck() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnoreAriaForFastPathContentObservationCheckQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnoreAriaForFastPathContentObservationCheckQuirk);
 }
 
 // wikipedia.org https://webkit.org/b/247636
@@ -902,7 +853,7 @@ bool Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk);
 }
 
 // slack.com rdar://138614711
@@ -910,14 +861,14 @@ bool Quirks::shouldIgnoreViewportArgumentsToAvoidEnlargedView() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk);
 }
 
 // slack.com rdar://171190689
 bool Quirks::shouldUseDynamicViewportUnitsAsDefault() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldUseDynamicViewportUnitsAsDefaultQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldUseDynamicViewportUnitsAsDefaultQuirk);
 }
 
 // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199933
@@ -949,7 +900,7 @@ bool Quirks::needsPreloadAutoQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsPreloadAutoQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsPreloadAutoQuirk);
 }
 
 // espn.com rdar://184169028
@@ -957,7 +908,7 @@ bool Quirks::needsSuppressedPauseEventOnFullscreenExitQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsSuppressedPauseEventOnFullscreenExitQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsSuppressedPauseEventOnFullscreenExitQuirk);
 }
 
 // vimeo.com rdar://56996057
@@ -967,7 +918,7 @@ bool Quirks::shouldBypassBackForwardCache() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::maybeBypassBackForwardCache))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::maybeBypassBackForwardCache))
         return false;
 
     RefPtr document = m_document.get();
@@ -1023,7 +974,7 @@ bool Quirks::shouldBypassAsyncScriptDeferring() const
 
     // Deferring 'mapbox-gl.js' script on bungalow.com causes the script to get in a bad state (rdar://problem/61658940).
     // Deferring the google maps script on sfusd.edu may get the page in a bad state (rdar://116292738).
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldBypassAsyncScriptDeferring);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldBypassAsyncScriptDeferring);
 }
 
 // smoothscroll JS library rdar://52712513
@@ -1069,7 +1020,7 @@ bool Quirks::shouldEnableFacebookFlagQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableFacebookFlagQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableFacebookFlagQuirk);
 }
 
 static Ref<Element> createFacebookFlagElement(Document& document, ASCIILiteral value)
@@ -1095,7 +1046,7 @@ static Vector<Ref<Element>> copyElements(const NodeList& nodeList)
 
 Ref<NodeList> Quirks::applyFacebookFlagQuirk(Document& document, NodeList& nodeList)
 {
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldEnableFacebookFlagQuirk, false);
+    m_quirksData.setEnabled(QuirkBehaviors::shouldEnableFacebookFlagQuirk.id, false);
 
     if (!document.settings().facebookLiveRecordingQuirkEnabled())
         return nodeList;
@@ -1110,7 +1061,7 @@ bool Quirks::shouldEnableLegacyGetUserMediaQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableLegacyGetUserMediaQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableLegacyGetUserMediaQuirk);
 }
 
 // zoom.us rdar://118185086
@@ -1118,56 +1069,56 @@ bool Quirks::shouldDisableImageCaptureQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableImageCaptureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableImageCaptureQuirk);
 }
 
 bool Quirks::shouldAllowMediaStreamTrackSerializationQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAllowMediaStreamTrackSerializationQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAllowMediaStreamTrackSerializationQuirk);
 }
 
 bool Quirks::shouldEnableCameraAndMicrophonePermissionStateQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableCameraAndMicrophonePermissionStateQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableCameraAndMicrophonePermissionStateQuirk);
 }
 
 bool Quirks::shouldEnableRemoteTrackLabelQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableRemoteTrackLabelQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableRemoteTrackLabelQuirk);
 }
 
 bool Quirks::shouldEnableCameraBackgroundPlayback() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableCameraBackgroundPlayback);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableCameraBackgroundPlayback);
 }
 
 bool Quirks::shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableSpeakerSelectionPermissionsPolicyQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableSpeakerSelectionPermissionsPolicyQuirk);
 }
 
 bool Quirks::shouldEnableEnumerateDeviceQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableEnumerateDeviceQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableEnumerateDeviceQuirk);
 }
 
 bool Quirks::shouldEnableRTCEncodedStreamsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableRTCEncodedStreamsQuirk) && m_document && m_document->settings().rtcEncodedStreamsQuirkEnabled();
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableRTCEncodedStreamsQuirk) && m_document && m_document->settings().rtcEncodedStreamsQuirkEnabled();
 }
 
 // FIXME: Remove this Quirk if Pinterest decides to trigger this notification from an user gesture (rdar://165745719)
@@ -1175,14 +1126,14 @@ bool Quirks::shouldAllowNotificationPermissionWithoutUserGesture() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAllowNotificationPermissionWithoutUserGesture);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAllowNotificationPermissionWithoutUserGesture);
 }
 
 bool Quirks::shouldUnloadHeavyFrame() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldUnloadHeavyFrames);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldUnloadHeavyFrames);
 }
 
 // hulu.com rdar://55041979
@@ -1190,7 +1141,7 @@ bool Quirks::needsCanPlayAfterSeekedQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsCanPlayAfterSeekedQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsCanPlayAfterSeekedQuirk);
 }
 
 // wikipedia.org rdar://54856323
@@ -1200,7 +1151,7 @@ bool Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() co
 
     // FIXME: We should consider replacing this with a heuristic to determine whether
     // or not the edges of the page mostly lack content after shrinking to fit.
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk);
 }
 
 bool Quirks::shouldNotAutoUpgradeToHTTPSNavigation(const URL& url)
@@ -1423,7 +1374,7 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
     // Facebook, X (twitter), and Reddit will naively pause a <video> element that has scrolled out of the viewport,
     // regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/67273166>, <rdar://problem/73369869>, and <rdar://problem/80645747> have been fixed.
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::requiresUserGestureToPauseInPictureInPictureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::requiresUserGestureToPauseInPictureInPictureQuirk);
 }
 
 // sports.yahoo.com: rdar://148284059
@@ -1431,7 +1382,7 @@ bool Quirks::requiresUserGestureToPauseInFullscreenAfterOrientationChange() cons
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::requiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::requiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk);
 }
 
 // youtube.com: rdar://178769976
@@ -1439,7 +1390,7 @@ bool Quirks::requiresUserGestureToPlayInFullscreen() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::requiresUserGestureToPlayInFullscreenQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::requiresUserGestureToPlayInFullscreenQuirk);
 }
 
 // bbc.co.uk: rdar://126494734
@@ -1448,7 +1399,7 @@ bool Quirks::returnNullPictureInPictureElementDuringFullscreenChange() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::returnNullPictureInPictureElementDuringFullscreenChangeQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::returnNullPictureInPictureElementDuringFullscreenChangeQuirk);
 }
 
 // x.com: rdar://73369869
@@ -1459,7 +1410,7 @@ bool Quirks::requiresUserGestureToLoadInPictureInPicture() const
     // X (Twitter) will remove the "src" attribute of a <video> element that has scrolled out of the viewport and
     // load the <video> element with an empty "src" regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/73369869> has been fixed.
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::requiresUserGestureToLoadInPictureInPictureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::requiresUserGestureToLoadInPictureInPictureQuirk);
 }
 
 // vimeo.com: rdar://problem/70788878
@@ -1471,7 +1422,7 @@ bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
     // returns to fullscreen from picture-in-picture. This quirk disables the "return to fullscreen
     // from picture-in-picture" feature for those sites. We should remove the quirk once
     // rdar://problem/73167931 has been fixed.
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::blocksReturnToFullscreenFromPictureInPictureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::blocksReturnToFullscreenFromPictureInPictureQuirk);
 }
 
 // vimeo.com: rdar://107592139
@@ -1481,7 +1432,7 @@ bool Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const
 
     // Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
     // This behavior is revealing a bug in the fullscreen handling. See rdar://107592139.
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::blocksEnteringStandardFullscreenFromPictureInPictureQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::blocksEnteringStandardFullscreenFromPictureInPictureQuirk);
 }
 
 // espn.com: rdar://problem/73227900
@@ -1494,7 +1445,7 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
     // from fullscreen for the sites which cannot handle the event properly in that case.
     // We should remove once the quirks have been fixed.
     // <rdar://90393832> vimeo.com
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk);
 }
 
 // teams.live.com rdar://88678598
@@ -1511,7 +1462,7 @@ bool Quirks::allowLayeredFullscreenVideos() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::allowLayeredFullscreenVideos);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::allowLayeredFullscreenVideos);
 }
 
 // x.com: rdar://132850672
@@ -1520,7 +1471,7 @@ bool Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk);
 }
 
 // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
@@ -1531,7 +1482,7 @@ bool Quirks::shouldEnableFontLoadingAPIQuirk() const
     if (m_document->settings().downloadableBinaryFontTrustedTypes() == DownloadableBinaryFontTrustedTypes::Any)
         return false;
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnableFontLoadingAPIQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnableFontLoadingAPIQuirk);
 }
 
 // play.hbomax.com rdar://158430821
@@ -1539,7 +1490,7 @@ bool Quirks::shouldDisableAdSkippingInPip() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableAdSkippingInPip);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableAdSkippingInPip);
 }
 
 // hulu.com rdar://100199996
@@ -1547,7 +1498,7 @@ bool Quirks::needsVideoShouldMaintainAspectRatioQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsVideoShouldMaintainAspectRatioQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsVideoShouldMaintainAspectRatioQuirk);
 }
 
 // Marcus: <rdar://101086391>.
@@ -1557,7 +1508,7 @@ bool Quirks::shouldExposeShowModalDialog() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldExposeShowModalDialog);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldExposeShowModalDialog);
 }
 
 // marcus.com rdar://102959860
@@ -1565,7 +1516,7 @@ bool Quirks::shouldNavigatorPluginsBeEmpty() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldNavigatorPluginsBeEmpty);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldNavigatorPluginsBeEmpty);
 }
 
 // Fix for the UNIQLO app (rdar://104519846).
@@ -1573,7 +1524,7 @@ bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableLazyIframeLoadingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableLazyIframeLoadingQuirk);
 }
 
 // Moon Player app (rdar://162452658): the app hides its WKWebView while continuing to display
@@ -1583,7 +1534,7 @@ bool Quirks::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
 }
 
 // reddit.com with Sink It extension (rdar://176377447) and apple.com/retail (rdar://181007316).
@@ -1591,7 +1542,7 @@ bool Quirks::shouldDisableScrollAnchoringQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableScrollAnchoringQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableScrollAnchoringQuirk))
         return false;
 
 #if PLATFORM(IOS_FAMILY)
@@ -1614,14 +1565,14 @@ bool Quirks::shouldDisableFetchMetadata() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableFetchMetadata);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableFetchMetadata);
 }
 
 bool Quirks::shouldBlockFetchWithNewlineAndLessThan() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldBlockFetchWithNewlineAndLessThan);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldBlockFetchWithNewlineAndLessThan);
 }
 
 // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
@@ -1629,7 +1580,7 @@ bool Quirks::shouldDisablePushStateFilePathRestrictions() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisablePushStateFilePathRestrictions);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisablePushStateFilePathRestrictions);
 }
 
 // ungap/@custom-elements polyfill (rdar://problem/111008826).
@@ -1694,7 +1645,7 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 #if PLATFORM(IOS_FAMILY)
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsResettingTransitionCancelsRunningTransitionQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsResettingTransitionCancelsRunningTransitionQuirk);
 #else
     return false;
 #endif
@@ -1705,14 +1656,14 @@ bool Quirks::shouldDisableDataURLPaddingValidation() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableDataURLPaddingValidation);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableDataURLPaddingValidation);
 }
 
 bool Quirks::needsDisableDOMPasteAccessQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return quirkIsEnabledAfterProbing(QuirkBehaviors::needsDisableDOMPasteAccessQuirk, [&] {
+    return isBehaviorEnabledAfterProbing(QuirkBehaviors::needsDisableDOMPasteAccessQuirk, [&] {
         RefPtr document = m_document.get();
         if (!document)
             return false;
@@ -1732,7 +1683,7 @@ bool Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk);
 }
 
 // rdar://133423460
@@ -1740,7 +1691,7 @@ bool Quirks::shouldFlipScreenDimensions() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldFlipScreenDimensionsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldFlipScreenDimensionsQuirk);
 }
 
 // rdar://175565114
@@ -1748,7 +1699,7 @@ bool Quirks::shouldAvoidProgrammaticScrollClamping() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAvoidProgrammaticScrollClampingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAvoidProgrammaticScrollClampingQuirk);
 }
 
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
@@ -1839,7 +1790,7 @@ bool Quirks::shouldIgnorePlaysInlineRequirementQuirk() const
 #if PLATFORM(IOS_FAMILY)
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnorePlaysInlineRequirementQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnorePlaysInlineRequirementQuirk);
 #else
     return false;
 #endif
@@ -1919,7 +1870,7 @@ bool Quirks::shouldIgnoreTextAutoSizing() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldIgnoreTextAutoSizingQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldIgnoreTextAutoSizingQuirk);
 }
 
 std::optional<TargetedElementSelectors> Quirks::defaultVisibilityAdjustmentSelectors(const URL& requestURL)
@@ -1932,53 +1883,23 @@ std::optional<TargetedElementSelectors> Quirks::defaultVisibilityAdjustmentSelec
 #endif
 }
 
-String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
+Vector<String, 1> Quirks::scriptsToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE({ });
-
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk))
-        return { };
 
     if (scriptURL.isEmpty())
         return { };
 
-    // iheart.com rdar://171198911
-    if (m_quirksData.isSite(QuirkSite::IHeart))
-        return "document.cookie = 'app=listen:60; path=/; domain=.iheart.com';"_s;
+    auto& behavior = QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk;
+    if (!m_quirksData.isBehaviorEnabled(behavior))
+        return { };
 
-    // bestbuy.com rdar://136235936
-    if (m_quirksData.isSite(QuirkSite::BestBuy)) [[unlikely]]
-        return "Object.defineProperty(navigator,'language',{get:function(){return'en-US'}});Object.defineProperty(navigator,'languages',{get:function(){return['en-US','en']}});"_s;
+    URLMatchContext scriptURLContext { scriptURL };
+    Vector<String, 1> scripts;
+    for (auto& parameters : m_quirksData.parametersFor(behavior, scriptURLContext))
+        scripts.append(parameters.script);
 
-#if PLATFORM(IOS_FAMILY)
-    // player.anyclip.com rdar://138789765
-    if ((m_quirksData.isSite(QuirkSite::Dictionary) || m_quirksData.isSite(QuirkSite::Thesaurus)) && scriptURL.lastPathComponent().endsWith("lre.js"_s)) [[unlikely]] {
-        if (scriptURL.host() == "player.anyclip.com"_s)
-            return chromeUserAgentScript;
-    }
-
-    if (m_quirksData.quirkIsEnabled(QuirkBehaviors::needsGoogleTranslateScrollingQuirk)) [[unlikely]]
-        return chromeUserAgentScript;
-
-    // nba.com rdar://147429596
-    if (m_quirksData.isSite(QuirkSite::NBA) && !scriptURL.isEmpty()) [[unlikely]]
-        return nbaSeekBarFixScript;
-
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (m_quirksData.isSite(QuirkSite::WebEx) && scriptURL.lastPathComponent().startsWith("pushdownload."_s)) [[unlikely]]
-        return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
-#endif
-#endif
-
-    // ceac.state.gov rdar://170258502
-    if (m_quirksData.isSite(QuirkSite::CEAC) && scriptURL.lastPathComponent() == "CheckBrowserClose.js"_s) [[unlikely]]
-        return ceacBeforeUnloadFixScript;
-
-    // invideo.io https://webkit.org/b/311602
-    if (m_quirksData.isSite(QuirkSite::InVideo)) [[unlikely]]
-        return "if(!window.chrome)window.chrome={};"_s;
-
-    return { };
+    return scripts;
 }
 
 // disneyplus: rdar://137613110
@@ -1986,7 +1907,7 @@ bool Quirks::shouldHideCoarsePointerCharacteristics() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldHideCoarsePointerCharacteristicsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldHideCoarsePointerCharacteristicsQuirk);
 }
 
 // hulu.com rdar://126096361
@@ -1994,7 +1915,7 @@ bool Quirks::implicitMuteWhenVolumeSetToZero() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::implicitMuteWhenVolumeSetToZero);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::implicitMuteWhenVolumeSetToZero);
 }
 
 bool Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(const URL& requestURL)
@@ -2008,7 +1929,7 @@ bool Quirks::shouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick);
 }
 
 // hbomax.com: rdar://138424489
@@ -2016,7 +1937,7 @@ bool Quirks::needsZeroMaxTouchPointsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsZeroMaxTouchPointsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsZeroMaxTouchPointsQuirk);
 }
 
 // imdb.com: rdar://137991466
@@ -2024,7 +1945,7 @@ bool Quirks::needsChromeMediaControlsPseudoElement() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsChromeMediaControlsPseudoElementQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsChromeMediaControlsPseudoElementQuirk);
 }
 
 static AccessibilityRole accessibilityRole(const Element& element)
@@ -2038,7 +1959,7 @@ bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) cons
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::mayNeedToIgnoreContentObservation))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::mayNeedToIgnoreContentObservation))
         return false;
 
     if (m_quirksData.isSite(QuirkSite::GoogleMaps)) {
@@ -2071,7 +1992,7 @@ bool Quirks::shouldHideSoftTopScrollEdgeEffectDuringFocus(const Element& focused
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldHideSoftTopScrollEdgeEffectDuringFocusQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldHideSoftTopScrollEdgeEffectDuringFocusQuirk))
         return false;
 
     return focusedElement.getIdAttribute().contains("crossword"_s);
@@ -2083,7 +2004,7 @@ bool Quirks::shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element& ta
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk))
         return false;
 
     if (m_quirksData.isSite(QuirkSite::CBSSports))
@@ -2107,7 +2028,7 @@ bool Quirks::needsChromeOSNavigatorUserAgentQuirk(const Document& document) cons
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsChromeOSNavigatorUserAgentQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsChromeOSNavigatorUserAgentQuirk))
         return false;
 
     if (document.url().lastPathComponent() != "wordeditorframe.aspx"_s)
@@ -2124,7 +2045,7 @@ bool Quirks::shouldSendFakeTouchForceChangeEvent() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSendFakeTouchForceChangeEvent);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSendFakeTouchForceChangeEvent);
 }
 
 // store.steampowered.com: rdar://142573562
@@ -2132,7 +2053,7 @@ bool Quirks::shouldTreatAddingMouseOutEventListenerAsContentChange() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldTreatAddingMouseOutEventListenerAsContentChange);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldTreatAddingMouseOutEventListenerAsContentChange);
 }
 
 // outlook.live.com: rdar://136624720
@@ -2140,7 +2061,7 @@ bool Quirks::needsMozillaFileTypeForDataTransfer() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsMozillaFileTypeForDataTransferQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsMozillaFileTypeForDataTransferQuirk);
 }
 
 // spotify.com rdar://171119015
@@ -2148,7 +2069,7 @@ bool Quirks::shouldLimitHLSPlaybackRate() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldLimitHLSPlaybackRate);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldLimitHLSPlaybackRate);
 }
 
 // nfl.com:
@@ -2156,7 +2077,7 @@ bool Quirks::shouldSuppressHLSSubtitles() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSuppressHLSSubtitles);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSuppressHLSSubtitles);
 }
 
 // spotify.com: block additive audible playback (e.g. Home-page track previews) while another
@@ -2164,14 +2085,14 @@ bool Quirks::shouldSuppressHLSSubtitles() const
 bool Quirks::shouldBlockAudiblePlaybackWhileAudioIsPlaying() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldBlockAudiblePlaybackWhileAudioIsPlaying);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldBlockAudiblePlaybackWhileAudioIsPlaying);
 }
 
 bool Quirks::shouldSuppressMediaSessionPauseActionOnInterruption() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSuppressMediaSessionPauseActionOnInterruption);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSuppressMediaSessionPauseActionOnInterruption);
 }
 
 // spotify.com rdar://140707449
@@ -2179,7 +2100,7 @@ bool Quirks::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(const Node
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor))
         return false;
 
     if (auto* style = target.renderStyle()) {
@@ -2194,7 +2115,7 @@ bool Quirks::shouldReuseLiveRangeForSelectionUpdate() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsReuseLiveRangeForSelectionUpdateQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsReuseLiveRangeForSelectionUpdateQuirk);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2283,7 +2204,7 @@ bool Quirks::needsExpediaGroupAnimationQuirk(Element& element) const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsExpediaGroupAnimationQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsExpediaGroupAnimationQuirk))
         return false;
 
     // Quick pre-filter to avoid running the full selector match on ~99% of elements.
@@ -2301,7 +2222,7 @@ bool Quirks::needsClaudeSidebarViewportUnitQuirk(Element& element, const Style::
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsClaudeSidebarViewportUnitQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsClaudeSidebarViewportUnitQuirk))
         return false;
 
     if (style.position() != PositionType::Fixed)
@@ -2321,7 +2242,7 @@ bool Quirks::needsClaudeSidebarViewportUnitQuirk(Element& element, const Style::
 bool Quirks::needsHideSelectionDuringOverflowScrollQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsHideSelectionDuringOverflowScrollQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsHideSelectionDuringOverflowScrollQuirk);
 }
 
 // amazon.design rdar://175953409
@@ -2329,7 +2250,7 @@ bool Quirks::needsAmazonDesignMenuViewportUnitQuirk(const Style::ComputedStyle& 
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsAmazonDesignMenuViewportUnitQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsAmazonDesignMenuViewportUnitQuirk))
         return false;
 
     if (style.display() != Style::DisplayType::BlockFlex)
@@ -2357,14 +2278,14 @@ bool Quirks::needsLimitedMatroskaSupport() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsLimitedMatroskaSupportQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsLimitedMatroskaSupportQuirk);
 }
 
 bool Quirks::needsSupportsProgressMonitoring() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsSupportsProgressMonitoringQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsSupportsProgressMonitoringQuirk);
 }
 
 // rdar://174779259.
@@ -2380,7 +2301,7 @@ void Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded(const URL& fetchURL, in
     if (!needsQuirks()) [[unlikely]]
         return;
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsLogoutCookieCleanupQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsLogoutCookieCleanupQuirk))
         return;
 
     if (httpStatusCode < 200 || httpStatusCode >= 300)
@@ -2410,28 +2331,28 @@ bool Quirks::needsCustomUserAgentData() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsCustomUserAgentData);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsCustomUserAgentData);
 }
 
 bool Quirks::needsNavigatorUserAgentDataQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsNavigatorUserAgentDataQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsNavigatorUserAgentDataQuirk);
 }
 
 bool Quirks::needsNowPlayingFullscreenSwapQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsNowPlayingFullscreenSwapQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsNowPlayingFullscreenSwapQuirk);
 }
 
 bool Quirks::needsSuppressPostLayoutBoundaryEventsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsSuppressPostLayoutBoundaryEventsQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsSuppressPostLayoutBoundaryEventsQuirk);
 }
 
 // tiktok.com rdar://149712691
@@ -2439,7 +2360,7 @@ std::optional<Quirks::TikTokOverflowingContentQuirkType> Quirks::needsTikTokOver
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE({ });
 
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsTikTokOverflowingContentQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsTikTokOverflowingContentQuirk))
         return { };
 
     if (parentStyle.display() != Style::DisplayType::BlockFlex)
@@ -2487,7 +2408,7 @@ bool Quirks::needsInstagramResizingReelsQuirk(const Element& element, const Styl
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
 #if ENABLE(VIDEO)
-    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsInstagramResizingReelsQuirk))
+    if (!m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsInstagramResizingReelsQuirk))
         return false;
 
     if (elementStyle.display() != Style::DisplayType::BlockFlow)
@@ -2518,7 +2439,7 @@ bool Quirks::needsWebKitMediaTextTrackDisplayQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsWebKitMediaTextTrackDisplayQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsWebKitMediaTextTrackDisplayQuirk);
 }
 
 // rdar://138806698
@@ -2526,14 +2447,14 @@ bool Quirks::shouldSupportHoverMediaQueries() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldSupportHoverMediaQueriesQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldSupportHoverMediaQueriesQuirk);
 }
 
 bool Quirks::shouldRewriteMediaRangeRequestForURL(const URL& url) const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsMediaRewriteRangeRequestQuirk) && RegistrableDomain(url).string() == "bing.com"_s;
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsMediaRewriteRangeRequestQuirk) && RegistrableDomain(url).string() == "bing.com"_s;
 }
 
 // rdar://106770785
@@ -2548,49 +2469,49 @@ bool Quirks::shouldPreventKeyframeEffectAcceleration(const KeyframeEffect& effec
 
 bool Quirks::shouldDisableThreadedAnimationsQuirk() const
 {
-    return needsQuirks() && m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableThreadedAnimationsQuirk);
+    return needsQuirks() && m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableThreadedAnimationsQuirk);
 }
 
 bool Quirks::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen);
 }
 
 bool Quirks::shouldDelayReloadWhenRegisteringServiceWorker() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDelayReloadWhenRegisteringServiceWorker);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDelayReloadWhenRegisteringServiceWorker);
 }
 
 bool Quirks::shouldDisableDOMAudioSessionQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldDisableDOMAudioSession);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldDisableDOMAudioSession);
 }
 
 bool Quirks::shouldComparareUsedValuesForBorderWidthForTriggeringTransitions() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldComparareUsedValuesForBorderWidthForTriggeringTransitions);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldComparareUsedValuesForBorderWidthForTriggeringTransitions);
 }
 
 bool Quirks::shouldReportVisibleDueToActivePictureInPictureContent() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldReportDocumentAsVisibleIfActivePIPQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldReportDocumentAsVisibleIfActivePIPQuirk);
 }
 
 bool Quirks::needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk);
+    return m_quirksData.isBehaviorEnabled(QuirkBehaviors::needsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk);
 }
 
 URL Quirks::topDocumentURL() const
@@ -2618,20 +2539,20 @@ void Quirks::determineRelevantQuirks()
     static const bool needsResettingTransitionCancelsRunningTransitionQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
     static const bool shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoMediaLayerTeardownOnPageVisibilityChangeQuirk) && WTF::IOSApplication::isMoonPlayer();
 
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldDisableLazyIframeLoadingQuirk, shouldDisableLazyIframeLoadingQuirk);
+    m_quirksData.setEnabled(QuirkBehaviors::shouldDisableLazyIframeLoadingQuirk.id, shouldDisableLazyIframeLoadingQuirk);
 
     // DOFUS Touch app (rdar://112679186)
-    m_quirksData.setQuirkState(QuirkBehaviors::needsResettingTransitionCancelsRunningTransitionQuirk, needsResettingTransitionCancelsRunningTransitionQuirk);
+    m_quirksData.setEnabled(QuirkBehaviors::needsResettingTransitionCancelsRunningTransitionQuirk.id, needsResettingTransitionCancelsRunningTransitionQuirk);
 
     // Moon Player app (rdar://162452658)
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk, shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
+    m_quirksData.setEnabled(QuirkBehaviors::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk.id, shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
 #endif
 
 #if PLATFORM(MAC)
     static const bool shouldDisablePushStateFilePathRestrictions = WTF::MacApplication::isMimeoPhotoProject();
 
     // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldDisablePushStateFilePathRestrictions, shouldDisablePushStateFilePathRestrictions);
+    m_quirksData.setEnabled(QuirkBehaviors::shouldDisablePushStateFilePathRestrictions.id, shouldDisablePushStateFilePathRestrictions);
 #endif
 
     auto quirksURL = topDocumentURL();
@@ -2643,11 +2564,11 @@ void Quirks::determineRelevantQuirks()
 
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
     // rdar://133423460
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldFlipScreenDimensionsQuirk, shouldFlipScreenDimensionsInternal(quirksURL));
+    m_quirksData.setEnabled(QuirkBehaviors::shouldFlipScreenDimensionsQuirk.id, shouldFlipScreenDimensionsInternal(quirksURL));
 #endif
 
     // rdar://133423460
-    m_quirksData.setQuirkState(QuirkBehaviors::shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk, shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(quirksURL));
+    m_quirksData.setEnabled(QuirkBehaviors::shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk.id, shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(quirksURL));
 }
 
 void Quirks::logQuirksToConsoleIfNecessary() const
@@ -2673,8 +2594,8 @@ Vector<String> Quirks::activeQuirks() const
 {
     Vector<String> result;
 
-    for (auto quirk : m_quirksData.activeQuirks)
-        result.append(WTF::enumName(static_cast<QuirkBehaviorID>(quirk)));
+    for (auto quirk : m_quirksData.enabledBehaviors())
+        result.append(String { WTF::enumName(static_cast<QuirkBehaviorID>(quirk)) });
 
     std::ranges::sort(result, codePointCompareLessThan);
     return result;
@@ -2682,7 +2603,7 @@ Vector<String> Quirks::activeQuirks() const
 
 bool Quirks::hasRelevantQuirks() const
 {
-    return !m_quirksData.activeQuirks.isEmpty();
+    return m_quirksData.hasEnabledBehaviors();
 }
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -261,14 +261,14 @@ public:
     bool NODELETE shouldDisableElementFullscreenQuirk() const;
     bool NODELETE shouldIgnorePlaysInlineRequirementQuirk() const;
 
-    bool shouldAllowPopupFromMicrosoftOfficeToOneDrive() const { return m_quirksData.quirkIsEnabled(QuirkBehaviors::shouldAllowPopupFromMicrosoftOfficeToOneDrive); }
+    bool shouldAllowPopupFromMicrosoftOfficeToOneDrive() const { return m_quirksData.isBehaviorEnabled(QuirkBehaviors::shouldAllowPopupFromMicrosoftOfficeToOneDrive); }
     bool needsPopupFromMicrosoftOfficeToOneDrive(const URL& targetURL) const;
 
     WEBCORE_EXPORT bool needsConsistentQueryParameterFilteringQuirk(const URL&) const;
     bool mayBenefitFromFingerprintingProtectionQuirk(const URL&) const;
     static String standardUserAgentWithApplicationNameIncludingCompatOverrides(const String&, const String&, UserAgentType);
 
-    String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);
+    Vector<String, 1> scriptsToEvaluateBeforeRunningScriptFromURL(const URL&);
 
     bool NODELETE shouldHideCoarsePointerCharacteristics() const;
 
@@ -366,14 +366,14 @@ private:
     mutable QuirkBitSet m_probedQuirks;
 
     template<typename Probe>
-    bool quirkIsEnabledAfterProbing(const QuirkBehavior& quirk, NOESCAPE Probe&& probe) const
+    bool isBehaviorEnabledAfterProbing(const QuirkBehavior& quirk, NOESCAPE Probe&& probe) const
     {
         auto index = static_cast<size_t>(quirk.id);
         if (!m_probedQuirks.get(index)) {
             m_probedQuirks.set(index);
-            m_quirksData.setQuirkState(quirk, probe());
+            m_quirksData.setEnabled(quirk.id, probe());
         }
-        return m_quirksData.quirkIsEnabled(quirk);
+        return m_quirksData.isBehaviorEnabled(quirk);
     }
 
     bool m_needsConfigurableIndexedPropertiesQuirk { false };

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -25,14 +25,40 @@
 
 #pragma once
 
+#include <WebCore/QuirkBehavior.h>
 #include <WebCore/QuirkNames.h>
 #include <initializer_list>
+#include <wtf/Vector.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct QuirksData {
-    QuirkBitSet activeQuirks;
+    Vector<QuirkBehavior> behaviors;
     QuirkSiteBitSet sites;
+
+    template<typename BehaviorType>
+    void forEachBehavior(NOESCAPE const Invocable<void(const BehaviorType&)> auto& callback) const
+    {
+        for (auto& behavior : behaviors) {
+            if (auto* payload = std::get_if<BehaviorType>(&behavior))
+                callback(*payload);
+        }
+    }
+
+    String scriptsToEvaluateBeforeRunningScript(const URL& scriptURL) const
+    {
+        StringBuilder builder;
+        forEachBehavior<ParameterizedQuirk::EvaluateScriptBeforeRunningScript>([&](auto& behavior) {
+            if (!behavior.appliesTo(scriptURL))
+                return;
+            if (!builder.isEmpty())
+                builder.append("\n;\n"_s);
+            builder.append(behavior.script);
+        });
+        return builder.toString();
+    }
 
     inline bool isSite(QuirkSite candidate) const
     {
@@ -44,9 +70,12 @@ struct QuirksData {
         sites.set(static_cast<size_t>(site));
     }
 
-    inline bool quirkIsEnabled(SiteSpecificQuirk quirk) const
+    inline bool quirkIsEnabled(SiteSpecificQuirk candidate) const
     {
-        return activeQuirks.get(static_cast<size_t>(quirk));
+        return behaviors.containsIf([&](auto& behavior) {
+            auto* quirk = std::get_if<SiteSpecificQuirk>(&behavior);
+            return quirk && *quirk == candidate;
+        });
     }
 
     inline void enableQuirks()
@@ -54,27 +83,41 @@ struct QuirksData {
         // No-op to support macro expansions
     }
 
-    constexpr void enableQuirks(std::initializer_list<SiteSpecificQuirk> quirks)
+    void enableQuirks(std::initializer_list<SiteSpecificQuirk> quirks)
     {
         for (auto quirk : quirks)
-            activeQuirks.set(static_cast<size_t>(quirk));
+            enableQuirk(quirk);
     }
 
     inline void enableQuirk(SiteSpecificQuirk quirk)
     {
-        return activeQuirks.set(static_cast<size_t>(quirk));
+        if (!quirkIsEnabled(quirk))
+            behaviors.append(quirk);
     }
 
     inline void setQuirkState(SiteSpecificQuirk quirk, bool state)
     {
-        return activeQuirks.set(static_cast<size_t>(quirk), state);
+        if (state) {
+            enableQuirk(quirk);
+            return;
+        }
+
+        behaviors.removeAllMatching([&](auto& behavior) {
+            auto* candidate = std::get_if<SiteSpecificQuirk>(&behavior);
+            return candidate && *candidate == quirk;
+        });
     }
 
-    constexpr void merge(const QuirksData& other)
+    void merge(QuirksData&& other)
     {
-        auto& [otherActiveQuirks, otherSites] = other;
-        activeQuirks.merge(otherActiveQuirks);
-        sites.merge(otherSites);
+        sites.merge(other.sites);
+
+        for (auto& behavior : other.behaviors) {
+            if (auto* quirk = std::get_if<SiteSpecificQuirk>(&behavior))
+                enableQuirk(*quirk);
+            else
+                behaviors.append(WTF::move(behavior));
+        }
     }
 };
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -26,51 +26,90 @@
 #pragma once
 
 #include <WebCore/QuirkBehaviors.h>
+#include <WebCore/URLMatch.h>
 #include <span>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
-struct QuirksData {
-    QuirkBitSet activeQuirks;
-    QuirkSiteBitSet sites;
+struct ParameterizedQuirkBehavior {
+    QuirkBehaviorID id;
+    std::optional<URLMatch> urlCondition { std::nullopt };
+    QuirkParameters parameters;
+};
 
-    inline bool isSite(QuirkSite candidate) const
+class QuirksData {
+public:
+    inline bool isBehaviorEnabled(const QuirkBehavior& quirk) const
     {
-        return sites.get(static_cast<size_t>(candidate));
+        return m_activeQuirks.get(static_cast<size_t>(quirk.id));
+    }
+
+    inline bool isSite(QuirkSite site) const
+    {
+        return m_sites.get(static_cast<size_t>(site));
+    }
+
+    inline bool hasEnabledBehaviors() const
+    {
+        return !m_activeQuirks.isEmpty();
+    }
+
+    inline const QuirkBitSet& enabledBehaviors() const LIFETIME_BOUND
+    {
+        return m_activeQuirks;
+    }
+
+    inline Vector<QuirkParameters, 1> parametersFor(const QuirkBehavior& behavior, const URLMatchContext& context) const
+    {
+        if (!isBehaviorEnabled(behavior))
+            return { };
+
+        Vector<QuirkParameters, 1> matching;
+        for (auto& candidate : m_parameterizedBehaviors) {
+            if (candidate.id != behavior.id)
+                continue;
+
+            if (!candidate.urlCondition || candidate.urlCondition->matches(context))
+                matching.append(candidate.parameters);
+        }
+
+        return matching;
+    }
+
+    inline void applyTableRow(std::span<const QuirkBehavior> behaviors)
+    {
+        for (auto& behavior : behaviors) {
+            m_activeQuirks.set(static_cast<size_t>(behavior.id));
+
+            if (behavior.parameters)
+                m_parameterizedBehaviors.append({ behavior.id, behavior.urlCondition, *behavior.parameters });
+        }
     }
 
     inline void addSite(QuirkSite site)
     {
-        sites.set(static_cast<size_t>(site));
+        m_sites.set(static_cast<size_t>(site));
     }
 
-    inline bool quirkIsEnabled(const QuirkBehavior& quirk) const
+    inline void setEnabled(QuirkBehaviorID id, bool state)
     {
-        return activeQuirks.get(static_cast<size_t>(quirk.id));
+        m_activeQuirks.set(static_cast<size_t>(id), state);
     }
 
-    inline void enableQuirks(std::span<const QuirkBehavior> quirks)
+    void merge(const QuirksData& other)
     {
-        for (auto& quirk : quirks)
-            enableQuirk(quirk);
+        auto& [otherActiveQuirks, otherSites, otherParameterizedBehaviors] = other;
+        m_activeQuirks.merge(otherActiveQuirks);
+        m_sites.merge(otherSites);
+        m_parameterizedBehaviors.appendVector(otherParameterizedBehaviors);
     }
 
-    inline void enableQuirk(const QuirkBehavior& quirk)
-    {
-        activeQuirks.set(static_cast<size_t>(quirk.id));
-    }
-
-    inline void setQuirkState(const QuirkBehavior& quirk, bool state)
-    {
-        activeQuirks.set(static_cast<size_t>(quirk.id), state);
-    }
-
-    constexpr void merge(const QuirksData& other)
-    {
-        auto& [otherActiveQuirks, otherSites] = other;
-        activeQuirks.merge(otherActiveQuirks);
-        sites.merge(otherSites);
-    }
+private:
+    QuirkBitSet m_activeQuirks;
+    QuirkSiteBitSet m_sites;
+    Vector<ParameterizedQuirkBehavior> m_parameterizedBehaviors;
 };
 
 } // namespace WebCore
+

--- a/Source/WebCore/page/URLMatch.cpp
+++ b/Source/WebCore/page/URLMatch.cpp
@@ -88,6 +88,12 @@ bool URLMatch::RefinementSet::matchesPathPattern(const URL& url) const
         return url.path() == pathPattern;
     case PathComparison::PathOrFragmentContains:
         return url.path().contains(pathPattern) || url.fragmentIdentifier().contains(pathPattern);
+    case PathComparison::LastPathComponentIs:
+        return url.lastPathComponent() == pathPattern;
+    case PathComparison::LastPathComponentStartsWith:
+        return url.lastPathComponent().startsWith(pathPattern);
+    case PathComparison::LastPathComponentEndsWith:
+        return url.lastPathComponent().endsWith(pathPattern);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/page/URLMatch.h
+++ b/Source/WebCore/page/URLMatch.h
@@ -155,6 +155,18 @@ struct PathOrFragmentContains {
     ASCIILiteral substring;
 };
 
+struct LastPathComponentIs {
+    ASCIILiteral component;
+};
+
+struct LastPathComponentStartsWith {
+    ASCIILiteral prefix;
+};
+
+struct LastPathComponentEndsWith {
+    ASCIILiteral suffix;
+};
+
 struct QueryContains {
     ASCIILiteral substring;
 };
@@ -185,6 +197,21 @@ constexpr PathIs pathIs(ASCIILiteral path)
 constexpr PathOrFragmentContains pathOrFragmentContains(ASCIILiteral substring)
 {
     return { substring };
+}
+
+constexpr LastPathComponentIs lastPathComponentIs(ASCIILiteral component)
+{
+    return { component };
+}
+
+constexpr LastPathComponentStartsWith lastPathComponentStartsWith(ASCIILiteral prefix)
+{
+    return { prefix };
+}
+
+constexpr LastPathComponentEndsWith lastPathComponentEndsWith(ASCIILiteral suffix)
+{
+    return { suffix };
 }
 
 constexpr QueryContains queryContains(ASCIILiteral substring)
@@ -276,6 +303,9 @@ private:
         PathStartsWith,
         PathIs,
         PathOrFragmentContains,
+        LastPathComponentIs,
+        LastPathComponentStartsWith,
+        LastPathComponentEndsWith,
     };
 
     struct RefinementSet {
@@ -316,6 +346,21 @@ private:
     static constexpr void applyRefinement(RefinementSet& set, URLRefinement::PathOrFragmentContains refinement)
     {
         setPathPattern(set, PathComparison::PathOrFragmentContains, refinement.substring);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, URLRefinement::LastPathComponentIs refinement)
+    {
+        setPathPattern(set, PathComparison::LastPathComponentIs, refinement.component);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, URLRefinement::LastPathComponentStartsWith refinement)
+    {
+        setPathPattern(set, PathComparison::LastPathComponentStartsWith, refinement.prefix);
+    }
+
+    static constexpr void applyRefinement(RefinementSet& set, URLRefinement::LastPathComponentEndsWith refinement)
+    {
+        setPathPattern(set, PathComparison::LastPathComponentEndsWith, refinement.suffix);
     }
 
     static constexpr void applyRefinement(RefinementSet& set, URLRefinement::QueryContains refinement)

--- a/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/QuirkMatch.cpp
@@ -39,17 +39,10 @@ using namespace WebCore::QuirkRefinement;
 
 static bool matchesURL(const QuirkMatch& match, ASCIILiteral urlString)
 {
-    return match.matches(QuirkMatchContext { URL { urlString }, URL { urlString }, WebCore::IsTopDocument::Yes });
-}
-
-static bool matchesEmbeddedURL(const QuirkMatch& match, ASCIILiteral topURLString, ASCIILiteral documentURLString)
-{
-    return match.matches(QuirkMatchContext { URL { topURLString }, URL { documentURLString }, WebCore::IsTopDocument::No });
+    return match.matches(QuirkMatchContext { URL { urlString } });
 }
 
 static constexpr std::array expediaGroupDomains { "hotels.com"_s, "orbitz.com"_s, "wotif.co.nz"_s };
-static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
-static constexpr std::array vimeoDomains { "vimeo.com"_s };
 static constexpr std::array excludedNaverHosts { "tv.naver.com"_s, "mail.naver.com"_s, "m.naver.com"_s };
 
 TEST(QuirkMatchTest, DomainMatchesRegistrableDomain)
@@ -183,6 +176,26 @@ TEST(QuirkMatchTest, PathOrFragmentContainsSearchesBoth)
     EXPECT_FALSE(matchesURL(match, "https://www.icloud.com/?app=mail"_s));
 }
 
+TEST(QuirkMatchTest, LastPathComponentRefinementsAreAnchoredToTheWholeComponent)
+{
+    auto exact = QuirkMatch::anyURL().when(lastPathComponentIs("CheckBrowserClose.js"_s));
+
+    EXPECT_TRUE(matchesURL(exact, "https://ceac.state.gov/js/CheckBrowserClose.js"_s));
+
+    EXPECT_FALSE(matchesURL(exact, "https://ceac.state.gov/js/CheckBrowserClose.js.map"_s));
+    EXPECT_FALSE(matchesURL(exact, "https://ceac.state.gov/CheckBrowserClose.js/inner.js"_s));
+
+    auto prefix = QuirkMatch::anyURL().when(lastPathComponentStartsWith("pushdownload."_s));
+
+    EXPECT_TRUE(matchesURL(prefix, "https://www.webex.com/x/pushdownload.min.js"_s));
+    EXPECT_FALSE(matchesURL(prefix, "https://www.webex.com/pushdownload./x.js"_s));
+
+    auto suffix = QuirkMatch::anyURL().when(lastPathComponentEndsWith("lre.js"_s));
+
+    EXPECT_TRUE(matchesURL(suffix, "https://player.anyclip.com/foo-lre.js"_s));
+    EXPECT_FALSE(matchesURL(suffix, "https://player.anyclip.com/lre.js/foo.js"_s));
+}
+
 TEST(QuirkMatchTest, EnvironmentIsANDedWithTheSiteMatch)
 {
     auto smallScreenOnly = QuirkMatch::domain("youtube.com"_s).when(smallScreen());
@@ -200,48 +213,9 @@ TEST(QuirkMatchTest, EnvironmentIsANDedWithTheSiteMatch)
 #endif
 }
 
-TEST(QuirkMatchTest, DocumentDomainIsMatchesEmbeddedDocuments)
+TEST(QuirkMatchTest, AnyURLMatchesEveryURLWithAHostWithoutFurtherRefinement)
 {
-    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(documentDomainIs(youTubeEmbedDomains));
-
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.co.uk/film"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
-
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://foo.bar.youtube.com/embed/abc"_s));
-
-    EXPECT_FALSE(matchesURL(match, "https://www.theguardian.com/film"_s));
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://vimeo.com/12345"_s));
-
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.youtube.com/"_s, "https://www.theguardian.com/film"_s));
-}
-
-TEST(QuirkMatchTest, DocumentDomainIsAcceptsASinglePattern)
-{
-    auto match = QuirkMatch::anySite().when(embedded(), documentDomainIs("x.com"_s));
-
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://x.com/i/status/123"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://platform.x.com/embed/Tweet.html"_s));
-
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://vimeo.com/12345"_s));
-    EXPECT_FALSE(matchesURL(match, "https://x.com/i/status/123"_s));
-}
-
-TEST(QuirkMatchTest, AnySiteWithOnlyIfEmbeddedMatchesEmbedsAnywhereButNeverTheTopDocument)
-{
-    auto match = QuirkMatch::anySite().when(embedded(), documentDomainIs(youTubeEmbedDomains));
-
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
-
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/"_s, "https://vimeo.com/12345"_s));
-    // youtube.com at the top level, and youtube.com embedded in itself, are both the top document.
-    EXPECT_FALSE(matchesURL(match, "https://www.youtube.com/watch?v=abc"_s));
-}
-
-TEST(QuirkMatchTest, AnySiteMatchesEverySiteWithoutFurtherRefinement)
-{
-    auto match = QuirkMatch::anySite();
+    auto match = QuirkMatch::anyURL();
 
     EXPECT_TRUE(matchesURL(match, "https://www.example.com/"_s));
     EXPECT_TRUE(matchesURL(match, "https://webkit.org/"_s));
@@ -299,16 +273,6 @@ TEST(QuirkMatchTest, HostIsNarrowsAMatchToOneHost)
     EXPECT_FALSE(matchesURL(match, "https://news.naver.com/"_s));
 }
 
-TEST(QuirkMatchTest, ExceptWhenTakesEveryRefinementIncludingEmbeddedDocuments)
-{
-    auto match = QuirkMatch::domain("theguardian.com"_s).exceptWhen(embedded(), documentDomainIs(vimeoDomains));
-
-    EXPECT_TRUE(matchesURL(match, "https://www.theguardian.com/film"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
-
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://vimeo.com/12345"_s));
-}
-
 TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)
 {
     auto match = QuirkMatch::domain("example.com"_s).when(pathStartsWith("/app"_s)).exceptWhen(pathStartsWith("/app/legacy"_s));
@@ -320,34 +284,26 @@ TEST(QuirkMatchTest, ExceptWhenAndTheMatchKeepSeparateRefinements)
 
 TEST(QuirkMatchTest, ExceptWhenRequiresEveryRefinementToExclude)
 {
-    auto match = QuirkMatch::domain("example.com"_s).exceptWhen(pathStartsWith("/embed"_s), embedded());
+    auto match = QuirkMatch::domain("example.com"_s).exceptWhen(pathStartsWith("/embed"_s), hostIs("legacy.example.com"_s));
 
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/embed/abc"_s, "https://vimeo.com/12345"_s));
+    EXPECT_FALSE(matchesURL(match, "https://legacy.example.com/embed/abc"_s));
 
+    // Neither half of the exception excludes on its own.
     EXPECT_TRUE(matchesURL(match, "https://www.example.com/embed/abc"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.example.com/other"_s, "https://vimeo.com/12345"_s));
+    EXPECT_TRUE(matchesURL(match, "https://legacy.example.com/other"_s));
 
     EXPECT_FALSE(matchesURL(match, "https://webkit.org/"_s));
 }
 
-TEST(QuirkMatchTest, MatchesIgnoreTheDocumentURLByDefault)
-{
-    auto match = QuirkMatch::domain("theguardian.com"_s);
-
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.youtube.com/"_s, "https://www.theguardian.com/film"_s));
-}
-
 TEST(QuirkMatchTest, RefinementsOfDifferentKindsAreAllANDed)
 {
-    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(pathStartsWith("/film/"_s), documentDomainIs(youTubeEmbedDomains));
+    auto match = QuirkMatch::anyTopLevelDomain("theguardian"_s).when(pathStartsWith("/film/"_s), hostIs("www.theguardian.com"_s));
 
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.com/film/2026/trailer"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_TRUE(matchesEmbeddedURL(match, "https://www.theguardian.co.uk/film/2026/trailer"_s, "https://www.youtube-nocookie.com/embed/abc"_s));
+    EXPECT_TRUE(matchesURL(match, "https://www.theguardian.com/film/2026/trailer"_s));
 
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.example.com/film/2026/trailer"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/news/2026/story"_s, "https://www.youtube.com/embed/abc"_s));
-    EXPECT_FALSE(matchesEmbeddedURL(match, "https://www.theguardian.com/film/2026/trailer"_s, "https://vimeo.com/12345"_s));
+    EXPECT_FALSE(matchesURL(match, "https://www.example.com/film/2026/trailer"_s));
+    EXPECT_FALSE(matchesURL(match, "https://www.theguardian.com/news/2026/story"_s));
+    EXPECT_FALSE(matchesURL(match, "https://amp.theguardian.com/film/2026/trailer"_s));
 }
 
 TEST(QuirkMatchTest, EnvironmentStacksWithAPathRefinement)
@@ -360,25 +316,22 @@ TEST(QuirkMatchTest, EnvironmentStacksWithAPathRefinement)
 
 TEST(QuirkMatchTest, ContextDerivesValuesFromTheRightURL)
 {
-    URL topURL { "https://www.bbc.co.uk/news?live=1#top"_s };
-    URL documentURL { "https://player.youtube-nocookie.com/embed/abc"_s };
-    QuirkMatchContext context { topURL, documentURL, WebCore::IsTopDocument::Yes };
+    URL url { "https://www.bbc.co.uk/news?live=1#top"_s };
+    QuirkMatchContext context { url };
 
-    EXPECT_EQ(context.topURL(), topURL);
-    EXPECT_EQ(context.topHost(), "www.bbc.co.uk"_s);
-    EXPECT_EQ(context.topRegistrableDomain(), "bbc.co.uk"_s);
-    EXPECT_EQ(context.topDomainWithoutPublicSuffix(), "bbc"_s);
-    EXPECT_EQ(context.documentRegistrableDomain(), "youtube-nocookie.com"_s);
+    EXPECT_EQ(context.url(), url);
+    EXPECT_EQ(context.host(), "www.bbc.co.uk"_s);
+    EXPECT_EQ(context.registrableDomain(), "bbc.co.uk"_s);
+    EXPECT_EQ(context.domainWithoutPublicSuffix(), "bbc"_s);
 }
 
 TEST(QuirkMatchTest, ContextCachesDerivedValues)
 {
     URL url { "https://www.example.com/"_s };
-    QuirkMatchContext context { url, url, WebCore::IsTopDocument::Yes };
+    QuirkMatchContext context { url };
 
-    EXPECT_EQ(&context.topRegistrableDomain(), &context.topRegistrableDomain());
-    EXPECT_EQ(&context.topDomainWithoutPublicSuffix(), &context.topDomainWithoutPublicSuffix());
-    EXPECT_EQ(&context.documentRegistrableDomain(), &context.documentRegistrableDomain());
+    EXPECT_EQ(&context.registrableDomain(), &context.registrableDomain());
+    EXPECT_EQ(&context.domainWithoutPublicSuffix(), &context.domainWithoutPublicSuffix());
 }
 
 TEST(QuirkMatchTest, HostsWithoutAPublicSuffixFallBackToTheHost)
@@ -391,8 +344,7 @@ TEST(QuirkMatchTest, HostsWithoutAPublicSuffixFallBackToTheHost)
 TEST(QuirkMatchTest, URLsWithoutAHostMatchNothing)
 {
     for (auto urlString : { "about:blank"_s, "data:text/html,hello"_s, ""_s }) {
-        URL url { urlString };
-        QuirkMatchContext context { url, url, WebCore::IsTopDocument::Yes };
+        QuirkMatchContext context { URL { urlString } };
 
         EXPECT_FALSE(QuirkMatch::domain("example.com"_s).matches(context));
         EXPECT_FALSE(QuirkMatch::host("example.com"_s).matches(context));

--- a/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
@@ -48,7 +48,27 @@ static std::optional<String> customUserAgentFor(ASCIILiteral urlString)
 
 static WebCore::QuirksData resolveQuirksForTopURL(ASCIILiteral urlString)
 {
-    return WebCore::resolveSiteSpecificQuirks({ URL { urlString }, URL { urlString }, WebCore::IsTopDocument::Yes });
+    return WebCore::resolveSiteSpecificQuirks(URL { urlString }, URL { urlString }, WebCore::IsTopDocument::Yes);
+}
+
+static WebCore::QuirksData resolveQuirksForEmbeddedDocument(ASCIILiteral topURLString, ASCIILiteral documentURLString)
+{
+    return WebCore::resolveSiteSpecificQuirks(URL { topURLString }, URL { documentURLString }, WebCore::IsTopDocument::No);
+}
+
+static std::optional<WebCore::ParameterizedQuirk::EvaluateScriptBeforeRunningScript> firstScriptBehavior(const WebCore::QuirksData& quirksData)
+{
+    std::optional<WebCore::ParameterizedQuirk::EvaluateScriptBeforeRunningScript> result;
+    quirksData.forEachBehavior<WebCore::ParameterizedQuirk::EvaluateScriptBeforeRunningScript>([&](auto& behavior) {
+        if (!result)
+            result = behavior;
+    });
+    return result;
+}
+
+TEST_F(QuirksTest, TheQuirkTableIsWellFormed)
+{
+    WebCore::validateQuirkTable();
 }
 
 TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)
@@ -58,11 +78,171 @@ TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)
     EXPECT_TRUE(resolveQuirksForTopURL("https://www.airindiaexpress.com/"_s).quirkIsEnabled(SiteSpecificQuirk::NeedsAirIndiaExpressLayeringQuirk));
     EXPECT_TRUE(resolveQuirksForTopURL("https://www.scribd.com/"_s).quirkIsEnabled(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk));
 
-    EXPECT_TRUE(resolveQuirksForTopURL("https://www.iheart.com/"_s).isSite(WebCore::QuirkSite::IHeart));
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.linkedin.com/"_s).isSite(WebCore::QuirkSite::LinkedIn));
 
     auto unrelatedSiteQuirks = resolveQuirksForTopURL("https://www.example.com/"_s);
-    EXPECT_TRUE(unrelatedSiteQuirks.activeQuirks.isEmpty());
-    EXPECT_FALSE(unrelatedSiteQuirks.isSite(WebCore::QuirkSite::IHeart));
+    EXPECT_TRUE(unrelatedSiteQuirks.behaviors.isEmpty());
+    EXPECT_FALSE(unrelatedSiteQuirks.isSite(WebCore::QuirkSite::LinkedIn));
+}
+
+TEST_F(QuirksTest, ParameterizedQuirksCarryTheirPayloadInTheTable)
+{
+    auto iHeartScript = firstScriptBehavior(resolveQuirksForTopURL("https://www.iheart.com/"_s));
+    ASSERT_TRUE(iHeartScript);
+    EXPECT_STREQ(iHeartScript->script.characters(), "document.cookie = 'app=listen:60; path=/; domain=.iheart.com';");
+
+    auto inVideoScript = firstScriptBehavior(resolveQuirksForTopURL("https://www.invideo.io/"_s));
+    ASSERT_TRUE(inVideoScript);
+    EXPECT_STREQ(inVideoScript->script.characters(), "if(!window.chrome)window.chrome={};");
+
+    auto unparameterizedQuirks = resolveQuirksForTopURL("https://www.example.com/"_s);
+    EXPECT_TRUE(unparameterizedQuirks.behaviors.isEmpty());
+}
+
+TEST_F(QuirksTest, ParameterizedQuirksResolveToAPayloadAndNothingElse)
+{
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+    using EvaluateScriptBeforeRunningScript = WebCore::ParameterizedQuirk::EvaluateScriptBeforeRunningScript;
+
+    for (auto url : { "https://www.iheart.com/"_s, "https://www.invideo.io/"_s }) {
+        auto quirks = resolveQuirksForTopURL(url);
+        ASSERT_EQ(quirks.behaviors.size(), 1u);
+        EXPECT_TRUE(std::holds_alternative<EvaluateScriptBeforeRunningScript>(quirks.behaviors[0]));
+    }
+
+    auto unparameterized = resolveQuirksForTopURL("https://www.scribd.com/"_s);
+    EXPECT_TRUE(unparameterized.quirkIsEnabled(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk));
+    EXPECT_FALSE(firstScriptBehavior(unparameterized));
+}
+
+TEST_F(QuirksTest, UngatedScriptParameterAppliesToEveryScriptURL)
+{
+    auto script = firstScriptBehavior(resolveQuirksForTopURL("https://www.iheart.com/"_s));
+    ASSERT_TRUE(script);
+
+    EXPECT_TRUE(script->appliesTo(URL { "https://www.iheart.com/anything.js"_s }));
+    EXPECT_TRUE(script->appliesTo(URL { "https://cdn.example.com/other.js"_s }));
+}
+
+TEST_F(QuirksTest, GatedScriptParameterAppliesOnlyToMatchingScriptURLs)
+{
+    auto script = firstScriptBehavior(resolveQuirksForTopURL("https://ceac.state.gov/"_s));
+    ASSERT_TRUE(script);
+
+    EXPECT_TRUE(script->appliesTo(URL { "https://ceac.state.gov/js/CheckBrowserClose.js"_s }));
+    EXPECT_TRUE(script->appliesTo(URL { "https://cdn.example.com/CheckBrowserClose.js"_s }));
+
+    EXPECT_FALSE(script->appliesTo(URL { "https://ceac.state.gov/js/CheckBrowserClose.js.map"_s }));
+    EXPECT_FALSE(script->appliesTo(URL { "https://ceac.state.gov/CheckBrowserClose.js/inner.js"_s }));
+    EXPECT_FALSE(script->appliesTo(URL { "https://ceac.state.gov/js/other.js"_s }));
+}
+
+
+static WebCore::QuirkBehavior scriptBehavior(ASCIILiteral script, std::optional<WebCore::QuirkMatch> gate = std::nullopt)
+{
+    return WebCore::ParameterizedQuirk::EvaluateScriptBeforeRunningScript::create(script, gate);
+}
+
+TEST_F(QuirksTest, EveryBehaviorNamesItself)
+{
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    auto bareQuirk = WebCore::QuirkBehavior { SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk };
+    EXPECT_STREQ(WebCore::quirkBehaviorName(bareQuirk).utf8().data(), "NeedsReuseLiveRangeForSelectionUpdateQuirk");
+    EXPECT_STREQ(WebCore::quirkBehaviorName(scriptBehavior("first();"_s)).utf8().data(), "EvaluateScriptBeforeRunningScript");
+}
+
+TEST_F(QuirksTest, EnablingABareQuirkIsIdempotentButPayloadsAccumulate)
+{
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    WebCore::QuirksData data;
+    data.enableQuirk(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk);
+    data.enableQuirk(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk);
+
+    EXPECT_EQ(data.behaviors.size(), 1u);
+    EXPECT_TRUE(data.quirkIsEnabled(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk));
+
+    data.behaviors.append(scriptBehavior("first();"_s));
+    data.behaviors.append(scriptBehavior("second();"_s));
+    EXPECT_EQ(data.behaviors.size(), 3u);
+}
+
+TEST_F(QuirksTest, ClearingAQuirkStateRemovesItFromTheBehaviorList)
+{
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    WebCore::QuirksData data;
+    data.setQuirkState(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk, true);
+    data.behaviors.append(scriptBehavior("first();"_s));
+
+    data.setQuirkState(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk, false);
+
+    EXPECT_FALSE(data.quirkIsEnabled(SiteSpecificQuirk::NeedsReuseLiveRangeForSelectionUpdateQuirk));
+    EXPECT_EQ(data.behaviors.size(), 1u);
+    EXPECT_TRUE(firstScriptBehavior(data));
+}
+
+TEST_F(QuirksTest, ASingleScriptIsReturnedVerbatim)
+{
+    WebCore::QuirksData data;
+    data.behaviors.append(scriptBehavior("first();"_s));
+
+    EXPECT_STREQ(data.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/a.js"_s }).utf8().data(), "first();");
+}
+
+TEST_F(QuirksTest, TwoMatchingScriptsAreConcatenatedInTableOrder)
+{
+    WebCore::QuirksData data;
+    data.behaviors.append(scriptBehavior("first();"_s));
+    data.behaviors.append(scriptBehavior("second();"_s));
+
+    EXPECT_STREQ(data.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/a.js"_s }).utf8().data(), "first();\n;\nsecond();");
+}
+
+TEST_F(QuirksTest, ConcatenationSkipsScriptsWhoseGateDoesNotMatch)
+{
+    using namespace WebCore::QuirkRefinement;
+
+    WebCore::QuirksData data;
+    data.behaviors.append(scriptBehavior("ungated();"_s));
+    data.behaviors.append(scriptBehavior("gated();"_s, WebCore::QuirkMatch::anyURL().when(lastPathComponentIs("wanted.js"_s))));
+
+    EXPECT_STREQ(data.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/other.js"_s }).utf8().data(), "ungated();");
+    EXPECT_STREQ(data.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/wanted.js"_s }).utf8().data(), "ungated();\n;\ngated();");
+}
+
+TEST_F(QuirksTest, NoMatchingScriptYieldsAnEmptyString)
+{
+    using namespace WebCore::QuirkRefinement;
+
+    WebCore::QuirksData data;
+    data.behaviors.append(scriptBehavior("gated();"_s, WebCore::QuirkMatch::anyURL().when(lastPathComponentIs("wanted.js"_s))));
+
+    EXPECT_TRUE(data.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/other.js"_s }).isEmpty());
+    EXPECT_TRUE(WebCore::QuirksData { }.scriptsToEvaluateBeforeRunningScript(URL { "https://example.com/a.js"_s }).isEmpty());
+}
+
+TEST_F(QuirksTest, ARealTableEntryResolvesToItsScriptAloneWithNoSeparator)
+{
+    auto script = resolveQuirksForTopURL("https://www.iheart.com/"_s).scriptsToEvaluateBeforeRunningScript(URL { "https://www.iheart.com/a.js"_s });
+    EXPECT_STREQ(script.utf8().data(), "document.cookie = 'app=listen:60; path=/; domain=.iheart.com';");
+}
+
+TEST_F(QuirksTest, ScriptGatesCanRequireBothAHostAndAFileName)
+{
+    auto script = firstScriptBehavior(resolveQuirksForTopURL("https://www.dictionary.com/"_s));
+
+#if PLATFORM(IOS_FAMILY)
+    ASSERT_TRUE(script);
+
+    EXPECT_TRUE(script->appliesTo(URL { "https://player.anyclip.com/foo-lre.js"_s }));
+
+    EXPECT_FALSE(script->appliesTo(URL { "https://player.anyclip.com/foo.js"_s }));
+    EXPECT_FALSE(script->appliesTo(URL { "https://cdn.example.com/foo-lre.js"_s }));
+#else
+    EXPECT_FALSE(script);
+#endif
 }
 
 TEST_F(QuirksTest, NeedsIPadMiniUserAgent)
@@ -181,5 +361,51 @@ TEST_F(QuirksTest, NeedsCustomUserAgentOverrideAmazonPrimeVideo)
     EXPECT_FALSE(customUserAgentFor("https://www.amazon.com/gp/video/storefront"_s).has_value());
 }
 #endif // PLATFORM(IOS)
+
+TEST_F(QuirksTest, ADocumentMatchAppliesToAnEmbedRegardlessOfTheEmbeddingPage)
+{
+#if PLATFORM(IOS_FAMILY)
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.theguardian.com/film"_s, "https://x.com/i/status/123"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::ShouldDisableElementFullscreenQuirk));
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://platform.x.com/embed/Tweet.html"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::ShouldDisableElementFullscreenQuirk));
+
+    EXPECT_FALSE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://vimeo.com/12345"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::ShouldDisableElementFullscreenQuirk));
+
+    EXPECT_FALSE(resolveQuirksForTopURL("https://x.com/i/status/123"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::ShouldDisableElementFullscreenQuirk));
+#endif
+}
+
+TEST_F(QuirksTest, NamingBothURLsRequiresBothToMatch)
+{
+#if PLATFORM(IOS_FAMILY)
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.theguardian.com/film"_s, "https://www.youtube.com/embed/abc"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsYouTubeEmbedAutoplayQuirk));
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.theguardian.co.uk/film"_s, "https://www.youtube-nocookie.com/embed/abc"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsYouTubeEmbedAutoplayQuirk));
+
+    EXPECT_FALSE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://www.youtube.com/embed/abc"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsYouTubeEmbedAutoplayQuirk));
+
+    EXPECT_FALSE(resolveQuirksForEmbeddedDocument("https://www.theguardian.com/film"_s, "https://vimeo.com/12345"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsYouTubeEmbedAutoplayQuirk));
+    EXPECT_FALSE(resolveQuirksForTopURL("https://www.theguardian.com/film"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsYouTubeEmbedAutoplayQuirk));
+#endif
+}
+
+TEST_F(QuirksTest, APageMatchStillAppliesInsideAnEmbeddedDocument)
+{
+    using SiteSpecificQuirk = WebCore::SiteSpecificQuirk;
+
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.airindiaexpress.com/"_s, "https://ads.example.com/frame.html"_s)
+        .quirkIsEnabled(SiteSpecificQuirk::NeedsAirIndiaExpressLayeringQuirk));
+}
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/SecurityOriginData.h>
 #include <array>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
@@ -120,26 +121,114 @@ static WebCore::QuirksData resolveQuirksForEmbeddedDocument(ASCIILiteral topURLS
 
 TEST_F(QuirksTest, EmbeddedQuirksResolveFromTheDocumentURL)
 {
-    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://www.youtube.com/embed/abc"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
+    EXPECT_TRUE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://www.youtube.com/embed/abc"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
 
-    EXPECT_FALSE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://vimeo.com/12345"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
+    EXPECT_FALSE(resolveQuirksForEmbeddedDocument("https://www.example.com/"_s, "https://vimeo.com/12345"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
 
-    EXPECT_FALSE(resolveQuirksForTopURL("https://www.example.com/"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
+    EXPECT_FALSE(resolveQuirksForTopURL("https://www.example.com/"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
 
-    EXPECT_FALSE(resolveQuirksForTopURL("https://www.youtube-nocookie.com/embed/abc"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
+    EXPECT_FALSE(resolveQuirksForTopURL("https://www.youtube-nocookie.com/embed/abc"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsYouTubeCaptionQuirk));
 }
 #endif
 
 TEST_F(QuirksTest, SiteSpecificQuirksResolveWithoutADocument)
 {
-    EXPECT_TRUE(resolveQuirksForTopURL("https://www.airindiaexpress.com/"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsAirIndiaExpressLayeringQuirk));
-    EXPECT_TRUE(resolveQuirksForTopURL("https://www.scribd.com/"_s).quirkIsEnabled(WebCore::QuirkBehaviors::needsReuseLiveRangeForSelectionUpdateQuirk));
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.airindiaexpress.com/"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsAirIndiaExpressLayeringQuirk));
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.scribd.com/"_s).isBehaviorEnabled(WebCore::QuirkBehaviors::needsReuseLiveRangeForSelectionUpdateQuirk));
 
-    EXPECT_TRUE(resolveQuirksForTopURL("https://www.iheart.com/"_s).isSite(WebCore::QuirkSite::IHeart));
+    EXPECT_TRUE(resolveQuirksForTopURL("https://www.bankofamerica.com/"_s).isSite(WebCore::QuirkSite::BankOfAmerica));
 
     auto unrelatedSiteQuirks = resolveQuirksForTopURL("https://www.example.com/"_s);
-    EXPECT_TRUE(unrelatedSiteQuirks.activeQuirks.isEmpty());
-    EXPECT_FALSE(unrelatedSiteQuirks.isSite(WebCore::QuirkSite::IHeart));
+    EXPECT_FALSE(unrelatedSiteQuirks.hasEnabledBehaviors());
+    EXPECT_FALSE(unrelatedSiteQuirks.isSite(WebCore::QuirkSite::BankOfAmerica));
+}
+
+static Vector<String> scriptsForScriptURL(const WebCore::QuirksData& quirks, ASCIILiteral scriptURLString)
+{
+    WebCore::URLMatchContext context { URL { scriptURLString } };
+    auto matching = quirks.parametersFor(WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk, context);
+    return WTF::map(matching, [](auto& parameters) {
+        return String { parameters.script };
+    });
+}
+
+TEST_F(QuirksTest, ScriptQuirkWithoutAScriptURLMatchAppliesToEveryScript)
+{
+    auto quirks = resolveQuirksForTopURL("https://www.iheart.com/"_s);
+
+    auto scripts = scriptsForScriptURL(quirks, "https://cdn.example.com/vendor.js"_s);
+    ASSERT_EQ(scripts.size(), 1u);
+    EXPECT_TRUE(scripts[0].contains("app=listen:60"_s));
+}
+
+TEST_F(QuirksTest, ScriptQuirkWithAScriptURLMatchAppliesOnlyToMatchingScripts)
+{
+    auto quirks = resolveQuirksForTopURL("https://ceac.state.gov/GenNIV/Default.aspx"_s);
+
+    auto scripts = scriptsForScriptURL(quirks, "https://ceac.state.gov/js/CheckBrowserClose.js"_s);
+    ASSERT_EQ(scripts.size(), 1u);
+    EXPECT_TRUE(scripts[0].contains("__ceacBeforeUnloadFix"_s));
+
+    EXPECT_TRUE(scriptsForScriptURL(quirks, "https://ceac.state.gov/js/Other.js"_s).isEmpty());
+}
+
+TEST_F(QuirksTest, DocumentsWithoutAScriptQuirkGetNoParameters)
+{
+    auto quirks = resolveQuirksForTopURL("https://www.example.com/"_s);
+    EXPECT_FALSE(quirks.isBehaviorEnabled(WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk));
+    EXPECT_TRUE(scriptsForScriptURL(quirks, "https://www.example.com/app.js"_s).isEmpty());
+}
+
+TEST_F(QuirksTest, ParametersAreOnlyReturnedForTheBehaviorThatSuppliedThem)
+{
+    static constexpr auto behaviors = WTF::toArray({
+        WebCore::QuirkBehaviors::needsAirIndiaExpressLayeringQuirk,
+        WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(WebCore::QuirkParameters::fromScript("script"_s)),
+    });
+
+    WebCore::QuirksData quirks;
+    quirks.applyTableRow(behaviors);
+
+    WebCore::URLMatchContext context { URL { "https://www.example.com/app.js"_s } };
+
+    EXPECT_TRUE(quirks.isBehaviorEnabled(WebCore::QuirkBehaviors::needsAirIndiaExpressLayeringQuirk));
+    EXPECT_TRUE(quirks.parametersFor(WebCore::QuirkBehaviors::needsAirIndiaExpressLayeringQuirk, context).isEmpty());
+    EXPECT_EQ(scriptsForScriptURL(quirks, "https://www.example.com/app.js"_s), Vector<String> { "script"_str });
+}
+
+TEST_F(QuirksTest, OneQuirkCanCarryDifferentParametersForDifferentScriptURLs)
+{
+    static constexpr auto firstScriptURL = WebCore::URLMatch::host("first.example.com"_s);
+    static constexpr auto secondScriptURL = WebCore::URLMatch::host("second.example.com"_s);
+
+    static constexpr auto behaviors = WTF::toArray({
+        WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(WebCore::QuirkParameters::fromScript("firstScript"_s)).when(firstScriptURL),
+        WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(WebCore::QuirkParameters::fromScript("secondScript"_s)).when(secondScriptURL),
+    });
+
+    WebCore::QuirksData quirks;
+    quirks.applyTableRow(behaviors);
+
+    EXPECT_EQ(scriptsForScriptURL(quirks, "https://first.example.com/a.js"_s), Vector<String> { "firstScript"_str });
+    EXPECT_EQ(scriptsForScriptURL(quirks, "https://second.example.com/b.js"_s), Vector<String> { "secondScript"_str });
+
+    EXPECT_TRUE(scriptsForScriptURL(quirks, "https://third.example.com/c.js"_s).isEmpty());
+}
+
+TEST_F(QuirksTest, EveryMatchingRowContributesWhenSeveralSupplyTheSameBehavior)
+{
+    static constexpr auto anyScriptURL = WebCore::URLMatch::anyURL();
+
+    static constexpr auto behaviors = WTF::toArray({
+        WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(WebCore::QuirkParameters::fromScript("firstScript"_s)).when(anyScriptURL),
+        WebCore::QuirkBehaviors::needsScriptToEvaluateBeforeRunningScriptFromURLQuirk(WebCore::QuirkParameters::fromScript("secondScript"_s)).when(anyScriptURL),
+    });
+
+    WebCore::QuirksData quirks;
+    quirks.applyTableRow(behaviors);
+
+    Vector<String> expected { "firstScript"_str, "secondScript"_str };
+    EXPECT_EQ(scriptsForScriptURL(quirks, "https://first.example.com/a.js"_s), expected);
 }
 
 TEST_F(QuirksTest, NeedsIPadMiniUserAgent)
@@ -193,7 +282,7 @@ TEST_F(QuirksTest, ShouldTranscodeHeicImagesForURL)
 TEST_F(QuirksTest, IsMicrosoftTeamsRedirectURL)
 {
     auto isRedirect = [](ASCIILiteral urlString) {
-        return resolveQuirksForTopURL(urlString).quirkIsEnabled(WebCore::QuirkBehaviors::isMicrosoftTeamsRedirectURLQuirk);
+        return resolveQuirksForTopURL(urlString).isBehaviorEnabled(WebCore::QuirkBehaviors::isMicrosoftTeamsRedirectURLQuirk);
     };
 
     EXPECT_TRUE(isRedirect("https://teams.microsoft.com/?error=Retried+3+times+without+success"_s));

--- a/Tools/TestWebKitAPI/Tests/WebCore/URLMatch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/URLMatch.cpp
@@ -177,6 +177,44 @@ TEST(URLMatchTest, PathIsMatchesTheWholePath)
     EXPECT_FALSE(matchesURL(match, "https://shopee.sg/Payment/Account-Linking/Landing"_s));
 }
 
+TEST(URLMatchTest, LastPathComponentIsMatchesOnlyTheFinalSegment)
+{
+    auto match = URLMatch::anyURL().when(lastPathComponentIs("CheckBrowserClose.js"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://ceac.state.gov/CheckBrowserClose.js"_s));
+    EXPECT_TRUE(matchesURL(match, "https://ceac.state.gov/js/vendor/CheckBrowserClose.js?v=3"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://ceac.state.gov/js/NotCheckBrowserClose.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://ceac.state.gov/CheckBrowserClose.js/inner.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://ceac.state.gov/checkbrowserclose.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://ceac.state.gov/"_s));
+}
+
+TEST(URLMatchTest, LastPathComponentStartsWithIgnoresEarlierSegments)
+{
+    auto match = URLMatch::anyURL().when(lastPathComponentStartsWith("pushdownload."_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://webex.com/pushdownload.js"_s));
+    EXPECT_TRUE(matchesURL(match, "https://webex.com/static/pushdownload.1a2b3c.js"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://webex.com/pushdownload/main.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://webex.com/vendor-pushdownload.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://webex.com/"_s));
+}
+
+TEST(URLMatchTest, LastPathComponentEndsWithIgnoresTheQuery)
+{
+    auto match = URLMatch::host("player.anyclip.com"_s).when(lastPathComponentEndsWith("lre.js"_s));
+
+    EXPECT_TRUE(matchesURL(match, "https://player.anyclip.com/lre.js"_s));
+    EXPECT_TRUE(matchesURL(match, "https://player.anyclip.com/player/lre.js?pubname=abc"_s));
+    EXPECT_TRUE(matchesURL(match, "https://player.anyclip.com/anyclip-widget-lre.js"_s));
+
+    EXPECT_FALSE(matchesURL(match, "https://player.anyclip.com/lre.js/wrapper.min.js"_s));
+    EXPECT_FALSE(matchesURL(match, "https://player.anyclip.com/lre.json"_s));
+    EXPECT_FALSE(matchesURL(match, "https://cdn.anyclip.com/lre.js"_s));
+}
+
 TEST(URLMatchTest, PathOrFragmentContainsSearchesBoth)
 {
     auto match = URLMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s));


### PR DESCRIPTION
#### 48ad1233623c8d84c12e38b8e1a6bde9df8d8ee3
<pre>
[Quirks] Add parameterized quirks to the table
<a href="https://rdar.apple.com/186013869">rdar://186013869</a>

Reviewed by Sammy Gill.

Some quirk behaviors cannot be represented by just a bit in the QuirkBitSet, and
need parameters. One example of this is the QuirkBehavior:
needsScriptToEvaluateBeforeRunningScriptFromURLQuirk, which needs to be parameterized
by a script.

This patch introduces a mechanism for the following:
1. defining QuirkBehaviors with parameters,
        The QuirkBehavior type has gained a new field to represent which parameters are needed
        and a field to hold those parameters.
2. verifying that parameterized QuirkBehaviors are being declared correctly at compile time
        I added a static assert to check that every behavior in the QuirkTable is passing the correct
        parameters.
3. representing parameterized QuirkBehaviors in the QuirksData.
        QuirksData now holds a vector of parameterized quirk behaviors as well as the active quirk bits.
        The quirk bits still act as the source of truth, while the parameterized quirk behaviors
        hold extra information about parameters, since most quirks are not parameterized.

On top of this new infrastructure, I ported all scripts used with
needsScriptToEvaluateBeforeRunningScriptFromURLQuirk from Quirks.cpp to the Quirk table.

Note that I also made it possible to have multiple scripts for one site.

* Source/WebCore/page/QuirkBehaviors.h:
(WebCore::QuirkParameters::fromScript):
(WebCore::QuirkBehavior::operator() const):
* Source/WebCore/page/QuirkTable.cpp:
(WebCore::SiteSpecificQuirks::firstQuirkWithInvalidParameters):

Canonical link: <a href="https://commits.webkit.org/320961@main">https://commits.webkit.org/320961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a63a7d856f0bac887762ea3a86cabdd677ae7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186390 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150884 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125971 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48029 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45736 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59926 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155204 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60637 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154842 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49260 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130103 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59060 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20715 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58464 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->