### PR TITLE
Move some part of collectScreenProperties to a background thread

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -30,6 +30,7 @@
 
 #include "ScreenProperties.h"
 #include <wtf/Lock.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -123,6 +124,19 @@ void PlatformScreen::updateSingletonContentsFormatsForTesting(OptionSet<Contents
     updateSingletonProperties(WTF::move(properties));
 }
 #endif
+
+#if PLATFORM(COCOA) && !PLATFORM(MAC)
+
+void collectScreenPropertiesAsync(CompletionHandler<void(ScreenProperties&&)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    callOnMainThread([screenProperties = collectScreenProperties(), completionHandler = WTF::move(completionHandler)]() mutable {
+        completionHandler(WTF::move(screenProperties));
+    });
+}
+
+#endif // PLATFORM(COCOA) && !PLATFORM(MAC)
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -28,6 +28,7 @@
 #include <WebCore/ContentsFormat.h>
 #include <WebCore/ScreenProperties.h>
 #include <memory>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -121,6 +122,7 @@ private:
 };
 
 WEBCORE_EXPORT ScreenProperties collectScreenProperties();
+WEBCORE_EXPORT void collectScreenPropertiesAsync(CompletionHandler<void(ScreenProperties&&)>&&);
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
 WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -39,7 +39,10 @@
 #import <pal/cocoa/OpenGLSoftLinkCocoa.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <wtf/MainThread.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/ProcessPrivilege.h>
+#import <wtf/WorkQueue.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
@@ -129,37 +132,51 @@ static DynamicRangeMode convertAVVideoRangeToEnum(NSString* range)
 }
 #endif
 
-ScreenProperties collectScreenProperties()
+// May run on the main thread or a background thread.
+static bool collectHDRStateForDisplay(PlatformDisplayID displayID, DynamicRangeMode& dynamicRangeMode)
+{
+    bool supportsHighDynamicRange = false;
+#if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
+    if (PAL::isAVFoundationFrameworkAvailable()) {
+        dynamicRangeMode = convertAVVideoRangeToEnum([PAL::getAVPlayerClassSingleton() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
+        supportsHighDynamicRange = dynamicRangeMode > DynamicRangeMode::Standard;
+    }
+#endif
+#if HAVE(AVPLAYER_VIDEORANGEOVERRIDE) && USE(MEDIATOOLBOX)
+    else
+#endif
+#if USE(MEDIATOOLBOX)
+    if (PAL::isMediaToolboxFrameworkAvailable() && PAL::canLoad_MediaToolbox_MTShouldPlayHDRVideo())
+        supportsHighDynamicRange = PAL::softLink_MediaToolbox_MTShouldPlayHDRVideo((__bridge CFArrayRef)@[ @(displayID) ]);
+#endif
+
+    if (!supportsHighDynamicRange && dynamicRangeMode > DynamicRangeMode::Standard)
+        dynamicRangeMode = DynamicRangeMode::Standard;
+
+    if (supportsHighDynamicRange && WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled())
+        supportsHighDynamicRange = false;
+
+    return supportsHighDynamicRange;
+}
+
+static void collectHDRState(ScreenProperties& screenProperties)
+{
+    for (auto& [displayID, screenData] : screenProperties.screenDataMap)
+        screenData.screenSupportsHighDynamicRange = collectHDRStateForDisplay(displayID, screenData.preferredDynamicRangeMode);
+}
+
+static WorkQueue& screenPropertiesQueueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("org.webkit.ScreenProperties"_s, WorkQueue::QOS::UserInitiated));
+    return queue.get();
+}
+
+static ScreenProperties collectScreenPropertiesExceptForHDRState()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
 
     ScreenProperties screenProperties;
     bool screenHasInvertedColors = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldInvertColors];
-
-    auto screenSupportsHighDynamicRange = [](PlatformDisplayID displayID, DynamicRangeMode& dynamicRangeMode) {
-        bool supportsHighDynamicRange = false;
-#if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
-        if (PAL::isAVFoundationFrameworkAvailable()) {
-            dynamicRangeMode = convertAVVideoRangeToEnum([PAL::getAVPlayerClassSingleton() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
-            supportsHighDynamicRange = dynamicRangeMode > DynamicRangeMode::Standard;
-        }
-#endif
-#if HAVE(AVPLAYER_VIDEORANGEOVERRIDE) && USE(MEDIATOOLBOX)
-        else
-#endif
-#if USE(MEDIATOOLBOX)
-        if (PAL::isMediaToolboxFrameworkAvailable() && PAL::canLoad_MediaToolbox_MTShouldPlayHDRVideo())
-            supportsHighDynamicRange = PAL::softLink_MediaToolbox_MTShouldPlayHDRVideo((__bridge CFArrayRef)@[ @(displayID) ]);
-#endif
-
-        if (!supportsHighDynamicRange && dynamicRangeMode > DynamicRangeMode::Standard)
-            dynamicRangeMode = DynamicRangeMode::Standard;
-
-        if (supportsHighDynamicRange && WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled())
-            supportsHighDynamicRange = false;
-
-        return supportsHighDynamicRange;
-    };
 
     for (NSScreen *screen in [NSScreen screens]) {
         ScreenData screenData;
@@ -182,7 +199,6 @@ ScreenProperties collectScreenProperties()
 
         screenData.screenSize = FloatSize { CGDisplayScreenSize(displayID) };
         screenData.scaleFactor = screen.backingScaleFactor;
-        screenData.screenSupportsHighDynamicRange = screenSupportsHighDynamicRange(displayID, screenData.preferredDynamicRangeMode);
 #if HAVE(SUPPORT_HDR_DISPLAY)
         screenData.maxEDRHeadroom = [screen maximumPotentialExtendedDynamicRangeColorComponentValue];
         screenData.currentEDRHeadroom = [screen maximumExtendedDynamicRangeColorComponentValue];
@@ -196,6 +212,27 @@ ScreenProperties collectScreenProperties()
     }
 
     return screenProperties;
+}
+
+ScreenProperties collectScreenProperties()
+{
+    auto screenProperties = collectScreenPropertiesExceptForHDRState();
+    collectHDRState(screenProperties);
+    return screenProperties;
+}
+
+void collectScreenPropertiesAsync(CompletionHandler<void(ScreenProperties&&)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    auto screenProperties = collectScreenPropertiesExceptForHDRState();
+
+    screenPropertiesQueueSingleton().dispatch([screenProperties = WTF::move(screenProperties), completionHandler = WTF::move(completionHandler)]() mutable {
+        collectHDRState(screenProperties);
+        callOnMainThread([screenProperties = WTF::move(screenProperties), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(screenProperties));
+        });
+    });
 }
 
 void setShouldOverrideScreenSupportsHighDynamicRange(bool shouldOverride, bool supportsHighDynamicRange)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -459,10 +459,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.shouldLogUserInteraction = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
 #endif
 
-    auto screenProperties = WebCore::collectScreenProperties();
-    parameters.screenProperties = WTF::move(screenProperties);
 #if PLATFORM(MAC)
+    parameters.screenProperties = cachedScreenProperties();
     parameters.useOverlayScrollbars = ([NSScroller preferredScrollerStyle] == NSScrollerStyleOverlay);
+#else
+    parameters.screenProperties = WebCore::collectScreenProperties();
 #endif
 
 #if PLATFORM(VISION)
@@ -1302,16 +1303,32 @@ void WebProcessPool::screenPropertiesUpdateTimerFired()
 {
     m_lastScreenPropertiesUpdateTime = ApproximateTime::now();
 
-    auto screenProperties = WebCore::collectScreenProperties();
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    if (m_suppressEDR) {
-        for (auto& properties : screenProperties.screenDataMap.values()) {
-            constexpr auto maxSuppressedHeadroom = 1.6f;
-            auto suppressedHeadroom = std::min(maxSuppressedHeadroom, properties.currentEDRHeadroom);
-            properties.currentEDRHeadroom = suppressedHeadroom;
-            properties.suppressEDR = true;
-        }
+    if (m_screenPropertiesState != ScreenPropertiesState::Idle) {
+        m_screenPropertiesState = ScreenPropertiesState::CollectingWithUpdatePending;
+        return;
     }
+
+    m_screenPropertiesState = ScreenPropertiesState::Collecting;
+    WebCore::collectScreenPropertiesAsync([weakThis = WeakPtr { *this }](WebCore::ScreenProperties&& screenProperties) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didCollectScreenProperties(WTF::move(screenProperties));
+    });
+}
+
+void WebProcessPool::didCollectScreenProperties(WebCore::ScreenProperties&& screenProperties)
+{
+    ASSERT(m_screenPropertiesState != ScreenPropertiesState::Idle);
+
+    // If we got a screen change notification while collecting screen properties, then we need to
+    // schedule another screen properties update to reflect the most recent state.
+    bool needsUpdate = m_screenPropertiesState == ScreenPropertiesState::CollectingWithUpdatePending;
+
+    m_screenPropertiesState = ScreenPropertiesState::Idle;
+
+    applyEDRSuppressionIfNeeded(screenProperties);
+
+#if PLATFORM(MAC)
+    m_cachedScreenProperties = screenProperties;
 #endif
 
     sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
@@ -1320,7 +1337,39 @@ void WebProcessPool::screenPropertiesUpdateTimerFired()
     if (RefPtr gpuProcess = this->gpuProcess())
         gpuProcess->setScreenProperties(screenProperties);
 #endif
+
+    if (needsUpdate)
+        screenPropertiesChanged();
 }
+
+void WebProcessPool::applyEDRSuppressionIfNeeded(WebCore::ScreenProperties& screenProperties)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (!m_suppressEDR)
+        return;
+
+    for (auto& properties : screenProperties.screenDataMap.values()) {
+        constexpr auto maxSuppressedHeadroom = 1.6f;
+        properties.currentEDRHeadroom = std::min(maxSuppressedHeadroom, properties.currentEDRHeadroom);
+        properties.suppressEDR = true;
+    }
+#else
+    UNUSED_PARAM(screenProperties);
+#endif
+}
+
+#if PLATFORM(MAC)
+const WebCore::ScreenProperties& WebProcessPool::cachedScreenProperties()
+{
+    if (!m_cachedScreenProperties) {
+        auto screenProperties = WebCore::collectScreenProperties();
+        applyEDRSuppressionIfNeeded(screenProperties);
+        m_cachedScreenProperties = WTF::move(screenProperties);
+    }
+
+    return *m_cachedScreenProperties;
+}
+#endif
 
 void WebProcessPool::screenPropertiesChanged()
 {

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -827,13 +827,15 @@ void GPUProcessProxy::updatePreferences(WebProcessProxy& webProcess)
     send(Messages::GPUProcess::UpdateGPUProcessPreferences(gpuPreferences), 0);
 }
 
-void GPUProcessProxy::updateScreenPropertiesIfNeeded()
+void GPUProcessProxy::updateScreenPropertiesIfNeeded(WebProcessPool& processPool)
 {
 #if PLATFORM(MAC)
     if (!canSendMessage())
         return;
 
-    setScreenProperties(collectScreenProperties());
+    setScreenProperties(processPool.cachedScreenProperties());
+#else
+    UNUSED_PARAM(processPool);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -73,6 +73,7 @@ enum class ProcessTerminationReason : uint8_t;
 
 class SandboxExtensionHandle;
 class WebPageProxy;
+class WebProcessPool;
 class WebProcessProxy;
 class WebsiteDataStore;
 
@@ -141,7 +142,7 @@ public:
 #endif
 
     void updatePreferences(WebProcessProxy&);
-    void updateScreenPropertiesIfNeeded();
+    void updateScreenPropertiesIfNeeded(WebProcessPool&);
 
     void childConnectionDidBecomeUnresponsive();
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -542,7 +542,7 @@ GPUProcessProxy& WebProcessPool::ensureGPUProcess()
         m_gpuProcess = gpuProcess.copyRef();
         for (Ref process : m_processes)
             gpuProcess->updatePreferences(process);
-        gpuProcess->updateScreenPropertiesIfNeeded();
+        gpuProcess->updateScreenPropertiesIfNeeded(*this);
     }
     return *m_gpuProcess;
 }
@@ -1447,7 +1447,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
 
     if (RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated()) {
         gpuProcess->updatePreferences(*process);
-        gpuProcess->updateScreenPropertiesIfNeeded();
+        gpuProcess->updateScreenPropertiesIfNeeded(*this);
     }
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -64,6 +64,7 @@ OBJC_CLASS WKProcessPoolWeakObserver;
 
 #if PLATFORM(MAC)
 #include <WebCore/PowerObserverMac.h>
+#include <WebCore/ScreenProperties.h>
 #include <pal/system/SystemSleepListener.h>
 #endif
 
@@ -106,6 +107,7 @@ enum class GamepadHapticEffectType : uint8_t;
 enum class ProcessSwapDisposition : uint8_t;
 struct GamepadEffectParameters;
 struct MockMediaDevice;
+struct ScreenProperties;
 #if PLATFORM(COCOA)
 class PowerSourceNotifier;
 #endif
@@ -259,6 +261,7 @@ public:
 #endif
 
 #if PLATFORM(MAC)
+    const WebCore::ScreenProperties& cachedScreenProperties();
     void displayPropertiesChanged(WebCore::PlatformDisplayID, CGDisplayChangeSummaryFlags);
 #endif
 
@@ -743,7 +746,15 @@ private:
     void clearAudibleActivity();
 
 #if PLATFORM(COCOA)
+    enum class ScreenPropertiesState : uint8_t {
+        Idle,
+        Collecting,
+        CollectingWithUpdatePending,
+    };
+
     void screenPropertiesUpdateTimerFired();
+    void didCollectScreenProperties(WebCore::ScreenProperties&&);
+    void applyEDRSuppressionIfNeeded(WebCore::ScreenProperties&);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -1027,6 +1038,11 @@ private:
 
     ApproximateTime m_lastScreenPropertiesUpdateTime;
     RunLoop::Timer m_screenPropertiesUpdateTimer;
+    ScreenPropertiesState m_screenPropertiesState { ScreenPropertiesState::Idle };
+#endif
+
+#if PLATFORM(MAC)
+    std::optional<WebCore::ScreenProperties> m_cachedScreenProperties;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -190,6 +190,7 @@ list(APPEND TestWebKit_SOURCES
     Tests/WebCore/TestPlatformStrategies.cpp
 
     Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
+    Tests/WebCore/cocoa/PlatformScreenTests.mm
 
     Tests/WebKit/WKWebView/WKBackForwardListTests.mm
 )

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -738,6 +738,7 @@
 				WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp,
 				WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm,
 				WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp,
+				WebCore/cocoa/PlatformScreenTests.mm,
 				WebCore/cocoa/PrivateClickMeasurementCocoa.mm,
 				WebCore/cocoa/ResourceMonitor.mm,
 				WebCore/cocoa/ScrollbarWidthCrash.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformScreenTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformScreenTests.mm
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA)
+
+#import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
+#import <WebCore/PlatformScreen.h>
+#import <WebCore/ScreenProperties.h>
+#import <wtf/MainThread.h>
+
+namespace TestWebKitAPI {
+
+TEST(PlatformScreen, CollectScreenPropertiesAsync)
+{
+    auto expectedProperties = WebCore::collectScreenProperties();
+
+    bool done = false;
+    std::optional<WebCore::ScreenProperties> actualProperties;
+    WebCore::collectScreenPropertiesAsync([&](WebCore::ScreenProperties&& properties) {
+        EXPECT_TRUE(isMainThread());
+        actualProperties = WTF::move(properties);
+        done = true;
+    });
+
+    EXPECT_FALSE(done);
+
+    Util::run(&done);
+
+    ASSERT_TRUE(actualProperties.has_value());
+    EXPECT_EQ(actualProperties->primaryDisplayID, expectedProperties.primaryDisplayID);
+    EXPECT_EQ(actualProperties->screenDataMap.size(), expectedProperties.screenDataMap.size());
+
+    // Only the dynamic range state is collected differently by the two functions, so limit the
+    // comparison to that. The other properties might differ (e.g. currentEDRHeadroom is affected by
+    // display brightness).
+    for (auto& [displayID, expectedScreenData] : expectedProperties.screenDataMap) {
+        auto iterator = actualProperties->screenDataMap.find(displayID);
+        ASSERT_TRUE(iterator != actualProperties->screenDataMap.end());
+        EXPECT_EQ(iterator->value.screenSupportsHighDynamicRange, expectedScreenData.screenSupportsHighDynamicRange);
+#if PLATFORM(MAC)
+        EXPECT_EQ(iterator->value.preferredDynamicRangeMode, expectedScreenData.preferredDynamicRangeMode);
+#endif
+    }
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 209e271d944ef2a3758bc25ca8ff8ab9bd149155
<pre>
Move some part of collectScreenProperties to a background thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=322756">https://bugs.webkit.org/show_bug.cgi?id=322756</a>
<a href="https://rdar.apple.com/184130213">rdar://184130213</a>

Reviewed by Simon Fraser.

We are getting hang logs showing that some part of collectScreenProperties (the call to
`+preferredVideoRangeForDisplays:`) ends up in a sync IPC to WindowServer that can sometimes block
the main thread of the UIProcess for multiple seconds.

To fix this, this patch adds a collectScreenPropertiesAsync function, which moves just the HDR state
collection for a display to a background thread. (Note that I considered just running all of
collectScreenProperties on a background thread, but after inspection it seems like some NSScreen
methods aren&apos;t meant to be called off the main thread.)

In addition, WebProcessPool now caches the last screen properties state and uses it on the
WebProcess creation path. This removes a sync IPC from the WebProcess creation path.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformScreenTests.mm

* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::collectScreenPropertiesAsync):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectHDRStateForDisplay):
(WebCore::collectHDRState):
(WebCore::collectScreenPropertiesExceptForHDRState):
(WebCore::collectScreenProperties):
(WebCore::collectScreenPropertiesAsync):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::screenPropertiesUpdateTimerFired):
(WebKit::WebProcessPool::didCollectScreenProperties):
(WebKit::WebProcessPool::applyEDRSuppressionIfNeeded):
(WebKit::WebProcessPool::cachedScreenProperties):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::updateScreenPropertiesIfNeeded):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::ensureGPUProcess):
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformScreenTests.mm: Added.
(TestWebKitAPI::TEST(PlatformScreen, CollectScreenPropertiesAsync)):

Canonical link: <a href="https://commits.webkit.org/320060@main">https://commits.webkit.org/320060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21f389ecf9fb3c9762a5390f2f1b5b60e2857961

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147909 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143309 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99504 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05c5c0e3-6921-41f8-af53-ae1afac95ec3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47075 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cda2fb4-e479-4cdc-9b88-b6706d97f174) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45777 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44009 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43597 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5018 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57212 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40948 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57916 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152525 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47069 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130195 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56424 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18607 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55795 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55862 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->