### PR TITLE
[JSC][Wasm] Handle mismatched arity on the JS-to-Wasm IC

### DIFF
--- a/JSTests/wasm/stress/js-to-wasm-arity.js
+++ b/JSTests/wasm/stress/js-to-wasm-arity.js
@@ -1,0 +1,36 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "addi32") (param i32 i32) (result i32)
+        local.get 0
+        local.get 1
+        i32.add)
+    (func (export "identf64") (param f64) (result f64)
+        local.get 0)
+    (func (export "identextern") (param externref) (result externref)
+        local.get 0)
+    (func (export "identi64") (param i64) (result i64)
+        local.get 0)
+    (func (export "nop"))
+)
+`
+
+async function test() {
+    const { addi32, identf64, identextern, identi64, nop } = (await instantiate(wat)).exports
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(addi32(1, 2), 3)
+        assert.eq(addi32(1), 1)
+        assert.eq(addi32(), 0)
+        assert.eq(addi32(1, 2, 99), 3)
+        assert.eq(Object.is(identf64(), NaN), true)
+        assert.eq(identf64(1.5), 1.5)
+        assert.eq(identextern(), undefined)
+        nop(1)
+        assert.throws(() => identi64(), TypeError, "")
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -511,16 +511,6 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
     // Don't store the Wasm::Callee until after our stack check.
     jit.storeWasmCalleeToCalleeCallFrame(scratchJSR.payloadGPR());
 
-    // Ensure:
-    // argCountPlusThis - 1 >= argumentCount()
-    // argCountPlusThis >= argumentCount() + 1
-    // FIXME: We should handle mismatched arity
-    // https://bugs.webkit.org/show_bug.cgi?id=196564
-    if (argumentCount() > 0) {
-        slowPath.append(jit.branch32(CCallHelpers::Below,
-            CCallHelpers::lowWordFor(CallFrameSlot::argumentCountIncludingThis), CCallHelpers::TrustedImm32(argumentCount() + 1)));
-    }
-
     bool haveTagRegisters = false;
     auto materializeTagRegistersIfNeeded = [&] {
         if (!haveTagRegisters) {
@@ -539,6 +529,12 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
 
         auto type = argumentType(i);
         JIT_COMMENT(jit, "Arg ", i, " : ", type);
+
+        bool missingUsesUndefined = type.isI32() || type.isF32() || type.isF64() || Wasm::isExternref(type);
+        auto missingArg = jit.branch32(CCallHelpers::BelowOrEqual, CCallHelpers::lowWordFor(CallFrameSlot::argumentCountIncludingThis), CCallHelpers::TrustedImm32(i + 1));
+        if (!missingUsesUndefined)
+            slowPath.append(missingArg);
+
         switch (type.kind()) {
         case Wasm::TypeKind::I32: {
             materializeTagRegistersIfNeeded();
@@ -653,6 +649,35 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
         case Wasm::TypeKind::V128:
         default:
             RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        if (missingUsesUndefined) {
+            auto argDone = jit.jump();
+            missingArg.link(&jit);
+            if (type.isI32()) {
+                if (isStack) {
+                    CCallHelpers::Address addr { calleeFrame.withOffset(wasmCallInfo.params[i].location.offsetFromSP()) };
+                    jit.store32(CCallHelpers::TrustedImm32(0), addr.withOffset(LowWordOffset));
+                } else
+                    jit.xorPtr(wasmCallInfo.params[i].location.jsr().payloadGPR(), wasmCallInfo.params[i].location.jsr().payloadGPR());
+            } else if (type.isF32() || type.isF64()) {
+                if (!isStack)
+                    scratchFPR = wasmCallInfo.params[i].location.fpr();
+                jit.move64ToDouble(CCallHelpers::TrustedImm64(std::bit_cast<uint64_t>(PNaN)), scratchFPR);
+                if (type.isF32())
+                    jit.convertDoubleToFloat(scratchFPR, scratchFPR);
+                if (isStack) {
+                    CCallHelpers::Address addr { calleeFrame.withOffset(wasmCallInfo.params[i].location.offsetFromSP()) };
+                    if (type.isF32())
+                        jit.storeFloat(scratchFPR, addr.withOffset(LowWordOffset));
+                    else
+                        jit.storeDouble(scratchFPR, addr);
+                }
+            } else if (isStack)
+                jit.storeTrustedValue(jsUndefined(), calleeFrame.withOffset(wasmCallInfo.params[i].location.offsetFromSP()));
+            else
+                jit.moveTrustedValue(jsUndefined(), wasmCallInfo.params[i].location.jsr());
+            argDone.link(&jit);
         }
     }
 


### PR DESCRIPTION
#### df0f74a4ed2afd738d3cb3c4d1d64853370a030a
<pre>
[JSC][Wasm] Handle mismatched arity on the JS-to-Wasm IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=196564">https://bugs.webkit.org/show_bug.cgi?id=196564</a>

Reviewed by NOBODY (OOPS!).

Missing JS arguments are converted on the IC fast path (0 / NaN /
undefined). i64 and funcref still take the slow path. Extra arguments
were already ignored.

* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
* JSTests/wasm/stress/js-to-wasm-arity.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0f74a4ed2afd738d3cb3c4d1d64853370a030a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147717 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143165 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99413 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43862 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5558 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12406 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43463 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4821 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44702 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57020 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152366 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46923 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130003 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126302 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->