### PR TITLE
[webkitscmpy] git-webkit revert crashes instead of reporting an unresolvable commit

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -73,8 +73,8 @@ class Revert(Command):
             try:
                 commit = repository.find(c, include_log=True)
             except (local.Scm.Exception, ValueError) as exception:
-                sys.stderr.write('Could not find "{}"'.format(c) + '\n')
-                return None, None, None
+                sys.stderr.write('Could not find "{}": {}\n'.format(c, exception))
+                return None, None
 
             commit_objects.append(commit)
             for i in commit.issues:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -293,6 +293,20 @@ index 05e8751..0bf3c85 100644
 
         self.assertEqual(captured.stderr.getvalue(), 'Please commit your changes or stash them before you revert commit: d8bce26fa65c6fc8f39c17927abb77f69fab82fc')
 
+    def test_unresolvable_commit(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, \
+                mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []):
+
+            result = program.main(
+                args=('revert', '319904@main.', '-v', '--no-pr'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+        self.assertTrue(captured.stderr.getvalue().startswith('Could not find "319904@main."'))
+        self.assertNotIn('Traceback', captured.stderr.getvalue())
+
     def test_update(self):
         with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)), OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),


### PR DESCRIPTION
#### 659cfaf4fb28aacbf69f6b7eccecc46181535460
<pre>
[webkitscmpy] git-webkit revert crashes instead of reporting an unresolvable commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=322744">https://bugs.webkit.org/show_bug.cgi?id=322744</a>
<a href="https://rdar.apple.com/186010871">rdar://186010871</a>

Reviewed by Aakash Jain.

Revert.get_commit_info() returns a 3-tuple on its error path but a 2-tuple on success, and
the sole caller unpacks two values. So any unresolvable commit id (such as a typo, wrong branch,
or a checkout that hasn&apos;t fetched a recent commit) raises &quot;too many values to unpack&quot; right after
printing the intended &quot;Could not find&quot; message, and the top-level handler turns that into a
full traceback with exit code -1 instead of a clean exit 1. This is also the underlying cause
of <a href="https://bugs.webkit.org/show_bug.cgi?id=322685.">https://bugs.webkit.org/show_bug.cgi?id=322685.</a>

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.get_commit_info): Return a 2-tuple on the error path, and include the exception&apos;s
message in the printed &quot;Could not find&quot; line so the reason for the error is more clear.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.test_unresolvable_commit): Added.

Canonical link: <a href="https://commits.webkit.org/320842@main">https://commits.webkit.org/320842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/712cee9794447021f8a68e7e3078185df2794775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57364 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/193661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46933 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b870413a-5978-4de1-98c5-9dc72cc81f3b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182767 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43871 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/193661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156028 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4835 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48138 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195600 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182844 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152694 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57738 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152375 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46927 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126316 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56246 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55684 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->