### PR TITLE
[WebKitBot] revert mis-parses a commit identifier followed by sentence punctuation

### DIFF
--- a/Tools/WebKitBot/src/CommandParser.mjs
+++ b/Tools/WebKitBot/src/CommandParser.mjs
@@ -62,6 +62,12 @@ function extractRevision(text)
         // Accept identifiers pasted as commits.webkit.org links, which is what webkitbot itself posts.
         candidate = candidate.replace(/^https?:\/\/commits\.webkit\.org\//, "");
 
+        // Strip trailing sentence punctuation (e.g. "319904@main.") so it isn't captured as part
+        // of the identifier or branch name, along with a leading "(" or "[" left unbalanced by
+        // that strip (e.g. "(319904@main)" or "(319904@main.").
+        candidate = candidate.replace(/[.;!?)\]]+$/, "");
+        candidate = candidate.replace(/^[(\[]+/, "");
+
         let match = candidate.match(/^r?(\d{5,6}|\d+@[^:\s]+|[0-9a-f]{6,40}):?$/);
         if (!match)
             return null;

--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -235,6 +235,17 @@ export default class WebKitBot {
                         });
                         return;
                     }
+                    if (usingGitWebkit) {
+                        let match = stderr.match(/Could not find "([^"]*)"(?::\s*(.*))?/);
+                        if (match) {
+                            let detail = match[2] ? ` ${escapeForSlackText(match[2].trim())}` : "";
+                            await this.postMessage({
+                                channel: event.channel,
+                                text: `<@${event.user}> Could not find commit \`${escapeForSlackText(match[1])}\`.${detail}`,
+                            });
+                            return;
+                        }
+                    }
                     // webkit-patch: merge conflict
                     {
                         let index = stderr.indexOf("Failed to apply reverse diff for revision");

--- a/Tools/WebKitBot/tests/WebKitBot.test.mjs
+++ b/Tools/WebKitBot/tests/WebKitBot.test.mjs
@@ -228,3 +228,71 @@ test("mention in different place", () => {
     expect(reason).toBe("testing revert");
     expect(revisions).toEqual(["263483", "263484", "263485", "263486"]);
 });
+
+test("identifier followed by trailing sentence punctuation", () => {
+    let message = `<@${WebKitBotID}> revert 319904@main. Broke Simulator and Catalyst builds.`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["319904@main"]);
+    expect(reason).toBe("Broke Simulator and Catalyst builds.");
+});
+
+test("identifier without trailing punctuation still works", () => {
+    let message = `<@${WebKitBotID}> revert 319904@main reason`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["319904@main"]);
+});
+
+test("branch name containing periods is preserved", () => {
+    let message = `<@${WebKitBotID}> revert 319904@safari-7620.1.16-branch reason`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["319904@safari-7620.1.16-branch"]);
+});
+
+test("bare svn revision with trailing period", () => {
+    let message = `<@${WebKitBotID}> revert 263483. reason`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["263483"]);
+});
+
+test("identifier wrapped in parentheses", () => {
+    let message = `<@${WebKitBotID}> revert (319904@main) reason`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["319904@main"]);
+});
+
+test("identifier wrapped in parentheses followed by a period", () => {
+    let message = `<@${WebKitBotID}> revert (319904@main). Broke the build.`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["319904@main"]);
+    expect(reason).toBe("Broke the build.");
+});


### PR DESCRIPTION
#### 42ad15583c7ebcb230a0ad4c400e274727dfd1a4
<pre>
[WebKitBot] revert mis-parses a commit identifier followed by sentence punctuation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322685">https://bugs.webkit.org/show_bug.cgi?id=322685</a>
<a href="https://rdar.apple.com/186002314">rdar://186002314</a>

Reviewed by Aakash Jain.

The regex used to extract the revision matched any non-colon / non-whitespace character after
the `@`, so a sentence-ending period got swallowed into the branch name. When that was passed
in verbatim to `git-webkit revert`, it wasn&apos;t able to resolve this non-existent `main.` branch
and errored out.

Strip trailing sentence punctuation from each candidate before matching, anchored to the end
of the token so branch names that legitimately contain periods (e.g. &quot;319904@safari-7620.1.16-branch&quot;)
are untouched. A git ref can&apos;t end in &quot;.&quot; per `git check-ref-format`, so this is always safe.
Also strip a leading &quot;(&quot; or &quot;[&quot; left unbalanced by that strip, so an identifier wrapped in
parentheses or brackets (e.g. &quot;(319904@main)&quot; or &quot;(319904@main).&quot;) still parses.

Also add a friendly error message for the &quot;Could not find&quot; case revert.py now produces (bug 322744),
including the detail it appends (e.g. &quot;Latest identifier on this branch is N&quot;) -- previously
this fell through to the generic handler, which dumps raw stderr into a Slack code block.

* Tools/WebKitBot/src/CommandParser.mjs:
(extractRevision): Strip trailing `.;!?)]` and unbalanced leading `(`/`[` from each candidate
before matching.
* Tools/WebKitBot/src/WebKitBot.mjs:
(WebKitBot.prototype.revertCommand): Add a `Could not find &quot;X&quot;` stderr matcher that posts
a short message instead of falling through to the raw stderr dump.
* Tools/WebKitBot/tests/WebKitBot.test.mjs: Added coverage for the reported regression,
an unpunctuated identifier, a branch name containing periods, a bare SVN revision with
a trailing period, and an identifier wrapped in parentheses (with and without trailing
punctuation).

Canonical link: <a href="https://commits.webkit.org/320834@main">https://commits.webkit.org/320834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2bbf5dd2213d8233bbf9c03c2c772ab481f2cdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147772 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6294d8c3-af08-4cf9-9ff3-c626cf60486a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143209 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99436 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f83aa2b-3a2a-46ec-9ae7-bd706da8e6eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123631 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5dc6bae2-bf29-4197-aeb4-855de7a3e9df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43901 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12438 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43495 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4878 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57075 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152726 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152406 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46959 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126357 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56287 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18504 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55658 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->