### PR TITLE
Cherry-pick 319245@main (cee623c24bfc). https://bugs.webkit.org/show_bug.cgi?id=320262

### DIFF
--- a/LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml
+++ b/LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><script>
+// Removing this frame from the parent document detaches this document's XML parser while
+// XMLDocumentParser::end() is still running.
+document.onreadystatechange = function () {
+    parent.postMessage("readystatechange", "*");
+    parent.document.querySelector("iframe").remove();
+};
+</script></body></html>

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+Test passes if it does not crash.
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+onmessage = function () { setTimeout(function () { testRunner?.notifyDone(); }, 0); };
+</script>
+<iframe src="resources/xml-parser-end-detach-frame.xhtml" style="display: none"></iframe>
+</html>

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Test passes if it does not crash.</p><script>
+testRunner?.dumpAsText();
+// XMLDocumentParser::end() dispatches readystatechange from setReadyState(). window.stop()
+// calls DocumentParser::finish() re-entrantly, which ends up detaching this parser and
+// nulling out its document, so end() must not keep using document() afterwards.
+document.onreadystatechange = function () { window.stop(); };
+</script></body></html>

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -208,14 +208,25 @@ void XMLDocumentParser::end()
             return;
     } else {
         updateLeafTextNode();
+
+        // Appending to the leaf text node may have fired mutation events, which can run arbitrary scripts.
+        if (isDetached())
+            return;
         document()->styleScope().didChangeStyleSheetEnvironment();
     }
 
     if (isParsing())
         prepareToStopParsing();
-    protectedDocument()->setReadyState(Document::ReadyState::Interactive);
+
+    Ref document = *this->document();
+    document->setReadyState(Document::ReadyState::Interactive);
+
+    // Setting the ready state above dispatches readystatechange, which can run arbitrary scripts.
+    if (isDetached())
+        return;
+
     clearCurrentNodeStack();
-    protectedDocument()->finishedParsing();
+    document->finishedParsing();
 }
 
 void XMLDocumentParser::finish()


### PR DESCRIPTION
#### a98add16dcd426c9891aa5b061199eef0dc4b999
<pre>
Cherry-pick 319245@main (cee623c24bfc). <a href="https://bugs.webkit.org/show_bug.cgi?id=320262">https://bugs.webkit.org/show_bug.cgi?id=320262</a>

    Null Document dereference in XMLDocumentParser::end() when readystatechange detaches the parser
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320262">https://bugs.webkit.org/show_bug.cgi?id=320262</a>
    <a href="https://rdar.apple.com/183186440">rdar://183186440</a>

    Reviewed by David Kilzer.

    XMLDocumentParser::end() dispatches readystatechange by calling
    Document::setReadyState(Interactive), which can run arbitrary script, and then
    kept using document() unconditionally. Script run from that event can detach the
    parser -- for example window.stop(), which calls DocumentParser::finish()
    re-entrantly and reaches Document::finishedParsing(), or removing the frame the
    XML document is loaded in -- after which document() is null and
    document()-&gt;finishedParsing() dereferences it. HTMLDocumentParser already
    re-checks isDetached() after setting the ready state for this reason; do the
    same in XMLDocumentParser::end(), and also re-check after updateLeafTextNode(),
    whose mutation events can run script two lines before another use of document().

    Bailing out is safe because detach() has already cleared the current node stack.

    Tests: fast/parser/xml-parser-end-detach-crash-frame-removal.html
           fast/parser/xml-parser-end-detach-crash-window-stop.xhtml

    * LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml: Added.
    (document.onreadystatechange):
    * LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt: Added.
    * LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html: Added.
    * LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt: Added.
    * LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml: Added.
    * Source/WebCore/xml/parser/XMLDocumentParser.cpp:
    (WebCore::XMLDocumentParser::end):

    Canonical link: <a href="https://commits.webkit.org/319245@main">https://commits.webkit.org/319245@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1124@webkitglib/2.52">https://commits.webkit.org/305877.1124@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58defbd2724e40ddaa55dc2ecc6cd39554840daa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183454 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57378 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147745 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185317 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58723 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57113 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143187 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147745 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186409 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58723 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123618 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58723 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57113 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58723 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4850 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50033 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57113 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195614 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57048 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152705 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57752 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152386 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27843 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57752 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130031 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126330 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/56260 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51195 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55631 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55870 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55698 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->