### PR TITLE
Remove MAYBE_EVALUATE_URL_WITH_TRANSITIVE_TRUST and MAYBE_REQUEST_PERMISSION_ASK_TO macros

### DIFF
--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -94,9 +94,16 @@ void WebParentalControlsURLFilter::isURLAllowedImpl(WebCore::IsMainFrameLoad isM
         RetainPtr filter = ensureWebContentFilter();
 #if HAVE(WEBCONTENTRESTRICTIONS_TRANSITIVE_TRUST)
 #if __has_include(<WebKitAdditions/BEKAdditions.h>)
-    if (WebCore::DeprecatedGlobalSettings::webContentRestrictionsTransitiveTrustEnabled()) {
-        MAYBE_EVALUATE_URL_WITH_TRANSITIVE_TRUST
-    }
+        if (WebCore::DeprecatedGlobalSettings::webContentRestrictionsTransitiveTrustEnabled()) {
+            BOOL isMainFrameForEvaluation = (isMainFrame == WebCore::IsMainFrameLoad::Yes);
+            if ([filter respondsToSelector:@selector(evaluateURL:mainFrameURL:isMainFrame:completionHandler:)]) {
+                [filter evaluateURL:url.createNSURL().get() mainFrameURL:mainDocumentURL.createNSURL().get() isMainFrame:isMainFrameForEvaluation completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+                    if (completionHandler)
+                        completionHandler(!shouldBlock, replacementData);
+                }).get()];
+                return;
+            }
+        }
 #endif
 #endif
         [filter evaluateURL:url.createNSURL().get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
@@ -154,11 +161,43 @@ void WebParentalControlsURLFilter::requestPermissionForURL(const URL& url, const
             });
             return;
         }
-        auto filter = ensureWebContentFilter();
+        RetainPtr filter = ensureWebContentFilter();
 #if __has_include(<WebKitAdditions/BEKAdditions.h>)
-        RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL starts execution");
-        MAYBE_REQUEST_PERMISSION_ASK_TO
+        if ([filter respondsToSelector:@selector(requestPermissionForURL:referrerURL:presentingView:completionHandler:)]) {
+            auto permissionDecisionCompletionHandler = makeBlockPtr([completionHandler = WTF::move(completionHandler)](BEWebContentFilterPermissionDecision result, NSError *) mutable {
+                switch (result) {
+                case BEWebContentFilterPermissionDecisionError:
+                    RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL result is error");
+                    break;
+                case BEWebContentFilterPermissionDecisionAllowed:
+                    RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL result is allowed");
+                    break;
+                case BEWebContentFilterPermissionDecisionDenied:
+                    RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL result is denied");
+                    break;
+                case BEWebContentFilterPermissionDecisionPending:
+                    RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL result is pending");
+                    break;
+                default:
+                    RELEASE_LOG_ERROR(Loading, "WebParentalControlsURLFilter::requestPermissionForURL result is invalid, result:%ld", (long)result);
+                    break;
+                }
+
+                bool didAllow = (result == BEWebContentFilterPermissionDecisionAllowed);
+                callOnMainRunLoop([didAllow, completionHandler = WTF::move(completionHandler)] mutable {
+                    if (completionHandler)
+                        completionHandler(didAllow);
+                });
+            });
+            [filter requestPermissionForURL:url.createNSURL().get() referrerURL:referrerURL.createNSURL().get() presentingView:presentingViewAsUIView completionHandler:permissionDecisionCompletionHandler.get()];
+            return;
+        }
 #endif
+        RELEASE_LOG_ERROR(Loading, "WebParentalControlsURLFilter::requestPermissionForURL is running an unsupported configuration - default to denying permission");
+        callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+            if (completionHandler)
+                completionHandler(false);
+        });
     });
 }
 #endif


### PR DESCRIPTION
#### dd8d64894febdb0f0eab97e19fc951317f23b4cc
<pre>
Remove MAYBE_EVALUATE_URL_WITH_TRANSITIVE_TRUST and MAYBE_REQUEST_PERMISSION_ASK_TO macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=322764">https://bugs.webkit.org/show_bug.cgi?id=322764</a>
<a href="https://rdar.apple.com/179995976">rdar://179995976</a>

Reviewed by Sihui Liu and Per Arne Vollan.

These macros are no longer needed.

There is a previous behavior change for WebParentalControlsURLFilter::requestPermissionForURL as we no longer fall
back to using the legacy flow of requestPermissionForURL if the BrowserEngineKit API requestPermissionForURL
is unavailable as we did with the macro. This was deemed acceptable as this filtering flow is only available
on iOS27 and all macOS/iOS27 platforms should have the latest BrowserEngineKit API&apos;s.

No new tests needed.

* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::isURLAllowedImpl):
(WebKit::WebParentalControlsURLFilter::requestPermissionForURL):

Canonical link: <a href="https://commits.webkit.org/320074@main">https://commits.webkit.org/320074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99c19fbc67e8aac90d8f3453364dfec350c7c1d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193886 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bc9ea17-6983-4342-89b7-fe9672da66b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143341 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8c7f7e7-8708-42f1-8d6b-3dcf7f815250) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123764 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae9f0aa9-4e09-4966-a190-f526540e7f21) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43623 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5070 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195824 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57258 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152877 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57962 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152562 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47102 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56470 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18633 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55841 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->