### PR TITLE
GitHub.com: v2: emoji reaction overlaps code box in comment

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4205,13 +4205,6 @@ imported/w3c/web-platform-tests/css/css-overflow/overflow-canvas.html [ ImageOnl
 imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-margin-border-radius-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-margin-border-radius.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
-
 # Tests that failed on the 2026-02-02 import of css-overflow
 imported/w3c/web-platform-tests/css/css-overflow/clip-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/column-style-change-triggers-relayout.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A horizontal scrollbar appears inside the flex container during its layout
+PASS An out-of-flow box under the same positioned inline is relaid out after the scrollbar change
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-vertical-lr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-vertical-lr-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A vertical scrollbar appears inside the flex container during its layout
+PASS An out-of-flow box under the same positioned inline is relaid out after the scrollbar change
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-vertical-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant-vertical-lr.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An absolutely positioned box is still relaid out after a scrollable descendant gains a scrollbar, in vertical-lr</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+/* Avoid auto scrollbars on the viewport, because that might trigger re-layout
+   (and thus hide bugs). */
+body { overflow: hidden; }
+
+/* Always-on scrollbars, so that the scrollbar below really does consume space and
+   change #scroller's content box. */
+#scroller::-webkit-scrollbar { width: 15px; height: 15px; }
+
+/* Same structure as abspos-relayout-with-scrollable-descendant.html, but in
+   vertical-lr, so the axes swap: it is a vertical scrollbar that consumes the flex
+   container's block-axis space, and the flex container's block size is its width.
+
+   The wrapper needs a definite block size of its own. It is orthogonal to the body,
+   so with an indefinite one it would be sized from its contents and would absorb the
+   scrollbar change before #flexContainer could. */
+#wrapper { writing-mode: vertical-lr; height: 800px; }
+
+#positionedInline { position: relative; }
+
+#inlineBlock { display: inline-block; height: 600px; vertical-align: top; }
+
+#flexContainer { display: flex; height: 500px; }
+
+#flexItem { flex: 0 0 auto; height: 100px; width: 30px; }
+
+#positionedFlexItem { position: relative; flex: 1 1 auto; }
+
+#scroller { position: absolute; top: 0; left: 0; height: 100%; width: 60px; overflow-y: auto; overflow-x: hidden; }
+#overflowingContent { height: 300px; width: 20px; }
+
+#targetContainingBlock { display: inline-block; position: relative; height: 300px; width: 120px; vertical-align: top; }
+#target { position: absolute; top: 0; left: 0; height: 100px; width: 20px; }
+</style>
+
+<div id="wrapper"><span id="positionedInline"><span id="inlineBlock"><div id="flexContainer"><div id="flexItem"></div><div id="positionedFlexItem"><div id="scroller"><div id="overflowingContent"></div></div></div></div></span><span id="targetContainingBlock"><div id="target"></div></span></span></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// #positionedFlexItem is 400px along the flex axis to begin with, so #scroller is
+// 400px and its 300px of content does not overflow.
+document.body.offsetHeight;
+
+// Growing #flexItem shrinks #positionedFlexItem, and therefore #scroller, to 50px.
+// The 300px of content now overflows, so a vertical scrollbar appears while
+// #flexContainer is being laid out.
+flexItem.style.height = "450px";
+document.body.offsetHeight;
+
+test(() => {
+    assert_greater_than(scroller.offsetWidth - scroller.clientWidth, 0,
+        "a vertical scrollbar should consume block-axis space in vertical-lr");
+}, "A vertical scrollbar appears inside the flex container during its layout");
+
+test(() => {
+    target.style.width = "80px";
+    assert_equals(target.offsetWidth, 80);
+}, "An out-of-flow box under the same positioned inline is relaid out after the scrollbar change");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-relayout-with-scrollable-descendant.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An absolutely positioned box is still relaid out after a scrollable descendant gains a scrollbar</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+/* Avoid auto scrollbars on the viewport, because that might trigger re-layout
+   (and thus hide bugs). */
+body { overflow: hidden; }
+
+/* Always-on scrollbars, so that the scrollbar below really does consume space and
+   change #scroller's content box. */
+#scroller::-webkit-scrollbar { width: 15px; height: 15px; }
+
+/* A relatively positioned inline. It is both the parent of #inlineBlock and the
+   containing block of #target, so the two branches below meet at this inline. */
+#positionedInline { position: relative; }
+
+/* Inline-level, so that #positionedInline is its actual parent rather than an
+   anonymous block. Fixed inline size, so its own size does not depend on its
+   contents. */
+#inlineBlock { display: inline-block; width: 600px; vertical-align: top; }
+
+/* Block-level flex container with an auto block size, so its size depends on its
+   contents and a scrollbar appearing inside it can change that size. */
+#flexContainer { display: flex; width: 500px; }
+
+/* Growing this along the main axis shrinks #positionedFlexItem, and with it
+   #scroller. */
+#flexItem { flex: 0 0 auto; width: 100px; height: 30px; }
+
+#positionedFlexItem { position: relative; flex: 1 1 auto; }
+
+/* Out of flow, and its inline size follows #positionedFlexItem. The scrollbar
+   therefore appears as a consequence of the flex layout, rather than as a
+   consequence of a style change on #scroller or its contents. */
+#scroller { position: absolute; top: 0; left: 0; width: 100%; height: 60px; overflow-x: auto; overflow-y: hidden; }
+#overflowingContent { width: 300px; height: 20px; }
+
+/* #target's containing block, also inline-level under #positionedInline. */
+#targetContainingBlock { display: inline-block; position: relative; width: 300px; height: 120px; vertical-align: top; }
+#target { position: absolute; top: 0; left: 0; width: 100px; height: 20px; }
+</style>
+
+<span id="positionedInline"><span id="inlineBlock"><div id="flexContainer"><div id="flexItem"></div><div id="positionedFlexItem"><div id="scroller"><div id="overflowingContent"></div></div></div></div></span><span id="targetContainingBlock"><div id="target"></div></span></span>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// #positionedFlexItem is 400px wide to begin with, so #scroller is 400px and its
+// 300px of content does not overflow.
+document.body.offsetHeight;
+
+// Growing #flexItem shrinks #positionedFlexItem, and therefore #scroller, to 50px.
+// The 300px of content now overflows, so a horizontal scrollbar appears while
+// #flexContainer is being laid out.
+flexItem.style.width = "450px";
+document.body.offsetHeight;
+
+test(() => {
+    assert_greater_than(scroller.offsetHeight - scroller.clientHeight, 0,
+        "a horizontal scrollbar should consume block-axis space");
+}, "A horizontal scrollbar appears inside the flex container during its layout");
+
+test(() => {
+    target.style.height = "80px";
+    assert_equals(target.offsetHeight, 80);
+}, "An out-of-flow box under the same positioned inline is relaid out after the scrollbar change");
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -556,18 +556,22 @@ static EnumSet<LogicalBoxAxis> sizesAffectedByScrollbarsForSubtreeRoot(const Ren
     if (layoutContext.subtreeScrollbarChangesState())
         return { };
 
+    EnumSet<LogicalBoxAxis> sizesAffected;
+
     auto& style = renderBlock.style();
     auto& computedLogicalWidth = style.logicalWidth();
-    if (computedLogicalWidth.isFixed())
-        return { };
+    if (!computedLogicalWidth.isFixed() && (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic() || renderBlock.sizesLogicalWidthToFitContent()))
+        sizesAffected.add(LogicalBoxAxis::Inline);
 
-    if (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic())
-        return LogicalBoxAxis::Inline;
+    auto& computedLogicalHeight = style.logicalHeight();
 
-    if (renderBlock.sizesLogicalWidthToFitContent())
-        return LogicalBoxAxis::Inline;
+    if (style.display().isFlexibleBox() && renderBlock.isBlockLevelBox() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
+        sizesAffected.add(LogicalBoxAxis::Block);
 
-    return { };
+    if (renderBlock.isRenderGrid() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
+        sizesAffected.add(LogicalBoxAxis::Block);
+
+    return sizesAffected;
 }
 
 static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -147,9 +147,14 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
 
     auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
     for (auto& rendererScrollbarChange : descendantsWithScrollbarChange) {
-        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.containsOnly(LogicalBoxAxis::Block))
-            continue;
-        protect(rendererScrollbarChange.renderer)->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
+        CheckedRef renderer = rendererScrollbarChange.renderer;
+        ASSERT(renderer->isDescendantOf(subtreeRoot.ptr()));
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Block)) {
+            renderer->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+            renderer->markContainingBlocksForLayout(subtreeRoot.ptr());
+        }
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Inline))
+            renderer->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
     }
     descendantsWithScrollbarChange.clear();
 


### PR DESCRIPTION
#### ef84d011acd78015778c666d39ab2b8b788bd44f
<pre>
GitHub.com: v2: emoji reaction overlaps code box in comment
<a href="https://bugs.webkit.org/show_bug.cgi?id=312152">https://bugs.webkit.org/show_bug.cgi?id=312152</a>
<a href="https://rdar.apple.com/183465635">rdar://183465635</a>

Reviewed by Alan Baradlay.

In 314501@main we attempted this patch in order to fix the described
problem on GitHub.com. This ended up causing a regression on
flights.google.com so it ended up getting reverted. Here we are
reattempting the same patch but with a fix for the regression. This
commit message will focus on that regression fix almost the entirety of
this patch is the same as the original so I will defer the explanation
of the underlying architecture to that commit message.

The main difference in this patch is that instead of calling
setNeedsLayout() on the affected renderer and invalidating all the way
up the containing block chain we invalidate only between that renderer
and the subtree root.

Specifically, instead of having

```
if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Block))
  renderer-&gt;setNeedsLayout();
```

we have

```
if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Block)) {
  renderer-&gt;setNeedsLayout(MarkingBehavior::MarkOnlyThis);
  renderer-&gt;markContainingBlocksForLayout(subtreeRoot.ptr());
}
```

Here is some markup from the reduced testcase that came out of
flights.google.com:

    &lt;span id=&quot;positionedInline&quot;&gt;                position: relative
      &lt;span id=&quot;inlineBlock&quot;&gt;                   inline-block, width: 600px
        &lt;div id=&quot;flexContainer&quot;&gt;                display: flex, width: 500px, height: auto
          &lt;div id=&quot;flexItem&quot;&gt;&lt;/div&gt;             width: 100px
          &lt;div id=&quot;positionedFlexItem&quot;&gt;         position: relative, flex: 1
            &lt;div id=&quot;scroller&quot;&gt;                 position: absolute, width: 100%, overflow-x: auto
              &lt;div id=&quot;overflowingContent&quot;&gt;     width: 300px
      &lt;span id=&quot;targetContainingBlock&quot;&gt;         inline-block, position: relative
        &lt;div id=&quot;target&quot;&gt;&lt;/div&gt;                 position: absolute, height: 20px

#flexContainer is the subtree root: a block-level flex box with an auto block-size, so
sizesAffectedByScrollbarsForSubtreeRoot() tracks its block axis. Widening #flexItem to
450px shrinks #positionedFlexItem, and therefore #scroller, to 50px, so
#overflowingContent overflows and #scroller gains a horizontal scrollbar during
#flexContainer&apos;s layout.

The call to setNeedsLayout() on #scroller walks up the containing block chain
and dirties the renderers past #flexContainer.

For RenderBlock ancestors above the subtree root this is harmless.
Layout is descending through them, so they already carry the bit and the walk early-outs, and
anything that does get set is cleared on the way back out. For
RenderInline this does not appear to be the case. Before we run inline
layout we run some invalidation via RenderBlockFlow::markInlineContentDirtyForLayout().
In the above example we would call clearNeedsLayout on #positionedInline
before running layout on the inline block. Then during the inline
block&apos;s layout we end up dirtying #positionedInline again from the
resulting scrollbar handling code.

To get around this we can scope our invalidation only to the subtree
root that is handling the scrollbar change. This is much more precise
anyways since we know for sure we will be running layout again starting
at that renderer.

Canonical link: <a href="https://commits.webkit.org/320066@main">https://commits.webkit.org/320066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cb4a2bff1c3ab78424c3bbdf1ac50b0100fd122

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193858 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/608956f3-3ead-43e3-9374-ff83b944d32d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143320 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99515 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86b75625-5797-4dbb-9ca5-f78d98d6a66f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186591 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47087 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure(s) based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89ce0de0-021f-4caa-8ef8-b2f1d8c76412) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44021 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43607 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5036 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40950 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57934 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152537 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47081 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130213 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56442 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55813 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56052 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->