### PR TITLE
All subsequent videos played after the first one auto exit fullscreen back to inline

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -198,7 +198,7 @@ struct WKWebViewState {
     BOOL _savedContentInsetAdjustmentBehaviorWasExternallyOverridden = NO;
 #endif
     UIScrollViewContentInsetAdjustmentBehavior _savedContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
-    CGPoint _savedContentOffset = CGPointZero;
+    std::optional<CGPoint> _savedContentOffset;
     BOOL _savedBouncesZoom = NO;
     BOOL _savedForceAlwaysUserScalable = NO;
     CGFloat _savedMinimumEffectiveDeviceWidth = baseMinimumEffectiveDeviceWidth;
@@ -224,7 +224,8 @@ struct WKWebViewState {
         else
             [scrollView _resetContentInset];
 
-        scrollView.get().contentOffset = _savedContentOffset;
+        if (_savedContentOffset)
+            scrollView.get().contentOffset = *_savedContentOffset;
         scrollView.get().scrollIndicatorInsets = _savedScrollIndicatorInsets;
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
@@ -1210,7 +1211,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [webView _setMinimumEffectiveDeviceWidth:0];
         [webView _setViewScale:1.f];
         [webView _setForcesInitialScaleFactor:YES];
-        [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
         WebKit::WKWebViewState().applyTo(webView.get());
         [webView setNeedsLayout];


### PR DESCRIPTION
#### a346ccb94edad6d8d4cae280e93c4dcdaac7dcc9
<pre>
All subsequent videos played after the first one auto exit fullscreen back to inline
<a href="https://bugs.webkit.org/show_bug.cgi?id=322768">https://bugs.webkit.org/show_bug.cgi?id=322768</a>
<a href="https://rdar.apple.com/174807377">rdar://174807377</a>

Reviewed by Jer Noble.

Entering element fullscreen resets the scroll view&apos;s content offset, which scrolls the page to the
top and dispatches a scroll event once the deferred events are flushed. The offset is restored on
exit, so the page is told it scrolled somewhere it was never meant to stay.

Sites that virtualize a list on scroll position re-window it in response, unmounting rows away from
the viewport. If the fullscreen element is in one of those rows it gets removed, which destroys a
fullscreen iframe&apos;s frame and exits fullscreen. On bing.com/videos every video below the fold exits
fullscreen right after entering.

The fullscreen presentation does not depend on the offset, so leave it alone: make the saved offset
optional so a default-constructed WKWebViewState no longer applies one, and stop explicitly
resetting it on entry. Exiting still restores the offset saved by store().

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/320084@main">https://commits.webkit.org/320084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff073029c1d2295fef8cb8d9a9cb1d1e928e0f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193894 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147963 "Build is in progress. Recent messages:Printed configuration; Running checkout-pull-request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb03f57d-3420-4c1a-a6dd-fde72da40653) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143348 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99537 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ccf0cd2b-1552-42de-99d4-c8193ac50d3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123771 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b41f43e5-1af0-4677-add0-98e694f31024) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45817 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44051 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43636 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57266 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40963 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57970 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152569 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47108 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130249 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56478 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18646 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55849 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->