### PR TITLE
Fix typo in `WGSL::Types::Primitive` and `WGSL::nameForPrimitiveKind`

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -2008,7 +2008,7 @@ static ASCIILiteral nameForPrimitiveKind(Types::Primitive::Kind primitiveKind)
     case Types::Primitive::Sampler:
         return "sampler"_s;
     case Types::Primitive::SamplerComparison:
-        return "sampler_comparion"_s;
+        return "sampler_comparison"_s;
     case Types::Primitive::TextureExternal:
         return "texture_external"_s;
     case Types::Primitive::AccessMode:

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -72,7 +72,7 @@ namespace Types {
     f(Void, "void") \
     f(Bool, "bool") \
     f(Sampler, "sampler") \
-    f(SamplerComparison, "sampler_comparion") \
+    f(SamplerComparison, "sampler_comparison") \
     f(TextureExternal, "texture_external") \
     f(AccessMode, "access_mode") \
     f(TexelFormat, "texel_format") \


### PR DESCRIPTION
#### c67740bfb13bb1719cd1be0a480c4970aedb0189
<pre>
Fix typo in `WGSL::Types::Primitive` and `WGSL::nameForPrimitiveKind`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322769">https://bugs.webkit.org/show_bug.cgi?id=322769</a>
<a href="https://rdar.apple.com/186031593">rdar://186031593</a>

Reviewed by Mike Wyrzykowski.

Both strings appear in WGSL diagnostics.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::nameForPrimitiveKind):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/320037@main">https://commits.webkit.org/320037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0fcfa95fed69b41788af666c16db5f9b17f3046

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147759 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143200 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99427 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163965 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123621 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43892 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43490 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4864 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57062 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57766 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152399 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46951 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130045 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126344 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56274 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->