### PR TITLE
Cherry-pick 319698@main (f69625842f31). https://bugs.webkit.org/show_bug.cgi?id=322113

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -31,6 +31,7 @@
 #include "BytecodeGraph.h"
 #include "BytecodeStructs.h"
 #include "CodeBlock.h"
+#include "IdentifierInlines.h"
 #include "JSCJSValueInlines.h"
 #include "UnlinkedCodeBlockGenerator.h"
 #include "UnlinkedMetadataTableInlines.h"

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -28,6 +28,7 @@
 
 #include "BytecodeRewriter.h"
 #include "ExpressionInfoInlines.h"
+#include "IdentifierInlines.h"
 #include "InstructionStream.h"
 #include "JSCJSValueInlines.h"
 #include "PreciseJumpTargets.h"

--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -52,7 +52,7 @@ AddressType::AddressType(TypeKind typeKind)
     }
 }
 
-#if !PLATFORM(PLAYSTATION)
+#if !PLATFORM(PLAYSTATION) && ENABLE(JIT)
 AddressType::AddressType(B3::Type type)
 {
     switch (type.kind()) {
@@ -92,7 +92,7 @@ Wasm::Type AddressType::asWasmType() const
     RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
 }
 
-#if !PLATFORM(PLAYSTATION)
+#if !PLATFORM(PLAYSTATION) && ENABLE(JIT)
 B3::TypeKind AddressType::asB3TypeKind() const
 {
     switch (m_type) {

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -46,7 +46,7 @@ public:
     AddressType() = default;
     AddressType(TypeKind);
     AddressType(AddressType::Kind);
-#if !PLATFORM(PLAYSTATION)
+#if !PLATFORM(PLAYSTATION) && ENABLE(JIT)
     AddressType(B3::Type);
 #endif
     explicit AddressType(bool is64bit);


### PR DESCRIPTION
#### 71f1a82c16c4f0b93848cadf3d5facd03c7f2252
<pre>
Cherry-pick 319698@main (f69625842f31). <a href="https://bugs.webkit.org/show_bug.cgi?id=322113">https://bugs.webkit.org/show_bug.cgi?id=322113</a>

    Build failure with jit disabled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322113">https://bugs.webkit.org/show_bug.cgi?id=322113</a>

    Reviewed by Yusuke Suzuki.

    Only compile the WasmAddressType B3::type constructor where B3::type is
    defined.

    * Source/JavaScriptCore/wasm/WasmAddressType.cpp:
    * Source/JavaScriptCore/wasm/WasmAddressType.h:

    Canonical link: <a href="https://commits.webkit.org/319698@main">https://commits.webkit.org/319698@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.160@webkitglib/2.54">https://commits.webkit.org/317695.160@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ac2b1a10845f4acbee4df17a69b0151909fe13a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183493 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57417 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193714 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147784 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58762 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57152 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143216 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147784 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186448 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58762 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123638 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58762 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57152 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5609 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58762 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4891 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/44769 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50072 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57152 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195653 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57087 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152735 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57791 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152415 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27845 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57791 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130070 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126369 "The change is no longer eligible for processing.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56299 "Build is in progress. Recent messages:") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51234 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55670 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55909 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55737 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->