### PR TITLE
[YARR] Fix lastIndex and ^ handling in dotAll mode

### DIFF
--- a/JSTests/stress/regexp-dot-star-enclosure-dot-all-last-index.js
+++ b/JSTests/stress/regexp-dot-star-enclosure-dot-all-last-index.js
@@ -1,0 +1,94 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+// Checks exec(), the lastIndex it leaves behind, and test(), which share the compiled path.
+function check(re, lastIndex, string, expectedIndex, expectedMatch) {
+    re.lastIndex = lastIndex;
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null);
+        shouldBe(re.lastIndex, 0);
+    } else {
+        shouldBe(result[0], expectedMatch);
+        shouldBe(result.index, expectedIndex);
+        shouldBe(re.lastIndex, expectedIndex + expectedMatch.length);
+    }
+
+    re.lastIndex = lastIndex;
+    shouldBe(re.test(string), expectedMatch !== null);
+}
+
+const dotAll = /.*X.*/gs;
+const dotAllEOL = /.*X.*$/gs;
+const dotAllMultiline = /.*X.*/gms;
+// `s` is a no-op by construction here, since [\s\S] already matches every code point, so this must
+// agree with the plain `g` spelling below.
+const explicitAnyDotAll = new RegExp("[\\s\\S]*X[\\s\\S]*", "gs");
+const plain = /.*X.*/g;
+
+const bolDotAll = /^.*X.*/gs;
+const bolEOLDotAll = /^.*X.*$/gs;
+const bolDotAllMultiline = /^.*X.*/gms;
+const bolEOLDotAllMultiline = /^.*X.*$/gms;
+const bolPlain = /^.*X.*/g;
+const bolPlainMultiline = /^.*X.*/gm;
+
+function step() {
+    // 1. A global match must begin at or after lastIndex.
+    check(dotAll, 0, "aaXb", 0, "aaXb");
+    check(dotAll, 1, "aaXb", 1, "aXb");
+    check(dotAll, 2, "aaXb", 2, "Xb");
+    check(dotAll, 3, "aaXb", 0, null);
+    check(dotAll, 4, "aaXb", 0, null);
+
+    check(dotAllEOL, 1, "aaXb", 1, "aXb");
+    check(dotAll, 1, "aaXbXc", 1, "aXbXc");
+
+    // The enclosure still reaches across line terminators; it just cannot reach past lastIndex.
+    check(dotAll, 1, "aa\nXb", 1, "a\nXb");
+    check(dotAllMultiline, 1, "aa\nXb", 1, "a\nXb");
+
+    check(explicitAnyDotAll, 1, "aaXb", 1, "aXb");
+    check(plain, 1, "aaXb", 1, "aXb");
+
+    // matchAll() starts from lastIndex too, and its first yield was wrong for the same reason.
+    dotAll.lastIndex = 0;
+    const all = [...("aaXb".matchAll(dotAll))];
+    shouldBe(all.length, 1);
+    shouldBe(all[0].index, 0);
+    shouldBe(all[0][0], "aaXb");
+
+    // 2. `^` still has to hold where the match is reported to begin.
+    check(bolDotAll, 0, "aaXb", 0, "aaXb");
+    check(bolDotAll, 1, "aaXb", 0, null);
+    check(bolDotAll, 2, "aaXb", 0, null);
+    check(bolEOLDotAll, 0, "aaXb", 0, "aaXb");
+    check(bolEOLDotAll, 1, "aaXb", 0, null);
+
+    // Non-zero lastIndex is fine when `^` genuinely holds: under `m` it holds after a newline.
+    check(bolDotAllMultiline, 0, "aa\nXb", 0, "aa\nXb");
+    check(bolDotAllMultiline, 1, "aa\nXb", 3, "Xb");
+    check(bolDotAllMultiline, 3, "aa\nXb", 3, "Xb");
+    check(bolDotAllMultiline, 1, "aaXb", 0, null);
+    check(bolEOLDotAllMultiline, 1, "aa\nXb", 3, "Xb");
+
+    // Under `m` the match can even have to begin at a line start *after* the X the enclosure would
+    // have matched: the leftmost X is at 1, but `^` does not hold there, so the match is "cXd" at 4.
+    // Widening backwards cannot reach that, which is why these patterns skip the enclosure.
+    check(bolDotAllMultiline, 1, "aXb\ncXd", 4, "cXd");
+    check(bolDotAllMultiline, 2, "aXb\ncXd", 4, "cXd");
+    check(bolDotAllMultiline, 4, "aXb\ncXd", 4, "cXd");
+    check(bolDotAllMultiline, 5, "aXb\ncXd", 0, null);
+    check(bolEOLDotAllMultiline, 1, "aXb\ncXd", 4, "cXd");
+
+    // Non-dotAll spellings keep using the enclosure and must be unaffected.
+    check(bolPlain, 0, "aaXb", 0, "aaXb");
+    check(bolPlain, 1, "aaXb", 0, null);
+    check(bolPlainMultiline, 0, "aa\nXb", 3, "Xb");
+    check(bolPlainMultiline, 1, "aa\nXb", 3, "Xb");
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1729,6 +1729,13 @@ public:
         UNUSED_PARAM(term);
 
         if (term.dotAll()) {
+            // In dotAll mode, .* can match line terminators. A non-multiline ^ matches only if the
+            // search begins at the start of the input (offset 0). A multiline ^ needs to check
+            // every line and is never optimized to a DotStarEnclosure.
+            ASSERT(!(term.anchors.m_bol && term.multiline()));
+            if (startOffset && term.anchors.m_bol && !term.multiline())
+                return false;
+
             context->matchBegin = startOffset;
             context->matchEnd = input.end();
             return true;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3744,7 +3744,17 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::JumpList foundEndingNewLine;
 
         if (term->dotAll()) {
-            m_jit.move(MacroAssembler::TrustedImm32(0), matchPos);
+            ASSERT(m_pattern.m_saveInitialStartValue);
+            ASSERT(!m_pattern.m_body->m_hasFixedSize);
+            loadFromFrame(m_pattern.m_initialStartValueFrameLocation, matchPos);
+
+            // In dotAll mode, .* can match line terminators. A non-multiline ^ matches only if the
+            // search begins at the start of the input (offset 0). A multiline ^ needs to check
+            // every line and is never optimized to a DotStarEnclosure.
+            ASSERT(!(term->anchors.bolAnchor && term->multiline()));
+            if (!term->multiline() && term->anchors.bolAnchor)
+                op.m_jumps.append(m_jit.branchTest32(MacroAssembler::NonZero, matchPos));
+
             setMatchStart(matchPos);
             m_jit.move(m_regs.length, m_regs.index);
             return;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2599,7 +2599,15 @@ public:
                 startsWithBOL = true;
                 ++termIndex;
             }
-            
+
+            // In dotAll mode, .* can match line terminators. In multiline mode, ^ matches the
+            // beginning of every line (instead of in non-multiline mode, it only matches the start
+            // of input). So a ^.* in the combined dotAll and multiline is not checkable by
+            // adjusting the beginning and the end of the match, because the match might begin at a
+            // line after the wrapped expression. In this case ^.* is not optimized.
+            if (startsWithBOL && dotAll() && multiline())
+                return;
+
             PatternTerm& firstNonAnchorTerm = terms[termIndex];
             if (firstNonAnchorTerm.type != PatternTerm::Type::CharacterClass
                 || firstNonAnchorTerm.characterClass != dotCharacterClass


### PR DESCRIPTION
#### 1c9b16dd56d5e2d6865ef612bf2323cb0c9c9920
<pre>
[YARR] Fix lastIndex and ^ handling in dotAll mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=322037">https://bugs.webkit.org/show_bug.cgi?id=322037</a>
<a href="https://rdar.apple.com/185814135">rdar://185814135</a>

Reviewed by Yusuke Suzuki.

This PR fixes two bugs with dotAll mode (/s).

One, lastIndex wasn&apos;t being respected in the JIT and was always considered
zero.

Two, ^.* was incorrectly handled in dotAll mode when the pattern was also in
multiline mode (/m). In that case, we still optimized ^.*&lt;expression&gt; to a
DotStarEnclosure, which would produce wrong results in multiline as ^ needs to
check every line. DotStarEnclosure matches &lt;expression&gt; and tries to walk
backwards and &quot;expand&quot; the .*. This optimization is wrong for the following
example:

  const re = /^.*X.*/gms;
  re.lastIndex = 1;
  re.exec(&quot;aXb\ncXd&quot;);

&quot;aXb\ncXd&quot; has \n at index 3, so under m the ^ positions are 0 and 4. The
search starts at 1, so 0 is out of reach and 4 is the only candidate. From 4,
.*X.* matches &quot;cXd&quot;. DotAllEnclosure is wrong in this case because it can&apos;t
ever match something at position 4 by expanding leftward from the X at index 1.

Test: JSTests/stress/regexp-dot-star-enclosure-dot-all-last-index.js

* JSTests/stress/regexp-dot-star-enclosure-dot-all-last-index.js: Added.
(shouldBe):
(check):
(step):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchDotStarEnclosure):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::optimizeDotStarWrappedExpressions):

Canonical link: <a href="https://commits.webkit.org/320086@main">https://commits.webkit.org/320086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cb16ee202f5b1db91ce9a91f5399145eb7d67f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147782 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143211 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99441 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123633 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43907 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5604 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12450 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43507 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44767 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195651 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57085 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40966 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57789 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46964 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130068 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126367 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56297 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18516 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55668 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->