### PR TITLE
REGRESSION(319888@main): [AppKit Gestures] Cannot back/forward navigate with gesture-driven swipe

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1483,53 +1483,66 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool canScrollVertically = [_panGestureRecognizer _canPanVertically] && !(pinnedState.top() && pinnedState.bottom());
     gestureDelta = WebCore::FloatSize { _directionalScrollLockTracker->update(gestureDelta, canScrollHorizontally, canScrollVertically, prefersUnlockedScroll, [gesture timestamp]) };
 
-    // FIXME: Fold this into WKDirectionalScrollLockTracker as a hard clamp  applied _after_ directional lock heuristics.
+    // This clamping is a workaround for the fact that if an axis is pinned,
+    // the scrolling tree turns it into a rubberband, and the orthogonal delta
+    // is discarded, which stops panning for the rest of the gesture. (if a
+    // transient zoom + pan sequence occurs simultaneously)
+    //
+    // The clamp applies only to the wheel event that reaches the page, though,
+    // since the swipe tracker has to see the unclamped delta, or else it is
+    // unable to determine PendingSwipeTracker::scrollEventCanBecomeSwipe().
+    //
+    // FIXME: Fold this into WKDirectionalScrollLockTracker as a hard clamp applied
+    // _after_ the directional lock heuristics, for the events that reach the page.
+    auto clampedGestureDelta = gestureDelta;
     if (!canScrollVertically)
-        gestureDelta.setHeight(0);
+        clampedGestureDelta.setHeight(0);
     if (!canScrollHorizontally)
-        gestureDelta.setWidth(0);
+        clampedGestureDelta.setWidth(0);
 
-    auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice = false;
     auto phase = toWebEventPhase(gesture.state);
     auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
     bool hasPreciseScrollingDeltas = true;
     uint32_t scrollCount = 1;
-    auto unacceleratedScrollingDelta = gestureDelta;
     auto ioHIDEventTimestamp = timestamp;
     std::optional<WebCore::FloatSize> rawPlatformDelta;
     auto momentumEndType = WebKit::WebWheelEvent::MomentumEndType::Unknown;
 
-    WebKit::WebWheelEvent wheelEvent {
-        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
-        WebCore::IntPoint { position },
-        WebCore::IntPoint { globalPosition },
-        gestureDelta,
-        wheelTicks,
-        granularity,
-        directionInvertedFromDevice,
-        phase,
-        momentumPhase,
-        hasPreciseScrollingDeltas,
-        scrollCount,
-        unacceleratedScrollingDelta,
-        ioHIDEventTimestamp,
-        rawPlatformDelta,
-        momentumEndType,
-        WebKit::WebEventInputSource::Automation
+    auto makeWheelEvent = [&](WebCore::FloatSize delta) {
+        auto wheelTicks { delta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
+        auto unacceleratedScrollingDelta = delta;
+        return WebKit::NativeWebWheelEvent {
+            WebKit::WebWheelEvent {
+                { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+                WebCore::IntPoint { position },
+                WebCore::IntPoint { globalPosition },
+                delta,
+                wheelTicks,
+                granularity,
+                directionInvertedFromDevice,
+                phase,
+                momentumPhase,
+                hasPreciseScrollingDeltas,
+                scrollCount,
+                unacceleratedScrollingDelta,
+                ioHIDEventTimestamp,
+                rawPlatformDelta,
+                momentumEndType,
+                WebKit::WebEventInputSource::Automation
+            }
+        };
     };
-
-    WebKit::NativeWebWheelEvent nativeEvent { wheelEvent };
 
     CheckedPtr impl = [webView _impl];
     bool forwardToGestureController = impl->allowsBackForwardNavigationGestures() && [self prefersForwardingToGestureController:gesture];
-    if (forwardToGestureController && protect(impl->ensureGestureController())->handleScrollWheelEvent(nativeEvent)) {
+    if (forwardToGestureController && protect(impl->ensureGestureController())->handleScrollWheelEvent(makeWheelEvent(gestureDelta))) {
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "View gesture controller handled gesture");
         return;
     }
 
-    [webView _protectedPage]->handleNativeWheelEvent(nativeEvent);
+    [webView _protectedPage]->handleNativeWheelEvent(makeWheelEvent(clampedGestureDelta));
 }
 
 #pragma mark - Momentum Handling

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1254,6 +1254,47 @@ extension AppKitGesturesTests.Basic {
         #expect(page.backForwardList.backList.count == 1)
     }
 
+    @Test(
+        .bug("https://webkit.org/b/322776", "Swiping at pinned state should trigger page navigation")
+    )
+    func swipingAtPinnedStateShouldTriggerPageNavigation() async throws {
+        // Establish a back-forward history entry so that a swiping would have somewhere to navigate to.
+        try await page.load(URL(string: "about:blank?1")).wait()
+        let firstPageURL = page.url
+
+        let testURL = try #require(Bundle.testResources.url(forResource: "red", withExtension: "html"))
+        try await page.load(testURL).wait()
+        await page.waitForNextPresentationUpdate()
+        let secondPageURL = page.url
+
+        #expect(page.backForwardList.backList.count == 1)
+
+        let start = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.width / 4, y: window.frame.height / 2))
+        let end = screenBounds(ofPointInWindowCoordinates: CGPoint(x: 3 * window.frame.width / 4, y: window.frame.height / 2))
+
+        // Swipe right, back navigation.
+        await recap.play { composer in
+            composer._wk_scroll(withStart: start, end: end, duration: .seconds(0.5))
+        }
+
+        try await Task.sleep(for: .seconds(1))
+
+        #expect(page.url == firstPageURL)
+        #expect(page.backForwardList.backList.count == 0)
+        #expect(page.backForwardList.forwardList.count == 1)
+
+        // Swipe left, forward navigation.
+        await recap.play { composer in
+            composer._wk_scroll(withStart: end, end: start, duration: .seconds(0.5))
+        }
+
+        try await Task.sleep(for: .seconds(1))
+
+        #expect(page.url == secondPageURL)
+        #expect(page.backForwardList.backList.count == 1)
+        #expect(page.backForwardList.forwardList.count == 0)
+    }
+
     @Test(arguments: [Duration.zero, .seconds(1)])
     func longPressAndDragOnImageSelectsEntireText(delay: Duration) async throws {
         let baseURL = try #require(Bundle.testResources.resourceURL)


### PR DESCRIPTION
#### 2715812bcdba4065f929c0633a226cf4755fc11d
<pre>
REGRESSION(319888@main): [AppKit Gestures] Cannot back/forward navigate with gesture-driven swipe
<a href="https://bugs.webkit.org/show_bug.cgi?id=322776">https://bugs.webkit.org/show_bug.cgi?id=322776</a>
<a href="https://rdar.apple.com/186040671">rdar://186040671</a>

Reviewed by Wenson Hsieh.

319888@main started clamping the delta of the wheel events produced by
the pan GR along any pinned axis, with the intention that a sideways
scroll component during a simultaneous pan + transient zoom could not
turn into a rubberband stretch (which makes the scrolling tree discard
the orthogonal delta for the rest of the gesture).

The wheel event in question feeds two systems, though; the swipe tracker
maintained by view gesture controller, and the actual page. For the
former, our clamping means we remove the signal used to determine
PendingSwipeTracker::scrollEventCanBecomeSwipe(), and as such we
inadvertently broke swiping -&gt; page navigation when the horizontal axis
is pinned, i.e. the common case at the default page scale.

In this patch, we build a separate event per consumer. The swipe tracker
gets the unclamped delta, and only the event that reaches the page is
clamped. A more principled fix would be to make the scrolling tree _not_
discard the orthogonal component of a scroll delta from the motivation
for 319888@main, but that is riskier and certainly not right in exactly
the form I described.

Test: AppKitGesturesTests.Basic.swipingAtPinnedStateShouldTriggerPageNavigation

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController sendWheelEventForGesture:]):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/320017@main">https://commits.webkit.org/320017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd13c0f6b2c7b5c1bfa02817e133d39b2becad6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/008d7fb3-31ed-4110-9685-6728231da6a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143222 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13d03773-1f13-4090-adaa-cb69d48e1e32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163980 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123644 "Found 3 new API test failures: TestAuthentication:/webkit/Authentication/authentication-storage, TestWebKit.WebKit.WKPageCopySessionStateWithFiltering, TestWebViewEditor:/webkit/WebKitWebView/editor-select-all-key-binding-non-editable (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bde01ec6-76c8-434c-8b9b-438380a29a29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45686 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43505 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4902 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50082 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195663 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57097 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152747 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57801 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152427 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46975 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56309 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18514 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->