### PR TITLE
[Swift in WebKit] Introduce a bridging mechanism to create `std::expected`s in Swift

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1465,6 +1465,7 @@ if (SWIFT_REQUIRED)
         ${WEBKIT_DIR}/Shared/Foundation+Extras.swift
         ${WEBKIT_DIR}/Shared/IPCTesterReceiver.swift
         ${WEBKIT_DIR}/Shared/WTFCompletionHandler+Extras.swift
+        ${WEBKIT_DIR}/Shared/WTFExpected+Extras.swift
         ${WebKit_DERIVED_SOURCES_DIR}/IPCTesterReceiverMessageReceiver.swift
     )
 endif ()

--- a/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
+++ b/Source/WebKit/Shared/WTFCompletionHandler+Extras.swift
@@ -197,7 +197,9 @@ extension CxxVoidCompletionHandler where Self: ~Copyable {
 
     /// Creates a `WTF::CompletionHandler` type from a Swift closure.
     ///
-    /// - Parameter body: The Swift closure to use.
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
     @safe
     init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping () -> Void) {
         self.init(box: SwiftVoidClosureBox(isolation: isolation, body))

--- a/Source/WebKit/Shared/WTFExpected+Extras.swift
+++ b/Source/WebKit/Shared/WTFExpected+Extras.swift
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// FIXME: (rdar://164119356) Move this file into WTF.
+
+#if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+
+/// Represents an `unexpected` value of an `std::expected<T, E>`.
+struct CxxUnexpected<Failure: Sendable>: Error {
+    /// The unexpected error.
+    let error: Failure
+}
+
+/// The machinery shared by ``CxxExpected`` and ``CxxConsumingExpected``.
+///
+/// - Important: Do not conform to this directly. Conform to one of those two instead.
+protocol CxxExpectedBase: ~Copyable {
+    /// The type of the expected value.
+    associatedtype Value: ~Copyable
+
+    /// The type of the unexpected value.
+    associatedtype Failure: Sendable
+
+    /// Checks whether the object contains an expected value.
+    /// - Returns: `true` if the object contains an expected value; `false` otherwise.
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    func has_value() -> Bool
+
+    /// Returns the expected value.
+    ///
+    /// - Note: Do not call or implement this yourself. It is unsafe to do so.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    func __valueUnsafe() -> UnsafePointer<Value>
+
+    /// Returns the unexpected value.
+    ///
+    /// - Note: Do not call or implement this yourself. It is unsafe to do so.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    func __errorUnsafe() -> UnsafePointer<Failure>
+}
+
+/// A protocol for concrete specializations of `std::expected<T, E>` to conform to when `T` is `Copyable`.
+///
+/// Conforming a specialization to this protocol allows Swift to safely access properties of the `expected`.
+/// For example, this makes it possible to use a type like
+///
+/// ```cpp
+/// using ExpectedResult = std::expected<int, ErrorCode>;
+/// ```
+///
+/// by creating this conformance:
+///
+/// ```swift
+/// extension ExpectedResult: CxxExpected {}
+/// ```
+///
+/// Swift can then use the `expected` naturally:
+///
+/// ```swift
+/// let expectedResult: ExpectedResult = ...
+/// let value = try expectedResult.value
+/// ```
+///
+protocol CxxExpected: CxxExpectedBase where Value: Copyable {
+}
+
+extension CxxExpected {
+    /// Returns the expected value, or throws the unexpected error if one exists.
+    var value: Value {
+        get throws(CxxUnexpected<Failure>) {
+            // Safety properties:
+            //
+            // Non-null, initialized, aligned: both point into `self`, which is a fully constructed
+            //     `std::expected`, so each is the address of a live object of the type it points to.
+            // Lifetime: `self` is borrowed for the whole of this getter, so neither pointer can dangle
+            //     here. Neither is stored; only the copy taken below escapes.
+            // Aliasing: `self` still owns what both point at, so this may only read them. `.pointee`
+            //     copies, running `Value`'s or `Failure`'s copy constructor, and leaves the `Expected`
+            //     intact and readable again.
+
+            guard has_value() else {
+                throw unsafe CxxUnexpected(error: __errorUnsafe().pointee)
+            }
+
+            return unsafe __valueUnsafe().pointee
+        }
+    }
+}
+
+/// A protocol for concrete specializations of `std::expected<T, E>` for noncopyable `T`s.
+///
+/// This is the same as ``CxxExpected`` except that it matches a C++ signature like:
+///
+/// ```cpp
+/// using ExpectedResult = std::expected<MoveOnlyThing, ErrorCode>;
+/// ```
+///
+/// Conformers to this protocol must explicitly implement the `__take(_:)` requirement like so:
+///
+/// ```swift
+/// extension ExpectedResult: CxxConsumingExpected {
+///     static func __take(_ expected: consuming Self) -> Value {
+///         takeValue(consuming: expected)
+///     }
+/// }
+/// ```
+///
+/// where `takeValue` is a C++ free function implemented exactly as
+///
+/// ```cpp
+/// inline ExpectedResult::value_type takeValue(ExpectedResult&& expected)
+/// {
+///     // Must be non-trivially destructible so that Swift runs the move constructor rather than
+///     // relocating the value byte-wise, which would leave a value holding a pointer into itself
+///     // dangling.
+///     static_assert(!std::is_trivially_destructible_v<ExpectedResult::value_type>);
+///     // Swift copies rather than consumes a copyable `Expected`, so the value would be moved out of
+///     // that copy and the caller's `Expected` left untouched.
+///     static_assert(!std::is_copy_constructible_v<ExpectedResult>);
+///     return WTF::move(*expected);
+/// }
+/// ```
+///
+/// Swift imports that rvalue reference parameter as `consuming`, and destroys the moved-from `expected` once the call
+/// returns.
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+protocol CxxConsumingExpected: CxxExpectedBase, ~Copyable {
+    /// Consumes the `expected`, moving its value out.
+    ///
+    /// - Parameter expected: The expected to take. It is guaranteed to have a value.
+    /// - Returns: The moved value of the expected.
+    /// - Note: Do not call this yourself.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    static func __take(_ expected: consuming Self) -> Value
+}
+
+extension CxxConsumingExpected where Self: ~Copyable, Value: ~Copyable {
+    /// Returns the expected value, or throws the unexpected error if one exists.
+    ///
+    /// - Returns: The consumed value of the expected, if one exists.
+    /// - Throws: The unexpected error, if one exists.
+    consuming func consume() throws(CxxUnexpected<Failure>) -> Value {
+        // Safety properties:
+        //
+        // As in `CxxExpected.value`, with one difference: `self` is consumed here rather than borrowed.
+        // `__errorUnsafe()` only borrows it, and `__take(_:)` is what finally takes it, so `self` is
+        // still live when the error is read out below.
+
+        guard has_value() else {
+            throw unsafe CxxUnexpected(error: __errorUnsafe().pointee)
+        }
+
+        return Self.__take(self)
+    }
+}
+
+#endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		029D6BB32C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAD2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h */; };
 		029D6BB42C407AA30068CF99 /* JSWebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
+		0708B49430413DF90014BF6C /* WTFExpected+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0708B49330413DF90014BF6C /* WTFExpected+Extras.swift */; };
 		071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467772DFE84E500F77867 /* WebPage+Transferable.swift */; };
 		07152D072F2F037D00B56C0E /* WKTextSelectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07152D062F2F037D00B56C0E /* WKTextSelectionController.swift */; };
 		07152D092F2F038A00B56C0E /* WKTextSelectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 07152D082F2F038A00B56C0E /* WKTextSelectionController.h */; };
@@ -3438,6 +3439,7 @@
 		0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerMIMETypeCache.cpp; sourceTree = "<group>"; };
 		0701789C23BAE262005F0FAA /* RemoteMediaPlayerMIMETypeCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerMIMETypeCache.h; sourceTree = "<group>"; };
 		070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestManagerProxy.mm; sourceTree = "<group>"; };
+		0708B49330413DF90014BF6C /* WTFExpected+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WTFExpected+Extras.swift"; sourceTree = "<group>"; };
 		071467772DFE84E500F77867 /* WebPage+Transferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Transferable.swift"; sourceTree = "<group>"; };
 		07152D062F2F037D00B56C0E /* WKTextSelectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKTextSelectionController.swift; sourceTree = "<group>"; };
 		07152D082F2F038A00B56C0E /* WKTextSelectionController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextSelectionController.h; sourceTree = "<group>"; };
@@ -10734,6 +10736,7 @@
 				E0E1E2E3E4E5E6E700000003 /* WriteWebArchiveToPasteBoardResult.serialization.in */,
 				5CA6A48B28F6621800F92B6E /* WTFArgumentCoders.serialization.in */,
 				077DD8E6303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift */,
+				0708B49330413DF90014BF6C /* WTFExpected+Extras.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -22686,6 +22689,7 @@
 				075369492DC589E1006446F8 /* WKWebView+TextExtraction.swift in Sources */,
 				079A4DA32D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift in Sources */,
 				077DD8E7303AE8A2000AA8FC /* WTFCompletionHandler+Extras.swift in Sources */,
+				0708B49430413DF90014BF6C /* WTFExpected+Extras.swift in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,
 				C14D306A24B79BE400480387 /* XPCEndpointClient.mm in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/WTFCompletionHandler+Extras.swift
@@ -156,7 +156,9 @@ extension CxxCompletionHandler where Self: ~Copyable {
 
     /// Creates a `WTF::CompletionHandler` type from a Swift closure.
     ///
-    /// - Parameter body: The Swift closure to use.
+    /// - Parameters:
+    ///   - isolation: The current isolation.
+    ///   - body: The Swift closure to use.
     @safe
     public init(isolation: isolated (any Actor)? = #isolation, _ body: @escaping (Argument) -> Void) {
         self.init(box: SwiftCopyingClosureBox(isolation: isolation, body))

--- a/Tools/TestWebKitAPI/Helpers/WTFExpected+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/WTFExpected+Extras.swift
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// FIXME: (rdar://164119356) Move this file into WTF.
+
+#if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+
+/// Represents an `unexpected` value of an `std::expected<T, E>`.
+public struct CxxUnexpected<Failure: Sendable>: Error {
+    /// The unexpected error.
+    public let error: Failure
+}
+
+/// The machinery shared by ``CxxExpected`` and ``CxxConsumingExpected``.
+///
+/// - Important: Do not conform to this directly. Conform to one of those two instead.
+public protocol CxxExpectedBase: ~Copyable {
+    /// The type of the expected value.
+    associatedtype Value: ~Copyable
+
+    /// The type of the unexpected value.
+    associatedtype Failure: Sendable
+
+    /// Checks whether the object contains an expected value.
+    /// - Returns: `true` if the object contains an expected value; `false` otherwise.
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    func has_value() -> Bool
+
+    /// Returns the expected value.
+    ///
+    /// - Note: Do not call or implement this yourself. It is unsafe to do so.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    func __valueUnsafe() -> UnsafePointer<Value>
+
+    /// Returns the unexpected value.
+    ///
+    /// - Note: Do not call or implement this yourself. It is unsafe to do so.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    func __errorUnsafe() -> UnsafePointer<Failure>
+}
+
+/// A protocol for concrete specializations of `std::expected<T, E>` to conform to when `T` is `Copyable`.
+///
+/// Conforming a specialization to this protocol allows Swift to safely access properties of the `expected`.
+/// For example, this makes it possible to use a type like
+///
+/// ```cpp
+/// using ExpectedResult = std::expected<int, ErrorCode>;
+/// ```
+///
+/// by creating this conformance:
+///
+/// ```swift
+/// extension ExpectedResult: CxxExpected {}
+/// ```
+///
+/// Swift can then use the `expected` naturally:
+///
+/// ```swift
+/// let expectedResult: ExpectedResult = ...
+/// let value = try expectedResult.value
+/// ```
+///
+public protocol CxxExpected: CxxExpectedBase where Value: Copyable {
+}
+
+extension CxxExpected {
+    /// Returns the expected value, or throws the unexpected error if one exists.
+    public var value: Value {
+        get throws(CxxUnexpected<Failure>) {
+            // Safety properties:
+            //
+            // Non-null, initialized, aligned: both point into `self`, which is a fully constructed
+            //     `std::expected`, so each is the address of a live object of the type it points to.
+            // Lifetime: `self` is borrowed for the whole of this getter, so neither pointer can dangle
+            //     here. Neither is stored; only the copy taken below escapes.
+            // Aliasing: `self` still owns what both point at, so this may only read them. `.pointee`
+            //     copies, running `Value`'s or `Failure`'s copy constructor, and leaves the `Expected`
+            //     intact and readable again.
+
+            guard has_value() else {
+                throw unsafe CxxUnexpected(error: __errorUnsafe().pointee)
+            }
+
+            return unsafe __valueUnsafe().pointee
+        }
+    }
+}
+
+/// A protocol for concrete specializations of `std::expected<T, E>` for noncopyable `T`s.
+///
+/// This is the same as ``CxxExpected`` except that it matches a C++ signature like:
+///
+/// ```cpp
+/// using ExpectedResult = std::expected<MoveOnlyThing, ErrorCode>;
+/// ```
+///
+/// Conformers to this protocol must explicitly implement the `__take(_:)` requirement like so:
+///
+/// ```swift
+/// extension ExpectedResult: CxxConsumingExpected {
+///     static func __take(_ expected: consuming Self) -> Value {
+///         takeValue(consuming: expected)
+///     }
+/// }
+/// ```
+///
+/// where `takeValue` is a C++ free function implemented exactly as
+///
+/// ```cpp
+/// inline ExpectedResult::value_type takeValue(ExpectedResult&& expected)
+/// {
+///     // Must be non-trivially destructible so that Swift runs the move constructor rather than
+///     // relocating the value byte-wise, which would leave a value holding a pointer into itself
+///     // dangling.
+///     static_assert(!std::is_trivially_destructible_v<ExpectedResult::value_type>);
+///     // Swift copies rather than consumes a copyable `Expected`, so the value would be moved out of
+///     // that copy and the caller's `Expected` left untouched.
+///     static_assert(!std::is_copy_constructible_v<ExpectedResult>);
+///     return WTF::move(*expected);
+/// }
+/// ```
+///
+/// Swift imports that rvalue reference parameter as `consuming`, and destroys the moved-from `expected` once the call
+/// returns.
+///
+/// - Important: Do not implement the protocol requirements yourself. It is unsafe if you do so.
+public protocol CxxConsumingExpected: CxxExpectedBase, ~Copyable {
+    /// Consumes the `expected`, moving its value out.
+    ///
+    /// - Parameter expected: The expected to take. It is guaranteed to have a value.
+    /// - Returns: The moved value of the expected.
+    /// - Note: Do not call this yourself.
+    // swift-format-ignore: AlwaysUseLowerCamelCase,NoLeadingUnderscores
+    static func __take(_ expected: consuming Self) -> Value
+}
+
+extension CxxConsumingExpected where Self: ~Copyable, Value: ~Copyable {
+    /// Returns the expected value, or throws the unexpected error if one exists.
+    ///
+    /// - Returns: The consumed value of the expected, if one exists.
+    /// - Throws: The unexpected error, if one exists.
+    public consuming func consume() throws(CxxUnexpected<Failure>) -> Value {
+        // Safety properties:
+        //
+        // As in `CxxExpected.value`, with one difference: `self` is consumed here rather than borrowed.
+        // `__errorUnsafe()` only borrows it, and `__take(_:)` is what finally takes it, so `self` is
+        // still live when the error is read out below.
+
+        guard has_value() else {
+            throw unsafe CxxUnexpected(error: __errorUnsafe().pointee)
+        }
+
+        return Self.__take(self)
+    }
+}
+
+#endif // compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
@@ -119,6 +119,34 @@ void resetCopyCountingProbeCounts()
     copyCountingProbeCopies() = 0;
 }
 
+static int& liveCountingProbeErrors()
+{
+    static int count = 0;
+    return count;
+}
+
+CountingProbeError::CountingProbeError(ProbeError value)
+    : m_value(value)
+{
+    ++liveCountingProbeErrors();
+}
+
+CountingProbeError::CountingProbeError(const CountingProbeError& other)
+    : m_value(other.m_value)
+{
+    ++liveCountingProbeErrors();
+}
+
+CountingProbeError::~CountingProbeError()
+{
+    --liveCountingProbeErrors();
+}
+
+int liveCountingProbeErrorCount()
+{
+    return liveCountingProbeErrors();
+}
+
 int callIntBoolFunction(bool argument, IntBoolFunction&& function)
 {
     return function(argument);
@@ -261,6 +289,11 @@ int sharedProbeDerefCalls()
     return sharedProbeDerefs();
 }
 
+int sharedProbeRefCount()
+{
+    return sharedProbe().refCount();
+}
+
 void resetSharedProbe()
 {
     sharedProbeRefs() = 0;
@@ -291,6 +324,68 @@ SelfReferentialProbe::~SelfReferentialProbe()
 void callSelfReferentialProbeCompletionHandler(int argument, SelfReferentialProbeCompletionHandler&& completionHandler)
 {
     completionHandler(SelfReferentialProbe { argument });
+}
+
+IntExpected makeIntExpected(int value)
+{
+    return IntExpected { value };
+}
+
+IntExpected makeIntUnexpected(ProbeError error)
+{
+    return IntExpected { makeUnexpected(error) };
+}
+
+CopyCountingProbeExpected makeCopyCountingProbeExpected(int value)
+{
+    // In place, so that the probe the `Expected` holds is the only one this constructed: a test counting
+    // copies is measuring what Swift did, not what building the `Expected` did.
+    return CopyCountingProbeExpected { std::in_place, value };
+}
+
+CopyCountingProbeExpected makeCopyCountingProbeUnexpected(ProbeError error)
+{
+    return CopyCountingProbeExpected { makeUnexpected(error) };
+}
+
+SharedProbeHolderExpected makeSharedProbeHolderExpected()
+{
+    return SharedProbeHolderExpected { SharedProbeHolder { &sharedProbe() } };
+}
+
+SharedProbeHolderExpected makeSharedProbeHolderUnexpected(ProbeError error)
+{
+    return SharedProbeHolderExpected { makeUnexpected(error) };
+}
+
+MoveOnlyProbeExpected makeMoveOnlyProbeExpected(int value)
+{
+    return MoveOnlyProbeExpected { std::in_place, value };
+}
+
+MoveOnlyProbeExpected makeMoveOnlyProbeUnexpected(ProbeError error)
+{
+    return MoveOnlyProbeExpected { makeUnexpected(error) };
+}
+
+SelfReferentialProbeExpected makeSelfReferentialProbeExpected(int value)
+{
+    return SelfReferentialProbeExpected { std::in_place, value };
+}
+
+SelfReferentialProbeExpected makeSelfReferentialProbeUnexpected(ProbeError error)
+{
+    return SelfReferentialProbeExpected { makeUnexpected(error) };
+}
+
+CountedErrorExpected makeCountedErrorExpected(int value)
+{
+    return CountedErrorExpected { std::in_place, value };
+}
+
+CountedErrorExpected makeCountedErrorUnexpected(ProbeError error)
+{
+    return CountedErrorExpected { makeUnexpected(CountingProbeError { error }) };
 }
 
 };

--- a/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
+++ b/Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #import <wtf/CompletionHandler.h>
+#import <wtf/Expected.h>
 #import <wtf/Function.h>
 #import <wtf/StdLibExtras.h>
 
@@ -106,6 +107,28 @@ private:
     int* m_self;
 };
 
+// The unexpected half of every `Expected` below. A scoped enum so that a test can tell one failure from
+// another, and numbered from one so that a zeroed-out read does not look like a valid error.
+enum class ProbeError : uint8_t {
+    TooSmall = 1,
+    TooLarge = 2,
+};
+
+// An error that counts its own lifetime. An `Expected` holding an error holds no value, so the value-side
+// counters cannot say anything about the failure path; this is what proves that path destroys the
+// `Expected` it consumed, exactly once, rather than leaking or double-destroying it.
+class SWIFT_UNCHECKED_SENDABLE CountingProbeError {
+public:
+    explicit CountingProbeError(ProbeError);
+    CountingProbeError(const CountingProbeError&);
+    ~CountingProbeError();
+
+    ProbeError value() const { return m_value; }
+
+private:
+    ProbeError m_value;
+};
+
 // MARK: Using declarations
 
 using IntBoolFunction = WTF::Function<int(bool)>;
@@ -117,6 +140,13 @@ using MoveOnlyProbeCompletionHandler = WTF::CompletionHandler<void(MoveOnlyProbe
 using CopyCountingProbeCompletionHandler = WTF::CompletionHandler<void(CopyCountingProbe)>;
 using SharedProbeHolderCompletionHandler = WTF::CompletionHandler<void(SharedProbeHolder)>;
 using SelfReferentialProbeCompletionHandler = WTF::CompletionHandler<void(SelfReferentialProbe&&)>;
+
+using IntExpected = Expected<int, ProbeError>;
+using CopyCountingProbeExpected = Expected<CopyCountingProbe, ProbeError>;
+using SharedProbeHolderExpected = Expected<SharedProbeHolder, ProbeError>;
+using MoveOnlyProbeExpected = Expected<MoveOnlyProbe, ProbeError>;
+using SelfReferentialProbeExpected = Expected<SelfReferentialProbe, ProbeError>;
+using CountedErrorExpected = Expected<MoveOnlyProbe, CountingProbeError>;
 
 // MARK: Function declarations
 
@@ -158,9 +188,69 @@ int callSharedProbeHolderCompletionHandler(SharedProbeHolderCompletionHandler&&)
 // How many times the bridge caused a retain or a release. These must match.
 int sharedProbeRefCalls();
 int sharedProbeDerefCalls();
+
+// The shared probe's current reference count. One means nothing but the caller's own reference is left.
+int sharedProbeRefCount();
+
 void resetSharedProbe();
 
 void callSelfReferentialProbeCompletionHandler(int, SelfReferentialProbeCompletionHandler&&);
+
+// MARK: Expected
+
+IntExpected makeIntExpected(int);
+IntExpected makeIntUnexpected(ProbeError);
+
+// A copyable value has to be copied out of the `Expected`, so exactly one copy constructor call should be
+// observable per read.
+CopyCountingProbeExpected makeCopyCountingProbeExpected(int);
+CopyCountingProbeExpected makeCopyCountingProbeUnexpected(ProbeError);
+
+// Holds a borrowed reference to the shared probe, like callSharedProbeHolderCompletionHandler() passes.
+SharedProbeHolderExpected makeSharedProbeHolderExpected();
+SharedProbeHolderExpected makeSharedProbeHolderUnexpected(ProbeError);
+
+MoveOnlyProbeExpected makeMoveOnlyProbeExpected(int);
+MoveOnlyProbeExpected makeMoveOnlyProbeUnexpected(ProbeError);
+
+SelfReferentialProbeExpected makeSelfReferentialProbeExpected(int);
+SelfReferentialProbeExpected makeSelfReferentialProbeUnexpected(ProbeError);
+
+CountedErrorExpected makeCountedErrorExpected(int);
+CountedErrorExpected makeCountedErrorUnexpected(ProbeError);
+
+// Zero once every error the bridge constructed has been destroyed. See CountingProbeError.
+int liveCountingProbeErrorCount();
+
+// The `__take(_:)` witnesses for the `CxxConsumingExpected` conformances. Swift imports the rvalue
+// reference as the `consuming` the protocol hands over, and destroys the moved-from `Expected` once the
+// call returns.
+//
+// The three checks each of these repeats are what make a witness safe to write; none of them is
+// diagnosed at the call site. See CxxConsumingExpected's documentation.
+
+inline MoveOnlyProbeExpected::value_type takeMoveOnlyProbeValue(MoveOnlyProbeExpected&& expected)
+{
+    static_assert(!std::is_trivially_destructible_v<MoveOnlyProbeExpected::value_type>);
+    static_assert(!std::is_copy_constructible_v<MoveOnlyProbeExpected>);
+    return WTF::move(*expected);
+}
+
+inline SelfReferentialProbeExpected::value_type takeSelfReferentialProbeValue(SelfReferentialProbeExpected&& expected)
+{
+    // See takeMoveOnlyProbeValue().
+    static_assert(!std::is_trivially_destructible_v<SelfReferentialProbeExpected::value_type>);
+    static_assert(!std::is_copy_constructible_v<SelfReferentialProbeExpected>);
+    return WTF::move(*expected);
+}
+
+inline CountedErrorExpected::value_type takeCountedErrorValue(CountedErrorExpected&& expected)
+{
+    // See takeMoveOnlyProbeValue().
+    static_assert(!std::is_trivially_destructible_v<CountedErrorExpected::value_type>);
+    static_assert(!std::is_copy_constructible_v<CountedErrorExpected>);
+    return WTF::move(*expected);
+}
 
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 				mac/VirtualGamepad.mm,
 				mac/WebKitAgnosticTest.mm,
 				"WTFCompletionHandler+Extras.swift",
+				"WTFExpected+Extras.swift",
 			);
 			target = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;
 		};
@@ -661,6 +662,7 @@
 				cocoa/UtilitiesCocoa.mm,
 				Counters.cpp,
 				"WTFCompletionHandler+Extras.swift",
+				"WTFExpected+Extras.swift",
 			);
 			target = 7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */;
 		};

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift
@@ -65,6 +65,42 @@ extension Cxx.SelfReferentialProbeCompletionHandler: @unsafe TestWTFLibrary.CxxC
     public typealias Argument = SwiftCxxInteropTestbed.SelfReferentialProbe
 }
 
+// The simplest `Expected` shape, and the one ``CxxExpected``'s documentation uses as its example.
+extension Cxx.IntExpected: TestWTFLibrary.CxxExpected {}
+
+// Copyable but not trivially copyable: reading this value out has to run its copy constructor.
+extension Cxx.CopyCountingProbeExpected: TestWTFLibrary.CxxExpected {}
+
+// Trivially copyable in C++, but Swift imports the `probe` field as a managed reference, so reading the
+// value has to leave the C++ side's ownership alone.
+extension Cxx.SharedProbeHolderExpected: TestWTFLibrary.CxxExpected {}
+
+// `MoveOnlyProbe` is move-only in C++, so the `Expected` holding one is noncopyable too and its value can
+// only be moved out, which is what `CxxConsumingExpected` is for.
+extension Cxx.MoveOnlyProbeExpected: TestWTFLibrary.CxxConsumingExpected {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation, AlwaysUseLowerCamelCase, NoLeadingUnderscores
+    public static func __take(_ expected: consuming Self) -> Value {
+        Cxx.takeMoveOnlyProbeValue(consuming: expected)
+    }
+}
+
+// Noncopyable, and notices if the value is relocated byte-wise on its way out.
+extension Cxx.SelfReferentialProbeExpected: @unsafe TestWTFLibrary.CxxConsumingExpected {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation, AlwaysUseLowerCamelCase, NoLeadingUnderscores
+    public static func __take(_ expected: consuming Self) -> Value {
+        unsafe Cxx.takeSelfReferentialProbeValue(consuming: expected)
+    }
+}
+
+// An error that counts its own lifetime, so that the failure path -- which holds no value, and so moves
+// none of the counters above -- can be checked at all.
+extension Cxx.CountedErrorExpected: TestWTFLibrary.CxxConsumingExpected {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation, AlwaysUseLowerCamelCase, NoLeadingUnderscores
+    public static func __take(_ expected: consuming Self) -> Value {
+        Cxx.takeCountedErrorValue(consuming: expected)
+    }
+}
+
 // MARK: - Helpers
 
 /// Observed via a weak reference to prove the closure context was released.
@@ -304,6 +340,255 @@ struct SwiftCxxInteropTests {
             recorder.values == [1, 7],
             "a noncopyable argument must be relocated with its move constructor, not by copying its bytes"
         )
+    }
+
+    // MARK: Expected
+
+    @Test
+    func expectedExposesItsValue() async throws {
+        let value = try Cxx.makeIntExpected(3).value
+
+        #expect(value == 3)
+    }
+
+    @Test
+    func unexpectedThrowsItsError() async throws {
+        let unexpected = Cxx.makeIntUnexpected(.TooLarge)
+
+        #expect(!unexpected.has_value())
+
+        let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+            _ = try unexpected.value
+        }
+        #expect(thrown.error == .TooLarge)
+    }
+
+    @Test
+    func readingTheValueLeavesTheExpectedAlone() async throws {
+        let expected = Cxx.makeIntExpected(7)
+
+        // `value` borrows rather than takes, so nothing here should be a one-shot read.
+        let first = try expected.value
+        let second = try expected.value
+
+        #expect(first == 7)
+        #expect(second == 7)
+        #expect(expected.has_value())
+    }
+
+    @Test
+    func readingAnUnexpectedLeavesTheErrorInPlace() async throws {
+        let unexpected = Cxx.makeIntUnexpected(.TooSmall)
+
+        // See readingTheValueLeavesTheExpectedAlone(): the failure path has to be repeatable too.
+        for _ in 0..<2 {
+            let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+                _ = try unexpected.value
+            }
+            #expect(thrown.error == .TooSmall)
+        }
+    }
+
+    // MARK: Copyable, non-trivially-copyable values
+
+    @Test
+    func readingACopyableValueCopiesItExactlyOnce() async throws {
+        Cxx.resetCopyCountingProbeCounts()
+
+        // Sampled rather than assumed to be zero. There is no way to reset a count of live objects, so a
+        // probe stranded by an earlier test would otherwise fail this one and point the reader here
+        // rather than at the leak.
+        let baseline = Cxx.liveCopyCountingProbeCount()
+
+        do {
+            let expected = Cxx.makeCopyCountingProbeExpected(11)
+            let probe = try expected.value
+
+            // Sampled before the last use of either probe below, so neither can have been released early
+            // by the time these are read.
+            let copies = Cxx.copyCountingProbeCopyCount()
+            let live = Cxx.liveCopyCountingProbeCount() - baseline
+
+            #expect(probe.value() == 11, "Swift should see the value C++ stored")
+            #expect(expected.has_value(), "reading the value should not have emptied the expected")
+            #expect(copies == 1, "exactly one copy should be made for Swift")
+            #expect(live == 2, "the expected should still hold its own probe")
+        }
+
+        #expect(Cxx.liveCopyCountingProbeCount() == baseline, "every probe should be destroyed")
+    }
+
+    @Test
+    func theValueOutlivesTheExpectedItWasReadFrom() async throws {
+        Cxx.resetCopyCountingProbeCounts()
+
+        // See readingACopyableValueCopiesItExactlyOnce().
+        let baseline = Cxx.liveCopyCountingProbeCount()
+
+        let probe: Cxx.CopyCountingProbe
+        do {
+            let expected = Cxx.makeCopyCountingProbeExpected(12)
+            probe = try expected.value
+        }
+
+        let live = Cxx.liveCopyCountingProbeCount() - baseline
+
+        // The expected -- and the probe it held -- are gone, so a `value` that handed Swift a pointer into
+        // the expected rather than a copy would be reading freed storage here.
+        #expect(probe.value() == 12)
+        #expect(live == 1, "only Swift's copy should still be alive")
+    }
+
+    @Test
+    func readingAnUnexpectedNeverTouchesTheValue() async throws {
+        Cxx.resetCopyCountingProbeCounts()
+
+        // See readingACopyableValueCopiesItExactlyOnce().
+        let baseline = Cxx.liveCopyCountingProbeCount()
+
+        do {
+            let unexpected = Cxx.makeCopyCountingProbeUnexpected(.TooSmall)
+
+            let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+                _ = try unexpected.value
+            }
+
+            #expect(thrown.error == .TooSmall)
+            #expect(Cxx.copyCountingProbeCopyCount() == 0, "an expected holding an error has no value to copy")
+        }
+
+        #expect(Cxx.liveCopyCountingProbeCount() == baseline, "every probe should be destroyed")
+    }
+
+    // MARK: Values holding a managed reference
+
+    @Test
+    func valueHoldingAManagedReferenceLeavesTheCallersCountAlone() async throws {
+        Cxx.resetSharedProbe()
+
+        do {
+            let holder = try Cxx.makeSharedProbeHolderExpected().value
+
+            // See readingACopyableValueCopiesItExactlyOnce(): sampled before the last use of `holder`, so
+            // its reference is certainly still held here.
+            let countWhileHeld = Cxx.sharedProbeRefCount()
+            withExtendedLifetime(holder) {}
+
+            #expect(countWhileHeld == 2, "Swift's copy of the value should hold a reference of its own")
+        }
+
+        #expect(
+            Cxx.sharedProbeRefCalls() == Cxx.sharedProbeDerefCalls(),
+            "reading the value must balance every retain and release it causes"
+        )
+        #expect(Cxx.sharedProbeRefCount() == 1, "the C++ side's own reference must survive the read")
+    }
+
+    @Test
+    func readingAnUnexpectedNeverRetainsTheManagedReference() async throws {
+        Cxx.resetSharedProbe()
+
+        do {
+            let unexpected = Cxx.makeSharedProbeHolderUnexpected(.TooSmall)
+
+            let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+                _ = try unexpected.value
+            }
+
+            // A bridge that loaded the value union before checking has_value() would have retained the
+            // shared probe by now.
+            #expect(thrown.error == .TooSmall)
+            #expect(Cxx.sharedProbeRefCount() == 1, "an expected holding an error has no value to retain")
+        }
+
+        #expect(
+            Cxx.sharedProbeRefCalls() == Cxx.sharedProbeDerefCalls(),
+            "reading the error must balance every retain and release it causes"
+        )
+        #expect(Cxx.sharedProbeRefCount() == 1, "the C++ side's own reference must survive the read")
+    }
+
+    // MARK: Noncopyable values
+
+    @Test
+    func noncopyableValueCanBeConsumed() async throws {
+        // See readingACopyableValueCopiesItExactlyOnce().
+        let baseline = Cxx.liveMoveOnlyProbeCount()
+
+        do {
+            let probe = try Cxx.makeMoveOnlyProbeExpected(5).consume()
+
+            let live = Cxx.liveMoveOnlyProbeCount() - baseline
+
+            // A moved-from probe reports -1, so this also proves Swift was handed the destination of the
+            // move rather than its source.
+            #expect(probe.value() == 5)
+            #expect(live == 1, "only the consumed value should still be alive")
+        }
+
+        #expect(
+            Cxx.liveMoveOnlyProbeCount() == baseline,
+            "the consumed value should be destroyed exactly once"
+        )
+    }
+
+    @Test
+    func consumingAnUnexpectedThrowsItsError() async throws {
+        let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+            _ = try Cxx.makeMoveOnlyProbeUnexpected(.TooLarge).consume()
+        }
+
+        #expect(thrown.error == .TooLarge)
+    }
+
+    @Test
+    func consumingAnUnsafeUnexpectedThrowsItsError() async throws {
+        // consumingAnUnexpectedThrowsItsError() covers the failure path for a value Swift imports as
+        // safe; this covers it for one Swift imports as `@unsafe`.
+        let thrown = try #require(throws: CxxUnexpected<Cxx.ProbeError>.self) {
+            _ = try unsafe Cxx.makeSelfReferentialProbeUnexpected(.TooSmall).consume()
+        }
+
+        #expect(thrown.error == .TooSmall)
+    }
+
+    @Test
+    func consumingAnUnexpectedDestroysTheExpectedItConsumed() async throws {
+        // An expected holding an error holds no value, so none of the value-side counters can see what
+        // the failure path did with the expected it was handed. An error that counts its own lifetime
+        // can: this is what proves `consume()` neither leaks nor double-destroys on the way out.
+        let baseline = Cxx.liveCountingProbeErrorCount()
+
+        do {
+            let thrown = try #require(throws: CxxUnexpected<Cxx.CountingProbeError>.self) {
+                _ = try Cxx.makeCountedErrorUnexpected(.TooLarge).consume()
+            }
+
+            #expect(thrown.error.value() == .TooLarge)
+        }
+
+        #expect(
+            Cxx.liveCountingProbeErrorCount() == baseline,
+            "the failure path should destroy the expected it consumed, exactly once"
+        )
+    }
+
+    @Test
+    func consumedNoncopyableValueIsRelocatedWithItsMoveConstructor() async throws {
+        // The same property noncopyableArgumentIsRelocatedWithItsMoveConstructor() pins, on the way out of
+        // an expected rather than into a completion handler: taking the value has to run the C++ move
+        // constructor, or the probe's pointer into itself is left aimed at storage C++ has abandoned.
+        // takeSelfReferentialProbeValue()'s static assertion is what makes Swift do that.
+        let probe = try unsafe Cxx.makeSelfReferentialProbeExpected(7).consume()
+
+        let interiorPointerIsValid = unsafe probe.interiorPointerIsValid()
+        let valueThroughInteriorPointer = unsafe probe.valueThroughInteriorPointer()
+
+        #expect(
+            interiorPointerIsValid,
+            "a noncopyable value must be relocated with its move constructor, not by copying its bytes"
+        )
+        #expect(valueThroughInteriorPointer == 7)
     }
 }
 


### PR DESCRIPTION
#### 00c991b3e660e26f50328266eb11bfb095f2461f
<pre>
[Swift in WebKit] Introduce a bridging mechanism to create `std::expected`s in Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=322806">https://bugs.webkit.org/show_bug.cgi?id=322806</a>
<a href="https://rdar.apple.com/186056463">rdar://186056463</a>

Reviewed by Adrian Taylor.

Add new CxxExpected and CxxConsumingExpected Swift protocols to be able to easily interoperate
with `std::expected` types.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift

* Source/WebKit/Shared/WTFExpected+Extras.swift: Added.
(CxxExpectedBase.has_value):
(CxxExpectedBase.__valueUnsafe):
(CxxExpectedBase.__errorUnsafe):
(CxxExpected.value):
(CxxConsumingExpected.__take(_:)):
(CxxConsumingExpected.consume() throws(CxxUnexpected&lt;Failure&gt;:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Helpers/WTFExpected+Extras.swift: Added.
(CxxExpectedBase.has_value):
(CxxExpectedBase.__valueUnsafe):
(CxxExpectedBase.__errorUnsafe):
(CxxExpected.value):
(CxxConsumingExpected.__take(_:)):
(CxxConsumingExpected.consume() throws(CxxUnexpected&lt;Failure&gt;:)):
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.cpp:
(SwiftCxxInteropTestbed::sharedProbeRefCount):
(SwiftCxxInteropTestbed::makeIntExpected):
(SwiftCxxInteropTestbed::makeIntUnexpected):
(SwiftCxxInteropTestbed::makeCopyCountingProbeExpected):
(SwiftCxxInteropTestbed::makeCopyCountingProbeUnexpected):
(SwiftCxxInteropTestbed::makeSharedProbeHolderExpected):
(SwiftCxxInteropTestbed::makeMoveOnlyProbeExpected):
(SwiftCxxInteropTestbed::makeMoveOnlyProbeUnexpected):
(SwiftCxxInteropTestbed::makeSelfReferentialProbeExpected):
* Tools/TestWebKitAPI/TestWTFLibrary/SwiftCxxInteropTestbed.h:
(SwiftCxxInteropTestbed::takeMoveOnlyProbeValue):
(SwiftCxxInteropTestbed::takeSelfReferentialProbeValue):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/SwiftCxxInteropTests.swift:
(Cxx.__take(_:)):
(SwiftCxxInteropTests.expectedExposesItsValue):
(SwiftCxxInteropTests.unexpectedThrowsItsError):
(SwiftCxxInteropTests.readingTheValueLeavesTheExpectedAlone):
(SwiftCxxInteropTests.readingAnUnexpectedLeavesTheErrorInPlace):
(SwiftCxxInteropTests.readingACopyableValueCopiesItExactlyOnce):
(SwiftCxxInteropTests.theValueOutlivesTheExpectedItWasReadFrom):
(SwiftCxxInteropTests.readingAnUnexpectedNeverTouchesTheValue):
(SwiftCxxInteropTests.valueHoldingAManagedReferenceLeavesTheCallersCountAlone):
(SwiftCxxInteropTests.noncopyableValueCanBeConsumed):
(SwiftCxxInteropTests.consumingAnUnexpectedThrowsItsError):
(SwiftCxxInteropTests.consumedNoncopyableValueIsRelocatedWithItsMoveConstructor):

Canonical link: <a href="https://commits.webkit.org/320032@main">https://commits.webkit.org/320032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7242e4494880e4b8d59e60e8b0a0d8f542827af8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183558 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193780 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14221362-1de7-446d-93e1-00e27ba80923) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48b769c5-80de-40da-9c86-6f3f3fb5f9f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123685 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57ee46cd-00c1-405a-bfa0-0674b7fef1f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45733 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43549 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4958 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195718 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57152 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152795 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40928 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57856 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152476 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47021 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56364 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18559 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55974 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->