### PR TITLE
[Site Isolation] FrameProcess lifetime should not be tied to navigation object

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -27,7 +27,6 @@
 #include "APINavigation.h"
 
 #include "BrowsingWarning.h"
-#include "FrameProcess.h"
 #include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
 #include <WebCore/RegistrableDomain.h>
@@ -207,12 +206,6 @@ size_t Navigation::redirectChainIndex(const WTF::URL& url)
     if (index == WTF::notFound)
         index = m_redirectChain.size();
     return index;
-}
-
-void Navigation::setPendingSharedProcess(FrameProcess& sharedProcess)
-{
-    // Extend the life of a shared process until the end of the current navigation.
-    m_pendingSharedProcess = sharedProcess;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -52,7 +52,6 @@ class ResourceResponse;
 
 namespace WebKit {
 class BrowsingWarning;
-class FrameProcess;
 class WebBackForwardListFrameItem;
 }
 
@@ -201,8 +200,6 @@ public:
     WebCore::ProcessIdentifier processID() const { return m_processID; }
     void setProcessID(WebCore::ProcessIdentifier processID) { m_processID = processID; }
 
-    void setPendingSharedProcess(WebKit::FrameProcess&);
-
     void NODELETE setHasStorageForCurrentSite(bool);
     bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
 
@@ -254,7 +251,6 @@ private:
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
     Vector<Function<void()>> m_safeBrowsingCheckCompletionCallbacks;
-    RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
     RefPtr<WebKit::FrameState> m_backForwardFrameState;
 };
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -238,6 +238,7 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
     if (process.isSharedProcess()) {
         m_sharedProcess = nullptr;
         m_sharedProcessSites.clear();
+        m_pagesInSharedProcess.clear();
     } else {
         auto& site = *process.site();
         // Either we are still the current entry for this site (normal teardown), or a

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6132,17 +6132,15 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
     ](FrameProcess* sharedProcess) mutable {
         if (sharedProcess) {
-            navigation->setPendingSharedProcess(*sharedProcess);
             ASSERT(!sharedProcess->process().isInProcessCache());
             if (frame->isMainFrame()) {
-                Ref process { sharedProcess->process() };
-                auto shutdownPreventingScope = process->shutdownPreventingScope();
+                auto shutdownPreventingScope = sharedProcess->process().shutdownPreventingScope();
                 protect(websiteDataStore->networkProcess())->addAllowedFirstPartyForCookies(sharedProcess->process(), site.domain(), LoadedWebArchive::No, [
-                    process = WTF::move(process),
                     shutdownPreventingScope = WTF::move(shutdownPreventingScope),
+                    sharedProcess = Ref { *sharedProcess },
                     continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
                 ] mutable {
-                    continueWithProcessForNavigation(WTF::move(process), nullptr, "Uses shared Web process"_s);
+                    continueWithProcessForNavigation(Ref { sharedProcess->process() }, nullptr, "Uses shared Web process"_s);
                 });
             } else
                 continueWithProcessForNavigation(sharedProcess->process(), nullptr, "Uses shared Web process"_s);


### PR DESCRIPTION
#### cd9128975e5151285f20dc0c2d29264f856c049c
<pre>
[Site Isolation] FrameProcess lifetime should not be tied to navigation object
<a href="https://bugs.webkit.org/show_bug.cgi?id=322809">https://bugs.webkit.org/show_bug.cgi?id=322809</a>
<a href="https://rdar.apple.com/186059703">rdar://186059703</a>

Reviewed by NOBODY (OOPS!).

The navigation object holds on to the per-browsing context group shared FrameProcess when Site
Isolation is enabled, which is unnecessary. This ties the lifetime of a WebProcess to a the lifetime
of a WKNavigation object in UIProcess which causes those shared processes to run for too long.

We originally added this in <a href="https://commits.webkit.org/301070@main">301070@main</a> as a way of avoiding some asserts that tripped when enabling
the shared process mode. This patch fixes the underlying the issues instead:

1. We weren&apos;t extending the lifetime of the FrameProcess in to the lambda that actually continues
navigation in to that process (we need the FrameProcess lifetime to be extended and not just the
WebProcessProxy to be extended since BCG only holds a WeakPtr to the shared FrameProecess).

2. We didn&apos;t clear the pages-in-shared-process state when a FrameProcess went away. So if a
BrowsingContextGroup ever shut down and then respawned a new shared process, the BCG would think
that the new shared process was already associated with pages from the old shared process.

The changes should be covered by the existing SharedProcessInProcessCacheAfterNavigation and
SharedProcessBasicWebProcessCacheCrash tests.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setPendingSharedProcess): Deleted.
* Source/WebKit/UIProcess/API/APINavigation.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::removeFrameProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd9128975e5151285f20dc0c2d29264f856c049c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183550 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57474 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193772 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147841 "Failed to checkout and rebase branch from PR 72683") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58819 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57209 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/193772 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/147841 "Failed to checkout and rebase branch from PR 72683") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186505 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/58819 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/193772 "Failed to checkout and rebase branch from PR 72683") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/58819 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/57209 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/193772 "Failed to checkout and rebase branch from PR 72683") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/58819 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4950 "Failed to checkout and rebase branch from PR 72683") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50129 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/57209 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195710 "Failed to checkout and rebase branch from PR 72683") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57144 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/195710 "Failed to checkout and rebase branch from PR 72683") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57848 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/195710 "Failed to checkout and rebase branch from PR 72683") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/57848 "Failed to checkout and rebase branch from PR 72683") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130127 "Failed to checkout and rebase branch from PR 72683") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126426 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56356 "Failed to checkout and rebase branch from PR 72683") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/51291 "Failed to checkout and rebase branch from PR 72683") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55727 "Failed to checkout and rebase branch from PR 72683") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55966 "Failed to checkout and rebase branch from PR 72683") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55794 "Failed to checkout and rebase branch from PR 72683") | | | | 
<!--EWS-Status-Bubble-End-->