### PR TITLE
[JSC] `FastStringifier` should not give up when it finds a 16-bit string late

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-16-bit-string-found-late.js
+++ b/JSTests/microbenchmarks/json-stringify-16-bit-string-found-late.js
@@ -1,0 +1,6 @@
+const body = { messages: [] };
+for (let i = 0; i < 200; ++i)
+    body.messages.push({ role: i & 1 ? "assistant" : "user", content: [{ type: "text", text: "abcdefgh".repeat(20) + i }] });
+body.messages.push({ role: "user", content: [{ type: "text", text: "\u3042\u3044\u3046" }] });
+for (let i = 0; i < 1e4; ++i)
+    JSON.stringify(body);

--- a/JSTests/stress/json-stringify-16-bit-string-found-late.js
+++ b/JSTests/stress/json-stringify-16-bit-string-found-late.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected " + expected);
+}
+
+function reference(value, space) {
+    return JSON.stringify(value, (key, value) => value, space);
+}
+
+function makeBody(prefixLength, wideString) {
+    let messages = [];
+    let produced = 0;
+    for (let i = 0; produced < prefixLength; ++i) {
+        let text = "x".repeat(100 + (i * 37) % 700);
+        messages.push({ role: i & 1 ? "assistant" : "user", content: [{ type: "text", text }], index: i });
+        produced += text.length + 60;
+    }
+    messages.push({ role: "user", content: [{ type: "text", text: wideString }], index: messages.length });
+    messages.push({ role: "assistant", content: [{ type: "text", text: "y".repeat(500) }], index: messages.length });
+    return { model: "m", max_tokens: 4096, stream: true, messages };
+}
+
+const wideStrings = [
+    "\u3042",
+    "abc\u3042def",
+    "\u2014 \u3042\u3044\u3046 \u00e9",
+    "\ud83d\ude00",
+    "\ud800",
+    "\udc00\ud800",
+    "line\n\u3042\ttab\"quote\\backslash ",
+    "\u3042".repeat(3000),
+];
+
+for (let prefixLength of [0, 1000, 5000, 7000, 9000]) {
+    for (let wideString of wideStrings) {
+        let body = makeBody(prefixLength, wideString);
+        for (let space of [undefined, 2, "\t"])
+            shouldBe(JSON.stringify(body, undefined, space), reference(body, space));
+    }
+}
+
+for (let prefixLength of [20000, 60000]) {
+    let body = makeBody(prefixLength, wideStrings[2]);
+    shouldBe(JSON.stringify(body), reference(body));
+    shouldBe(JSON.stringify(body, undefined, 2), reference(body, 2));
+}
+
+for (let prefixLength of [5000, 20000]) {
+    let array = [];
+    for (let i = 0; i < prefixLength / 4; ++i)
+        array.push(i);
+    array.push([{ wide: "\u3042" }]);
+    shouldBe(JSON.stringify(array), reference(array));
+    shouldBe(JSON.stringify(array, undefined, 1), reference(array, 1));
+}
+
+{
+    let object = { long: "z".repeat(20000), wide: "\u3042", toJSONHolder: { toJSON() { return "replaced"; } } };
+    shouldBe(JSON.stringify(object), reference(object));
+    shouldBe(JSON.stringify(object, undefined, 2), reference(object, 2));
+}

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -698,11 +698,16 @@ enum class FailureReason : uint8_t {
     Unknown,
 };
 
+struct FastStringifyFailure {
+    FailureReason reason { FailureReason::Unknown };
+    unsigned length { 0 };
+};
+
 template<typename CharType, BufferMode bufferMode>
 class FastStringifier {
 public:
     // Returns null string if the fast case fails.
-    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space, std::optional<FailureReason>&);
+    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space, FastStringifyFailure&);
 
     static constexpr unsigned staticBufferSize = bufferMode == BufferMode::StaticBuffer ? 8192 : 8;
     static constexpr unsigned dynamicBufferInlineCapacity = bufferMode == BufferMode::StaticBuffer ? 0 : 1024;
@@ -710,7 +715,7 @@ public:
     static constexpr bool useShortCopyTier = bufferMode == BufferMode::DynamicBuffer;
 
 private:
-    explicit FastStringifier(JSGlobalObject&);
+    FastStringifier(JSGlobalObject&, unsigned previousAttemptLength);
     template<HasGap hasGap> void append(JSValue);
     void appendInt32(int32_t);
     template<HasGap hasGap> void appendInt32Array(JSArray&);
@@ -900,15 +905,17 @@ inline unsigned FastStringifier<CharType, bufferMode>::usableBufferSize(unsigned
 }
 
 template<typename CharType, BufferMode bufferMode>
-inline FastStringifier<CharType, bufferMode>::FastStringifier(JSGlobalObject& globalObject)
+inline FastStringifier<CharType, bufferMode>::FastStringifier(JSGlobalObject& globalObject, unsigned previousAttemptLength)
     : m_globalObject(globalObject)
     , m_vm(globalObject.vm())
 {
     if constexpr (bufferMode == BufferMode::StaticBuffer)
         m_capacity = m_length + usableBufferSize(staticBufferSize);
     else {
-        m_dynamicBuffer.grow(dynamicBufferInlineCapacity);
-        m_capacity = dynamicBufferInlineCapacity;
+        size_t initialCapacity = std::max<size_t>(dynamicBufferInlineCapacity, static_cast<size_t>(previousAttemptLength) + (previousAttemptLength >> 2));
+        if (!StringImpl::isValidLength<CharType>(initialCapacity) || !m_dynamicBuffer.tryGrow(initialCapacity))
+            m_dynamicBuffer.grow(dynamicBufferInlineCapacity);
+        m_capacity = m_dynamicBuffer.size();
         m_stackLimit = std::bit_cast<uint8_t*>(m_vm.softStackLimit());
     }
 }
@@ -922,8 +929,7 @@ inline bool FastStringifier<CharType, bufferMode>::haveFailure() const
 template<typename CharType, BufferMode bufferMode>
 inline String FastStringifier<CharType, bufferMode>::result()
 {
-    if (haveFailure())
-        return { };
+    ASSERT(!haveFailure());
 #if FAST_STRINGIFY_LOG_USAGE
     static std::atomic<unsigned> maxSizeSeen;
     if (m_length > maxSizeSeen) {
@@ -1469,10 +1475,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 // It's possible the UTF-16 string is actually Latin-1. We try to avoid that but bailing out here is _way_ more expensive if it does sometimes happen.
                 bool success = WTF::appendEscapedJSONStringContent(output, string.data.span16());
                 if (!success) [[unlikely]] {
-                    if constexpr (bufferMode == BufferMode::DynamicBuffer)
-                        recordFailure(FailureReason::Unknown, "16-bit string, "_s);
-                    else
-                        recordFailure(m_length < (m_capacity / 2) ? FailureReason::Found16BitEarly : FailureReason::Found16BitLate, "16-bit string, "_s);
+                    recordFailure(bufferMode == BufferMode::StaticBuffer && m_length < (m_capacity / 2) ? FailureReason::Found16BitEarly : FailureReason::Found16BitLate, "16-bit string, "_s);
                     return;
                 }
             }
@@ -1822,13 +1825,13 @@ NEVER_INLINE void FastStringifier<CharType, bufferMode>::appendInt32Array(JSArra
 }
 
 template<typename CharType, BufferMode bufferMode>
-inline String FastStringifier<CharType, bufferMode>::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space, std::optional<FailureReason>& failureReason)
+inline String FastStringifier<CharType, bufferMode>::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space, FastStringifyFailure& failure)
 {
     if (replacer.isObject()) {
         logOutcome("replacer"_s);
         return { };
     }
-    FastStringifier stringifier(globalObject);
+    FastStringifier stringifier(globalObject, failure.length);
     if (!space.isUndefined()) {
         if (!stringifier.setGap(space)) [[unlikely]] {
             logOutcome("space"_s);
@@ -1839,7 +1842,10 @@ inline String FastStringifier<CharType, bufferMode>::stringify(JSGlobalObject& g
         stringifier.append<HasGap::Yes>(value);
     else
         stringifier.append<HasGap::No>(value);
-    failureReason = stringifier.m_failureReason;
+    if (stringifier.haveFailure()) [[unlikely]] {
+        failure = { *stringifier.m_failureReason, stringifier.m_length };
+        return { };
+    }
     return stringifier.result();
 }
 
@@ -1848,23 +1854,21 @@ static NEVER_INLINE String stringify(JSGlobalObject& globalObject, JSValue value
     VM& vm = globalObject.vm();
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
     if (std::bit_cast<uint8_t*>(currentStackPointer()) >= stackLimit) [[likely]] {
-        std::optional<FailureReason> failureReason;
-        failureReason = std::nullopt;
-        if (String result = FastStringifier<Latin1Character, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
+        FastStringifyFailure failure;
+        if (String result = FastStringifier<Latin1Character, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failure); !result.isNull())
             return result;
-        if (failureReason == FailureReason::Found16BitEarly) {
-            failureReason = std::nullopt;
-            if (String result = FastStringifier<char16_t, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
+        bool retryWith16BitDynamicBuffer = failure.reason == FailureReason::Found16BitLate;
+        if (failure.reason == FailureReason::Found16BitEarly) {
+            if (String result = FastStringifier<char16_t, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failure); !result.isNull())
                 return result;
-
-            if (failureReason == FailureReason::BufferFull) {
-                failureReason = std::nullopt;
-                if (String result = FastStringifier<char16_t, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
-                    return result;
-            }
-        } else if (failureReason == FailureReason::BufferFull) {
-            failureReason = std::nullopt;
-            if (String result = FastStringifier<Latin1Character, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
+            retryWith16BitDynamicBuffer = failure.reason == FailureReason::BufferFull;
+        } else if (failure.reason == FailureReason::BufferFull) {
+            if (String result = FastStringifier<Latin1Character, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failure); !result.isNull())
+                return result;
+            retryWith16BitDynamicBuffer = failure.reason == FailureReason::Found16BitLate;
+        }
+        if (retryWith16BitDynamicBuffer) {
+            if (String result = FastStringifier<char16_t, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failure); !result.isNull())
                 return result;
         }
     }


### PR DESCRIPTION
#### 9b54b23c1565ba7a0de283bd4ca4e540a171c741
<pre>
[JSC] `FastStringifier` should not give up when it finds a 16-bit string late
<a href="https://bugs.webkit.org/show_bug.cgi?id=322827">https://bugs.webkit.org/show_bug.cgi?id=322827</a>

Reviewed by NOBODY (OOPS!).

When FastStringifier finds a 16-bit string after filling more than half of
its static buffer, or at any point while using a dynamic buffer, it gives up
and the generic Stringifier serializes the whole value from scratch. Large
objects with a non-Latin-1 string near the end, such as API request bodies
carrying one non-ASCII message, always take this path, and the generic
Stringifier is about 4x slower than the 16-bit FastStringifier on them.

Retry with FastStringifier&lt;char16_t, DynamicBuffer&gt; instead. The retry redoes
the prefix, but that is much cheaper than the generic path. Each failed
attempt now reports the output length it reached, and a dynamic-buffer
attempt starts its buffer at 5/4 of that length, so a short tail after the
16-bit string fits without a further doubling; this also skips the first few
doublings when a static-buffer attempt overflows.

                                                  Baseline                  Patched

json-stringify-short-strings-upconvert       117.9794+-0.2577          117.7136+-0.4479
json-stringify-16-bit-string-found-late      574.7950+-2.1299     ^    218.8583+-0.5103        ^ definitely 2.6263x faster
json-stringify-int32-array                    19.8764+-0.2280     ?     20.1038+-0.1788        ? might be 1.0114x slower
json-stringify-many-objects                  146.4678+-0.6816     !    148.0488+-0.6626        ! definitely 1.0108x slower
json-stringify-empty-array                    17.1271+-0.1676           16.8823+-0.0875          might be 1.0145x faster
json-stringify-pretty-tab                    282.2410+-2.0685     ^    279.2594+-0.8431        ^ definitely 1.0107x faster
json-stringify-class-instances                70.8965+-0.4723     ?     71.5469+-0.4959        ?
json-stringify-array-replacer                 14.2938+-0.1224           14.2835+-0.1305
json-stringify-pretty                        315.3305+-1.0444     ^    312.9562+-0.8374        ^ definitely 1.0076x faster
json-stringify-many-objects-to-json           88.1441+-0.3506           87.8662+-0.4242
vanilla-todomvc-json-parse                    26.4485+-0.1311           26.2677+-0.1548
vanilla-todomvc-json-stringify                30.7695+-0.2798     ?     31.1737+-0.2438        ? might be 1.0131x slower

Tests: JSTests/microbenchmarks/json-stringify-16-bit-string-found-late.js
       JSTests/stress/json-stringify-16-bit-string-found-late.js

* JSTests/microbenchmarks/json-stringify-16-bit-string-found-late.js: Added.
* JSTests/stress/json-stringify-16-bit-string-found-late.js: Added.
(shouldBe):
(reference):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::FastStringifier):
(JSC::bufferMode&gt;::result):
(JSC::bufferMode&gt;::append):
(JSC::bufferMode&gt;::stringify):
(JSC::stringify):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b54b23c1565ba7a0de283bd4ca4e540a171c741

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147859 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143271 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99474 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43970 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5663 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12498 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43555 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4968 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44844 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57162 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57866 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40181 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152485 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130145 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126444 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18565 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->