### PR TITLE
[scroll-animations] make timeline names loosely-matched

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can not see scroll timeline defined by :host assert_equals: expected "x" but got "y"
-FAIL Outer animation can not see scroll timeline defined by ::slotted assert_equals: expected "x" but got "y"
+PASS Outer animation can not see scroll timeline defined by :host
+PASS Outer animation can not see scroll timeline defined by ::slotted
 PASS Inner animation can see scroll timeline defined by ::part
 PASS Animation inside shadow DOM can see the scroll timeline defined by the ancestor DOM
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can not see view timeline defined by :host assert_equals: expected "x" but got "y"
-FAIL Outer animation can not see view timeline defined by ::slotted assert_equals: expected "x" but got "y"
+PASS Outer animation can not see view timeline defined by :host
+PASS Outer animation can not see view timeline defined by ::slotted
 PASS Inner animation can see view timeline defined by ::part
 PASS Animation inside shadow DOM can see the view timeline defined by the ancestor DOM
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -40,6 +40,7 @@
 #include "ScrollTimeline.h"
 #include "Settings.h"
 #include "StyleableInlines.h"
+#include "StyleScope.h"
 #include "ViewTimeline.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
@@ -125,7 +126,20 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
     return nullptr;
 }
 
-ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(const Vector<Ref<ScrollTimeline>>& timelines, const Styleable& styleable, const Element* timelineScopeElement)
+static bool timelineIsInScopeForTarget(const Ref<ScrollTimeline>& timeline, Element& targetElement, Style::ScopeOrdinal animationTimelineNameScopeOrdinal)
+{
+    if (!targetElement.isConnected())
+        return false;
+    RefPtr timelineOriginatingElement { originatingElement(timeline).element() };
+    ASSERT(timelineOriginatingElement);
+    CheckedPtr scrollTimelineNameStyleScope = Style::Scope::forOrdinal(*timelineOriginatingElement, timeline->name().scopeOrdinal);
+    ASSERT(scrollTimelineNameStyleScope);
+    return Style::resolveTreeScopedReference(targetElement, { timeline->name().name, animationTimelineNameScopeOrdinal }, [&](const Style::Scope& scope, const Style::ScopedName&) {
+        return scrollTimelineNameStyleScope == &scope;
+    });
+}
+
+ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(const Vector<Ref<ScrollTimeline>>& timelines, const Styleable& styleable, Style::ScopeOrdinal targetTimelineScopeOrdinal, const Element* timelineScopeElement)
 {
     // https://drafts.csswg.org/scroll-animations-1/#timeline-scoping
     // A named scroll progress timeline or view progress timeline is referenceable by:
@@ -138,6 +152,9 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
     for (auto& timeline : timelines) {
         auto styleableForTimeline = originatingStyleableIncludingTimelineScope(timeline).styleable();
         if (!styleableForTimeline)
+            continue;
+        Ref targetElement { styleable.element };
+        if (!timelineIsInScopeForTarget(timeline, targetElement.get(), targetTimelineScopeOrdinal))
             continue;
         Ref protectedElementForTimeline { styleableForTimeline->element };
         if (&styleableForTimeline->element == &styleable.element || styleable.element.isComposedTreeDescendantOf(protectedElementForTimeline.get()))
@@ -385,7 +402,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
             protectedAnimation->setTimeline(nullptr);
     } else {
         auto& timelines = it->value;
-        RefPtr timeline = determineTimelineForElement(timelines, *target, relevantTimelineScopeElement.get());
+        RefPtr timeline = determineTimelineForElement(timelines, *target, timelineName->scopeOrdinal, relevantTimelineScopeElement.get());
         LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->name << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
         // A deferred inactive timeline means there was a conflict with multiple timelines existing within
         // a parent element with a "timeline-scope" property. In that case, we must reconsider timeline attachment

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -84,7 +84,7 @@ private:
 
     enum class AllowsDeferral : bool { No, Yes };
     void attachAnimation(CSSAnimation&, AllowsDeferral);
-    ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Element*);
+    ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, Style::ScopeOrdinal targetTimelineScopeOrdinal, const Element*);
     ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Element*);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
 


### PR DESCRIPTION
#### d729ce684003576e8ba3bceb657927685fac982f
<pre>
[scroll-animations] make timeline names loosely-matched
<a href="https://bugs.webkit.org/show_bug.cgi?id=322013">https://bugs.webkit.org/show_bug.cgi?id=322013</a>
<a href="https://rdar.apple.com/185206745">rdar://185206745</a>

Reviewed by Anne van Kesteren.

Now that we have the `animation-timeline`, `scroll-timeline-name` and `view-timeline-name`
CSS properties track their style scope (see 320026@main) we can use `Style::resolveTreeScopedReference()`
to correctly match style-originated timelines.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::timelineIsInScopeForTarget):
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/320040@main">https://commits.webkit.org/320040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97cab16354c29c0667bda8f052c667415b47d334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd5e012c-b8c6-4999-9bdd-548160727427) 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/524c2bd6-0f3e-442e-96d9-5954d12a35f4) 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93a666b9-f998-46e4-9be4-dbe42d1c5e64) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27862 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->