### PR TITLE
Cherry-pick 319855@main (d115ce184f96). https://bugs.webkit.org/show_bug.cgi?id=322494

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -70,6 +70,11 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
     if (domain == "www.apple.com"_s)
         return true;
 
+#if ENABLE(THUNDER)
+    if (baseDomain == "primevideo.com"_s)
+        return true;
+#endif
+
     return false;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -113,6 +113,10 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasChromeBrowserQuirk("http://soundcloud.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://www.apple.com/");
 
+#if ENABLE(THUNDER)
+    assertUserAgentForURLHasChromeBrowserQuirk("http://www.primevideo.com/");
+#endif
+
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://bugzilla.redhat.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.bilibili.com/");
 


### PR DESCRIPTION
#### 64abfa28ea1c39a37e361cb48ddea206c596b833
<pre>
Cherry-pick 319855@main (d115ce184f96). <a href="https://bugs.webkit.org/show_bug.cgi?id=322494">https://bugs.webkit.org/show_bug.cgi?id=322494</a>

    [WPE][GTK] Use a Chrome UA for PrimeVideo
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322494">https://bugs.webkit.org/show_bug.cgi?id=322494</a>

    Reviewed by Adrian Perez de Castro.

    Otherwise our ports are assumed to support HLS and Legacy EME, which is not the case. And in our
    case DRM is unlikely supported for that media transport anyway. By using a Chrome UA playback is
    handled with MSE/EME.

    Test: Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp

    * Source/WebCore/platform/glib/UserAgentQuirks.cpp:
    (WebCore::urlRequiresChromeBrowser):
    * Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp:
    (TestWebKitAPI::TEST(UserAgentTest, Quirks)):

    Canonical link: <a href="https://commits.webkit.org/319855@main">https://commits.webkit.org/319855@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1127@webkitglib/2.52">https://commits.webkit.org/305877.1127@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/973e81cad229719a9500ccb5e58123246810f6a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183582 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57506 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193804 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147873 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185445 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/58851 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57241 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143283 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147873 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186537 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/58851 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123706 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/58851 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57241 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/58851 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4982 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50161 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57241 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195742 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57176 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152817 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/57880 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152500 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27859 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/57880 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130159 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126458 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/56388 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51323 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/55759 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/55998 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55826 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->