### PR TITLE
[cmake] build-webkit should be building SwiftBrowser by default

### DIFF
--- a/Tools/Scripts/build-swiftbrowser
+++ b/Tools/Scripts/build-swiftbrowser
@@ -1,0 +1,95 @@
+#!/usr/bin/env perl
+
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+# 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use File::Basename;
+use File::Spec;
+use FindBin;
+use Getopt::Long qw(:config pass_through);
+use lib $FindBin::Bin;
+use webkitdirs;
+use POSIX;
+
+my $showHelp = 0;
+my $clean = 0;
+
+my $programName = basename($0);
+my $usage = <<EOF;
+Usage: $programName [options] [options to pass to build system]
+  --help        Show this help message
+  --clean       Clean up the build directory
+EOF
+
+my $result = GetOptions(
+    'help' => \$showHelp,
+    'clean' => \$clean,
+);
+
+if ($showHelp or not $result) {
+   print STDERR $usage;
+   exit 1;
+}
+
+checkRequiredSystemConfig();
+setConfiguration();
+chdirWebKit();
+
+die "SwiftBrowser can only be built for Apple platforms\n" if !isAppleCocoaWebKit();
+
+my $isCMake = isCMakeBuild();
+
+# SwiftBrowser is not part of any workspace.
+overrideConfiguredXcodeWorkspace("");
+my @xcodeOptions = ("-project", "SwiftBrowser.xcodeproj");
+
+if ($isCMake) {
+    # The frameworks SwiftBrowser links against were built by CMake, so the Xcode
+    # options that describe a WebKit build don't apply. The project only has Debug
+    # and Release configurations, while the tree can be configured for ASan or
+    # TSan, so name the output directory directly instead of deriving it from the
+    # configuration, and keep Xcode's intermediates out of it.
+    my $productDir = productDir();
+    my $intermediatesDir = File::Spec->catdir($productDir, "SwiftBrowser");
+    push @xcodeOptions, ("-configuration", configuration());
+    push @xcodeOptions, ("SYMROOT=$intermediatesDir", "OBJROOT=$intermediatesDir");
+    push @xcodeOptions, "CONFIGURATION_BUILD_DIR=$productDir";
+    my $sdk = xcodeSDK();
+    push @xcodeOptions, "SDKROOT=$sdk" if $sdk;
+    # ONLY_ACTIVE_ARCH needs a run destination to name an architecture, otherwise
+    # the app is built for every architecture the SDK supports.
+    my $destination = xcodeDestination();
+    push @xcodeOptions, ("-destination", $destination) if $destination;
+} else {
+    push @xcodeOptions, XcodeOptions();
+}
+
+# Build. xcodebuild only honours a run destination when it is given a scheme.
+chdir "Tools/SwiftBrowser" or die;
+$result = buildXcodeScheme("SwiftBrowser", $clean, @xcodeOptions, @ARGV);
+exit exitStatus($result);

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -47,6 +47,8 @@ use POSIX;
 use Text::ParseWords;
 
 sub writeCongrats();
+sub swiftBrowserNeedsBuild($);
+sub touchSwiftBrowserStamp($);
 
 maybeEnterWebKitContainerSDK();
 
@@ -76,6 +78,7 @@ my $prefixPath;
 my $makeArgs = "";
 my @cmakeArgs;
 my $onlyWebKitProject = 0;
+my $buildSwiftBrowser = 1;
 my $xcodeScheme;
 my $coverageSupport = 0;
 my $shouldRunStaticAnalyzer = 0;
@@ -151,6 +154,8 @@ Usage: $programName [options] [options to pass to build system]
   --only-webkit                     Build only the WebKit project
   --only=<scheme>                   Build only the given scheme, instead of the entire project (Xcode builds only)
 
+  --[no-]swiftbrowser               Build SwiftBrowser.app (CMake builds on Apple platforms; on by default)
+
   --skip-library-update             Skip the check to see if windows libraries are up to date
 
   --[no-]use-ccache                 Enable (or disable) CCache, if available
@@ -170,6 +175,7 @@ my %options = (
     'cmakeargs=s' => \@cmakeArgs,
     'minimal' => \$minimal,
     'only-webkit' => \$onlyWebKitProject,
+    'swiftbrowser!' => \$buildSwiftBrowser,
     'only=s' => \$xcodeScheme,
     'coverage' => \$coverageSupport,
     'analyze' => \$shouldRunStaticAnalyzer,
@@ -326,6 +332,21 @@ if (isCMakeBuild() && !isAnyWindows() && !isWin()) {
     }
 
     buildCMakeProjectOrExit($clean, $prefixPath, $makeArgs, @featureArgs, @cmakeArgs);
+
+    # SwiftBrowser has no CMake project of its own, so build it out of its Xcode
+    # project against the frameworks CMake just produced.
+    if (isAppleCocoaWebKit() && $buildSwiftBrowser && !$onlyWebKitProject && swiftBrowserNeedsBuild($productDir)) {
+        my @command = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "build-swiftbrowser");
+        die "build-swiftbrowser script not found" if !-e $command[0];
+
+        # @ARGV holds the CMake arguments in this branch, so pass only the configuration.
+        push @command, argumentsForConfiguration();
+        $result = system(@command);
+        if (exitStatus($result)) {
+            exit exitStatus($result);
+        }
+        touchSwiftBrowserStamp($productDir);
+    }
 }
 
 my $baseProductDir = baseProductDir();
@@ -431,6 +452,51 @@ chdir $originalWorkingDirectory;
 writeCongrats();
 
 exit 0;
+
+sub swiftBrowserStampFile($)
+{
+    my ($productDir) = @_;
+    return File::Spec->catfile($productDir, "SwiftBrowser", "build-swiftbrowser.stamp");
+}
+
+# xcodebuild takes a few seconds to decide it has nothing to do, which is the common
+# case once the frameworks are built, so compare the inputs of the Xcode project
+# against the last successful run ourselves.
+sub swiftBrowserNeedsBuild($)
+{
+    my ($productDir) = @_;
+
+    my $stamp = swiftBrowserStampFile($productDir);
+    return 1 if !-e $stamp;
+    return 1 if !-e File::Spec->catdir($productDir, "SwiftBrowser.app");
+
+    my $stampTime = (stat($stamp))[9];
+    my @inputs = (File::Spec->catfile(sourceDir(), "LocalOverrides.xcconfig"),
+                  File::Spec->catfile(sourceDir(), "Configurations", "CommonBase.xcconfig"));
+    my $collect = sub { push @inputs, $File::Find::name if -f $_; };
+    find($collect, File::Spec->catdir(sourceDir(), "Tools", "SwiftBrowser"));
+    foreach my $framework ("WebKit.framework", "_WebKit_SwiftUI.framework") {
+        my $path = File::Spec->catdir($productDir, $framework);
+        find($collect, $path) if -d $path;
+    }
+
+    # Modification times have a one second resolution, so treat an input written in
+    # the same second as the stamp as newer and pay for a build that does nothing.
+    foreach my $input (@inputs) {
+        my @stat = stat($input);
+        return 1 if @stat && $stat[9] >= $stampTime;
+    }
+    return 0;
+}
+
+sub touchSwiftBrowserStamp($)
+{
+    my ($productDir) = @_;
+    my $stamp = swiftBrowserStampFile($productDir);
+    mkdir dirname($stamp);
+    open my $stampHandle, ">", $stamp or die "Unable to write $stamp: $!";
+    close $stampHandle;
+}
 
 sub writeCongrats()
 {

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -209,6 +209,7 @@ BEGIN {
        &willUseVisionSimulatorSDK
        &winVersion
        &wrapperPrefixIfNeeded
+       &xcodeDestination
        &xcodeSDK
        &xcodeSDKPlatformName
        &xcodeVersion


### PR DESCRIPTION
#### b2850d33c968e6fa213baee757d43f83608bdf7a
<pre>
[cmake] build-webkit should be building SwiftBrowser by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=322810">https://bugs.webkit.org/show_bug.cgi?id=322810</a>
<a href="https://rdar.apple.com/186060752">rdar://186060752</a>

Reviewed by Elliott Williams.

SwiftBrowser  was only buildable from its own Xcode project, so a CMake
WebKit had no SwiftBrowser to run against it.

Add an ENABLE_SWIFTBROWSER option, on by default, that builds the app from
the main CMake build the way ENABLE_MINIBROWSER builds MiniBrowser, and a
--[no-]swiftbrowser flag to build-webkit that sets it. It is a plain option
rather than a WEBKIT_OPTION so that it stays out of cmakeconfig.h, which
every translation unit includes and where a change of value would rebuild
the world. The target needs the macOS 26 SDK, which is the gate
Configurations/Base.xcconfig applies through WK_MACOS_2600, and says which
way it went at configure time. Resources/mac/Info.plist now spells its
substitutions ${NAME}, a form both configure_file() and Xcode expand.

* Tools/PlatformCocoa.cmake:
* Tools/Scripts/build-webkit:
* Tools/SwiftBrowser/CMakeLists.txt: Added.
* Tools/SwiftBrowser/Resources/mac/Info.plist:

Canonical link: <a href="https://commits.webkit.org/321299@main">https://commits.webkit.org/321299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44d89b10e56d8572a35639bd205479d96c1f00c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55080 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/197729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/152124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/atp/4e5466f0-b22e-11f1-5058-8e4c62be6647) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61080 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/197729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/152124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/atp/4e5466f0-b22e-11f1-d806-240cd254899b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/50157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/197729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/atp/4e5466f0-b22e-11f1-372b-75a5da86b46d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/48882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/197729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/15449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/159174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46519 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8836 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/48675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/51295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199776 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60967 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/156110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41829 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/61684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/43026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155764 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/61684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131382 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/60064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/21511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/59486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/59666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->