### PR TITLE
[css-overflow-4] `text-overflow: <string>` should work on `<input>`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-expected-mismatch.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow: &lt;string&gt; in text inputs - not reference</title>
+<input value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-notref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow: &lt;string&gt; in text inputs - not reference</title>
+<input value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow: &lt;string&gt; in text inputs</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#text-overflow">
+<link rel="mismatch" href="text-overflow-string-in-input-notref.html">
+<input value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" style="text-overflow: '[...]'">

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2269,7 +2269,7 @@ bool HTMLInputElement::shouldTruncateText(const Style::ComputedStyle& style) con
 {
     if (!isTextField())
         return false;
-    return document().focusedElement() != this && style.textOverflow().isEllipsis();
+    return document().focusedElement() != this && !style.textOverflow().isClip();
 }
 
 void HTMLInputElement::invalidateStyleOnFocusChangeIfNeeded()
@@ -2277,7 +2277,7 @@ void HTMLInputElement::invalidateStyleOnFocusChangeIfNeeded()
     if (!isTextField())
         return;
     // Focus change may affect the result of shouldTruncateText().
-    if (CheckedPtr style = renderStyle(); style && style->textOverflow().isEllipsis())
+    if (CheckedPtr style = renderStyle(); style && !style->textOverflow().isClip())
         invalidateStyleForSubtree();
 }
 
@@ -2369,7 +2369,7 @@ Style::ComputedStyle HTMLInputElement::createInnerTextStyle(const Style::Compute
     textBlockStyle.setOverflowX(Overflow::Hidden);
     textBlockStyle.setOverflowY(Overflow::Hidden);
     if (shouldTruncateText(style))
-        textBlockStyle.setTextOverflow(CSS::Keyword::Ellipsis { });
+        textBlockStyle.setTextOverflow(Style::TextOverflow { style.textOverflow() });
     else
         textBlockStyle.setTextOverflow(CSS::Keyword::Clip { });
 


### PR DESCRIPTION
#### 24a47dd197933b56dd372a9c4d181515a2c60354
<pre>
[css-overflow-4] `text-overflow: &lt;string&gt;` should work on `&lt;input&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322843">https://bugs.webkit.org/show_bug.cgi?id=322843</a>
<a href="https://rdar.apple.com/186085377">rdar://186085377</a>

Reviewed by Alan Baradlay.

Stop checking explicitly for ellipsis text-overflow, and instead check for non-clip text-overflow.

Transfer non-clip text-overflow value into the inner text element.

Tests: imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-notref.html
       imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input-notref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-string-in-input.html: Added.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::shouldTruncateText const):
(WebCore::HTMLInputElement::invalidateStyleOnFocusChangeIfNeeded):
(WebCore::HTMLInputElement::createInnerTextStyle):

Canonical link: <a href="https://commits.webkit.org/320088@main">https://commits.webkit.org/320088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3500189e8beb1df9185509e7ee0bdfd7cec7422a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147982 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb0c6e76-fc36-434c-b2a3-8f3d6131bb38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143367 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99546 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adfc78fb-9741-4173-b80a-45e149254e21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b18e94c-3925-4dec-ab06-88411c4dae4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45840 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44067 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43651 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195851 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152902 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57989 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152587 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47126 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130268 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126582 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56497 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18661 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->