### PR TITLE
[Interop 2026] Sync with upstream WPT for popover related tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/WEB_FEATURES.yml
@@ -1,73 +1,42 @@
-features:
-- name: selectors
-  files:
-  - attribute.html
-  - class-id-attr.html
-  - sibling.html
-  - insert-sibling-*
-  - selectorText-dynamic-001.html
-  - sheet-going-away-*
-- name: has
-  files:
-  - has-*
-  - "*-in-has.*"
-  - "*-in-has-*"
-- name: link-selectors
-  files:
-  - "any-link-*"
-- name: media-pseudos
-  files:
-  - media-loading-pseudo-classes-in-has.sub.html
-  - media-pseudo-classes-in-has.html
-- name: modal
-  files:
-  - modal-pseudo-class-in-has.html
-- name: not
-  files:
-  - not-*
-- name: nth-child
-  files:
-  - first-child-last-child.html
-  - nth-child-in-shadow-root.html
-- name: nth-child-of
-  files:
-  - nth-child-of-*
-  - nth-child-when-*
-  - nth-child-whole-subtree.html
-  - nth-child-containing-ancestor.html
-  - negated-nth-child-when-*
-  - nth-last-child-of-*
-  - nth-last-child-when-*
-  - nth-last-child-containing-ancestor.html
-  - negated-nth-last-child-when-*
-- name: nth-of-type
-  files:
-  - 'negated-*-of-type*'
-- name: user-pseudos
-  files:
-  - user-valid-user-invalid.html
-- name: state
-  files:
-  - state-in-has.html
-- name: placeholder-shown
-  files:
-  - placeholder-shown.html
-- name: shadow-parts
-  files:
-  - part-dir.html
-  - part-lang.html
-  - part-pseudo.html
-- name: host
-  files:
-  - host-*
-  - "!host-context-*"
-- name: is
-  files:
-  - is.html
-  - negated-is-*
-- name: where
-  files:
-  - where.html
-- name: input-selectors
-  files:
-  - enabled-disabled.html
+rules:
+- attribute.html: [selectors]
+- class-id-attr.html: [selectors]
+- sibling.html: [selectors]
+- insert-sibling-*: [selectors]
+- selectorText-dynamic-001.html: [selectors]
+- sheet-going-away-*: [selectors]
+- has-*: [has]
+- "*-in-has-*": [has, has]
+- media-loading-pseudo-classes-in-has.sub.html: [media-pseudos, has]
+- media-pseudo-classes-in-has.html: [media-pseudos, has]
+- modal-pseudo-class-in-has.html: [modal, has]
+- not-pseudo-containing-sibling-relationship-in-has.html: [has, not]
+- not-pseudo-containing-complex-in-has.html: [has, not]
+- state-in-has.html: [state, has]
+- host-pseudo-class-in-has.html: [has, host]
+- host-context-pseudo-class-in-has.html: [has]
+- "*-in-has.*": [has]
+- any-link-*: [link-selectors]
+- not-*: [not]
+- first-child-last-child.html: [nth-child]
+- nth-child-in-shadow-root.html: [nth-child]
+- nth-child-of-*: [nth-child-of]
+- nth-child-when-*: [nth-child-of]
+- nth-child-whole-subtree.html: [nth-child-of]
+- nth-child-containing-ancestor.html: [nth-child-of]
+- negated-nth-child-when-*: [nth-child-of]
+- nth-last-child-of-*: [nth-child-of]
+- nth-last-child-when-*: [nth-child-of]
+- nth-last-child-containing-ancestor.html: [nth-child-of]
+- negated-nth-last-child-when-*: [nth-child-of]
+- negated-is-*: [is, nth-of-type]
+- negated-*-of-type*: [nth-of-type]
+- user-valid-user-invalid.html: [user-pseudos]
+- placeholder-shown.html: [placeholder-shown]
+- part-dir.html: [shadow-parts]
+- part-lang.html: [shadow-parts]
+- part-pseudo.html: [shadow-parts]
+- host-*: [host]
+- is.html: [is]
+- where.html: [where]
+- enabled-disabled.html: [input-selectors]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/crashtests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/crashtests/has-pseudoclass-only-crash.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/WEB_FEATURES.yml
@@ -50,6 +48,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-nested-pseudo-002-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-nested-pseudo-003-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudoclass-only.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt
@@ -1,3 +1,3 @@
 
-PASS reparenting a dialog should not cause it to move in the open dialogs list
+FAIL reparenting a dialog should not cause it to move in the open dialogs list promise_test: Unhandled rejection with value: object "TypeError: new_parent.moveBefore is not a function. (In 'new_parent.moveBefore(dialog, null)', 'new_parent.moveBefore' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
 <!doctype html>
 <title>moveBefore should not re-run dialog setup steps</title>
 <link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
@@ -4,7 +4,7 @@
 <style>
 body p, span {
     -webkit-user-select: none;
-    -webkit-user-select: none;
+    user-select: none;
 }
 
 ::backdrop {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Hit-testing doesn't reach contents of an inert SVG
-PASS Hit-testing can reach contents of a no longer inert SVG
+FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -43,7 +43,6 @@ promise_test(async function() {
         .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_false(target.matches(":active"), "target is not active");
     assert_false(target.matches(":hover"), "target is not hovered");
@@ -62,7 +61,6 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_true(target.matches(":active"), "target is active");
     assert_true(reachedTarget, "target got event");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Top layer UA styles stop applying once a dialog leaves the top layer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Removing a dialog from the top layer invalidates the top layer UA styles</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+<link rel="help" href="https://www.w3.org/TR/css-position-4/#top-styling">
+<link rel="author" href="mailto:mhochk@microsoft.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<dialog style="display:block"></dialog>
+<script>
+test(() => {
+  const dialog = document.querySelector('dialog');
+  const computedStyle = getComputedStyle(dialog);
+
+  assert_equals(computedStyle.position, 'absolute',
+                'position before entering the top layer');
+  assert_equals(computedStyle.overflow, 'visible',
+                'overflow before entering the top layer');
+
+  dialog.showModal();
+
+  assert_equals(computedStyle.position, 'fixed',
+                'position while in the top layer');
+  assert_equals(computedStyle.overflow, 'auto',
+                'overflow while in the top layer');
+
+  dialog.close();
+  assert_equals(computedStyle.position, 'absolute',
+                'position after leaving the top layer');
+  assert_equals(computedStyle.overflow, 'visible',
+                'overflow after leaving the top layer');
+}, 'Top layer UA styles stop applying once a dialog leaves the top layer');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log
@@ -9,7 +9,7 @@ Do NOT modify or remove this file.
 
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
-user-select
+None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -228,6 +228,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-position-static-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-position-static.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-position.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-remove-popover-attribute-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-remove-popover-attribute-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-remove-popover-attribute.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-change-type-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-change-type-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#the-popover-attribute">
+
+<div id="p1" popover="auto">Popover 1</div>
+<div id="p2" popover="auto">Popover 2</div>
+
+<script>
+  p1.addEventListener('beforetoggle', (e) => {
+    if (e.newState === 'closed') {
+      p1.setAttribute('popover', 'manual');
+      p2.showPopover();
+    }
+  });
+
+  p1.showPopover();
+  p1.hidePopover();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover-expected.txt
@@ -1,0 +1,4 @@
+Click me first Close  Click me second, THEN press tab After
+
+FAIL Popover with an internal tabindex=-1 invoker does not cause infinite recursion assert_equals: focus should remain on before button expected Element node <button id="before" popovertarget="p" popovertargetaction... but got Element node <body><button id="before" popovertarget="p" popovertarget...
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://crbug.com/542274292">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/popover.html">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
+
+<button id="before" popovertarget="p" popovertargetaction="show">Click me first</button>
+<div id="p" popover>
+  <button id="b" popovertarget="p" tabindex="-1">Close</button>
+  <button id="inside">Click me second, THEN press tab</button>
+</div>
+<button id="after">After</button>
+
+<script>
+promise_test(async () => {
+  p.showPopover({source: b});
+  assert_true(p.matches(':popover-open'), 'popover should be open');
+  before.focus();
+  assert_equals(document.activeElement, before, 'focus starts on before button');
+
+  await clickOn(before);
+  assert_true(p.matches(':popover-open'), 'popover should stay open');
+  assert_equals(document.activeElement, before, 'focus should remain on before button');
+
+  await clickOn(inside);
+  assert_true(p.matches(':popover-open'), 'popover should stay open');
+  assert_equals(document.activeElement, inside, 'focus should move to inside button');
+
+  await sendTab();
+  assert_true(p.matches(':popover-open'), 'popover should stay open');
+  assert_equals(document.activeElement, after, 'focus should move to after button');
+}, "Popover with an internal tabindex=-1 invoker does not cause infinite recursion");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child-expected.txt
@@ -1,0 +1,4 @@
+Hover me
+
+FAIL Showing a child hint popover in loseinterest should function promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: waitForRender"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/html/semantics/interestfor/resources/invoker-utils.js"></script>
+
+<button id="invoker" interestfor="hint1">Hover me</button>
+<div id="hint1" popover="hint">
+  Parent hint
+  <div id="hint2" popover="hint">Child hint</div>
+</div>
+
+<style>
+  #invoker {
+    interest-delay: 0s 1000s;
+  }
+</style>
+
+<script>
+  promise_test(async (t) => {
+    hint1.addEventListener('loseinterest', () => {
+      try {
+        hint2.showPopover();
+      } catch (e) {}
+    });
+    invoker.focus();
+    await waitForRender();
+    assert_true(hint1.matches(':popover-open'), 'hint1 should be open via interest');
+    hint1.hidePopover();
+    assert_false(hint1.matches(':popover-open'), 'hint1 should be closed');
+    // Should not crash here.
+  }, 'Showing a child hint popover in loseinterest should function');
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
@@ -50,6 +50,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-change-type-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-opening-event.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-checkbox-backdrop-expected.html
@@ -71,6 +72,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-inert-invoker.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-inside-shadow-dom.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-inside-slot.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-overflow-visible.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-previous-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-slotted.html
@@ -83,6 +85,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hidden-display.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-reentrant-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-iframe-backdrop-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-iframe-backdrop.html


### PR DESCRIPTION
#### 868c07528b3d79e0f77c30408960246554a483a4
<pre>
[Interop 2026] Sync with upstream WPT for popover related tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=322850">https://bugs.webkit.org/show_bug.cgi?id=322850</a>
<a href="https://rdar.apple.com/186093277">rdar://186093277</a>

Unreviewed sync with upstream Interop 2026 content.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/9e894db9485551eee017d7c0620be9cdd294670a">https://github.com/web-platform-tests/wpt/commit/9e894db9485551eee017d7c0620be9cdd294670a</a>

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-removal-invalidates-ua-styles.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-change-type-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-invoker-inside-popover.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-loseinterest-show-child.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/320065@main">https://commits.webkit.org/320065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e3c892e8aa1ef73970f758203ec9582f1325b86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da82544d-fdaf-4290-ab00-99ef030d567f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71820a85-86e4-4ba9-9d70-5a5af45352a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186607 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5810a4ba-d2ac-4f23-b284-292bdf4f0031) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5053 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195812 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163580 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57950 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152552 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47093 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56458 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55829 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56068 "Hash 0e3c892e for PR 72718 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->