### PR TITLE
[Interop 2026] Correct two Dialogs and Popover failures after WPT sync

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL reparenting a dialog should not cause it to move in the open dialogs list promise_test: Unhandled rejection with value: object "TypeError: new_parent.moveBefore is not a function. (In 'new_parent.moveBefore(dialog, null)', 'new_parent.moveBefore' is undefined)"
+PASS reparenting a dialog should not cause it to move in the open dialogs list
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
 <!doctype html>
 <title>moveBefore should not re-run dialog setup steps</title>
 <link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Hit-testing doesn't reach contents of an inert SVG
-FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
+PASS Hit-testing can reach contents of a no longer inert SVG
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -43,6 +43,7 @@ promise_test(async function() {
         .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
+    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_false(target.matches(":active"), "target is not active");
     assert_false(target.matches(":hover"), "target is not hovered");
@@ -61,6 +62,7 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
+    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_true(target.matches(":active"), "target is active");
     assert_true(reachedTarget, "target got event");


### PR DESCRIPTION
#### 37966e503a143192cb90918fb1d8af70ef42d9a3
<pre>
[Interop 2026] Correct two Dialogs and Popover failures after WPT sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=322854">https://bugs.webkit.org/show_bug.cgi?id=322854</a>
<a href="https://rdar.apple.com/186097567">rdar://186097567</a>

Unreviewed re-sync with WPT after landing upstream fix.

I forgot to push a local fix upstream:
    <a href="https://github.com/web-platform-tests/wpt/commit/aa609de82b6914e5308cb01b2fc0828b23bc2336">https://github.com/web-platform-tests/wpt/commit/aa609de82b6914e5308cb01b2fc0828b23bc2336</a>

That has now been corrected, so resyncing locally:
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/073a34f030ad68af980d7a627e829900b003961b">https://github.com/web-platform-tests/wpt/commit/073a34f030ad68af980d7a627e829900b003961b</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-movebefore-setup.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html:

Canonical link: <a href="https://commits.webkit.org/320080@main">https://commits.webkit.org/320080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddccee330d7b1e46e4945bc63d3922a928b49681

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b7e98ab-def2-45a5-98f9-0a0c6cf7a78c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43641 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5087 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163602 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57982 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152583 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27879 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47120 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126575 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56490 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18651 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55928 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->