### PR TITLE
[EWS] Activate flaky test verdicts

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -86,7 +86,7 @@ class ResultsDatabase(object):
     ]
 
     PRS_FOR_DIRTY_TREE_FLAKE = 2
-    AUTHORS_FOR_DIRTY_TREE_FLAKE = 1
+    AUTHORS_FOR_DIRTY_TREE_FLAKE = 2
     PRS_FOR_BETWEEN_BUILD_FLAKE = 3
     AUTHORS_FOR_BETWEEN_BUILD_FLAKE = 2
 
@@ -99,6 +99,11 @@ class ResultsDatabase(object):
     WITHIN_STEP_CLEAN_TREE = 'WithinStepCleanTree'
     WITHIN_STEP_DIRTY_TREE = 'WithinStepDirtyTree'
     BETWEEN_STEPS_DIRTY_TREE = 'BetweenStepsDirtyTree'
+
+    # What the read path concludes, which is what a caller decides to act on.
+    CLEAN_TREE_VERDICT = 'CleanTree'
+    DIRTY_TREE_VERDICT = 'DirtyTree'
+    BETWEEN_BUILDS_VERDICT = 'BetweenBuilds'
 
     @classmethod
     def platform_for_query(cls, platform):
@@ -313,12 +318,12 @@ class ResultsDatabase(object):
 
         if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE):
             evidence = cls._evidence_in(clean_tree)
-            evidence.flaky_type = 'CleanTree'
+            evidence.flaky_type = cls.CLEAN_TREE_VERDICT
             return evidence
 
         with_change = rows.get(cls.WITHIN_STEP_DIRTY_TREE, []) + rows.get(cls.BETWEEN_STEPS_DIRTY_TREE, [])
         return cls._convict(
-            cls._evidence_in(with_change), 'DirtyTree',
+            cls._evidence_in(with_change), cls.DIRTY_TREE_VERDICT,
             cls.PRS_FOR_DIRTY_TREE_FLAKE, cls.AUTHORS_FOR_DIRTY_TREE_FLAKE,
         )
 
@@ -328,7 +333,7 @@ class ResultsDatabase(object):
         evidence = cls._evidence_in(rows)
 
         if verdict := cls._convict(
-            evidence, 'BetweenBuilds',
+            evidence, cls.BETWEEN_BUILDS_VERDICT,
             cls.PRS_FOR_BETWEEN_BUILD_FLAKE, cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE,
         ):
             return verdict

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3949,7 +3949,11 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
     ENABLE_ADDITIONAL_ARGUMENTS = True
     EXIT_AFTER_FAILURES = '60'
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 60
-    SHOULD_IGNORE_FLAKY_TESTS = False
+    INCLUDED_FLAKY_VERDICTS = frozenset({
+        ResultsDatabase.CLEAN_TREE_VERDICT,
+        ResultsDatabase.DIRTY_TREE_VERDICT,
+        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
+    })
     STRESS_MODE = False
     command = ['python3', 'Tools/Scripts/run-webkit-tests',
                '--no-build',
@@ -4125,6 +4129,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         if flake_logs:
             yield self._addToLog(self.results_db_log_name, flake_logs)
 
+        ignored, shadowed = [], []
         for test in tests:
             data = pre_existing[test]
             flake = flakes.get(test, FlakyVerdict(request_failed=True))
@@ -4134,11 +4139,14 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                 self.failing_tests_filtered.remove(test)
             elif flake.is_flaky:
                 self.flaky_failures_in_results_db[test] = flake.flaky_type
-                if flake.flaky_type == 'BetweenBuilds' and not flake.intra_build_evidence:
+                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
                     self.unsupported_flakes_in_results_db.append(test)
                 flake_summary = f'{flake.flaky_type}: {flake.evidence}'
-                if self.SHOULD_IGNORE_FLAKY_TESTS:
+                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS:
+                    ignored.append(test)
                     self.failing_tests_filtered.remove(test)
+                else:
+                    shadowed.append(test)
             elif flake.request_failed:
                 self.unknown_flakes_in_results_db.append(test)
                 flake_summary = 'Unknown'
@@ -4151,13 +4159,12 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                 f"pre-existing-flake={flake_summary}\n"
             )
 
-        if self.flaky_failures_in_results_db:
-            action = 'Ignored' if self.SHOULD_IGNORE_FLAKY_TESTS else 'Would have ignored'
-            yield self._addToLog(
-                self.results_db_log_name,
-                f"\n{action} {len(self.flaky_failures_in_results_db)} flaky "
-                f"test(s): {', '.join(sorted(self.flaky_failures_in_results_db))}\n",
-            )
+        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
+            if acted_on:
+                yield self._addToLog(
+                    self.results_db_log_name,
+                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
+                )
 
     def results_db_ignore_message(self) -> str:
         parts = []

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -30,6 +30,7 @@ import shutil
 import sys
 import tempfile
 import time
+from typing import Any, Generator
 from unittest import skip as skipTest
 from unittest.mock import call, create_autospec, patch
 
@@ -3359,8 +3360,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         )
 
     @defer.inlineCallbacks
-    def test_a_flaky_verdict_is_recorded_without_ignoring_the_failure(self):
-        # SHOULD_IGNORE_FLAKY_TESTS is False, so the verdict is recorded but the test is not removed.
+    def test_a_verdict_in_the_included_set_removes_the_failure(self) -> Generator[Any, Any, None]:
         step = self._configure(set())
         builds = [f'https://build.webkit.org/#/builders/1/builds/{number}' for number in (11, 12, 13)]
         self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
@@ -3373,10 +3373,27 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
 
         yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
 
-        self.assertEqual(step.failing_tests_filtered, ['real.html', 'flaky.html'])
+        self.assertEqual(step.failing_tests_filtered, ['real.html'])
         self.assertEqual(step.flaky_failures_in_results_db, {'flaky.html': 'DirtyTree'})
         self.assertEqual(step.preexisting_failures_in_results_db, [])
         self.assertEqual(step.results_db_ignore_message(), 'Ignored flaky tests: flaky.html based on results-db')
+
+    @defer.inlineCallbacks
+    def test_a_verdict_outside_the_included_set_is_recorded_without_ignoring_the_failure(self) -> Generator[Any, Any, None]:
+        step = self._configure(set())
+        step.INCLUDED_FLAKY_VERDICTS = frozenset({'CleanTree'})
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({
+                test: (
+                    FlakyVerdict(flaky_type='BetweenBuilds')
+                    if test == 'flaky.html' else FlakyVerdict()
+                ) for test in tests
+            }, ''))))
+
+        yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
+
+        self.assertEqual(step.failing_tests_filtered, ['real.html', 'flaky.html'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'flaky.html': 'BetweenBuilds'})
 
     @defer.inlineCallbacks
     def test_a_test_with_no_verdict_is_not_treated_as_sound(self):
@@ -3404,7 +3421,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
 
         yield step.filter_failures_using_results_db(['pre-existing.html', 'flaky.html'])
 
-        self.assertEqual(step.failing_tests_filtered, ['flaky.html'])
+        self.assertEqual(step.failing_tests_filtered, [])
         self.assertEqual(
             step.results_db_ignore_message(),
             'Ignored pre-existing failures: pre-existing.html; flaky tests: flaky.html based on results-db',
@@ -12585,6 +12602,18 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         rows = [
             self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=1, authors=['alice']),
             self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/2', authors=['bob']),
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_single_author_across_two_pull_requests_is_not_flaky(self) -> Generator[Any, Any, None]:
+        # A stack of pull requests is one author's work, so the parent commit's own regression must
+        # not excuse itself: a build's first run writes rows its own re-run then reads.
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n, authors=['alice'])
+            for n in range(1, 4)
         ]
         with self._mock(self._response(rows=rows), self._response()):
             verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')


### PR DESCRIPTION
#### 651c2a2cdcac1fb8bde41eb878db83fbf0525f31
<pre>
[EWS] Activate flaky test verdicts
<a href="https://bugs.webkit.org/show_bug.cgi?id=322866">https://bugs.webkit.org/show_bug.cgi?id=322866</a>
<a href="https://rdar.apple.com/186115028">rdar://186115028</a>

Reviewed by Aakash Jain.

EWS computes a flakiness verdict for every layout-test failure it cannot
explain as a pre-existing failure, then throws it away:
`SHOULD_IGNORE_FLAKY_TESTS` is `False`, so a convicted test stays in
`failing_tests_filtered` and still blames the pull request. A recent
48-hour window produced 1292 such convictions across 4737 builds.

Act on them. `INCLUDED_FLAKY_VERDICTS` names the verdicts a queue ignores
a failure for, one entry per verdict rather than one boolean for all
three, so a verdict can be withdrawn from production without reverting
the read path. All three are included. The results-db log reports
`Ignored` and `Would have ignored` separately and counts the tests each
applied to, not every conviction.

`AUTHORS_FOR_DIRTY_TREE_FLAKE` rises from 1 to 2. A build&apos;s first run
reports its own flakes before its re-run reads them back, so a
`DirtyTree` conviction could rest on one author&apos;s stack of pull requests
excusing its own regression. Requiring a second author makes the evidence
independent of the change under test.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase):
(ResultsDatabase._is_intra_build_flake):
(ResultsDatabase._is_inter_build_flake):
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests):
(RunWebKitTests.filter_failures_using_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_verdict_in_the_included_set_removes_the_failure):
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_verdict_outside_the_included_set_is_recorded_without_ignoring_the_failure):
(TestFilterLayoutTestFailuresUsingResultsDB.test_the_ignore_message_covers_both_categories):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_flaky_verdict_is_recorded_without_ignoring_the_failure): Deleted.

Canonical link: <a href="https://commits.webkit.org/320087@main">https://commits.webkit.org/320087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c02d9bcdb66f74a7ae40172336166a13b5b8a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193924 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123795 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183030 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45847 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5764 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12600 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43658 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5105 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44979 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195862 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183106 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163619 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40965 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58000 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47137 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56508 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18668 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55879 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->