### PR TITLE
[Cocoa] A document with an opaque origin should never be same-site for cookies

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1040,8 +1040,6 @@ imported/w3c/web-platform-tests/cookies/samesite/about-blank-subresource.https.h
 imported/w3c/web-platform-tests/cookies/samesite/about-blank-toplevel.https.html [ Failure Crash Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/iframe.document.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/multiple-samesite-attributes.https.html [ Failure Pass ]
-imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https.html [ Failure Pass ]
-imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/setcookie-lax.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/setcookie-navigation.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite-none-secure/cookies-without-samesite-must-be-secure.https.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL SameSite cookies with intervening sandboxed iframe and navigation assert_equals: `samesite_lax=0.07283376622792892` in request to `https://localhost:9443`. expected (undefined) undefined but got (string) "0.07283376622792892"
+PASS SameSite cookies with intervening sandboxed iframe and navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL SameSite cookies with intervening sandboxed iframe and subresources assert_equals: `samesite_lax=0.959107380167203` in request to `https://localhost:9443`. expected (undefined) undefined but got (string) "0.959107380167203"
+PASS SameSite cookies with intervening sandboxed iframe and subresources
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4212,8 +4212,6 @@ webkit.org/b/227189 fast/forms/checkbox-and-pseudo.html [ Skip ]
 # These mostly pass but fail because some cross-origin cases fail with a random value.
 imported/w3c/web-platform-tests/cookies/samesite/iframe.document.https.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/samesite/multiple-samesite-attributes.https.html [ Failure ]
-imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https.html [ Failure ]
-imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/samesite/setcookie-lax.https.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/samesite/setcookie-navigation.https.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-iframe-subresource.tentative.html [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL SameSite cookies with intervening sandboxed iframe and navigation assert_equals: `samesite_lax=0.35549777691779794` in request to `https://web-platform.test:9443`. expected (undefined) undefined but got (string) "0.35549777691779794"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL SameSite cookies with intervening sandboxed iframe and subresources assert_equals: `samesite_lax=0.07583713055641716` in request to `https://web-platform.test:9443`. expected (undefined) undefined but got (string) "0.07583713055641716"
-

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -12152,6 +12152,15 @@ bool Document::hasElementWithPendingUserAgentShadowTreeUpdate(Element& element) 
 
 bool Document::isSameSiteForCookies(const URL& url) const
 {
+    // https://html.spec.whatwg.org/multipage/browsers.html#site-for-cookies
+    // A document with an opaque origin is never same-site with anything, so a sandboxed frame gets a
+    // null site for cookies even when its URL is same-site with the top-level site. Sandbox flags are
+    // inherited, so this covers documents nested inside a sandboxed frame as well.
+    // FIXME: The site for cookies should also be null when a document is same-site with the top-level
+    // site but has a cross-site ancestor between the two, which we do not yet detect.
+    if (securityOrigin().isOpaque())
+        return false;
+
     auto domain = isTopDocument() ? RegistrableDomain(securityOrigin().data()) : RegistrableDomain(siteForCookies());
     return domain.matches(url);
 }


### PR DESCRIPTION
#### 2d208620a70fe9dd8237e832b07a51930c941e2f
<pre>
[Cocoa] A document with an opaque origin should never be same-site for cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=322867">https://bugs.webkit.org/show_bug.cgi?id=322867</a>
<a href="https://rdar.apple.com/186115005">rdar://186115005</a>

Reviewed by NOBODY (OOPS!).

Document::isSameSiteForCookies() compares the document&apos;s URL against the top-level
registrable domain, so a sandboxed iframe counts as same-site whenever its URL
happened to be same-site with the top-level site. A sandboxed frame has an opaque
origin, and per the HTML &quot;site for cookies&quot; algorithm an opaque origin is never
same-site with anything, so SameSite=Lax and SameSite=Strict cookies were being sent
to subresources and nested navigations underneath a sandboxed frame.

This causes us to fail some WPT tests. This patch addresses the failures that can be
resolved within WebKit iteself.

We now return early when the document&apos;s security origin is opaque. Sandbox flags are
inherited, so this also covers documents nested inside a sandboxed frame.

The check is made here rather than in FrameLoader::setFirstPartyForCookies() because a
CSP-delivered sandbox directive is applied by initContentSecurityPolicy(), which
didBeginDocument() runs after updateFirstPartyForCookies(). Evaluating at request time
avoids that ordering problem, and Document::isSameSiteForCookies() is the only real
consumer of siteForCookies().

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-nested.https-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/samesite/sandbox-iframe-subresource.https-expected.txt: Removed.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isSameSiteForCookies const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d208620a70fe9dd8237e832b07a51930c941e2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5e84a7a-ce85-4ba9-9688-2c17d2470343) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143378 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99553 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc3a1e7f-97c4-4059-9253-fe60f96c5830) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4db17dd-fbd6-4c97-bbce-93415bc0ca2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45848 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44075 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43659 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152913 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58001 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152598 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47138 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130280 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126596 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56509 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18669 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->