### PR TITLE
Web Inspector: add `watch(object)` Command Line API

### DIFF
--- a/LayoutTests/inspector/console/resources/watch-utilities.js
+++ b/LayoutTests/inspector/console/resources/watch-utilities.js
@@ -1,0 +1,119 @@
+TestPage.registerInitializer(() => {
+    InspectorTest.WatchObject = {};
+
+    InspectorTest.WatchObject.evaluateWithCommandLineAPI = function(expression) {
+        return promisify((callback) => {
+            WI.runtimeManager.evaluateInInspectedWindow(expression, {objectGroup: "test", includeCommandLineAPI: true}, callback);
+        });
+    };
+
+    InspectorTest.WatchObject.watchObject = async function(expression) {
+        let [remoteObject, wasThrown] = await InspectorTest.WatchObject.evaluateWithCommandLineAPI(`watch(${expression})`);
+        if (wasThrown) {
+            InspectorTest.fail(`Watching ${expression} should not throw.`);
+            InspectorTest.log(remoteObject.description);
+            throw new Error("Unable to continue without watching the object.");
+        }
+    };
+
+    InspectorTest.WatchObject.unwatchObject = async function(expression) {
+        let [remoteObject, wasThrown] = await InspectorTest.WatchObject.evaluateWithCommandLineAPI(`unwatch(${expression})`);
+        if (wasThrown) {
+            InspectorTest.fail(`Unwatching ${expression} should not throw.`);
+            InspectorTest.log(remoteObject.description);
+            throw new Error("Unable to continue without unwatching the object.");
+        }
+    };
+
+    InspectorTest.WatchObject.ensureDFGCompiled = async function(functionExpression, invocationExpression) {
+        await InspectorTest.evaluateInPage(`testRunner.neverInlineFunction(${functionExpression})`);
+
+        for (let i = 0; i < 100; ++i) {
+            let numberOfDFGCompiles = await InspectorTest.evaluateInPage(`(() => {
+                for (let j = 0; j < 1000; ++j)
+                    ${invocationExpression};
+                return testRunner.numberOfDFGCompiles(${functionExpression});
+            })()`);
+            if (numberOfDFGCompiles)
+                return numberOfDFGCompiles;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+
+        return 0;
+    };
+
+    InspectorTest.WatchObject.expectPause = async function({expression, beforeExpression, whilePausedExpression, afterExpression, description, includeCommandLineAPI}) {
+        let pausedListener;
+        let pausePromise = new Promise((resolve) => {
+            pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, resolve);
+        });
+
+        let evaluationPromise = includeCommandLineAPI
+            ? InspectorTest.WatchObject.evaluateWithCommandLineAPI(expression)
+            : InspectorTest.evaluateInPage(expression);
+        let didPause = await Promise.race([
+            pausePromise.then(() => true),
+            evaluationPromise.then(() => false),
+        ]);
+
+        WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+
+        if (!didPause) {
+            InspectorTest.fail(`Should pause before ${description}.`);
+            return;
+        }
+
+        let callFrame = WI.debuggerManager.activeCallFrame;
+        let targetData = WI.debuggerManager.dataForTarget(callFrame.target);
+        InspectorTest.expectEqual(targetData.pauseReason, WI.DebuggerManager.PauseReason.WatchedObject, "Pause reason should be WatchedObject.");
+        let {result, wasThrown} = await DebuggerAgent.evaluateOnCallFrame.invoke({
+            callFrameId: callFrame.id,
+            expression: beforeExpression,
+            objectGroup: "test",
+            doNotPauseOnExceptionsAndMuteConsole: true,
+            returnByValue: true,
+        });
+        InspectorTest.expectTrue(!wasThrown && result.value, `Should pause before ${description}.`);
+
+        if (whilePausedExpression) {
+            let {wasThrown} = await DebuggerAgent.evaluateOnCallFrame.invoke({
+                callFrameId: callFrame.id,
+                expression: whilePausedExpression,
+                objectGroup: "test",
+                includeCommandLineAPI: true,
+                doNotPauseOnExceptionsAndMuteConsole: true,
+                returnByValue: true,
+            });
+            InspectorTest.expectFalse(wasThrown, "Should run the requested expression while paused.");
+        }
+
+        let additionalPauseHandlers = [];
+        let additionalPausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, () => {
+            additionalPauseHandlers.push(WI.debuggerManager.resume());
+        });
+
+        try {
+            await WI.debuggerManager.resume();
+            await evaluationPromise;
+            await Promise.all(additionalPauseHandlers);
+        } finally {
+            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, additionalPausedListener);
+        }
+
+        if (!await InspectorTest.evaluateInPage(afterExpression))
+            InspectorTest.fail(`Should complete ${description} after resuming.`);
+    };
+
+    InspectorTest.WatchObject.expectNoPause = async function(expression, description) {
+        let paused = false;
+        let pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, () => {
+            paused = true;
+            WI.debuggerManager.resume();
+        });
+
+        await InspectorTest.evaluateInPage(expression);
+
+        WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+        InspectorTest.expectFalse(paused, description);
+    };
+});

--- a/LayoutTests/inspector/console/unwatch-expected.txt
+++ b/LayoutTests/inspector/console/unwatch-expected.txt
@@ -1,0 +1,22 @@
+Tests for the unwatch function in the Command Line API.
+
+
+== Running test suite: CommandLineAPI.unwatch
+-- Running test case: CommandLineAPI.unwatch.Object
+PASS: Unwatching should flatten the dictionary created for watching.
+PASS: Should not pause after unwatching the object.
+PASS: Rewatching should convert the object to a new uncacheable dictionary Structure.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write to a rewatched object.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write to a separately watched object.
+
+-- Running test case: CommandLineAPI.unwatch.PreexistingUncacheableDictionary
+PASS: Watching should replace a preexisting uncacheable dictionary with a protected Structure.
+PASS: An attempted flatten should preserve a preexisting dictionary while it is watched.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write to a watched preexisting dictionary.
+PASS: Unwatching should preserve a preexisting uncacheable dictionary.
+PASS: Replacing the dictionary Structure should preserve its properties.
+PASS: The preexisting dictionary should remain flattenable after unwatching.
+

--- a/LayoutTests/inspector/console/unwatch.html
+++ b/LayoutTests/inspector/console/unwatch.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/watch-utilities.js"></script>
+<script>
+let Objects = {
+    target: {value: 1, removable: true, tail: true},
+    sibling: {value: 1},
+    preexistingUncacheableDictionary: {first: 1, removable: true, value: 0, last: 3},
+};
+
+function mutateTarget(value)
+{
+    Objects.target.value = value;
+}
+
+function mutateSibling()
+{
+    Objects.sibling.value = 2;
+}
+
+function mutatePreexistingUncacheableDictionary(value)
+{
+    Objects.preexistingUncacheableDictionary.value = value;
+}
+
+function currentStructureData(object)
+{
+    let transitionList = $vm.getStructureTransitionList(object);
+    return JSON.stringify({
+        id: transitionList[transitionList.length - 5],
+        maxOffset: transitionList[transitionList.length - 3],
+    });
+}
+
+function test()
+{
+    WI.debuggerManager.createWatchedObjectBreakpoint();
+
+    let suite = InspectorTest.createAsyncSuite("CommandLineAPI.unwatch");
+    let {expectNoPause, expectPause, unwatchObject, watchObject} = InspectorTest.WatchObject;
+
+    suite.addTestCase({
+        name: "CommandLineAPI.unwatch.Object",
+        async test() {
+            await watchObject("Objects.target");
+            await watchObject("Objects.sibling");
+
+            await InspectorTest.evaluateInPage("delete Objects.target.removable");
+            let watchedStructureData = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.target)"));
+            await unwatchObject("Objects.target");
+
+            let unwatchedStructureData = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.target)"));
+            InspectorTest.expectLessThan(unwatchedStructureData.maxOffset, watchedStructureData.maxOffset, "Unwatching should flatten the dictionary created for watching.");
+
+            await expectNoPause("mutateTarget(2)", "Should not pause after unwatching the object.");
+
+            await watchObject("Objects.target");
+
+            let rewatchedStructureData = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.target)"));
+            InspectorTest.expectNotEqual(rewatchedStructureData.id, unwatchedStructureData.id, "Rewatching should convert the object to a new uncacheable dictionary Structure.");
+
+            await expectPause({
+                expression: "mutateTarget(3)",
+                beforeExpression: "Objects.target.value === 2",
+                afterExpression: "Objects.target.value === 3",
+                description: "a property write to a rewatched object",
+            });
+            await expectPause({
+                expression: "mutateSibling()",
+                beforeExpression: "Objects.sibling.value === 1",
+                afterExpression: "Objects.sibling.value === 2",
+                description: "a property write to a separately watched object",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.unwatch.PreexistingUncacheableDictionary",
+        async test() {
+            await InspectorTest.evaluateInPage("$vm.toUncacheableDictionary(Objects.preexistingUncacheableDictionary); delete Objects.preexistingUncacheableDictionary.removable");
+            let beforeWatch = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.preexistingUncacheableDictionary)"));
+
+            await watchObject("Objects.preexistingUncacheableDictionary");
+            let afterWatch = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.preexistingUncacheableDictionary)"));
+            InspectorTest.expectNotEqual(afterWatch.id, beforeWatch.id, "Watching should replace a preexisting uncacheable dictionary with a protected Structure.");
+
+            await InspectorTest.evaluateInPage("$vm.flattenDictionaryObject(Objects.preexistingUncacheableDictionary)");
+            let afterFlattenAttempt = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.preexistingUncacheableDictionary)"));
+            InspectorTest.expectEqual(afterFlattenAttempt.id, afterWatch.id, "An attempted flatten should preserve a preexisting dictionary while it is watched.");
+
+            await expectPause({
+                expression: "mutatePreexistingUncacheableDictionary(1)",
+                beforeExpression: "Objects.preexistingUncacheableDictionary.value === 0",
+                afterExpression: "Objects.preexistingUncacheableDictionary.value === 1",
+                description: "a property write to a watched preexisting dictionary",
+            });
+            await unwatchObject("Objects.preexistingUncacheableDictionary");
+
+            let afterUnwatch = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.preexistingUncacheableDictionary)"));
+            InspectorTest.expectEqual(afterUnwatch.maxOffset, beforeWatch.maxOffset, "Unwatching should preserve a preexisting uncacheable dictionary.");
+            InspectorTest.expectTrue(await InspectorTest.evaluateInPage("Objects.preexistingUncacheableDictionary.first === 1 && Objects.preexistingUncacheableDictionary.value === 1 && Objects.preexistingUncacheableDictionary.last === 3"), "Replacing the dictionary Structure should preserve its properties.");
+
+            await InspectorTest.evaluateInPage("$vm.flattenDictionaryObject(Objects.preexistingUncacheableDictionary)");
+            let afterExplicitFlatten = JSON.parse(await InspectorTest.evaluateInPage("currentStructureData(Objects.preexistingUncacheableDictionary)"));
+            InspectorTest.expectLessThan(afterExplicitFlatten.maxOffset, afterUnwatch.maxOffset, "The preexisting dictionary should remain flattenable after unwatching.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for the <code>unwatch</code> function in the Command Line API.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/console/watch-expected.txt
+++ b/LayoutTests/inspector/console/watch-expected.txt
@@ -1,0 +1,124 @@
+Tests for the watch function in the Command Line API.
+
+
+== Running test suite: CommandLineAPI.watch
+-- Running test case: CommandLineAPI.watch.WarmedMutator
+PASS: The mutator should DFG compile before watch.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write from a mutator warmed before watch.
+
+-- Running test case: CommandLineAPI.watch.API
+PASS: Should return undefined after watching an object.
+PASS: Should return undefined without an argument.
+PASS: Should throw a TypeError for a primitive.
+
+-- Running test case: CommandLineAPI.watch.ObjectTypes
+PASS: Should watch and unwatch a null-prototype object.
+PASS: Should watch and unwatch a class instance with private members.
+PASS: Should watch and unwatch an object from another realm.
+PASS: Should watch and unwatch an object with an Array constructor and toStringTag.
+PASS: watch should reject an array.
+PASS: unwatch should reject an array.
+PASS: watch should reject an Array subclass instance.
+PASS: unwatch should reject an Array subclass instance.
+PASS: watch should reject a regular expression.
+PASS: unwatch should reject a regular expression.
+PASS: watch should reject a RegExp subclass instance.
+PASS: unwatch should reject a RegExp subclass instance.
+PASS: watch should reject a Map.
+PASS: unwatch should reject a Map.
+PASS: watch should reject a Set.
+PASS: unwatch should reject a Set.
+PASS: watch should reject a WeakMap.
+PASS: unwatch should reject a WeakMap.
+PASS: watch should reject a WeakSet.
+PASS: unwatch should reject a WeakSet.
+PASS: watch should reject a Promise.
+PASS: unwatch should reject a Promise.
+PASS: watch should reject an ArrayBuffer.
+PASS: unwatch should reject an ArrayBuffer.
+PASS: watch should reject a typed array.
+PASS: unwatch should reject a typed array.
+PASS: watch should reject a DataView.
+PASS: unwatch should reject a DataView.
+PASS: watch should reject a function.
+PASS: unwatch should reject a function.
+PASS: watch should reject a Date.
+PASS: unwatch should reject a Date.
+PASS: watch should reject an Error.
+PASS: unwatch should reject an Error.
+PASS: watch should reject a boxed primitive.
+PASS: unwatch should reject a boxed primitive.
+PASS: watch should reject an arguments object.
+PASS: unwatch should reject an arguments object.
+PASS: watch should reject a Proxy without invoking its traps.
+PASS: unwatch should reject a Proxy without invoking its traps.
+PASS: watch should reject a revoked Proxy.
+PASS: unwatch should reject a revoked Proxy.
+PASS: watch should reject a DOM object.
+PASS: unwatch should reject a DOM object.
+PASS: watch should reject Object.prototype.
+PASS: unwatch should reject Object.prototype.
+PASS: watch should reject ArrayBuffer.prototype.
+PASS: unwatch should reject ArrayBuffer.prototype.
+PASS: watch should reject an array from another realm.
+PASS: unwatch should reject an array from another realm.
+
+-- Running test case: CommandLineAPI.watch.PropertyAddition
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before adding an ordinary named property.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before writing a named property after a Structure transition.
+
+-- Running test case: CommandLineAPI.watch.SuperPropertyWrite
+PASS: The super-property mutator should DFG compile before watch.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a named super-property write to a watched receiver.
+
+-- Running test case: CommandLineAPI.watch.ComputedSuperPropertyWrite
+PASS: The computed super-property mutator should DFG compile after watch.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a computed super-property write from a mutator compiled after watch.
+PASS: Should pause exactly once for the compiled computed super-property write.
+
+-- Running test case: CommandLineAPI.watch.SloppyComputedSuperPropertyWrite
+PASS: The non-strict computed super-property mutator should DFG compile after watch.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a non-strict computed super-property write from a mutator compiled after watch.
+PASS: Should pause exactly once for the compiled non-strict computed super-property write.
+
+-- Running test case: CommandLineAPI.watch.FlattenAttempt
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write after an attempted dictionary flatten.
+
+-- Running test case: CommandLineAPI.watch.ReentrantUnwatch
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write whose receiver is unwatched while paused.
+PASS: Should run the requested expression while paused.
+PASS: Should not pause for a subsequent write after reentrant unwatch.
+
+-- Running test case: CommandLineAPI.watch.WarmedOwnRead
+PASS: The own-property reader should DFG compile before watch.
+PASS: The watched object's property should remain readable after invalidating the warmed read cache.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write after warming an own-property read cache.
+
+-- Running test case: CommandLineAPI.watch.WarmedInheritedRead
+PASS: The inherited-property reader should DFG compile before watch.
+PASS: The inherited property should remain readable after watching its prototype.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a direct prototype write after warming an inherited read cache.
+
+-- Running test case: CommandLineAPI.watch.ObjectIdentity
+PASS: Should not pause for an unwatched object with the same original Structure.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write to the watched object rather than its same-Structure sibling.
+
+-- Running test case: CommandLineAPI.watch.GarbageCollection
+PASS: A watched object should be garbage collected.
+
+-- Running test case: CommandLineAPI.watch.OtherObjectsWatchedDFGMutator
+PASS: A mutator should DFG compile while other watched objects exist.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a property write reached from DFG code compiled while other objects were watched.
+

--- a/LayoutTests/inspector/console/watch-garbage-collection-expected.txt
+++ b/LayoutTests/inspector/console/watch-garbage-collection-expected.txt
@@ -1,0 +1,8 @@
+Tests clearing watched objects after Eden garbage collection.
+
+
+== Running test suite: CommandLineAPI.watch.GarbageCollection
+-- Running test case: CommandLineAPI.watch.GarbageCollection.Eden
+PASS: The watched object should be collected by Eden GC.
+PASS: Disabling the Debugger should finish after its only watched object is collected.
+

--- a/LayoutTests/inspector/console/watch-garbage-collection.html
+++ b/LayoutTests/inspector/console/watch-garbage-collection.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useDollarVM=true ] -->
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/watch-utilities.js"></script>
+<script>
+let weakObject;
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CommandLineAPI.watch.GarbageCollection");
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.GarbageCollection.Eden",
+        async test() {
+            await HeapAgent.gc();
+            // watch returns undefined, so the Inspector does not retain the object as an evaluation result.
+            await InspectorTest.WatchObject.watchObject("(() => { let object = {}; weakObject = new WeakRef(object); return object; })()");
+            // Use a separate evaluation so the WeakRef no longer keeps its target alive for the current job.
+            InspectorTest.expectTrue(await InspectorTest.evaluateInPage("$vm.edenGC(); !weakObject.deref()"), "The watched object should be collected by Eden GC.");
+            await DebuggerAgent.disable();
+            InspectorTest.pass("Disabling the Debugger should finish after its only watched object is collected.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests clearing watched objects after Eden garbage collection.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/console/watch-super-property-expected.txt
+++ b/LayoutTests/inspector/console/watch-super-property-expected.txt
@@ -1,0 +1,52 @@
+Tests watching computed super-property writes.
+
+
+== Running test suite: CommandLineAPI.watch.SuperProperty
+-- Running test case: CommandLineAPI.watch.SuperProperty.ComputedKeys
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a strict computed super-property write with a string key.
+PASS: Should pause exactly once before a strict computed super-property write with a string key.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a strict computed super-property write with a symbol key.
+PASS: Should pause exactly once before a strict computed super-property write with a symbol key.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a strict computed super-property write with a numeric key.
+PASS: Should pause exactly once before a strict computed super-property write with a numeric key.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.SloppyMethod
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a non-strict computed super-property write.
+PASS: Should pause exactly once before a non-strict computed super-property write.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.ProxyBase
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a computed super-property write forwarded by a Proxy superclass.
+PASS: Should pause exactly once before a computed super-property write forwarded by a Proxy superclass.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.LiteralBracketCompound
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a literal-bracket compound super-property write.
+PASS: Should pause exactly once before a literal-bracket compound super-property write.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.KeyConversion
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a super-property write after converting its key exactly once.
+PASS: Should pause exactly once before a super-property write after converting its key exactly once.
+PASS: Should not pause when converting the key throws.
+PASS: Throwing key conversion should leave the receiver unchanged.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.ReentrantUnwatch
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a super-property write whose receiver is unwatched while paused.
+PASS: Should run the requested expression while paused.
+PASS: Should pause exactly once before a super-property write whose receiver is unwatched while paused.
+PASS: Should not pause for a subsequent super-property write after reentrant unwatch.
+
+-- Running test case: CommandLineAPI.watch.SuperProperty.Inactive
+PASS: Should not pause for a computed super-property write while disabled.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before a computed super-property write after re-enabling the breakpoint.
+PASS: Should pause exactly once before a computed super-property write after re-enabling the breakpoint.
+PASS: Should not pause for a computed super-property write after unwatch.
+PASS: An unwatched computed super-property write should complete.
+

--- a/LayoutTests/inspector/console/watch-super-property.html
+++ b/LayoutTests/inspector/console/watch-super-property.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/watch-utilities.js"></script>
+<script>
+let symbol = Symbol("property");
+class SuperPropertyWriterBase { }
+SuperPropertyWriterBase.prototype.value = 10;
+class SuperPropertyWriter extends SuperPropertyWriterBase {
+    constructor()
+    {
+        super();
+        this.value = this[0] = this[symbol] = 0;
+    }
+
+    write(property, value)
+    {
+        super[property] = value;
+    }
+
+    addLiteral(value)
+    {
+        super["value"] += value;
+    }
+}
+
+let Objects = {
+    strict: new SuperPropertyWriter,
+    sloppy: {__proto__: SuperPropertyWriterBase.prototype, value: 0, write(property, value) { super[property] = value; }},
+    proxyBase: {
+        __proto__: new Proxy(SuperPropertyWriterBase.prototype, {}),
+        value: 0,
+        write(property, value) { "use strict"; super[property] = value; },
+    },
+    compound: new SuperPropertyWriter,
+    keyConversion: new SuperPropertyWriter,
+    reentrantUnwatch: new SuperPropertyWriter,
+    inactive: new SuperPropertyWriter,
+};
+let State = {conversions: 0, property: "value", shouldThrow: false, didThrow: false};
+let key = {
+    [Symbol.toPrimitive]() {
+        ++State.conversions;
+        if (State.shouldThrow)
+            throw new Error("key conversion");
+        return State.property;
+    },
+};
+
+function test()
+{
+    WI.debuggerManager.createWatchedObjectBreakpoint();
+    let suite = InspectorTest.createAsyncSuite("CommandLineAPI.watch.SuperProperty");
+    let {expectNoPause, expectPause, unwatchObject, watchObject} = InspectorTest.WatchObject;
+    let expectSinglePause = async (options) => {
+        let pauseCount = 0;
+        let pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, () => ++pauseCount);
+        try {
+            await expectPause(options);
+        } finally {
+            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+        }
+        InspectorTest.expectEqual(pauseCount, 1, `Should pause exactly once before ${options.description}.`);
+    };
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.ComputedKeys",
+        async test() {
+            await watchObject("Objects.strict");
+            for (let [property, description] of [["'value'", "string"], ["symbol", "symbol"], ["0", "numeric"]]) {
+                await expectSinglePause({
+                    expression: `Objects.strict.write(${property}, 1)`,
+                    beforeExpression: `Objects.strict[${property}] === 0`,
+                    afterExpression: `Objects.strict[${property}] === 1`,
+                    description: `a strict computed super-property write with a ${description} key`,
+                });
+            }
+            await unwatchObject("Objects.strict");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.SloppyMethod",
+        async test() {
+            await watchObject("Objects.sloppy");
+            await expectSinglePause({
+                expression: "Objects.sloppy.write('value', 1)",
+                beforeExpression: "Objects.sloppy.value === 0",
+                afterExpression: "Objects.sloppy.value === 1",
+                description: "a non-strict computed super-property write",
+            });
+            await unwatchObject("Objects.sloppy");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.ProxyBase",
+        async test() {
+            await watchObject("Objects.proxyBase");
+            await expectSinglePause({
+                expression: "Objects.proxyBase.write('value', 1)",
+                beforeExpression: "Objects.proxyBase.value === 0",
+                afterExpression: "Objects.proxyBase.value === 1 && SuperPropertyWriterBase.prototype.value === 10",
+                description: "a computed super-property write forwarded by a Proxy superclass",
+            });
+            await unwatchObject("Objects.proxyBase");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.LiteralBracketCompound",
+        async test() {
+            await watchObject("Objects.compound");
+            await expectSinglePause({
+                expression: "Objects.compound.addLiteral(2)",
+                beforeExpression: "Objects.compound.value === 0 && SuperPropertyWriterBase.prototype.value === 10",
+                afterExpression: "Objects.compound.value === 12 && SuperPropertyWriterBase.prototype.value === 10",
+                description: "a literal-bracket compound super-property write",
+            });
+            await unwatchObject("Objects.compound");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.KeyConversion",
+        async test() {
+            await watchObject("Objects.keyConversion");
+            await expectSinglePause({
+                expression: "Objects.keyConversion.write(key, 1)",
+                beforeExpression: "State.conversions === 1 && Objects.keyConversion.value === 0",
+                afterExpression: "State.conversions === 1 && Objects.keyConversion.value === 1",
+                description: "a super-property write after converting its key exactly once",
+            });
+            await InspectorTest.evaluateInPage("State.conversions = 0; State.shouldThrow = true");
+            await expectNoPause("try { Objects.keyConversion.write(key, 2); } catch (error) { State.didThrow = error.message === 'key conversion'; }", "Should not pause when converting the key throws.");
+            InspectorTest.expectTrue(await InspectorTest.evaluateInPage("State.didThrow && State.conversions === 1 && Objects.keyConversion.value === 1"), "Throwing key conversion should leave the receiver unchanged.");
+            await unwatchObject("Objects.keyConversion");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.ReentrantUnwatch",
+        async test() {
+            await InspectorTest.evaluateInPage("State.conversions = 0; State.shouldThrow = false");
+            await watchObject("Objects.reentrantUnwatch");
+            await expectSinglePause({
+                expression: "Objects.reentrantUnwatch.write(key, 1)",
+                beforeExpression: "State.conversions === 1 && Objects.reentrantUnwatch.value === 0",
+                whilePausedExpression: "unwatch(Objects.reentrantUnwatch); State.property = 'other'",
+                afterExpression: "State.conversions === 1 && Objects.reentrantUnwatch.value === 1 && !Object.hasOwn(Objects.reentrantUnwatch, 'other')",
+                description: "a super-property write whose receiver is unwatched while paused",
+            });
+            await expectNoPause("Objects.reentrantUnwatch.write('value', 2)", "Should not pause for a subsequent super-property write after reentrant unwatch.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperProperty.Inactive",
+        async test() {
+            await watchObject("Objects.inactive");
+            WI.debuggerManager.watchedObjectBreakpoint.disabled = true;
+            await expectNoPause("Objects.inactive.write('value', 1)", "Should not pause for a computed super-property write while disabled.");
+            WI.debuggerManager.watchedObjectBreakpoint.disabled = false;
+            await expectSinglePause({
+                expression: "Objects.inactive.write('value', 2)",
+                beforeExpression: "Objects.inactive.value === 1",
+                afterExpression: "Objects.inactive.value === 2",
+                description: "a computed super-property write after re-enabling the breakpoint",
+            });
+            await unwatchObject("Objects.inactive");
+            await expectNoPause("Objects.inactive.write('value', 3)", "Should not pause for a computed super-property write after unwatch.");
+            InspectorTest.expectEqual(await InspectorTest.evaluateInPage("Objects.inactive.value"), 3, "An unwatched computed super-property write should complete.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests watching computed super-property writes.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/console/watch.html
+++ b/LayoutTests/inspector/console/watch.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/watch-utilities.js"></script>
+<script>
+let Objects = {
+    returnValue: {},
+    warmedMutator: {value: 0},
+    otherObjectsWatchedMutator: {value: 0},
+    flattenAttempt: {value: 0},
+    reentrantUnwatch: {value: 0},
+    ownRead: {value: 0},
+    watchedPrototype: {value: 0},
+};
+Objects.inheritingObject = Object.create(Objects.watchedPrototype);
+
+class SuperPropertyWriterBase { }
+class SuperPropertyWriter extends SuperPropertyWriterBase {
+    write(value)
+    {
+        super.value = value;
+    }
+}
+
+let superPropertyWriteWarmupObject = new SuperPropertyWriter;
+Objects.superPropertyWrite = new SuperPropertyWriter;
+
+class ComputedSuperPropertyWriter extends SuperPropertyWriterBase {
+    write(property, value)
+    {
+        super[property] = value;
+    }
+}
+
+let computedSuperPropertyWriteWarmupObject = new ComputedSuperPropertyWriter;
+Objects.computedSuperPropertyWrite = new ComputedSuperPropertyWriter;
+
+let sloppyComputedSuperPropertyWriter = {
+    write(property, value) {
+        super[property] = value;
+    },
+};
+let sloppyComputedSuperPropertyWriteWarmupObject = Object.create(sloppyComputedSuperPropertyWriter);
+Objects.sloppyComputedSuperPropertyWrite = Object.create(sloppyComputedSuperPropertyWriter);
+
+function warmedNamedWrite(object, value)
+{
+    object.value = value;
+}
+
+function otherObjectsWatchedNamedWrite(object, value)
+{
+    object.value = value;
+}
+
+function warmedNamedRead(object)
+{
+    return object.value;
+}
+
+function warmedInheritedRead(object)
+{
+    return object.value;
+}
+
+function createIdentityTestObject()
+{
+    return {value: 0};
+}
+
+function addNamedProperty(object, value)
+{
+    object.added = value;
+}
+
+let warmupObject = {value: 0};
+let identityWatchedObject = createIdentityTestObject();
+let identitySiblingObject = createIdentityTestObject();
+
+function test()
+{
+    WI.debuggerManager.createWatchedObjectBreakpoint();
+
+    let suite = InspectorTest.createAsyncSuite("CommandLineAPI.watch");
+    let {ensureDFGCompiled, evaluateWithCommandLineAPI, expectNoPause, expectPause, unwatchObject, watchObject} = InspectorTest.WatchObject;
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.WarmedMutator",
+        async test() {
+            let numberOfDFGCompiles = await ensureDFGCompiled("warmedNamedWrite", "warmedNamedWrite(warmupObject, j)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The mutator should DFG compile before watch.");
+            await watchObject("Objects.warmedMutator");
+            await expectPause({
+                expression: "warmedNamedWrite(Objects.warmedMutator, 1)",
+                beforeExpression: "Objects.warmedMutator.value === 0",
+                afterExpression: "Objects.warmedMutator.value === 1",
+                description: "a property write from a mutator warmed before watch",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.API",
+        async test() {
+            let [remoteObject, wasThrown] = await evaluateWithCommandLineAPI("watch(Objects.returnValue)");
+            InspectorTest.expectTrue(!wasThrown && remoteObject.type === "undefined", "Should return undefined after watching an object.");
+
+            [remoteObject, wasThrown] = await evaluateWithCommandLineAPI("watch()");
+            InspectorTest.expectTrue(!wasThrown && remoteObject.type === "undefined", "Should return undefined without an argument.");
+
+            [remoteObject, wasThrown] = await evaluateWithCommandLineAPI("watch(42)");
+            InspectorTest.expectTrue(wasThrown && remoteObject.description.startsWith("TypeError:"), "Should throw a TypeError for a primitive.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.ObjectTypes",
+        async test() {
+            await InspectorTest.evaluateInPage("Objects.otherRealm = document.body.appendChild(document.createElement('iframe')).contentWindow");
+
+            for (let [description, expression] of [
+                ["a null-prototype object", "Object.create(null)"],
+                ["a class instance with private members", "new (class { #value; #method() {} })"],
+                ["an object from another realm", "new Objects.otherRealm.Object"],
+                ["an object with an Array constructor and toStringTag", "({constructor: Array, [Symbol.toStringTag]: 'Array'})"],
+            ]) {
+                let [remoteObject, wasThrown] = await evaluateWithCommandLineAPI(`(() => { let object = ${expression}; watch(object); unwatch(object); return true; })()`);
+                InspectorTest.expectTrue(!wasThrown && remoteObject.value === true, `Should watch and unwatch ${description}.`);
+            }
+
+            for (let [description, expression] of [
+                ["an array", "[]"],
+                ["an Array subclass instance", "new (class extends Array {})"],
+                ["a regular expression", "/a/"],
+                ["a RegExp subclass instance", "new (class extends RegExp {})('a')"],
+                ["a Map", "new Map"],
+                ["a Set", "new Set"],
+                ["a WeakMap", "new WeakMap"],
+                ["a WeakSet", "new WeakSet"],
+                ["a Promise", "Promise.resolve()"],
+                ["an ArrayBuffer", "new ArrayBuffer(0)"],
+                ["a typed array", "new Uint8Array(0)"],
+                ["a DataView", "new DataView(new ArrayBuffer(0))"],
+                ["a function", "function() {}"],
+                ["a Date", "new Date"],
+                ["an Error", "new Error"],
+                ["a boxed primitive", "new Number(0)"],
+                ["an arguments object", "(function() { return arguments; })()"],
+                ["a Proxy without invoking its traps", "new Proxy({}, {getPrototypeOf() { throw new Error('Should not invoke Proxy traps.'); }})"],
+                ["a revoked Proxy", "(() => { let {proxy, revoke} = Proxy.revocable({}, {}); revoke(); return proxy; })()"],
+                ["a DOM object", "document.body"],
+                ["Object.prototype", "Object.prototype"],
+                ["ArrayBuffer.prototype", "ArrayBuffer.prototype"],
+                ["an array from another realm", "new Objects.otherRealm.Array"],
+            ]) {
+                for (let command of ["watch", "unwatch"]) {
+                    let [remoteObject, wasThrown] = await evaluateWithCommandLineAPI(`${command}(${expression})`);
+                    InspectorTest.expectTrue(wasThrown && remoteObject.description.startsWith(`TypeError: ${command} first argument must be a regular object.`), `${command} should reject ${description}.`);
+                }
+            }
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.PropertyAddition",
+        async test() {
+            await InspectorTest.evaluateInPage("Objects.propertyAddition = {}");
+            await watchObject("Objects.propertyAddition");
+            await expectPause({
+                expression: "addNamedProperty(Objects.propertyAddition, 1)",
+                beforeExpression: "!('added' in Objects.propertyAddition)",
+                afterExpression: "Objects.propertyAddition.added === 1",
+                description: "adding an ordinary named property",
+            });
+            await expectPause({
+                expression: "addNamedProperty(Objects.propertyAddition, 2)",
+                beforeExpression: "Objects.propertyAddition.added === 1",
+                afterExpression: "Objects.propertyAddition.added === 2",
+                description: "writing a named property after a Structure transition",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SuperPropertyWrite",
+        async test() {
+            let numberOfDFGCompiles = await ensureDFGCompiled("SuperPropertyWriter.prototype.write", "SuperPropertyWriter.prototype.write.call(superPropertyWriteWarmupObject, j)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The super-property mutator should DFG compile before watch.");
+            await watchObject("Objects.superPropertyWrite");
+            await expectPause({
+                expression: "Objects.superPropertyWrite.write(1)",
+                beforeExpression: "!('value' in Objects.superPropertyWrite)",
+                afterExpression: "Objects.superPropertyWrite.value === 1",
+                description: "a named super-property write to a watched receiver",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.ComputedSuperPropertyWrite",
+        async test() {
+            await watchObject("Objects.computedSuperPropertyWrite");
+            let numberOfDFGCompiles = await ensureDFGCompiled("ComputedSuperPropertyWriter.prototype.write", "ComputedSuperPropertyWriter.prototype.write.call(computedSuperPropertyWriteWarmupObject, 'value', j)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The computed super-property mutator should DFG compile after watch.");
+            let pauseCount = 0;
+            let pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, () => ++pauseCount);
+            try {
+                await expectPause({
+                    expression: "Objects.computedSuperPropertyWrite.write('value', 1)",
+                    beforeExpression: "!('value' in Objects.computedSuperPropertyWrite)",
+                    afterExpression: "Objects.computedSuperPropertyWrite.value === 1",
+                    description: "a computed super-property write from a mutator compiled after watch",
+                });
+            } finally {
+                WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+            }
+            InspectorTest.expectEqual(pauseCount, 1, "Should pause exactly once for the compiled computed super-property write.");
+            await unwatchObject("Objects.computedSuperPropertyWrite");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.SloppyComputedSuperPropertyWrite",
+        async test() {
+            await watchObject("Objects.sloppyComputedSuperPropertyWrite");
+            let numberOfDFGCompiles = await ensureDFGCompiled("sloppyComputedSuperPropertyWriter.write", "sloppyComputedSuperPropertyWriter.write.call(sloppyComputedSuperPropertyWriteWarmupObject, 'value', j)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The non-strict computed super-property mutator should DFG compile after watch.");
+            let pauseCount = 0;
+            let pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, () => ++pauseCount);
+            try {
+                await expectPause({
+                    expression: "Objects.sloppyComputedSuperPropertyWrite.write('value', 1)",
+                    beforeExpression: "!('value' in Objects.sloppyComputedSuperPropertyWrite)",
+                    afterExpression: "Objects.sloppyComputedSuperPropertyWrite.value === 1",
+                    description: "a non-strict computed super-property write from a mutator compiled after watch",
+                });
+            } finally {
+                WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+            }
+            InspectorTest.expectEqual(pauseCount, 1, "Should pause exactly once for the compiled non-strict computed super-property write.");
+            await unwatchObject("Objects.sloppyComputedSuperPropertyWrite");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.FlattenAttempt",
+        async test() {
+            await watchObject("Objects.flattenAttempt");
+            await InspectorTest.evaluateInPage("$vm.flattenDictionaryObject(Objects.flattenAttempt)");
+            await expectPause({
+                expression: "warmedNamedWrite(Objects.flattenAttempt, 1)",
+                beforeExpression: "Objects.flattenAttempt.value === 0",
+                afterExpression: "Objects.flattenAttempt.value === 1",
+                description: "a property write after an attempted dictionary flatten",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.ReentrantUnwatch",
+        async test() {
+            await watchObject("Objects.reentrantUnwatch");
+            await expectPause({
+                expression: "warmedNamedWrite(Objects.reentrantUnwatch, 1)",
+                beforeExpression: "Objects.reentrantUnwatch.value === 0",
+                whilePausedExpression: "unwatch(Objects.reentrantUnwatch)",
+                afterExpression: "Objects.reentrantUnwatch.value === 1",
+                description: "a property write whose receiver is unwatched while paused",
+            });
+            await expectNoPause("warmedNamedWrite(Objects.reentrantUnwatch, 2)", "Should not pause for a subsequent write after reentrant unwatch.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.WarmedOwnRead",
+        async test() {
+            let numberOfDFGCompiles = await ensureDFGCompiled("warmedNamedRead", "warmedNamedRead(Objects.ownRead)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The own-property reader should DFG compile before watch.");
+            await watchObject("Objects.ownRead");
+            InspectorTest.expectEqual(await InspectorTest.evaluateInPage("warmedNamedRead(Objects.ownRead)"), 0, "The watched object's property should remain readable after invalidating the warmed read cache.");
+            await expectPause({
+                expression: "warmedNamedWrite(Objects.ownRead, 1)",
+                beforeExpression: "Objects.ownRead.value === 0",
+                afterExpression: "Objects.ownRead.value === 1",
+                description: "a property write after warming an own-property read cache",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.WarmedInheritedRead",
+        async test() {
+            let numberOfDFGCompiles = await ensureDFGCompiled("warmedInheritedRead", "warmedInheritedRead(Objects.inheritingObject)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "The inherited-property reader should DFG compile before watch.");
+            await watchObject("Objects.watchedPrototype");
+            InspectorTest.expectEqual(await InspectorTest.evaluateInPage("warmedInheritedRead(Objects.inheritingObject)"), 0, "The inherited property should remain readable after watching its prototype.");
+            await expectPause({
+                expression: "warmedNamedWrite(Objects.watchedPrototype, 1)",
+                beforeExpression: "Objects.watchedPrototype.value === 0",
+                afterExpression: "Objects.watchedPrototype.value === 1",
+                description: "a direct prototype write after warming an inherited read cache",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.ObjectIdentity",
+        async test() {
+            await watchObject("identityWatchedObject");
+            await expectNoPause("warmedNamedWrite(identitySiblingObject, 1)", "Should not pause for an unwatched object with the same original Structure.");
+            await expectPause({
+                expression: "warmedNamedWrite(identityWatchedObject, 1)",
+                beforeExpression: "identityWatchedObject.value === 0",
+                afterExpression: "identityWatchedObject.value === 1",
+                description: "a property write to the watched object rather than its same-Structure sibling",
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.GarbageCollection",
+        async test() {
+            await InspectorTest.evaluateInPage("Objects.garbageCollection = {}; Objects.weakGarbageCollection = new WeakRef(Objects.garbageCollection)");
+            await watchObject("Objects.garbageCollection");
+            await InspectorTest.evaluateInPage("Objects.garbageCollection = null");
+            await HeapAgent.gc();
+            InspectorTest.expectTrue(await InspectorTest.evaluateInPage("!Objects.weakGarbageCollection.deref()"), "A watched object should be garbage collected.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CommandLineAPI.watch.OtherObjectsWatchedDFGMutator",
+        async test() {
+            let numberOfDFGCompiles = await ensureDFGCompiled("otherObjectsWatchedNamedWrite", "otherObjectsWatchedNamedWrite(warmupObject, j)");
+            InspectorTest.expectGreaterThan(numberOfDFGCompiles, 0, "A mutator should DFG compile while other watched objects exist.");
+            await watchObject("Objects.otherObjectsWatchedMutator");
+            await expectPause({
+                expression: "otherObjectsWatchedNamedWrite(Objects.otherObjectsWatchedMutator, 1)",
+                beforeExpression: "Objects.otherObjectsWatchedMutator.value === 0",
+                afterExpression: "Objects.otherObjectsWatchedMutator.value === 1",
+                description: "a property write reached from DFG code compiled while other objects were watched",
+            });
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for the <code>watch</code> function in the Command Line API.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/debugger/setPauseOnWatchedObject-expected.txt
+++ b/LayoutTests/inspector/debugger/setPauseOnWatchedObject-expected.txt
@@ -1,0 +1,9 @@
+Tests for Debugger.setPauseOnWatchedObject command.
+
+
+== Running test suite: Debugger.setPauseOnWatchedObject
+-- Running test case: Debugger.setPauseOnWatchedObject.Toggle
+PASS: Should not pause while disabled.
+PASS: Pause reason should be WatchedObject.
+PASS: Should pause before an ordinary named property write while enabled.
+

--- a/LayoutTests/inspector/debugger/setPauseOnWatchedObject.html
+++ b/LayoutTests/inspector/debugger/setPauseOnWatchedObject.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../console/resources/watch-utilities.js"></script>
+<script>
+let watchedObject = {value: 0};
+
+function writeWatchedObject()
+{
+    ++watchedObject.value;
+}
+
+async function test()
+{
+    await InspectorTest.WatchObject.watchObject("watchedObject");
+
+    let suite = InspectorTest.createAsyncSuite("Debugger.setPauseOnWatchedObject");
+    let {expectNoPause, expectPause} = InspectorTest.WatchObject;
+
+    suite.addTestCase({
+        name: "Debugger.setPauseOnWatchedObject.Toggle",
+        description: "Pause before writing an ordinary named property of a watched object only when enabled.",
+        async test() {
+            WI.debuggerManager.createWatchedObjectBreakpoint({disabled: true});
+
+            await expectNoPause("writeWatchedObject()", "Should not pause while disabled.");
+
+            WI.debuggerManager.watchedObjectBreakpoint.disabled = false;
+
+            await expectPause({
+                expression: "writeWatchedObject()",
+                beforeExpression: "watchedObject.value === 1",
+                afterExpression: "watchedObject.value === 2",
+                description: "an ordinary named property write while enabled",
+            });
+
+            WI.debuggerManager.watchedObjectBreakpoint.remove();
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for Debugger.setPauseOnWatchedObject command.</p>
+</body>
+</html>
+

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -33,6 +33,7 @@
 #include "DFGOperations.h"
 #include "DFGSpeculativeJIT.h"
 #include "DOMJITGetterSetter.h"
+#include "Debugger.h"
 #include "DirectArguments.h"
 #include "ECMAMode.h"
 #include "ExecutableBaseInlines.h"
@@ -1034,6 +1035,12 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
             return GiveUpOnCache;
 
         JSCell* baseCell = baseValue.asCell();
+
+        if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+            JSObject* receiver = slot.thisValue().getObject();
+            if (receiver && receiver->structure()->isUncacheableDictionary() && debugger->isWatchingObject(*receiver)) [[unlikely]]
+                return GiveUpOnCache;
+        }
 
         RefPtr<AccessCase> newCase;
 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -34,9 +34,12 @@
 #include "Microtask.h"
 #include "SourceOrigin.h"
 #include "SourceProvider.h"
+#include "Strong.h"
 #include "VMEntryScopeInlines.h"
+#include "VMInlines.h"
 #include "VMTrapsInlines.h"
 #include "WasmModuleInformation.h"
+#include "WeakGCSetInlines.h"
 #include <atomic>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/ForbidHeapAllocation.h>
@@ -157,6 +160,9 @@ Debugger::Debugger(VM& vm)
     , m_reasonForPause(NotPaused)
     , m_lastExecutedLine(UINT_MAX)
     , m_lastExecutedSourceID(noSourceID)
+    , m_watchedObjects(vm)
+    , m_objectsToFlattenOnUnwatch(vm)
+    , m_objectsToResetFlattenedFlagOnUnwatch(vm)
     , m_pausingBreakpointID(noBreakpointID)
 {
     m_vm.addDebugger(*this);
@@ -165,6 +171,10 @@ Debugger::Debugger(VM& vm)
 Debugger::~Debugger()
 {
     resetAsyncPauseState();
+
+    ASSERT(m_watchedObjects.isEmptyIgnoringNullReferences());
+    ASSERT(m_objectsToFlattenOnUnwatch.isEmptyIgnoringNullReferences());
+    ASSERT(m_objectsToResetFlattenedFlagOnUnwatch.isEmptyIgnoringNullReferences());
 
     m_vm.removeDebugger(*this);
 
@@ -288,6 +298,81 @@ void Debugger::registerCodeBlock(CodeBlock* codeBlock)
     applyBreakpoints(codeBlock);
     if (isStepping())
         codeBlock->setSteppingMode(CodeBlock::SteppingModeEnabled);
+}
+
+bool Debugger::isWatchingObject(JSObject& object) const
+{
+    return m_watchedObjects.contains(&object);
+}
+
+bool Debugger::isWatchedObject(VM& vm, JSObject& object)
+{
+    bool result = false;
+    vm.forEachDebugger([&] (Debugger& debugger) {
+        if (debugger.isWatchingObject(object))
+            result = true;
+    });
+    return result;
+}
+
+void Debugger::watchObject(JSObject& object)
+{
+    ASSERT(object.type() == FinalObjectType);
+
+    if (isWatchingObject(object))
+        return;
+
+    m_watchedObjects.add(&object);
+
+    Structure* structure = object.structure();
+    if (!structure->isUncacheableDictionary()) {
+        m_objectsToFlattenOnUnwatch.add(&object);
+        object.replaceWithUncacheableDictionary(m_vm, HasBeenFlattenedBefore::Yes);
+    } else if (!structure->hasBeenFlattenedBefore()) {
+        m_objectsToResetFlattenedFlagOnUnwatch.add(&object);
+        object.replaceWithUncacheableDictionary(m_vm, HasBeenFlattenedBefore::Yes);
+    }
+}
+
+void Debugger::unwatchObject(JSObject& object)
+{
+    if (!m_watchedObjects.remove(&object))
+        return;
+
+    unwatchObjectAfterRemoval(object);
+}
+
+void Debugger::unwatchObjectAfterRemoval(JSObject& object)
+{
+    bool shouldFlatten = m_objectsToFlattenOnUnwatch.remove(&object);
+    bool shouldRestoreHasBeenFlattenedBefore = m_objectsToResetFlattenedFlagOnUnwatch.remove(&object);
+
+    if (shouldFlatten && object.structure()->isUncacheableDictionary()) {
+        object.flattenDictionaryObject(m_vm);
+        RELEASE_ASSERT(!object.structure()->isDictionary());
+    } else if (shouldRestoreHasBeenFlattenedBefore) {
+        RELEASE_ASSERT(object.structure()->isUncacheableDictionary());
+        object.replaceWithUncacheableDictionary(m_vm, HasBeenFlattenedBefore::No);
+    }
+}
+
+void Debugger::clearWatchedObjects()
+{
+    while (!m_watchedObjects.isEmptyIgnoringNullReferences()) {
+        Weak<JSObject> weakObject = m_watchedObjects.takeAny();
+        if (!weakObject)
+            continue;
+
+        JSObject* object = weakObject.get();
+        Strong<JSObject> protectedObject(m_vm, object);
+        unwatchObjectAfterRemoval(*object);
+    }
+    m_watchedObjects.clear();
+
+    ASSERT(m_objectsToFlattenOnUnwatch.isEmptyIgnoringNullReferences());
+    m_objectsToFlattenOnUnwatch.clear();
+    ASSERT(m_objectsToResetFlattenedFlagOnUnwatch.isEmptyIgnoringNullReferences());
+    m_objectsToResetFlattenedFlagOnUnwatch.clear();
 }
 
 void Debugger::forEachRegisteredCodeBlock(NOESCAPE const Function<void(CodeBlock*)>& callback)
@@ -773,6 +858,8 @@ private:
 void Debugger::clearBreakpoints()
 {
     m_vm.heap.completeAllJITPlans();
+
+    clearWatchedObjects();
 
     m_breakpointsForSourceID.clear();
     m_breakpoints.clear();
@@ -1322,6 +1409,19 @@ void Debugger::atExpression(CallFrame* callFrame)
 
     PauseReasonDeclaration reason(*this, PausedAtExpression);
     updateCallFrame(lexicalGlobalObjectForCallFrame(m_vm, callFrame), callFrame, shouldAttemptPause ? AttemptPause : NoPause);
+}
+
+void Debugger::willModifyUncacheableDictionary(JSObject& object)
+{
+    if (m_isPaused)
+        return;
+
+    if (!isWatchingObject(object))
+        return;
+
+    dispatchFunctionToObservers([&] (Observer& observer) {
+        observer.willModifyWatchedObject();
+    });
 }
 
 void Debugger::willAwait(CallFrame* callFrame, JSValue generatorValue)

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSRunLoopTimer.h>
 #include <JavaScriptCore/Microtask.h>
 #include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakGCSet.h>
 #include <wtf/DoublyLinkedList.h>
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
@@ -44,6 +45,7 @@ class Exception;
 class InternalFunction;
 class JSAsyncFunctionGenerator;
 class JSGlobalObject;
+class JSObject;
 class Microtask;
 class NativeExecutable;
 class SourceProvider;
@@ -80,6 +82,11 @@ public:
     bool setBreakpoint(Breakpoint&);
     bool removeBreakpoint(Breakpoint&);
     void clearBreakpoints();
+
+    void watchObject(JSObject&);
+    void unwatchObject(JSObject&);
+    bool isWatchingObject(JSObject&) const;
+    static bool isWatchedObject(VM&, JSObject&);
 
     void activateBreakpoints() { setBreakpointsActivated(true); }
     void deactivateBreakpoints() { setBreakpointsActivated(false); }
@@ -158,6 +165,7 @@ public:
     void exception(JSGlobalObject*, CallFrame*, JSValue exceptionValue, bool hasCatchHandler);
     void atStatement(CallFrame*);
     void atExpression(CallFrame*);
+    void willModifyUncacheableDictionary(JSObject&);
     void willAwait(CallFrame*, JSValue generator);
     void didAwait(CallFrame*, JSValue generator);
     void callEvent(CallFrame*);
@@ -222,6 +230,8 @@ public:
         virtual void willCallInternalFunction(InternalFunction&) { }
 
         virtual void willEnter(CallFrame*) { }
+
+        virtual void willModifyWatchedObject() { }
 
         virtual void didQueueMicrotask(JSGlobalObject*, MicrotaskIdentifier) { }
         virtual void willRunMicrotask(JSGlobalObject*, MicrotaskIdentifier) { }
@@ -291,6 +301,9 @@ protected:
 
 private:
     JSValue exceptionOrCaughtValue(JSGlobalObject*);
+
+    void clearWatchedObjects();
+    void unwatchObjectAfterRemoval(JSObject&);
 
     class ClearCodeBlockDebuggerRequestsFunctor;
     class ClearDebuggerRequestsFunctor;
@@ -370,6 +383,10 @@ private:
         Debugger& m_debugger;
     };
     RefPtr<AbandonPauseInAwaitTimer> m_abandonPauseInAwaitTimer;
+
+    WeakGCSet<JSObject> m_watchedObjects;
+    WeakGCSet<JSObject> m_objectsToFlattenOnUnwatch;
+    WeakGCSet<JSObject> m_objectsToResetFlattenedFlagOnUnwatch;
 
     using LineToBreakpointsMap = UncheckedKeyHashMap<unsigned, BreakpointsVector, WTF::IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>>;
     UncheckedKeyHashMap<SourceID, LineToBreakpointsMap, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_breakpointsForSourceID;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -43,6 +43,7 @@
 #include "DFGToFTLDeferredCompilationCallback.h"
 #include "DFGToFTLForOSREntryDeferredCompilationCallback.h"
 #include "DateInstance.h"
+#include "Debugger.h"
 #include "DefinePropertyAttributes.h"
 #include "DirectArguments.h"
 #include "FTLForOSREntryJITCode.h"
@@ -169,12 +170,43 @@ char* newTypedArrayWithSize(JSGlobalObject* globalObject, VM& vm, Structure* str
     RELEASE_AND_RETURN(scope, std::bit_cast<char*>(ViewClass::create(globalObject, structure, unsignedSize)));
 }
 
-template <bool strict>
-static ALWAYS_INLINE void putWithThis(JSGlobalObject* globalObject, EncodedJSValue encodedBase, EncodedJSValue encodedThis, EncodedJSValue encodedValue, const Identifier& ident)
+ALWAYS_INLINE static bool willPutWithThisToUncacheableDictionary(CallFrame* callFrame, JSGlobalObject* globalObject, JSValue thisValue)
+{
+    auto* debugger = globalObject->debugger();
+    if (!debugger) [[likely]]
+        return false;
+
+    JSObject* receiver = thisValue.getObject();
+    if (!receiver) [[unlikely]]
+        return false;
+    if (!receiver->structure()->isUncacheableDictionary()) [[likely]]
+        return false;
+
+    auto* codeBlock = callFrame->codeBlock();
+    auto codeOrigin = callFrame->codeOrigin();
+    if (JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
+        codeBlock = baselineCodeBlockForOriginAndBaselineCodeBlock(codeOrigin, codeBlock->baselineAlternative());
+    if (codeBlock->unlinkedCodeBlock()->isBuiltinFunction()) [[unlikely]]
+        return false;
+
+    auto* instruction = codeBlock->instructions().at(codeOrigin.bytecodeIndex()).ptr();
+    if (!instruction->is<OpPutByIdWithThis>() && !instruction->is<OpPutByValWithThis>()) [[unlikely]]
+        return false;
+
+    debugger->willModifyUncacheableDictionary(*receiver);
+    return true;
+}
+
+template<bool strict>
+static ALWAYS_INLINE void putWithThis(JSGlobalObject* globalObject, CallFrame* callFrame, EncodedJSValue encodedBase, EncodedJSValue encodedThis, EncodedJSValue encodedValue, const Identifier& ident, ThrowScope& scope)
 {
     JSValue baseValue = JSValue::decode(encodedBase);
     JSValue thisVal = JSValue::decode(encodedThis);
     JSValue putValue = JSValue::decode(encodedValue);
+
+    if (willPutWithThisToUncacheableDictionary(callFrame, globalObject, thisVal)) [[unlikely]]
+        RETURN_IF_EXCEPTION(scope, void());
+
     PutPropertySlot slot(thisVal, strict);
     baseValue.putInline(globalObject, ident, putValue, slot);
 }
@@ -2570,7 +2602,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdWithThisStrict, void, (JSGlobalObject* 
     CacheableIdentifier identifier = CacheableIdentifier::createFromRawBits(rawCacheableIdentifier);
     Identifier ident = Identifier::fromUid(vm, identifier.uid());
 
-    putWithThis<true>(globalObject, encodedBase, encodedThis, encodedValue, ident);
+    putWithThis<true>(globalObject, callFrame, encodedBase, encodedThis, encodedValue, ident, scope);
     OPERATION_RETURN(scope);
 }
 
@@ -2584,7 +2616,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdWithThis, void, (JSGlobalObject* global
     CacheableIdentifier identifier = CacheableIdentifier::createFromRawBits(rawCacheableIdentifier);
     Identifier ident = Identifier::fromUid(vm, identifier.uid());
 
-    putWithThis<false>(globalObject, encodedBase, encodedThis, encodedValue, ident);
+    putWithThis<false>(globalObject, callFrame, encodedBase, encodedThis, encodedValue, ident, scope);
     OPERATION_RETURN(scope);
 }
 
@@ -2597,8 +2629,8 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValWithThisStrict, void, (JSGlobalObject*
 
     Identifier property = JSValue::decode(encodedSubscript).toPropertyKey(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope);
-    scope.release();
-    putWithThis<true>(globalObject, encodedBase, encodedThis, encodedValue, property);
+
+    putWithThis<true>(globalObject, callFrame, encodedBase, encodedThis, encodedValue, property, scope);
     OPERATION_RETURN(scope);
 }
 
@@ -2611,8 +2643,8 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValWithThis, void, (JSGlobalObject* globa
 
     Identifier property = JSValue::decode(encodedSubscript).toPropertyKey(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope);
-    scope.release();
-    putWithThis<false>(globalObject, encodedBase, encodedThis, encodedValue, property);
+
+    putWithThis<false>(globalObject, callFrame, encodedBase, encodedThis, encodedValue, property, scope);
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -1676,6 +1676,8 @@ CommandLineAPI.methods["values"] = function(object) { return @Object.@values(obj
 CommandLineAPI.methods["queryInstances"] = function() { return InjectedScriptHost.queryInstances(...createIterableWithoutPrototypeFromArguments(arguments)); };
 CommandLineAPI.methods["queryObjects"] = function() { return InjectedScriptHost.queryInstances(...createIterableWithoutPrototypeFromArguments(arguments)); };
 CommandLineAPI.methods["queryHolders"] = function() { return InjectedScriptHost.queryHolders(...createIterableWithoutPrototypeFromArguments(arguments)); };
+CommandLineAPI.methods["unwatch"] = function() { return InjectedScriptHost.unwatch(...createIterableWithoutPrototypeFromArguments(arguments)); };
+CommandLineAPI.methods["watch"] = function() { return InjectedScriptHost.watch(...createIterableWithoutPrototypeFromArguments(arguments)); };
 
 CommandLineAPI.methods["inspect"] = function(object) { return injectedScript.inspectObject(object); };
 

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -30,6 +30,7 @@
 #include "BuiltinNames.h"
 #include "Completion.h"
 #include "DateInstance.h"
+#include "Debugger.h"
 #include "DeferGCInlines.h"
 #include "DirectArguments.h"
 #include "EnumerationMode.h"
@@ -1199,6 +1200,50 @@ JSValue JSInjectedScriptHost::queryHolders(JSGlobalObject* globalObject, CallFra
     }
 
     return result;
+}
+
+JSValue JSInjectedScriptHost::watch(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    if (callFrame->argumentCount() < 1)
+        return jsUndefined();
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue target = callFrame->uncheckedArgument(0);
+    if (!target.isObject())
+        return throwTypeError(globalObject, scope, "watch first argument must be an object."_s);
+
+    auto* object = asObject(target);
+    if (object->type() != FinalObjectType)
+        return throwTypeError(globalObject, scope, "watch first argument must be a regular object."_s);
+
+    if (auto* debugger = globalObject->debugger())
+        debugger->watchObject(*object);
+
+    return jsUndefined();
+}
+
+JSValue JSInjectedScriptHost::unwatch(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    if (callFrame->argumentCount() < 1)
+        return jsUndefined();
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue target = callFrame->uncheckedArgument(0);
+    if (!target.isObject())
+        return throwTypeError(globalObject, scope, "unwatch first argument must be an object."_s);
+
+    auto* object = asObject(target);
+    if (object->type() != FinalObjectType)
+        return throwTypeError(globalObject, scope, "unwatch first argument must be a regular object."_s);
+
+    if (auto* debugger = globalObject->debugger())
+        debugger->unwatchObject(*object);
+
+    return jsUndefined();
 }
 
 Structure* JSInjectedScriptHost::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
@@ -82,6 +82,8 @@ public:
     JSC::JSValue iteratorEntries(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue queryInstances(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue queryHolders(JSC::JSGlobalObject*, JSC::CallFrame*);
+    JSC::JSValue unwatch(JSC::JSGlobalObject*, JSC::CallFrame*);
+    JSC::JSValue watch(JSC::JSGlobalObject*, JSC::CallFrame*);
 
 private:
     JSInjectedScriptHost(JSC::VM&, JSC::Structure*, Ref<InjectedScriptHost>&&);

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
@@ -51,6 +51,8 @@ static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakSetEnt
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIteratorEntries);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionQueryInstances);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionQueryHolders);
+static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionUnwatch);
+static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWatch);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension);
 
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeAttributeEvaluate);
@@ -82,6 +84,8 @@ void JSInjectedScriptHostPrototype::finishCreation(VM& vm, JSGlobalObject* globa
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("queryInstances"_s, jsInjectedScriptHostPrototypeFunctionQueryInstances, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("queryHolders"_s, jsInjectedScriptHostPrototypeFunctionQueryHolders, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("unwatch"_s, jsInjectedScriptHostPrototypeFunctionUnwatch, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("watch"_s, jsInjectedScriptHostPrototypeFunctionWatch, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
 
     JSC_NATIVE_GETTER_WITHOUT_TRANSITION("evaluate"_s, jsInjectedScriptHostPrototypeAttributeEvaluate, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);
     JSC_NATIVE_GETTER_WITHOUT_TRANSITION("savedResultAlias"_s, jsInjectedScriptHostPrototypeAttributeSavedResultAlias, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);
@@ -267,6 +271,32 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionQueryHolders, (JSG
         return throwVMTypeError(globalObject, scope);
 
     return JSValue::encode(castedThis->queryHolders(globalObject, callFrame));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWatch, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
+    if (!castedThis)
+        return throwVMTypeError(globalObject, scope);
+
+    return JSValue::encode(castedThis->watch(globalObject, callFrame));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionUnwatch, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
+    if (!castedThis)
+        return throwVMTypeError(globalObject, scope);
+
+    return JSValue::encode(castedThis->unwatch(globalObject, callFrame));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1419,6 +1419,23 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setPauseOnMicrotasks(bool 
     return { };
 }
 
+Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setPauseOnWatchedObject(bool enabled, RefPtr<JSON::Object>&& options)
+{
+    if (!enabled) {
+        m_watchedObjectBreakpoint = nullptr;
+        return { };
+    }
+
+    Protocol::ErrorString errorString;
+    auto breakpoint = debuggerBreakpointFromPayload(errorString, WTF::move(options));
+    if (!breakpoint)
+        return makeUnexpected(errorString);
+
+    m_watchedObjectBreakpoint = WTF::move(breakpoint);
+
+    return { };
+}
+
 Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> InspectorDebuggerAgent::evaluateOnCallFrame(const Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
 {
     auto injectedScript = injectedScriptManager().injectedScriptForObjectId(callFrameId);
@@ -1928,6 +1945,12 @@ void InspectorDebuggerAgent::willEnter(JSC::CallFrame* callFrame)
     schedulePauseForSpecialBreakpoint(*m_symbolicBreakpoints[index].specialBreakpoint, DebuggerFrontendDispatcher::Reason::FunctionCall, WTF::move(pauseData));
 }
 
+void InspectorDebuggerAgent::willModifyWatchedObject()
+{
+    if (breakpointsActive() && m_watchedObjectBreakpoint)
+        breakProgram(DebuggerFrontendDispatcher::Reason::WatchedObject, nullptr, m_watchedObjectBreakpoint.copyRef());
+}
+
 void InspectorDebuggerAgent::didQueueMicrotask(JSC::JSGlobalObject* globalObject, JSC::MicrotaskIdentifier identifier)
 {
     if (!breakpointsActive())
@@ -2133,6 +2156,8 @@ void InspectorDebuggerAgent::clearInspectorBreakpointState()
 
     m_pauseOnAssertionsBreakpoint = nullptr;
     m_pauseOnMicrotasksBreakpoint = nullptr;
+
+    m_watchedObjectBreakpoint = nullptr;
 
 #if ENABLE(JIT)
     {

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -98,6 +98,7 @@ public:
     Protocol::ErrorStringOr<void> setPauseOnExceptions(const String& state, RefPtr<JSON::Object>&& options) final;
     Protocol::ErrorStringOr<void> setPauseOnAssertions(bool enabled, RefPtr<JSON::Object>&& options) final;
     Protocol::ErrorStringOr<void> setPauseOnMicrotasks(bool enabled, RefPtr<JSON::Object>&& options) final;
+    Protocol::ErrorStringOr<void> setPauseOnWatchedObject(bool enabled, RefPtr<JSON::Object>&& options) final;
     Protocol::ErrorStringOr<void> setPauseForInternalScripts(bool shouldPause) final;
     Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluateOnCallFrame(const Protocol::Debugger::CallFrameId&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture) override;
     Protocol::ErrorStringOr<void> setShouldBlackboxURL(const String& url, bool shouldBlackbox, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, RefPtr<JSON::Array>&& sourceRanges) final;
@@ -115,6 +116,7 @@ public:
     void didCreateInternalFunction(JSC::InternalFunction&) final;
     void willCallInternalFunction(JSC::InternalFunction&) final;
     void willEnter(JSC::CallFrame*) final;
+    void willModifyWatchedObject() final;
     void didQueueMicrotask(JSC::JSGlobalObject*, JSC::MicrotaskIdentifier) final;
     void willRunMicrotask(JSC::JSGlobalObject*, JSC::MicrotaskIdentifier) final;
     void didRunMicrotask(JSC::JSGlobalObject*, JSC::MicrotaskIdentifier) final;
@@ -305,6 +307,7 @@ private:
 
     RefPtr<JSC::Breakpoint> m_pauseOnAssertionsBreakpoint;
     RefPtr<JSC::Breakpoint> m_pauseOnMicrotasksBreakpoint;
+    RefPtr<JSC::Breakpoint> m_watchedObjectBreakpoint;
 
     struct SymbolicBreakpoint {
         String symbol;

--- a/Source/JavaScriptCore/inspector/protocol/Debugger.json
+++ b/Source/JavaScriptCore/inspector/protocol/Debugger.json
@@ -322,6 +322,14 @@
             ]
         },
         {
+            "name": "setPauseOnWatchedObject",
+            "description": "Enable or disable pausing for supported operations involving objects watched by the debugger.",
+            "parameters": [
+                { "name": "enabled", "type": "boolean" },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ]
+        },
+        {
             "name": "setPauseForInternalScripts",
             "description": "Change whether to pause in the debugger for internal scripts. The default value is false.",
             "parameters": [
@@ -415,7 +423,7 @@
             "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.",
             "parameters": [
                 { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
-                { "name": "reason", "type": "string", "enum": ["URL", "DOM", "AnimationFrame", "Interval", "Listener", "Timeout", "exception", "assert", "CSPViolation", "DebuggerStatement", "Breakpoint", "PauseOnNextStatement", "Microtask", "FunctionCall", "BlackboxedScript", "other"], "description": "Pause reason." },
+                { "name": "reason", "type": "string", "enum": ["URL", "DOM", "AnimationFrame", "Interval", "Listener", "Timeout", "exception", "assert", "CSPViolation", "DebuggerStatement", "Breakpoint", "PauseOnNextStatement", "Microtask", "FunctionCall", "WatchedObject", "BlackboxedScript", "other"], "description": "Pause reason." },
                 { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." },
                 { "name": "asyncStackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Linked list of asynchronous StackTraces." }
             ]

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -1101,6 +1101,31 @@ JSC_DEFINE_JIT_OPERATION(operationHasPrivateBrandGaveUp, EncodedJSValue, (Encode
     OPERATION_RETURN(scope, JSValue::encode(jsBoolean(asObject(baseValue)->hasPrivateBrand(globalObject, JSValue::decode(encodedBrand)))));
 }
 
+ALWAYS_INLINE static bool willPutByIdToUncacheableDictionary(CallFrame* callFrame, JSGlobalObject* globalObject, JSValue baseValue)
+{
+    auto* debugger = globalObject->debugger();
+    if (!debugger) [[likely]]
+        return false;
+
+    JSObject* object = baseValue.getObject();
+    if (!object) [[unlikely]]
+        return false;
+    if (!object->structure()->isUncacheableDictionary()) [[likely]]
+        return false;
+
+    auto* codeBlock = callFrame->codeBlock();
+    auto codeOrigin = callFrame->codeOrigin();
+    if (JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
+        codeBlock = baselineCodeBlockForOriginAndBaselineCodeBlock(codeOrigin, codeBlock->baselineAlternative());
+    if (codeBlock->unlinkedCodeBlock()->isBuiltinFunction()) [[unlikely]]
+        return false;
+    if (!codeBlock->instructions().at(codeOrigin.bytecodeIndex()).ptr()->is<OpPutById>()) [[unlikely]]
+        return false;
+
+    debugger->willModifyUncacheableDictionary(*object);
+    return true;
+}
+
 JSC_DEFINE_JIT_OPERATION(operationPutByIdStrictGaveUp, void, (EncodedJSValue encodedValue, EncodedJSValue encodedBase, PropertyInlineCache* propertyCache))
 {
     SuperSamplerScope superSamplerScope(false);
@@ -1114,9 +1139,12 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdStrictGaveUp, void, (EncodedJSValue enc
     propertyCache->tookSlowPath = true;
     
     JSValue baseValue = JSValue::decode(encodedBase);
+    JSValue value = JSValue::decode(encodedValue);
     CacheableIdentifier identifier = propertyCache->identifier();
     PutPropertySlot slot(baseValue, true, callFrame->codeBlock()->putByIdContext());
-    baseValue.putInline(globalObject, identifier, JSValue::decode(encodedValue), slot);
+    if (willPutByIdToUncacheableDictionary(callFrame, globalObject, baseValue)) [[unlikely]]
+        OPERATION_RETURN_IF_EXCEPTION(scope);
+    baseValue.putInline(globalObject, identifier, value, slot);
     
     LOG_IC((ICEvent::OperationPutByIdStrictGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
@@ -1135,9 +1163,12 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSloppyGaveUp, void, (EncodedJSValue enc
     propertyCache->tookSlowPath = true;
     
     JSValue baseValue = JSValue::decode(encodedBase);
+    JSValue value = JSValue::decode(encodedValue);
     CacheableIdentifier identifier = propertyCache->identifier();
     PutPropertySlot slot(baseValue, false, callFrame->codeBlock()->putByIdContext());
-    baseValue.putInline(globalObject, identifier, JSValue::decode(encodedValue), slot);
+    if (willPutByIdToUncacheableDictionary(callFrame, globalObject, baseValue)) [[unlikely]]
+        OPERATION_RETURN_IF_EXCEPTION(scope);
+    baseValue.putInline(globalObject, identifier, value, slot);
 
     LOG_IC((ICEvent::OperationPutByIdSloppyGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
@@ -1200,6 +1231,8 @@ ALWAYS_INLINE static void putByIdMegamorphic(JSGlobalObject* globalObject, VM& v
         return;
     }
 
+    if (willPutByIdToUncacheableDictionary(callFrame, globalObject, baseValue)) [[unlikely]]
+        RETURN_IF_EXCEPTION(scope, void());
     scope.release();
     putMegamorphic(globalObject, vm, callFrame, propertyCache, asObject(baseValue), uid, value, slot, kind);
 }
@@ -1358,7 +1391,8 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdStrictOptimize, void, (EncodedJSValue e
     JSValue baseValue = JSValue::decode(encodedBase);
     CodeBlock* codeBlock = callFrame->codeBlock();
     PutPropertySlot slot(baseValue, true, codeBlock->putByIdContext());
-
+    if (willPutByIdToUncacheableDictionary(callFrame, globalObject, baseValue)) [[unlikely]]
+        OPERATION_RETURN_IF_EXCEPTION(scope);
     Structure* structure = CommonSlowPaths::originalStructureBeforePut(baseValue);
     baseValue.putInline(globalObject, identifier, value, slot);
 
@@ -1391,7 +1425,8 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSloppyOptimize, void, (EncodedJSValue e
     JSValue baseValue = JSValue::decode(encodedBase);
     CodeBlock* codeBlock = callFrame->codeBlock();
     PutPropertySlot slot(baseValue, false, codeBlock->putByIdContext());
-
+    if (willPutByIdToUncacheableDictionary(callFrame, globalObject, baseValue)) [[unlikely]]
+        OPERATION_RETURN_IF_EXCEPTION(scope);
     Structure* structure = CommonSlowPaths::originalStructureBeforePut(baseValue);
     baseValue.putInline(globalObject, identifier, value, slot);
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -35,6 +35,7 @@
 #include "CheckpointOSRExitSideState.h"
 #include "CodeBlockInlines.h"
 #include "CommonSlowPathsInlines.h"
+#include "Debugger.h"
 #include "Error.h"
 #include "ErrorHandlingScope.h"
 #include "Exception.h"
@@ -1077,11 +1078,23 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_id)
     JSValue baseValue = getOperand(callFrame, bytecode.m_base);
     PutPropertySlot slot(baseValue, bytecode.m_flags.ecmaMode().isStrict(), codeBlock->putByIdContext());
 
+    JSValue value = getOperand(callFrame, bytecode.m_value);
+
+    if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+        if (!bytecode.m_flags.isDirect() && !codeBlock->unlinkedCodeBlock()->isBuiltinFunction()) [[likely]] {
+            if (JSObject* object = baseValue.getObject(); object && object->structure()->isUncacheableDictionary()) [[unlikely]] {
+                debugger->willModifyUncacheableDictionary(*object);
+                LLINT_CHECK_EXCEPTION();
+            }
+        }
+    }
+
     Structure* oldStructure = baseValue.isCell() ? baseValue.asCell()->structure() : nullptr;
+
     if (bytecode.m_flags.isDirect())
-        CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), ident, getOperand(callFrame, bytecode.m_value), slot, &oldStructure);
+        CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), ident, value, slot, &oldStructure);
     else
-        baseValue.putInline(globalObject, ident, getOperand(callFrame, bytecode.m_value), slot);
+        baseValue.putInline(globalObject, ident, value, slot);
     LLINT_CHECK_EXCEPTION();
     
     if (Options::useLLIntICs()

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -31,6 +31,7 @@
 #include "BytecodeStructs.h"
 #include "ClonedArguments.h"
 #include "CommonSlowPathsInlines.h"
+#include "Debugger.h"
 #include "DefinePropertyAttributes.h"
 #include "DirectArguments.h"
 #include "ErrorHandlingScope.h"
@@ -1494,6 +1495,16 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_put_by_id_with_this)
     JSValue thisVal = GET_C(bytecode.m_thisValue).jsValue();
     JSValue putValue = GET_C(bytecode.m_value).jsValue();
     PutPropertySlot slot(thisVal, bytecode.m_ecmaMode.isStrict(), codeBlock->putByIdContext());
+
+    if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+        if (!codeBlock->unlinkedCodeBlock()->isBuiltinFunction()) [[likely]] {
+            if (JSObject* receiver = thisVal.getObject(); receiver && receiver->structure()->isUncacheableDictionary()) [[unlikely]] {
+                debugger->willModifyUncacheableDictionary(*receiver);
+                CHECK_EXCEPTION();
+            }
+        }
+    }
+
     baseValue.putInline(globalObject, ident, putValue, slot);
     END();
 }
@@ -1510,6 +1521,16 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_put_by_val_with_this)
     auto property = subscript.toPropertyKey(globalObject);
     CHECK_EXCEPTION();
     PutPropertySlot slot(thisValue, bytecode.m_ecmaMode.isStrict());
+
+    if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+        if (!codeBlock->unlinkedCodeBlock()->isBuiltinFunction()) [[likely]] {
+            if (JSObject* receiver = thisValue.getObject(); receiver && receiver->structure()->isUncacheableDictionary()) [[unlikely]] {
+                debugger->willModifyUncacheableDictionary(*receiver);
+                CHECK_EXCEPTION();
+            }
+        }
+    }
+
     baseValue.put(globalObject, property, value, slot);
     END();
 }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4108,6 +4108,16 @@ void JSObject::convertToUncacheableDictionary(VM& vm)
         vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
 }
 
+void JSObject::replaceWithUncacheableDictionary(VM& vm, HasBeenFlattenedBefore hasBeenFlattenedBefore)
+{
+    Structure* oldStructure = structure();
+    DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, oldStructure);
+    Structure* newStructure = Structure::cloneAsUncacheableDictionary(vm, oldStructure, hasBeenFlattenedBefore, &deferredWatchpointFire);
+    setStructure(vm, newStructure);
+    if (mayBePrototype()) [[unlikely]]
+        vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
+}
+
 
 void JSObject::shiftButterflyAfterFlattening(const GCSafeConcurrentJSLocker&, VM& vm, Structure* structure, size_t outOfLineCapacityAfter)
 {

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -565,6 +565,7 @@ public:
 
     JS_EXPORT_PRIVATE void convertToDictionary(VM&);
     JS_EXPORT_PRIVATE void convertToUncacheableDictionary(VM&);
+    JS_EXPORT_PRIVATE void replaceWithUncacheableDictionary(VM&, HasBeenFlattenedBefore);
 
     void flattenDictionaryObject(VM& vm)
     {

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -29,10 +29,12 @@
 
 #include "BrandedStructure.h"
 #include "BuiltinNames.h"
+#include "Debugger.h"
 #include "DumpContext.h"
 #include "JSCInlines.h"
 #include "PropertyNameArray.h"
 #include "PropertyTable.h"
+#include "VMInlines.h"
 #include "WebAssemblyGCStructure.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/NeverDestroyed.h>
@@ -890,6 +892,23 @@ Structure* Structure::toUncacheableDictionaryTransition(VM& vm, Structure* struc
     return toDictionaryTransition(vm, structure, UncachedDictionaryKind, deferred);
 }
 
+Structure* Structure::cloneAsUncacheableDictionary(VM& vm, Structure* structure, HasBeenFlattenedBefore hasBeenFlattenedBefore, DeferredStructureTransitionWatchpointFire* deferred)
+{
+    DeferGC deferGC(vm);
+
+    Structure* clone = Structure::create(vm, structure, deferred);
+
+    PropertyTable* table = structure->copyPropertyTableForPinning(vm);
+    clone->pin(Locker { clone->m_lock }, vm, table);
+    clone->setMaxOffset(vm, structure->maxOffset());
+    clone->setDictionaryKind(UncachedDictionaryKind);
+    clone->setHasBeenDictionary(true);
+    clone->setHasBeenFlattenedBefore(hasBeenFlattenedBefore == HasBeenFlattenedBefore::Yes);
+
+    clone->checkOffsetConsistency();
+    return clone;
+}
+
 Structure* Structure::sealTransition(VM& vm, Structure* structure, DeferredStructureTransitionWatchpointFire* deferred)
 {
     return nonPropertyTransition(vm, structure, TransitionKind::Seal, deferred);
@@ -1028,6 +1047,9 @@ Structure* Structure::flattenDictionaryStructure(VM& vm, JSObject* object)
     checkOffsetConsistency();
     ASSERT(isDictionary());
     ASSERT(object->structure() == this);
+
+    if (hasBeenFlattenedBefore() && Debugger::isWatchedObject(vm, *object)) [[unlikely]]
+        return this;
 
     Locker<JSCellLock> cellLocker(NoLockingNecessary);
 

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -191,6 +191,8 @@ private:
     const Structure* m_structure;
 };
 
+enum class HasBeenFlattenedBefore : bool { No, Yes };
+
 class Structure : public JSCell {
     static constexpr uint16_t shortInvalidOffset = std::numeric_limits<uint16_t>::max() - 1;
     static constexpr uint16_t useRareDataFlag = std::numeric_limits<uint16_t>::max();
@@ -290,6 +292,7 @@ public:
     JS_EXPORT_PRIVATE static Structure* attributeChangeTransitionToExistingStructure(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* toCacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* toUncacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
+    static Structure* cloneAsUncacheableDictionary(VM&, Structure*, HasBeenFlattenedBefore, DeferredStructureTransitionWatchpointFire* = nullptr);
     JS_EXPORT_PRIVATE static Structure* sealTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     JS_EXPORT_PRIVATE static Structure* freezeTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* preventExtensionsTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -46,12 +46,14 @@ template<typename T>
 struct WeakGCSetHash {
     // We only prune stale entries on Full GCs so we have to handle non-Live entries in the table.
     static unsigned hash(const Weak<T>& p) { return PtrHash<T*>::hash(p.get()); }
+    static unsigned hash(const T* p) { return PtrHash<const T*>::hash(p); }
     static bool equal(const Weak<T>& a, const Weak<T>& b)
     {
         if (!a || !b)
             return false;
         return a.get() == b.get();
     }
+    static bool equal(const Weak<T>& a, const T* b) { return b && a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
 
@@ -76,6 +78,11 @@ public:
         m_set.clear();
     }
 
+    bool isEmptyIgnoringNullReferences() const
+    {
+        return m_set.isEmptyIgnoringNullReferences();
+    }
+
     AddResult add(ValueArg* key)
     {
         // Constructing a Weak shouldn't trigger a GC but add this ASSERT for good measure.
@@ -92,6 +99,26 @@ public:
         
         auto result = m_set.template ensure<HashTranslator>(std::forward<T>(key), functor);
         return result.iterator->get();
+    }
+
+    iterator find(const ValueArg* key) const
+    {
+        return m_set.template find<HashArg>(key);
+    }
+
+    bool contains(const ValueArg* key) const
+    {
+        return m_set.template contains<HashArg>(key);
+    }
+
+    bool remove(const ValueArg* key)
+    {
+        return m_set.remove(find(key));
+    }
+
+    Weak<ValueArg> takeAny()
+    {
+        return m_set.takeAny();
     }
 
     // It's not safe to call into the VM or allocate an object while an iterator is open.

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1978,6 +1978,9 @@ localizedStrings["Warn @ Audit Tab - Test Case"] = "Warn";
 localizedStrings["Warning: "] = "Warning: ";
 localizedStrings["Warnings"] = "Warnings";
 localizedStrings["Watch Expressions"] = "Watch Expressions";
+localizedStrings["Watched Object"] = "Watched Object";
+/* Break (pause) on supported operations involving a watched object */
+localizedStrings["Watched Objects @ JavaScript Breakpoint"] = "Watched Objects";
 localizedStrings["Waterfall"] = "Waterfall";
 localizedStrings["Web Animation"] = "Web Animation";
 /* Section title for the JavaScript backtrace of the creation of a web animation */

--- a/Source/WebInspectorUI/UserInterface/Base/LoadLocalizedStrings.js
+++ b/Source/WebInspectorUI/UserInterface/Base/LoadLocalizedStrings.js
@@ -107,6 +107,10 @@ WI.repeatedUIString.allMicrotasks = function() {
     return WI.UIString("All Microtasks", "All Microtasks @ JavaScript Breakpoint", "Break (pause) on all microtasks");
 };
 
+WI.repeatedUIString.watchedObjects = function() {
+    return WI.UIString("Watched Objects", "Watched Objects @ JavaScript Breakpoint", "Break (pause) on supported operations involving a watched object");
+};
+
 WI.repeatedUIString.allAnimationFrames = function() {
     return WI.UIString("All Animation Frames", "All Animation Frames @ Event Breakpoint", "Break (pause) on All animation frames");
 };

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -86,6 +86,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         this._allMicrotasksBreakpointSetting = new WI.Setting("all-microtasks-breakpoint", null);
         this._allMicrotasksBreakpoint = null;
 
+        this._watchedObjectBreakpointSetting = new WI.Setting("watched-object-breakpoint", null);
+        this._watchedObjectBreakpoint = null;
+
         this._breakpoints = [];
         this._breakpointContentIdentifierMap = new Multimap;
         this._breakpointScriptIdentifierMap = new Multimap;
@@ -202,6 +205,12 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
                     this.addBreakpoint(this._allMicrotasksBreakpoint);
             }
 
+            if (WI.JavaScriptBreakpoint.supportsWatchedObjectBreakpoint()) {
+                this._watchedObjectBreakpoint = loadSpecialBreakpoint(this._watchedObjectBreakpointSetting);
+                if (this._watchedObjectBreakpoint)
+                    this.addBreakpoint(this._watchedObjectBreakpoint);
+            }
+
             this._restoringBreakpoints = false;
         })());
     }
@@ -236,6 +245,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         if (this._allMicrotasksBreakpoint)
             this._updateSpecialBreakpoint(this._allMicrotasksBreakpoint, target);
+
+        if (this._watchedObjectBreakpoint)
+            this._updateSpecialBreakpoint(this._watchedObjectBreakpoint, target);
 
         target.DebuggerAgent.setAsyncStackTraceDepth(this._asyncStackTraceDepthSetting.value);
 
@@ -326,6 +338,8 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             return WI.DebuggerManager.PauseReason.Listener;
         case InspectorBackend.Enum.Debugger.PausedReason.Microtask:
             return WI.DebuggerManager.PauseReason.Microtask;
+        case InspectorBackend.Enum.Debugger.PausedReason.WatchedObject:
+            return WI.DebuggerManager.PauseReason.WatchedObject;
         case InspectorBackend.Enum.Debugger.PausedReason.PauseOnNextStatement:
             return WI.DebuggerManager.PauseReason.PauseOnNextStatement;
         case InspectorBackend.Enum.Debugger.PausedReason.Timeout:
@@ -389,6 +403,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
     get uncaughtExceptionsBreakpoint() { return this._uncaughtExceptionsBreakpoint; }
     get assertionFailuresBreakpoint() { return this._assertionFailuresBreakpoint; }
     get allMicrotasksBreakpoint() { return this._allMicrotasksBreakpoint; }
+    get watchedObjectBreakpoint() { return this._watchedObjectBreakpoint; }
     get breakpoints() { return this._breakpoints; }
 
     createAssertionFailuresBreakpoint(options = {})
@@ -405,6 +420,14 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         this._allMicrotasksBreakpoint = this._createSpecialBreakpoint(options);
         this.addBreakpoint(this._allMicrotasksBreakpoint);
+    }
+
+    createWatchedObjectBreakpoint(options = {})
+    {
+        console.assert(!this._watchedObjectBreakpoint);
+
+        this._watchedObjectBreakpoint = this._createSpecialBreakpoint(options);
+        this.addBreakpoint(this._watchedObjectBreakpoint);
     }
 
     breakpointForIdentifier(id)
@@ -822,6 +845,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             case this._allMicrotasksBreakpoint:
                 this._allMicrotasksBreakpointSetting.reset();
                 this._allMicrotasksBreakpoint = null;
+                break;
+
+            case this._watchedObjectBreakpoint:
+                this._watchedObjectBreakpointSetting.reset();
+                this._watchedObjectBreakpoint = null;
                 break;
             }
         } else if (!this._restoringBreakpoints)
@@ -1447,6 +1475,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             setting = this._allMicrotasksBreakpointSetting;
             command = "setPauseOnMicrotasks";
             break;
+
+        case this._watchedObjectBreakpoint:
+            setting = this._watchedObjectBreakpointSetting;
+            command = "setPauseOnWatchedObject";
+            break;
         }
         console.assert(setting);
 
@@ -1876,6 +1909,7 @@ WI.DebuggerManager.PauseReason = {
     Interval: "interval",
     Listener: "listener",
     Microtask: "microtask",
+    WatchedObject: "watched-object",
     PauseOnNextStatement: "pause-on-next-statement",
     Timeout: "timeout",
     URL: "url",

--- a/Source/WebInspectorUI/UserInterface/Models/JavaScriptBreakpoint.js
+++ b/Source/WebInspectorUI/UserInterface/Models/JavaScriptBreakpoint.js
@@ -68,6 +68,12 @@ WI.JavaScriptBreakpoint = class JavaScriptBreakpoint extends WI.Breakpoint
         return InspectorBackend.hasCommand("Debugger.setPauseOnDebuggerStatements", parameter);
     }
 
+    static supportsWatchedObjectBreakpoint()
+    {
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): Debugger.setPauseOnWatchedObject did not exist yet.
+        return InspectorBackend.hasCommand("Debugger.setPauseOnWatchedObject");
+    }
+
     // Import / Export
 
     static fromJSON(json)
@@ -125,6 +131,9 @@ WI.JavaScriptBreakpoint = class JavaScriptBreakpoint extends WI.Breakpoint
 
         case WI.debuggerManager.allMicrotasksBreakpoint:
             return WI.repeatedUIString.allMicrotasks();
+
+        case WI.debuggerManager.watchedObjectBreakpoint:
+            return WI.repeatedUIString.watchedObjects();
         }
 
         return this._sourceCodeLocation.displayLocationString()

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -403,6 +403,9 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         if (WI.debuggerManager.assertionFailuresBreakpoint)
             this._addBreakpoint(WI.debuggerManager.assertionFailuresBreakpoint);
 
+        if (WI.debuggerManager.watchedObjectBreakpoint)
+            this._addBreakpoint(WI.debuggerManager.watchedObjectBreakpoint);
+
         if (WI.debuggerManager.allMicrotasksBreakpoint)
             this._addBreakpoint(WI.debuggerManager.allMicrotasksBreakpoint);
 
@@ -2029,6 +2032,13 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
             }
             return true;
 
+        case WI.DebuggerManager.PauseReason.WatchedObject:
+            if (!this._updatePauseReasonForBreakpoint(WI.debuggerManager.watchedObjectBreakpoint, WI.UIString("Watched Object"))) {
+                console.assert(false, "not reached");
+                break;
+            }
+            return true;
+
         case WI.DebuggerManager.PauseReason.PauseOnNextStatement:
             this._pauseReasonTextRow.text = WI.UIString("Immediate Pause Requested");
             this._pauseReasonGroup.rows = [this._pauseReasonTextRow];
@@ -2273,6 +2283,12 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
             });
 
             contextMenu.appendSeparator();
+        }
+
+        if (WI.JavaScriptBreakpoint.supportsWatchedObjectBreakpoint()) {
+            addToggleForSpecialBreakpoint(WI.repeatedUIString.watchedObjects(), WI.debuggerManager.watchedObjectBreakpoint, () => {
+                WI.debuggerManager.createWatchedObjectBreakpoint();
+            });
         }
 
         addToggleForSpecialBreakpoint(WI.repeatedUIString.assertionFailures(), WI.debuggerManager.assertionFailuresBreakpoint, () => {


### PR DESCRIPTION
#### 2f56e1fed2f274d9543324d48ce42b5bc8207128
<pre>
Web Inspector: add `watch(object)` Command Line API
<a href="https://bugs.webkit.org/show_bug.cgi?id=322799">https://bugs.webkit.org/show_bug.cgi?id=322799</a>

Reviewed by NOBODY (OOPS!).

Calling `watch(object)` from the Console marks `object` for the configurable `Watched Objects` breakpoint.
When enabled, the breakpoint pauses before ordinary named property writes and named or computed `super` writes to watched objects.
The watch follows the object across aliases and remains active for repeated writes until `unwatch(object)` is called.

* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(CommandLineAPI.methods.unwatch): Added.
(CommandLineAPI.methods.watch): Added.
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.h:
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::watch): Added.
(Inspector::JSInjectedScriptHost::unwatch): Added.
* Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp:
(Inspector::JSInjectedScriptHostPrototype::finishCreation):
(Inspector::jsInjectedScriptHostPrototypeFunctionWatch): Added.
(Inspector::jsInjectedScriptHostPrototypeFunctionUnwatch): Added.
* Source/JavaScriptCore/debugger/Debugger.h:
(JSC::Debugger::Observer::willModifyWatchedObject): Added.
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::Debugger):
(JSC::Debugger::~Debugger):
(JSC::Debugger::isWatchingObject const): Added.
(JSC::Debugger::isWatchedObject): Added.
(JSC::Debugger::watchObject): Added.
(JSC::Debugger::unwatchObject): Added.
(JSC::Debugger::unwatchObjectAfterRemoval): Added.
(JSC::Debugger::clearWatchedObjects): Added.
(JSC::Debugger::clearBreakpoints):
(JSC::Debugger::willModifyUncacheableDictionary): Added.

* Source/JavaScriptCore/runtime/Structure.h:
(JSC::HasBeenFlattenedBefore): Added.
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::cloneAsUncacheableDictionary): Added.
(JSC::Structure::flattenDictionaryStructure):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::replaceWithUncacheableDictionary): Added.
Use uncacheable dictionaries to route watched writes through existing slow paths.

* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCachePutBy):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::slow_path_put_by_id):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::willPutByIdToUncacheableDictionary): Added.
(JSC::operationPutByIdStrictGaveUp):
(JSC::operationPutByIdSloppyGaveUp):
(JSC::putByIdMegamorphic):
(JSC::operationPutByIdStrictOptimize):
(JSC::operationPutByIdSloppyOptimize):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::slow_path_put_by_id_with_this):
(JSC::slow_path_put_by_val_with_this):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::willPutWithThisToUncacheableDictionary): Added.
(JSC::DFG::putWithThis):
(JSC::DFG::operationPutByIdWithThisStrict):
(JSC::DFG::operationPutByIdWithThis):
(JSC::DFG::operationPutByValWithThisStrict):
(JSC::DFG::operationPutByValWithThis):
Notify `Debugger` before property writes from existing interpreter and JIT slow paths.

* Source/JavaScriptCore/inspector/protocol/Debugger.json:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::setPauseOnWatchedObject): Added.
(Inspector::InspectorDebuggerAgent::willModifyWatchedObject): Added.
(Inspector::InspectorDebuggerAgent::clearInspectorBreakpointState):
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.constructor):
(WI.DebuggerManager.prototype.initializeTarget):
(WI.DebuggerManager.pauseReasonFromPayload):
(WI.DebuggerManager.prototype.get watchedObjectBreakpoint): Added.
(WI.DebuggerManager.prototype.createWatchedObjectBreakpoint): Added.
(WI.DebuggerManager.prototype.removeBreakpoint):
(WI.DebuggerManager.prototype._updateSpecialBreakpoint):
* Source/WebInspectorUI/UserInterface/Models/JavaScriptBreakpoint.js:
(WI.JavaScriptBreakpoint.supportsWatchedObjectBreakpoint): Added.
(WI.JavaScriptBreakpoint.prototype.get displayName):
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.prototype.constructor):
(WI.SourcesNavigationSidebarPanel.prototype._updatePauseReason):
(WI.SourcesNavigationSidebarPanel.prototype._populateCreateBreakpointContextMenu):
Add a new `Watched Objects` breakpoint to the navigation sidebar of the Sources Tab.

* Source/JavaScriptCore/runtime/WeakGCSet.h:
(JSC::WeakGCSetHash::hash): Added.
(JSC::WeakGCSetHash::equal): Added.
(JSC::WeakGCSet::isEmptyIgnoringNullReferences const): Added.
(JSC::WeakGCSet::find const): Added.
(JSC::WeakGCSet::contains const): Added.
(JSC::WeakGCSet::remove): Added.
(JSC::WeakGCSet::takeAny): Added.
Support weak object lookup and cleanup using the same conventions as `WeakGCMap`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/LoadLocalizedStrings.js:
(WI.repeatedUIString.watchedObjects): Added.

* LayoutTests/inspector/console/resources/watch-utilities.js: Added.
* LayoutTests/inspector/console/watch.html: Added.
* LayoutTests/inspector/console/watch-expected.txt: Added.
* LayoutTests/inspector/console/watch-garbage-collection.html: Added.
* LayoutTests/inspector/console/watch-garbage-collection-expected.txt: Added.
* LayoutTests/inspector/console/watch-super-property.html: Added.
* LayoutTests/inspector/console/watch-super-property-expected.txt: Added.
* LayoutTests/inspector/console/unwatch.html: Added.
* LayoutTests/inspector/console/unwatch-expected.txt: Added.
* LayoutTests/inspector/debugger/setPauseOnWatchedObject.html: Added.
* LayoutTests/inspector/debugger/setPauseOnWatchedObject-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f56e1fed2f274d9543324d48ce42b5bc8207128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150000 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144646 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100345 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45119 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6857 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13737 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44805 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6491 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46364 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58683 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164741 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59392 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153800 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48296 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131689 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57872 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19824 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->