### PR TITLE
[Site Isolation] Only broadcast frame geometry from frames with a cross-process descendant

### DIFF
--- a/LayoutTests/http/tests/site-isolation/intersection-observer/resources/report-intersections-frame.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/resources/report-intersections-frame.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<body style="margin: 0">
+<div id="visible" style="position: absolute; left: 0; top: 0; width: 100px; height: 100px; background: green"></div>
+<div id="clipped" style="position: absolute; left: 0; top: 250px; width: 100px; height: 100px; background: red"></div>
+<script>
+
+const isIntersecting = { };
+
+const observer = new IntersectionObserver(entries => {
+    for (const entry of entries)
+        isIntersecting[entry.target.id] = entry.isIntersecting;
+    window.top.postMessage(JSON.stringify(isIntersecting), "*");
+});
+
+observer.observe(document.getElementById("visible"));
+observer.observe(document.getElementById("clipped"));
+
+</script>

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/resources/same-site-middle-frame.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/resources/same-site-middle-frame.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<body style="margin: 0">
+<iframe style="position: absolute; left: 0; top: 0; width: 400px; height: 400px; border: none"
+    src="http://localhost:8000/site-isolation/intersection-observer/resources/report-intersections-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersections in a cross-site frame account for clipping applied across a same-site frame
+

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body style="margin: 0">
+
+<div style="position: absolute; left: 0; top: 0; width: 400px; height: 150px; overflow: hidden">
+    <iframe style="position: absolute; left: 0; top: 0; width: 400px; height: 400px; border: none"
+        src="http://127.0.0.1:8000/site-isolation/intersection-observer/resources/same-site-middle-frame.html"></iframe>
+</div>
+
+<script>
+
+let latestReport = null;
+window.addEventListener("message", event => latestReport = JSON.parse(event.data));
+
+promise_test(async t => {
+    // Wait for the first report, then let the intersection state settle before asserting on it.
+    while (!latestReport)
+        await new Promise(resolve => requestAnimationFrame(resolve));
+    for (let i = 0; i < 20; i++)
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+    assert_true(latestReport.visible,
+        "a target inside the unclipped part of the grandchild frame must be intersecting");
+    assert_false(latestReport.clipped,
+        "a target clipped away by an ancestor in another process must not be intersecting");
+}, "Intersections in a cross-site frame account for clipping applied across a same-site frame");
+
+</script>

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Frame geometry is only broadcast by frames that have a cross-process descendant
+

--- a/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants.html
+++ b/LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants.html
@@ -1,0 +1,78 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body style="margin: 0">
+<script>
+
+const crossSiteURL = "http://localhost:8000/site-isolation/resources/frame-with-text.html";
+const sameSiteURL = "http://127.0.0.1:8000/site-isolation/resources/frame-with-text.html";
+
+let broadcastCount = 0;
+
+// Frame geometry shares this IPC with the other frame tree sync properties, so this test compares
+// idle rendering update counts against each other rather than asserting an absolute number.
+if (window.IPC) {
+    IPC.addOutgoingMessageListener("UI", message => {
+        if (message.description === "WebPageProxy_BroadcastFrameTreeSyncData")
+            broadcastCount++;
+    });
+}
+
+async function settle()
+{
+    // Two rendering updates and a task, so that the layout and frame rect changes caused by adding
+    // a frame have finished propagating before the next measurement starts.
+    for (let i = 0; i < 2; i++)
+        await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function countBroadcastsDuringIdleRenderingUpdate()
+{
+    await settle();
+    broadcastCount = 0;
+    await settle();
+    return broadcastCount;
+}
+
+function addIframe(url, top, parentDocument = document)
+{
+    return new Promise(resolve => {
+        const iframe = parentDocument.createElement("iframe");
+        // Position the frames absolutely so that adding one does not move the others, which would
+        // broadcast frame rects and perturb the counts below.
+        iframe.style.cssText = `position: absolute; left: 0; top: ${top}px; width: 100px; height: 100px; border: none`;
+        iframe.onload = () => resolve(iframe);
+        iframe.src = url;
+        parentDocument.body.appendChild(iframe);
+    });
+}
+
+promise_test(async t => {
+    // IPC interception only works in debug builds.
+    if (!window.IPC)
+        return;
+
+    t.add_cleanup(() => document.querySelectorAll("iframe").forEach(iframe => iframe.remove()));
+
+    // The main frame has a cross-process child, so the process hosting that child needs the main
+    // frame's geometry to map its own frames up to the root.
+    await addIframe(crossSiteURL, 0);
+    const withCrossSiteChildOnly = await countBroadcastsDuringIdleRenderingUpdate();
+    assert_greater_than(withCrossSiteChildOnly, 0,
+        "a frame with a cross-process child must broadcast its geometry");
+
+    // This frame and everything below it is in this process, so no other process can read its
+    // geometry. It shouldn't broadcast any geometry.
+    const sameSiteIframe = await addIframe(sameSiteURL, 100);
+    assert_equals(await countBroadcastsDuringIdleRenderingUpdate(), withCrossSiteChildOnly,
+        "a frame whose whole subtree is in this process must not broadcast its geometry");
+
+    // If we add a cross-site grandchild iframe under the local same-site iframe, then we need to
+    // start sending geometry again.
+    await addIframe(crossSiteURL, 0, sameSiteIframe.contentDocument);
+    assert_greater_than(await countBroadcastsDuringIdleRenderingUpdate(), withCrossSiteChildOnly,
+        "a frame with a cross-process descendant must broadcast its geometry");
+}, "Frame geometry is only broadcast by frames that have a cross-process descendant");
+</script>

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -372,6 +372,15 @@ bool FrameTree::containsRemoteFrame() const
     return false;
 }
 
+bool FrameTree::containsLocalFrame() const
+{
+    for (RefPtr frame = m_thisFrame.ptr(); frame; frame = frame->tree().traverseNext(m_thisFrame.ptr())) {
+        if (is<LocalFrame>(*frame))
+            return true;
+    }
+    return false;
+}
+
 bool FrameTree::hasRemoteFrameAncestor() const
 {
     for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->tree().parent()) {

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -62,6 +62,7 @@ public:
     WEBCORE_EXPORT bool NODELETE isDescendantOf(const Frame* ancestor) const;
 
     bool containsRemoteFrame() const;
+    bool containsLocalFrame() const;
     WEBCORE_EXPORT bool hasRemoteFrameAncestor() const;
     
     WEBCORE_EXPORT Frame* NODELETE traverseNext(const Frame* stayWithin = nullptr) const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2269,7 +2269,20 @@ bool Page::hasRemoteFrames() const
 
 void Page::syncLocalFrameInfoToRemote()
 {
-    forEachLocalFrame([] (LocalFrame& frame) {
+    ASSERT(hasRemoteFrames());
+
+    // Memoize FrameTree::containsRemoteFrame for the entire frame tree.
+    HashSet<FrameIdentifier> subtreeContainsRemoteFrame;
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        if (!is<RemoteFrame>(*frame))
+            continue;
+        for (RefPtr ancestor = frame; ancestor; ancestor = ancestor->tree().parent()) {
+            if (!subtreeContainsRemoteFrame.add(ancestor->frameID()).isNewEntry)
+                break;
+        }
+    }
+
+    forEachLocalFrame([&] (LocalFrame& frame) {
         RefPtr<LocalFrameView> frameView = frame.view();
 
         HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
@@ -2287,6 +2300,12 @@ void Page::syncLocalFrameInfoToRemote()
 #endif
 
         for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+            if (!subtreeContainsRemoteFrame.contains(child->frameID())) {
+                ASSERT(!child->tree().containsRemoteFrame());
+                continue;
+            }
+            ASSERT(child->tree().containsRemoteFrame());
+
             auto absoluteToChildFrameOwnerLocalTransform = frameView->absoluteToChildFrameOwnerLocalTransform(*child);
             auto contentBoxLocation = frameView->childFrameOwnerContentBoxLocation(*child);
 
@@ -2340,6 +2359,11 @@ void Page::syncLocalFrameInfoToRemote()
                 contentBoxLocation,
                 frameView->appearanceOfOwnerElementOfChildFrame(*child)
             ));
+        }
+
+        if (childrenFrameLayoutInfo.isEmpty()) {
+            ASSERT(!frame.tree().containsRemoteFrame());
+            return;
         }
 
         frame.loader().client().broadcastFrameGeometryToOtherProcesses({

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -38,6 +38,14 @@
 
 namespace WebCore {
 
+// Page::syncLocalFrameInfoToRemote running in a parent frame process only sends transforms for
+// child frame subtrees containing a remote frame. From our perspective, that means that the
+// transforms are only valid on child subtrees containing a local frame.
+//
+// As an example, the absoluteToChildFrameOwnerLocalTransform for a child frame whose subtree is
+// hosted entirely in other processes will likely return an invalid result in this process.
+#define ASSERT_CHILD_CONTAINS_LOCAL_FRAME(child) ASSERT((child).tree().containsLocalFrame())
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameView);
 
 RemoteFrameView::RemoteFrameView(RemoteFrame& frame)
@@ -108,6 +116,8 @@ LayoutPoint RemoteFrameView::childFrameOwnerContentBoxLocation(const Frame& chil
 
 TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(const Frame& child) const
 {
+    ASSERT_CHILD_CONTAINS_LOCAL_FRAME(child);
+
     if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->childFrameOwnerToRootContentTransform();
 
@@ -116,6 +126,8 @@ TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(cons
 
 TransformationMatrix RemoteFrameView::absoluteToChildFrameOwnerLocalTransform(const Frame& child) const
 {
+    ASSERT_CHILD_CONTAINS_LOCAL_FRAME(child);
+
     if (RefPtr info = m_frame->frameTreeSyncData().frameGeometry.childrenFrameLayoutInfo.get(child.frameID()))
         return info->absoluteToChildFrameOwnerLocalTransform();
 


### PR DESCRIPTION
#### a7cd2f5b0eb407ec31e9815dc5c9c3491e5f4451
<pre>
[Site Isolation] Only broadcast frame geometry from frames with a cross-process descendant
<a href="https://bugs.webkit.org/show_bug.cgi?id=322890">https://bugs.webkit.org/show_bug.cgi?id=322890</a>
<a href="https://rdar.apple.com/problem/186140629">rdar://problem/186140629</a>

Reviewed by Kiet Ho and Matt Woodrow.

On every rendering update, each local frame broadcasts its frame geometry to every other process
rendering the page.

This is mostly unnecessary, because remote frames only care about geometry from ancestors, not the
entire tree:

 - IntersectionObserver: computeClippedRectInRootContentsSpace uses clip geometry from ancestors
   only, e.g. layoutViewportRect and visibleRectOfChild.
 - LocalFrameView::windowClipRect: root frames in the remote process calculate their clip rect from
   their parent&apos;s visibleRectInParent.
 - exposedContentRect: frames in the remote process calculate their exposedContentRect from their
   parent&apos;s exposedContentRectInParent.

To fix this, skip calculating geometry for any child that is entirely local to this process.
Additionally, if a local frame has no remote descendants, then we should send nothing, since no
remote frame exists that could use that geometry.

One complication here is with remote frames nested under multiple local frames:

  Local main frame =&gt; local child frame =&gt; remote grandchild frame

When we process the local main frame in the syncLocalFrameInfoToRemote loop, we still have to send
geometry associated with that local main frame even though its direct child is local. This is
because an IntersectionObserver in the remote grandchild frame walks all the way up to the root of
the frame tree and uses clipping rectangles from all ancestor nodes.

We add a layout test to test this specific frame hierarchy with IntersectionObserver. Note that it
is similar to but differs from the existing nested-cross-origin-iframe.sub.html IntersectionObserver
test in WPT, since the frame hierarchy in that test contains only remote child frames.

There is an obvious follow-up optimization here to stop broadcasting frame geometry and only send
it to remote processes that actually need that particular state. That requires more significant
refactoring so we&apos;ll optimize that in a subsequent patch.

Tests: http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame.html
       http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants.html

* LayoutTests/http/tests/site-isolation/intersection-observer/resources/report-intersections-frame.html: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/resources/same-site-middle-frame.html: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/target-in-cross-site-frame-nested-in-same-site-frame.html: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/only-broadcast-frame-geometry-from-frames-with-cross-process-descendants.html: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::containsLocalFrame const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::childFrameOwnerToRootContentTransform const):
(WebCore::RemoteFrameView::absoluteToChildFrameOwnerLocalTransform const):

Canonical link: <a href="https://commits.webkit.org/320553@main">https://commits.webkit.org/320553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c324c14544a9b17a71820f4604363de6a9d004d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195367 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/094a652e-cfa9-485d-9a41-d164c76b87db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46d4585e-f02c-416d-aae1-d4e9b3c5fa53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78160198-cb4c-41e4-ac74-83034a7135ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45076 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44759 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197314 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154088 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41363 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153744 "Found 3 new API test failures: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/4294967297444MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672971MallocReadOnly (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48250 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131618 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128260 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57818 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19778 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57429 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->