### PR TITLE
ScrollingStateTree::insertNode reorders children in O(n²) on pages with many sibling scrolling nodes

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -31,6 +31,7 @@
 #include "ScrollingStateFixedNode.h"
 #include "ScrollingStateScrollingNode.h"
 #include "ScrollingStateTree.h"
+#include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -167,6 +168,29 @@ void ScrollingStateNode::insertChild(Ref<ScrollingStateNode>&& childNode, size_t
     } else
         m_children.insert(index, WTF::move(childNode));
     
+    setPropertyChanged(Property::ChildNodes);
+}
+
+void ScrollingStateNode::moveChildToIndex(ScrollingStateNode& childNode, size_t index)
+{
+    size_t currentIndex = m_children.findIf([&](auto& child) {
+        return child.ptr() == &childNode;
+    });
+    if (currentIndex == notFound) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    index = std::min(index, m_children.size() - 1);
+    if (currentIndex == index)
+        return;
+
+    auto span = m_children.mutableSpan();
+    if (currentIndex < index)
+        std::rotate(span.begin() + currentIndex, span.begin() + currentIndex + 1, span.begin() + index + 1);
+    else
+        std::rotate(span.begin() + index, span.begin() + currentIndex, span.begin() + currentIndex + 1);
+
     setPropertyChanged(Property::ChildNodes);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -300,6 +300,7 @@ public:
 
     void appendChild(Ref<ScrollingStateNode>&&);
     void insertChild(Ref<ScrollingStateNode>&&, size_t index);
+    void moveChildToIndex(ScrollingStateNode&, size_t index);
 
     // Note that node ownership is via the parent, so these functions can trigger node deletion.
     void removeFromParent();

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -196,12 +196,7 @@ std::optional<ScrollingNodeID> ScrollingStateTree::insertNode(ScrollingNodeType 
             if (parent->childAtIndex(childIndex) == node)
                 return newNodeID;
 
-            parent->removeChild(*node);
-
-            if (childIndex == notFound)
-                parent->appendChild(node.releaseNonNull());
-            else
-                parent->insertChild(node.releaseNonNull(), childIndex);
+            parent->moveChildToIndex(*node, childIndex);
 
             return newNodeID;
         }


### PR DESCRIPTION
#### b507abf84cc2aabf4be4021fc7539b4fa4d6bbae
<pre>
ScrollingStateTree::insertNode reorders children in O(n²) on pages with many sibling scrolling nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322891">https://bugs.webkit.org/show_bug.cgi?id=322891</a>
<a href="https://rdar.apple.com/186143008">rdar://186143008</a>

Reviewed by NOBODY (OOPS!).

ScrollingStateNode keeps its children in a Vector. When insertNode() moves an
existing node to a new index it called removeChild() then insertChild(), each a
linear scan plus tail memmove. Since registerScrollingNodeID() runs this once
per layer during every compositing update, a parent with N children does O(n²)
work.

Replace the remove + insert with moveChildToIndex(), which finds the child once
and std::rotate()s only the range between its current and target index. No
behavior change, so covered by existing tests.

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::moveChildToIndex):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::insertNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b507abf84cc2aabf4be4021fc7539b4fa4d6bbae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193986 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148056 "Failed to checkout and rebase branch from PR 72763") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64213752-a5fa-481d-834e-7731dda97d47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143426 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148056 "Failed to checkout and rebase branch from PR 72763") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91730ea5-0251-43e0-8fe8-01a16cbe1f92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123847 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef5321e3-84c7-4241-b837-ba5b23879383) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45901 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43708 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5168 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48396 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195924 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57358 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152964 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58062 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152648 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47190 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130342 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126685 "Failed to checkout and rebase branch from PR 72763") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56570 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18719 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55941 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56008 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->