### PR TITLE
ScrollingStateTree::insertNode does redundant work reordering children on pages with many sibling scrolling nodes

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -899,6 +899,7 @@ public:
 
     void removeAt(size_t position);
     void removeAt(size_t position, size_t length);
+    void moveTo(size_t oldPosition, size_t newPosition);
     bool removeFirst(const auto&);
     template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
     bool removeFirst(V*);
@@ -1727,6 +1728,26 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
     TypeOperations::moveOverlapping(endSpot, end(), beginSpot.data());
     asanBufferSizeWillChangeTo(m_size - length);
     m_size -= length;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::moveTo(size_t oldPosition, size_t newPosition)
+{
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(oldPosition < size());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(newPosition < size());
+
+    if (oldPosition == newPosition)
+        return;
+
+    // Lift the element out, shift only the range between the two positions into the gap, then drop it back.
+    T* data = mutableSpan().data();
+    T element = WTF::move(data[oldPosition]);
+    TypeOperations::destruct(data + oldPosition, data + oldPosition + 1);
+    if (oldPosition < newPosition)
+        TypeOperations::moveOverlapping(data + oldPosition + 1, data + newPosition + 1, data + oldPosition);
+    else
+        TypeOperations::moveOverlapping(data + newPosition, data + oldPosition, data + newPosition + 1);
+    new (NotNull, data + newPosition) T(WTF::move(element));
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -195,12 +195,18 @@ std::optional<ScrollingNodeID> ScrollingStateTree::insertNode(ScrollingNodeType 
             if (parent->childAtIndex(childIndex) == node)
                 return newNodeID;
 
-            parent->removeChild(*node);
+            auto& children = parent->children();
+            size_t currentIndex = children.find(node.get());
+            if (currentIndex == notFound) {
+                ASSERT_NOT_REACHED();
+                return newNodeID;
+            }
 
-            if (childIndex == notFound)
-                parent->appendChild(node.releaseNonNull());
-            else
-                parent->insertChild(node.releaseNonNull(), childIndex);
+            size_t targetIndex = std::min(childIndex, children.size() - 1);
+            if (currentIndex != targetIndex) {
+                children.moveTo(currentIndex, targetIndex);
+                parent->setPropertyChanged(ScrollingStateNode::Property::ChildNodes);
+            }
 
             return newNodeID;
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -431,6 +431,148 @@ TEST(WTF_Vector, Reverse)
     EXPECT_EQ(13, intVector[4]);
 }
 
+TEST(WTF_Vector, MoveTo)
+{
+    Vector<int> intVector { 10, 11, 12, 13, 14 };
+
+    // Move an earlier element to a later index: only the range in between shifts.
+    intVector.moveTo(1, 3);
+    EXPECT_EQ(10, intVector[0]);
+    EXPECT_EQ(12, intVector[1]);
+    EXPECT_EQ(13, intVector[2]);
+    EXPECT_EQ(11, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+
+    // Move a later element back to an earlier index.
+    intVector.moveTo(3, 0);
+    EXPECT_EQ(11, intVector[0]);
+    EXPECT_EQ(10, intVector[1]);
+    EXPECT_EQ(12, intVector[2]);
+    EXPECT_EQ(13, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+
+    // Moving to the same index is a no-op.
+    intVector.moveTo(2, 2);
+    EXPECT_EQ(11, intVector[0]);
+    EXPECT_EQ(10, intVector[1]);
+    EXPECT_EQ(12, intVector[2]);
+    EXPECT_EQ(13, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+
+    // Move first to last and last to first.
+    intVector.moveTo(0, 4);
+    EXPECT_EQ(10, intVector[0]);
+    EXPECT_EQ(12, intVector[1]);
+    EXPECT_EQ(13, intVector[2]);
+    EXPECT_EQ(14, intVector[3]);
+    EXPECT_EQ(11, intVector[4]);
+
+    intVector.moveTo(4, 0);
+    EXPECT_EQ(11, intVector[0]);
+    EXPECT_EQ(10, intVector[1]);
+    EXPECT_EQ(12, intVector[2]);
+    EXPECT_EQ(13, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+}
+
+TEST(WTF_Vector, MoveToAdjacent)
+{
+    Vector<int> intVector { 1, 2, 3 };
+
+    intVector.moveTo(0, 1);
+    EXPECT_EQ(2, intVector[0]);
+    EXPECT_EQ(1, intVector[1]);
+    EXPECT_EQ(3, intVector[2]);
+
+    intVector.moveTo(2, 1);
+    EXPECT_EQ(2, intVector[0]);
+    EXPECT_EQ(3, intVector[1]);
+    EXPECT_EQ(1, intVector[2]);
+}
+
+TEST(WTF_Vector, MoveToSamePosition)
+{
+    Vector<int> intVector { 10, 11, 12 };
+
+    intVector.moveTo(0, 0);
+    intVector.moveTo(1, 1);
+    intVector.moveTo(2, 2);
+    EXPECT_EQ(3U, intVector.size());
+    EXPECT_EQ(10, intVector[0]);
+    EXPECT_EQ(11, intVector[1]);
+    EXPECT_EQ(12, intVector[2]);
+
+    // A single-element vector: the only valid move is a no-op.
+    Vector<int> single { 42 };
+    single.moveTo(0, 0);
+    EXPECT_EQ(1U, single.size());
+    EXPECT_EQ(42, single[0]);
+}
+
+TEST(WTF_Vector, MoveToInlineCapacity)
+{
+    Vector<int, 8> intVector { 10, 11, 12, 13, 14 };
+
+    intVector.moveTo(1, 3);
+    EXPECT_EQ(10, intVector[0]);
+    EXPECT_EQ(12, intVector[1]);
+    EXPECT_EQ(13, intVector[2]);
+    EXPECT_EQ(11, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+
+    intVector.moveTo(3, 0);
+    EXPECT_EQ(11, intVector[0]);
+    EXPECT_EQ(10, intVector[1]);
+    EXPECT_EQ(12, intVector[2]);
+    EXPECT_EQ(13, intVector[3]);
+    EXPECT_EQ(14, intVector[4]);
+
+    intVector.moveTo(2, 2);
+    EXPECT_EQ(12, intVector[2]);
+}
+
+TEST(WTF_Vector, MoveToMoveOnly)
+{
+    Vector<MoveOnly> vector;
+    for (unsigned i = 0; i < 5; ++i)
+        vector.append(MoveOnly(i));
+
+    // Move an earlier element to a later index.
+    vector.moveTo(1, 3);
+    EXPECT_EQ(0U, vector[0].value());
+    EXPECT_EQ(2U, vector[1].value());
+    EXPECT_EQ(3U, vector[2].value());
+    EXPECT_EQ(1U, vector[3].value());
+    EXPECT_EQ(4U, vector[4].value());
+
+    // Move a later element back to an earlier index.
+    vector.moveTo(3, 0);
+    EXPECT_EQ(1U, vector[0].value());
+    EXPECT_EQ(0U, vector[1].value());
+    EXPECT_EQ(2U, vector[2].value());
+    EXPECT_EQ(3U, vector[3].value());
+    EXPECT_EQ(4U, vector[4].value());
+
+    // Same-position move leaves a move-only element untouched.
+    vector.moveTo(2, 2);
+    EXPECT_EQ(2U, vector[2].value());
+
+    // First to last and last to first.
+    vector.moveTo(0, 4);
+    EXPECT_EQ(0U, vector[0].value());
+    EXPECT_EQ(2U, vector[1].value());
+    EXPECT_EQ(3U, vector[2].value());
+    EXPECT_EQ(4U, vector[3].value());
+    EXPECT_EQ(1U, vector[4].value());
+
+    vector.moveTo(4, 0);
+    EXPECT_EQ(1U, vector[0].value());
+    EXPECT_EQ(0U, vector[1].value());
+    EXPECT_EQ(2U, vector[2].value());
+    EXPECT_EQ(3U, vector[3].value());
+    EXPECT_EQ(4U, vector[4].value());
+}
+
 TEST(WTF_Vector, ReverseIterator)
 {
     Vector<int> intVector;


### PR DESCRIPTION
#### da79705ade01755efb0bf2144b1636e4e744a592
<pre>
ScrollingStateTree::insertNode does redundant work reordering children on pages with many sibling scrolling nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322891">https://bugs.webkit.org/show_bug.cgi?id=322891</a>
<a href="https://rdar.apple.com/186143008">rdar://186143008</a>

Reviewed by Chris Dumez and Simon Fraser.

ScrollingStateNode keeps its children in a Vector. When insertNode() moves an
existing node to a new index it called removeChild() (a linear scan plus a tail
memmove) followed by insertChild()/appendChild() (another tail memmove). Since
registerScrollingNodeID() runs this once per layer during every compositing
update, a parent with N children that need reordering does more shifting than
necessary.

Add Vector::moveTo(), which relocates the element at one index to another by
lifting it out, shifting only the elements between the current and target
positions into the gap with Vector&apos;s own TypeOperations::moveOverlapping(), and
dropping it back at its new home. Every element outside that range stays put.
ScrollingStateTree::insertNode() now finds the node once and calls moveTo()
instead of remove + insert.

This is a constant-factor improvement, not an asymptotic one: the find() is
still O(n) and moveTo() shifts O(distance) elements, so a full reordering of N
siblings remains O(n^2) in the worst case. What it removes is the redundant
work each reorder did before -- one bounded shift instead of a full-length
remove memmove plus a full-length insert memmove -- and, in the common case
where a node moves only a short distance, the shift touches just the elements
in between rather than the whole tail.

The reorder path is unchanged behaviorally, so it stays covered by existing
tests. A childIndex of notFound (or otherwise past the end) still means
&quot;append&quot;: it is clamped to the last slot, preserving the tolerance
insertChild() has long needed for the out-of-range indices that crash data
shows do occur, rather than tripping moveTo()&apos;s bounds assertion. moveTo()
itself gets direct coverage in TestWebKitAPI, including same-position and
move-only element cases.

* Source/WTF/wtf/Vector.h:
(WTF::Vector::moveTo):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::insertNode):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/320527@main">https://commits.webkit.org/320527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38ae8d5179f696dd05c5750fd7e0786c4eb9505

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/413f1938-3abc-4100-875b-e783ee0162fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144574 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37509a94-d641-42c5-b639-4639a6952e9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89decf63-9c42-4e8c-9bc8-7919023ce87b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46963 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13658 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44726 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6373 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46255 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58573 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154044 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41265 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153702 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48214 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131573 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128208 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57775 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57135 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->