### PR TITLE
Reduce sizeof(DocumentThreadableLoader) by grouping its one-byte members

### DIFF
--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011, 2012 Google Inc. All rights reserved.
- * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -124,12 +124,12 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
     , m_options(options)
     , m_origin(WTF::move(origin))
     , m_referrer(WTF::move(referrer))
+    , m_contentSecurityPolicy(WTF::move(contentSecurityPolicy))
+    , m_crossOriginEmbedderPolicy(WTF::move(crossOriginEmbedderPolicy))
     , m_sameOriginRequest(protect(securityOrigin())->canRequest(request.url(), OriginAccessPatternsForWebProcess::singleton()))
     , m_simpleRequest(true)
     , m_async(blockingBehavior == LoadAsynchronously)
     , m_delayCallbacksForIntegrityCheck(!m_options.integrity.isEmpty())
-    , m_contentSecurityPolicy(WTF::move(contentSecurityPolicy))
-    , m_crossOriginEmbedderPolicy(WTF::move(crossOriginEmbedderPolicy))
     , m_shouldLogError(shouldLogError)
 {
     // Setting a referrer header is only supported in the async code path.

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, 2012 Google Inc. All rights reserved.
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -131,21 +131,21 @@ class CachedRawResource;
         WeakPtr<ThreadableLoaderClient> m_client;
         WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
         ThreadableLoaderOptions m_options;
-        bool m_responsesCanBeOpaque { true };
         RefPtr<SecurityOrigin> m_origin;
         String m_referrer;
-        bool m_sameOriginRequest;
-        bool m_simpleRequest;
-        bool m_async;
-        bool m_delayCallbacksForIntegrityCheck;
         std::unique_ptr<ContentSecurityPolicy> m_contentSecurityPolicy;
         std::optional<CrossOriginEmbedderPolicy> m_crossOriginEmbedderPolicy;
         RefPtr<CrossOriginPreflightChecker> m_preflightChecker;
         std::optional<HTTPHeaderMap> m_originalHeaders;
         URL m_responseURL;
-
-        ShouldLogError m_shouldLogError;
         std::optional<ResourceRequest> m_bypassingPreflightForServiceWorkerRequest;
+
+        bool m_responsesCanBeOpaque { true };
+        bool m_sameOriginRequest;
+        bool m_simpleRequest;
+        bool m_async;
+        bool m_delayCallbacksForIntegrityCheck;
+        ShouldLogError m_shouldLogError;
     };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0be71db6a0fd7c8d70790518ec8ba38870e92aca
<pre>
Reduce sizeof(DocumentThreadableLoader) by grouping its one-byte members
<a href="https://bugs.webkit.org/show_bug.cgi?id=322896">https://bugs.webkit.org/show_bug.cgi?id=322896</a>
<a href="https://rdar.apple.com/186149141">rdar://186149141</a>

Reviewed by Chris Dumez.

DocumentThreadableLoader declared its six one-byte members
(m_responsesCanBeOpaque, m_sameOriginRequest, m_simpleRequest, m_async,
m_delayCallbacksForIntegrityCheck, and the enum class : bool
m_shouldLogError) interleaved with 8-byte-aligned RefPtr/String/
unique_ptr/optional members. That scattered them across three separate
slots, each leaving alignment padding, and inflated the object.

Move all six one-byte members to the end of the member list so their
padding coalesces into a single slot, and reorder the constructor
initializer list to match the new declaration order (no -Wreorder). The
initialization is unaffected: m_sameOriginRequest still reads m_origin
and m_delayCallbacksForIntegrityCheck still reads m_options.integrity,
both of which remain initialized ahead of the grouped members.

sizeof(DocumentThreadableLoader) shrinks by 16 bytes on all 64-bit
targets (4 bytes on 32-bit); no behavior change.

* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
* Source/WebCore/loader/DocumentThreadableLoader.h:

Canonical link: <a href="https://commits.webkit.org/320314@main">https://commits.webkit.org/320314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7db34293f534d1bce607676363a1eb68c07ef2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148068 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c30efe6-9f22-4d24-a5a1-c2d1e55f6e85) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143436 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99604 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eed4c26a-3080-4423-8257-d0a147bef99d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186731 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47206 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure(s) based on results-db; Uploaded test results") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164193 "Build is in progress. Recent messages:Running configuration; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123857 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b653498-6acb-40cf-b76c-1babddf1bcbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45908 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44137 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43718 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57370 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58074 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40344 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; Ignored 3 pre-existing failure(s) based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152658 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47199 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130354 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126713 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56582 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18729 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55953 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->