### PR TITLE
PolicyChecker.cpp has a dead #undef and leaks five macros into the unified build

### DIFF
--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -420,7 +420,11 @@ void PolicyChecker::handleUnimplementablePolicy(const ResourceError& error)
 
 } // namespace WebCore
 
-#undef IS_ALLOWED
 #undef PAGE_ID
+#undef PAGE_ID_WITH_THIS
 #undef FRAME_ID
+#undef FRAME_ID_WITH_THIS
+#undef POLICYCHECKER_RELEASE_LOG_WITH_THIS
 #undef POLICYCHECKER_RELEASE_LOG
+#undef POLICYCHECKER_RELEASE_LOG_FORWARDABLE
+#undef POLICYCHECKER_RELEASE_LOG_FORWARDABLE_WITH_THIS


### PR DESCRIPTION
#### 8d2e7896295d7b73aaf7d2450ec35908326fbc55
<pre>
PolicyChecker.cpp has a dead #undef and leaks five macros into the unified build
<a href="https://bugs.webkit.org/show_bug.cgi?id=322897">https://bugs.webkit.org/show_bug.cgi?id=322897</a>
<a href="https://rdar.apple.com/186149389">rdar://186149389</a>

Reviewed by Chris Dumez.

The #undef block at the end of PolicyChecker.cpp did not match the
macros defined at the top of the file: it undef&apos;d IS_ALLOWED, which is
never defined, while leaving PAGE_ID_WITH_THIS, FRAME_ID_WITH_THIS,
POLICYCHECKER_RELEASE_LOG_WITH_THIS, POLICYCHECKER_RELEASE_LOG_FORWARDABLE,
and POLICYCHECKER_RELEASE_LOG_FORWARDABLE_WITH_THIS defined. These leak
into subsequent translation units in the unified build.

Remove the dead #undef and undef all eight macros that are defined.

* Source/WebCore/loader/PolicyChecker.cpp:

Canonical link: <a href="https://commits.webkit.org/320313@main">https://commits.webkit.org/320313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec354e8357bd92a5626aa023ac0fa7a0980d0c83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/feb9b586-d031-4196-8f6f-c167d31932fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57436 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143438 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 2 flakes 2 failures; Uploaded test results; 1 flakes 1 failures; Compiled WebKit (warnings); 1 failures; Running analyze-layout-tests-results") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99605 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff529af7-5660-43a8-a2a4-4ecebefed42a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123859 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/593009cb-bad2-492b-a3c9-6a587b0cc6fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45909 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44138 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43717 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5181 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195937 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57371 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41110 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58075 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152660 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47198 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130355 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126714 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56583 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18728 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56021 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->