### PR TITLE
[JSC] incorrect ValueProfile is used in BaselineJIT iterator_next

### DIFF
--- a/JSTests/stress/for-of-mixed-element-types-value-profile.js
+++ b/JSTests/stress/for-of-mixed-element-types-value-profile.js
@@ -1,0 +1,40 @@
+//@ skip if not $jitTests
+//@ $skipModes << :lockdown
+//@ requireOptions("--forceUnlinkedDFG=0")
+
+// The baseline JIT's fast-array op_iterator_next path must profile the iterated element into the
+// getValue checkpoint's value profile. When it wrote to the computeNext slot instead, the DFG kept
+// predicting the loop variable from whatever the LLInt had sampled, so it re-speculated the same
+// wrong type on every recompilation until the reoptimization retry counter ran out.
+
+function events(i)
+{
+    // Only the baseline JIT ever sees the number: by iteration 20000 this function is long past the
+    // LLInt.
+    return i < 20000 ? ["a", "bb", "ccc"] : ["a", "bb", 0];
+}
+noInline(events);
+
+function walk(i)
+{
+    let count = 0;
+    for (let event of events(i)) {
+        if (typeof event === "number")
+            count += event;
+        else
+            count += event.length;
+    }
+    return count;
+}
+noInline(walk);
+
+let total = 0;
+for (let i = 0; i < 300000; ++i)
+    total += walk(i);
+
+if (total !== 960000)
+    throw new Error(`bad result: ${total}`);
+
+const compiles = numberOfDFGCompiles(walk);
+if (compiles > 4)
+    throw new Error(`walk was DFG-compiled ${compiles} times; the loop variable's value profile is not being updated`);

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -465,7 +465,6 @@ void JIT::emit_op_iterator_next(const JSInstruction* instruction)
     genericCases.append(branchIfNotType(nextJSR.payloadGPR(), SentinelType));
 
     JumpList doneCases;
-#if CPU(ARM64) || CPU(X86_64)
     loadGlobalObject(argumentGPR0);
     emitGetVirtualRegister(bytecode.m_iterator, argumentGPR1);
     emitGetVirtualRegister(bytecode.m_iterable, argumentGPR2);
@@ -474,19 +473,7 @@ void JIT::emit_op_iterator_next(const JSInstruction* instruction)
     emitPutVirtualRegister(bytecode.m_done, returnValueGPR);
     emitPutVirtualRegister(bytecode.m_value, returnValueGPR2);
     doneCases.append(branchIfEmpty(JSValueRegs { returnValueGPR2 }));
-    emitValueProfilingSite(bytecode, JSValueRegs { returnValueGPR2 });
-#else
-    auto* tryFastFunction = ([&] () {
-        switch (instruction->width()) {
-        case Narrow: return iterator_next_try_fast_narrow;
-        case Wide16: return iterator_next_try_fast_wide16;
-        case Wide32: return iterator_next_try_fast_wide32;
-        default: RELEASE_ASSERT_NOT_REACHED();
-        }
-    })();
-    JITSlowPathCall slowPathCall(this, tryFastFunction);
-    slowPathCall.call();
-#endif
+    emitValueProfilingSite(bytecode, m_bytecodeIndex.withCheckpoint(OpIteratorNext::getValue), JSValueRegs { returnValueGPR2 });
     doneCases.append(jump());
 
     genericCases.link(this);


### PR DESCRIPTION
#### 26f0db0fe1756a9579a48c146dfc3f140bbfc193
<pre>
[JSC] incorrect ValueProfile is used in BaselineJIT iterator_next
<a href="https://bugs.webkit.org/show_bug.cgi?id=322899">https://bugs.webkit.org/show_bug.cgi?id=322899</a>
<a href="https://rdar.apple.com/186150753">rdar://186150753</a>

Reviewed by Keith Miller.

iterator_next fast path&apos;s result needs to be stored to getValue
checkpoint&apos;s ValueProfile.

Test: JSTests/stress/for-of-mixed-element-types-value-profile.js

* JSTests/stress/for-of-mixed-element-types-value-profile.js: Added.
(events):
(walk):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_iterator_next):

Canonical link: <a href="https://commits.webkit.org/320104@main">https://commits.webkit.org/320104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/802a23145f75976fb6404870f0e7ec16cc98e763

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148072 "Built successfully") | ⏳ 🛠 ios-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59049 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143440 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99608 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186735 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47210 "Found 1 new test failure: fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123861 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44141 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5830 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12663 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156306 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 2 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43721 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5184 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45057 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50359 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48409 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 343 new passes 14 flakes 7 failures; Uploaded test results; 343 new passes 16 flakes 4 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195940 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57374 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152978 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152662 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47202 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130358 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126719 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56586 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55957 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->