### PR TITLE
Inset box-shadow with a large spread paints outside the box on an inline box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box only</title>
+<style>
+div {
+    width: 200px;
+    height: 100px;
+    border: 40px solid transparent;
+    background-color: blue;
+    background-clip: padding-box;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box only</title>
+<style>
+div {
+    width: 200px;
+    height: 100px;
+    border: 40px solid transparent;
+    background-color: blue;
+    background-clip: padding-box;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: inset box-shadow with a spread larger than the box is clipped to the padding box</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#shadow-shape">
+<link rel="match" href="inset-shadow-large-spread-clipped-to-padding-box-ref.html">
+<style>
+div {
+    width: 200px;
+    height: 100px;
+    border: 40px solid transparent;
+    box-shadow: inset 0 0 0 400px blue;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box of each cloned inline fragment</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    width: 200px;
+    font: 20px/3 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    border: 10px solid transparent;
+    background-color: blue;
+    background-clip: padding-box;
+}
+</style>
+<div class="container">xx<span class="highlighted">xxxx xxxx</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box of each cloned inline fragment</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    width: 200px;
+    font: 20px/3 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    border: 10px solid transparent;
+    background-color: blue;
+    background-clip: padding-box;
+}
+</style>
+<div class="container">xx<span class="highlighted">xxxx xxxx</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: inset box-shadow with a spread larger than the box on a cloned inline fragment</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#shadow-shape">
+<link rel="help" href="https://drafts.csswg.org/css-break-3/#break-decoration">
+<link rel="match" href="inset-shadow-large-spread-cloned-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    width: 200px;
+    font: 20px/3 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    border: 10px solid transparent;
+    box-shadow: inset 0 0 0 400px blue;
+}
+</style>
+<div class="container">xx<span class="highlighted">xxxx xxxx</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box of each inline fragment</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    margin-left: 100px;
+    width: 200px;
+    font: 20px/1 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    background-color: blue;
+}
+</style>
+<div class="container">xxxx<span class="highlighted">xxxxxx xxxxxx</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: inset box-shadow covering the padding box of each inline fragment</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    margin-left: 100px;
+    width: 200px;
+    font: 20px/1 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    background-color: blue;
+}
+</style>
+<div class="container">xxxx<span class="highlighted">xxxxxx xxxxxx</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: inset box-shadow with a spread larger than the box on a fragmented inline box</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#shadow-shape">
+<link rel="match" href="inset-shadow-large-spread-fragmented-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+    margin-left: 100px;
+    width: 200px;
+    font: 20px/1 Ahem;
+    color: transparent;
+}
+
+.highlighted {
+    box-shadow: inset 0 0 0 400px blue;
+}
+</style>
+<div class="container">xxxx<span class="highlighted">xxxxxx xxxxxx</span></div>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -1055,7 +1055,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Style:
 
             auto shapeForInnerHole = BorderShape(outerRectExpandedToObscureOpenEdges, borderWidthsWithSpread, borderShape.radii(), borderShape.cornerCurvatures());
             if (shapeForInnerHole.snappedInnerRect(deviceScaleFactor).isEmpty()) {
-                shapeForInnerHole.fillOuterShape(context, shadowColor, deviceScaleFactor);
+                borderShape.fillInnerShape(context, shadowColor, deviceScaleFactor);
                 continue;
             }
 


### PR DESCRIPTION
#### 60dff96f744e06b88277d5035aa145ea000e6bb4
<pre>
Inset box-shadow with a large spread paints outside the box on an inline box
<a href="https://bugs.webkit.org/show_bug.cgi?id=322214">https://bugs.webkit.org/show_bug.cgi?id=322214</a>
&lt;<a href="https://rdar.apple.com/problem/185651318">rdar://problem/185651318</a>&gt;

Reviewed by Simon Fraser.

  &lt;div style=&quot;width: 200px&quot;&gt;
    before
    &lt;span style=&quot;box-shadow: inset 0 0 0 400px blue&quot;&gt;
      first &lt;br&gt;
      second
    &lt;/span&gt;
  &lt;/div&gt;

The blue _inset_ shadow should stop at the end of each line&apos;s fragment. Instead it ran 400px past it to the containing block.
When an inline box is split across lines, the incoming edge value (where it breaks) is &quot;open&quot; and the box keeps growing to the next line.
(Note inset shadows are clipped to the padding box)

  paintRect                      expansion = blur extent + spread
  +--------------------------+- - - - - - - - - - - - - - - - -+
  |##########################|                                 |
  |###+----------------------+- - - - - - - - - - - - - - -+   |
  |###|  hole, reaching the break edge                     |   |
  |###+----------------------+- - - - - - - - - - - - - - -+   |
  |##########################|                                 |
  +--------------------------+- - - - - - - - - - - - - - - - -+
  |&lt;--- clip: padding box --&gt;|  everything past here is clipped

On trunk we call shapeForInnerHole.fillOuterShape() when shapeForInnerHole is empty (i.e. inset shadow covers the box).
With no hole left, we just call fill on the &quot;grown&quot; rect before any clip is applied.

  +-----------+- - - - - - - - - - - - - -+
  |###########|###########################|
  +-----------+- - - - - - - - - - - - - -+
   fragment     spread carries it 400px
                past the line break

but what we should do instead is this:

  +-----------+
  |###########|
  +-----------+
    fragment

So let&apos;s call borderShape.fillInnerShape() instead. borderShape is the box itself, not the &quot;grown&quot; rect, and its inner shape is the padding box.

It also fixes blocks: on trunk a block with a transparent border paints the shadow under the border (the outer shape is the border box),
now it stops at the padding box.

Tests: imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box.html
       imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline.html
       imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline.html

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-clipped-to-padding-box.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-cloned-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/inset-shadow-large-spread-fragmented-inline.html: Added.

Canonical link: <a href="https://commits.webkit.org/320150@main">https://commits.webkit.org/320150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d87459e73d82f3f6c26370b55ffd20b1da366727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148077 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143445 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99612 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123866 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44146 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43726 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5189 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152983 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41002 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58083 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152667 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47207 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130363 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126734 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56591 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18737 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55962 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56029 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->