### PR TITLE
LegacyWebArchive iframe wrapper for copied framesets emits literal "98%%" width/height

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -894,7 +894,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createFromSelection(LocalFrame* frame
 
     // Wrap the frameset document in an iframe so it can be pasted into
     // another document (which will have a body or frameset of its own). 
-    auto iframeMarkup = makeString("<iframe frameborder=\"no\" marginwidth=\"0\" marginheight=\"0\" width=\"98%%\" height=\"98%%\" src=\""_s, frame->loader().documentLoader()->response().url().string(), "\"></iframe>"_s);
+    auto iframeMarkup = makeString("<iframe frameborder=\"no\" marginwidth=\"0\" marginheight=\"0\" width=\"98%\" height=\"98%\" src=\""_s, frame->loader().documentLoader()->response().url().string(), "\"></iframe>"_s);
     auto iframeResource = ArchiveResource::create(utf8Buffer(iframeMarkup), aboutBlankURL(), textHTMLContentTypeAtom(), "UTF-8"_s, String());
 
     return create(iframeResource.releaseNonNull(), { }, { archive.releaseNonNull() }, frame->frameID());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
@@ -82,6 +82,45 @@ NSString *readHTMLStringFromPasteboard()
 
 #endif
 
+static RetainPtr<NSData> readWebArchiveDataFromPasteboard()
+{
+#if PLATFORM(MAC)
+    return [NSPasteboard.generalPasteboard dataForType:UTTypeWebArchive.identifier];
+#else
+    return [UIPasteboard.generalPasteboard dataForPasteboardType:UTTypeWebArchive.identifier];
+#endif
+}
+
+// When a frameset document is copied, LegacyWebArchive::createFromSelection wraps the frameset in an
+// <iframe> so it can be pasted into a document that has its own body/frameset. The wrapper markup must
+// use a single-percent width/height ("98%"), not a printf-style escaped "98%%".
+TEST(CopyHTML, FramesetSelectionIframeWrapperUsesSinglePercent)
+{
+    auto webView = createWebViewWithCustomPasteboardDataEnabled();
+    [webView synchronouslyLoadHTMLString:@"<frameset rows=\"50%,50%\">"
+        "<frame src=\"about:blank\">"
+        "<frame src=\"about:blank\">"
+        "</frameset>" baseURL:[NSURL URLWithString:@"https://webkit.org/frameset.html"]];
+    [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.documentElement)"];
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr archiveData = readWebArchiveDataFromPasteboard();
+    EXPECT_GT([archiveData length], 0U);
+
+    RetainPtr archive = dynamic_objc_cast<NSDictionary>([NSPropertyListSerialization propertyListWithData:archiveData.get() options:0 format:nullptr error:nullptr]);
+    RetainPtr mainResourceData = dynamic_objc_cast<NSData>([[archive objectForKey:@"WebMainResource"] objectForKey:@"WebResourceData"]);
+    RetainPtr mainMarkup = adoptNS([[NSString alloc] initWithData:mainResourceData.get() encoding:NSUTF8StringEncoding]);
+
+    EXPECT_TRUE([mainMarkup containsString:@"<iframe"]);
+    EXPECT_TRUE([mainMarkup containsString:@"width=\"98%\""]);
+    EXPECT_TRUE([mainMarkup containsString:@"height=\"98%\""]);
+    EXPECT_FALSE([mainMarkup containsString:@"98%%"]);
+
+    // The frameset itself is preserved as a subframe archive of the iframe wrapper.
+    EXPECT_NOT_NULL([archive objectForKey:@"WebSubframeArchives"]);
+}
+
 TEST(CopyHTML, Sanitizes)
 {
     auto webView = createWebViewWithCustomPasteboardDataEnabled();


### PR DESCRIPTION
#### a70377af0564cae4749383349407e6e2c6be4b1e
<pre>
LegacyWebArchive iframe wrapper for copied framesets emits literal &quot;98%%&quot; width/height
<a href="https://bugs.webkit.org/show_bug.cgi?id=322902">https://bugs.webkit.org/show_bug.cgi?id=322902</a>
<a href="https://rdar.apple.com/186161217">rdar://186161217</a>

Reviewed by Chris Dumez.

When a frameset document is copied, LegacyWebArchive::createFromSelection() wraps
the frameset in an &lt;iframe&gt; so it can be pasted into a document that has its own
body or frameset. The wrapper markup is built with makeString(), which does no
printf-style format expansion, but the width and height were written as &quot;98%%&quot;.
The doubled percent is only meaningful to a printf-family formatter; makeString()
copies it verbatim, so the generated markup contained the invalid literal
width=&quot;98%%&quot; height=&quot;98%%&quot; instead of width=&quot;98%&quot; height=&quot;98%&quot;.

Use a single percent so the wrapper iframe is sized correctly.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createFromSelection): Emit &quot;98%&quot; instead of &quot;98%%&quot;.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm:
(TestWebKitAPI::readWebArchiveDataFromPasteboard): Added.
(TestWebKitAPI::TEST(CopyHTML, FramesetSelectionIframeWrapperUsesSinglePercent)):
Added. Copies a frameset, reads the web archive off the pasteboard, and asserts
the wrapper main resource uses width=&quot;98%&quot;/he%&quot;.

Canonical link: <a href="https://commits.webkit.org/320317@main">https://commits.webkit.org/320317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d912be9ad05e5b0274a343177d47404a294e080c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/41118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28003 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->