### PR TITLE
Use StringView for more CSS parsing functions now that CSSTokenizer supports it

### DIFF
--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -82,7 +82,7 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
         // CSSNestedDeclarations parsing is allowed if there is an ancestor style rule or an ancestor scope rule.
         if (!nestedContextWithCurrentRule)
             return Exception { ExceptionCode::SyntaxError };
-        newRule = CSSParser::parseNestedDeclarations(parserContext(), ruleString);
+        newRule = CSSParser::parseNestedDeclarations(ruleString, parserContext());
         if (!newRule)
             return Exception { ExceptionCode::SyntaxError };
     }

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -239,7 +239,7 @@ ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigne
     RefPtr styleSheet = parentStyleSheet();
     RefPtr newRule = CSSParser::parseRule(ruleString, parserContext(), styleSheet ? protect(styleSheet->contents()).ptr() : nullptr, CSSParser::AllowedRules::ImportRules, CSSParserEnum::NestedContextType::Style);
     if (!newRule) {
-        newRule = CSSParser::parseNestedDeclarations(parserContext(), ruleString);
+        newRule = CSSParser::parseNestedDeclarations(ruleString, parserContext());
         if (!newRule)
             return Exception { ExceptionCode::SyntaxError };
     }

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -101,7 +101,7 @@ CSSParser::CSSParser(const CSSParserContext& context, StyleSheetContents* styleS
 {
 }
 
-CSSParser::CSSParser(const CSSParserContext& context, const String& string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper, CSSParserEnum::NestedContext nestedContext)
+CSSParser::CSSParser(const CSSParserContext& context, StringView string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper, CSSParserEnum::NestedContext nestedContext)
     : m_context(context)
     , m_styleSheet(styleSheet)
     , m_tokenizer(wrapper ? CSSTokenizer::tryCreate(string, *wrapper) : CSSTokenizer::tryCreate(string))
@@ -112,7 +112,7 @@ CSSParser::CSSParser(const CSSParserContext& context, const String& string, Styl
         m_ancestorRuleTypeStack.append(*nestedContext);
 }
 
-auto CSSParser::parseValue(MutableStyleProperties& declaration, CSSPropertyID propertyID, const String& string, IsImportant important, const CSSParserContext& context) -> ParseResult
+auto CSSParser::parseValue(MutableStyleProperties& declaration, CSSPropertyID propertyID, StringView string, IsImportant important, const CSSParserContext& context) -> ParseResult
 {
     auto ruleType = context.enclosingRuleType.value_or(StyleRuleType::Style);
 
@@ -132,7 +132,7 @@ auto CSSParser::parseValue(MutableStyleProperties& declaration, CSSPropertyID pr
     return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? ParseResult::Changed : ParseResult::Unchanged;
 }
 
-auto CSSParser::parseCustomPropertyValue(MutableStyleProperties& declaration, const AtomString& propertyName, const String& string, IsImportant important, const CSSParserContext& context) -> ParseResult
+auto CSSParser::parseCustomPropertyValue(MutableStyleProperties& declaration, const AtomString& propertyName, StringView string, IsImportant important, const CSSParserContext& context) -> ParseResult
 {
     CSSParser parser(context, string);
 
@@ -187,7 +187,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     return result;
 }
 
-Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const String& string, const Element& element)
+Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(StringView string, const Element& element)
 {
     CSSParserContext context(element.document());
     context.mode = strictToCSSParserMode(element.isHTMLElement() && !element.document().inQuirksMode());
@@ -197,7 +197,7 @@ Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const Strin
     return createStyleProperties(parser.topContext().m_parsedProperties, context.mode);
 }
 
-bool CSSParser::parseDeclarationList(MutableStyleProperties& declaration, const String& string, const CSSParserContext& context)
+bool CSSParser::parseDeclarationList(MutableStyleProperties& declaration, StringView string, const CSSParserContext& context)
 {
     CSSParser parser(context, string);
     auto ruleType = context.enclosingRuleType.value_or(StyleRuleType::Style);
@@ -216,7 +216,7 @@ bool CSSParser::parseDeclarationList(MutableStyleProperties& declaration, const 
     return declaration.addParsedProperties(results);
 }
 
-RefPtr<StyleRuleBase> CSSParser::parseRule(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRules allowedRules, CSSParserEnum::NestedContext nestedContext)
+RefPtr<StyleRuleBase> CSSParser::parseRule(StringView string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRules allowedRules, CSSParserEnum::NestedContext nestedContext)
 {
     CSSParser parser(context, string, styleSheet, nullptr, nestedContext);
     CSSParserTokenRange range = parser.tokenizer()->tokenRange();
@@ -236,13 +236,13 @@ RefPtr<StyleRuleBase> CSSParser::parseRule(const String& string, const CSSParser
     return rule;
 }
 
-RefPtr<StyleRuleKeyframe> CSSParser::parseKeyframeRule(const String& string, const CSSParserContext& context)
+RefPtr<StyleRuleKeyframe> CSSParser::parseKeyframeRule(StringView string, const CSSParserContext& context)
 {
     RefPtr keyframe = parseRule(string, context, nullptr, CSSParser::AllowedRules::KeyframeRules);
     return downcast<StyleRuleKeyframe>(keyframe.get());
 }
 
-RefPtr<StyleRuleNestedDeclarations> CSSParser::parseNestedDeclarations(const CSSParserContext&context , const String& string)
+RefPtr<StyleRuleNestedDeclarations> CSSParser::parseNestedDeclarations(StringView string, const CSSParserContext& context)
 {
     auto properties = MutableStyleProperties::createEmpty();
     if (!parseDeclarationList(properties, string , context))
@@ -251,7 +251,7 @@ RefPtr<StyleRuleNestedDeclarations> CSSParser::parseNestedDeclarations(const CSS
     return StyleRuleNestedDeclarations::create(WTF::move(properties));
 }
 
-void CSSParser::parseStyleSheet(const String& string, const CSSParserContext& context, StyleSheetContents& styleSheet)
+void CSSParser::parseStyleSheet(StringView string, const CSSParserContext& context, StyleSheetContents& styleSheet)
 {
     CSSParser parser(context, string, &styleSheet, nullptr);
     bool firstRuleValid = parser.consumeRuleList(parser.tokenizer()->tokenRange(), RuleList::TopLevel, [&](Ref<StyleRuleBase> rule) {
@@ -318,7 +318,7 @@ bool CSSParser::supportsDeclaration(CSSParserTokenRange& range)
     return result;
 }
 
-void CSSParser::parseDeclarationListForInspector(const String& declaration, const CSSParserContext& context, CSSParserObserver& observer)
+void CSSParser::parseDeclarationListForInspector(StringView declaration, const CSSParserContext& context, CSSParserObserver& observer)
 {
     Ref wrapper = CSSParserObserverWrapper::create(observer);
     CSSParser parser(context, declaration, nullptr, wrapper.ptr());
@@ -327,7 +327,7 @@ void CSSParser::parseDeclarationListForInspector(const String& declaration, cons
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), StyleRuleType::Style);
 }
 
-void CSSParser::parseStyleSheetForInspector(const String& string, const CSSParserContext& context, StyleSheetContents& styleSheet, CSSParserObserver& observer)
+void CSSParser::parseStyleSheetForInspector(StringView string, const CSSParserContext& context, StyleSheetContents& styleSheet, CSSParserObserver& observer)
 {
     Ref wrapper = CSSParserObserverWrapper::create(observer);
     CSSParser parser(context, string, &styleSheet, wrapper.ptr());

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -71,10 +71,6 @@ class ImmutableStyleProperties;
 class Element;
 class MutableStyleProperties;
 
-namespace Style {
-struct Color;
-}
-
 enum CSSAtRuleID : uint8_t;
 
 class CSSParser {
@@ -85,9 +81,6 @@ public:
         Unchanged,
         Error
     };
-
-    CSSParser(const CSSParserContext&, const String&, StyleSheetContents* = nullptr, CSSParserObserverWrapper* = nullptr, CSSParserEnum::NestedContext = { });
-    ~CSSParser();
 
     enum class AllowedRules : uint8_t {
         // As per css-syntax, css-cascade and css-namespaces, @charset rules
@@ -106,28 +99,32 @@ public:
         NoRules, // For parsing at-rules inside declaration lists (without nesting support)
     };
 
-    static ParseResult parseValue(MutableStyleProperties&, CSSPropertyID, const String&, IsImportant, const CSSParserContext&);
-    static ParseResult parseCustomPropertyValue(MutableStyleProperties&, const AtomString& propertyName, const String&, IsImportant, const CSSParserContext&);
-    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element&);
-    WEBCORE_EXPORT static bool parseDeclarationList(MutableStyleProperties&, const String&, const CSSParserContext&);
-    static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRules, CSSParserEnum::NestedContext = { });
-    static RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&, const CSSParserContext&);
-    static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
+    CSSParser(const CSSParserContext&, StringView string LIFETIME_BOUND, StyleSheetContents* = nullptr, CSSParserObserverWrapper* = nullptr, CSSParserEnum::NestedContext = { });
+    ~CSSParser();
+
+    static ParseResult parseValue(MutableStyleProperties&, CSSPropertyID, StringView, IsImportant, const CSSParserContext&);
+    static ParseResult parseCustomPropertyValue(MutableStyleProperties&, const AtomString& propertyName, StringView, IsImportant, const CSSParserContext&);
+    WEBCORE_EXPORT static bool parseDeclarationList(MutableStyleProperties&, StringView, const CSSParserContext&);
+
+    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(StringView, const Element&);
+    static RefPtr<StyleRuleBase> parseRule(StringView, const CSSParserContext&, StyleSheetContents*, AllowedRules, CSSParserEnum::NestedContext = { });
+    static RefPtr<StyleRuleKeyframe> parseKeyframeRule(StringView, const CSSParserContext&);
+    static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(StringView, const CSSParserContext&);
+
+    static void parseStyleSheet(StringView, const CSSParserContext&, StyleSheetContents&);
     static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
 
     bool supportsDeclaration(CSSParserTokenRange&);
-    const CSSParserContext& context() const LIFETIME_BOUND { return m_context; }
 
     // This function updates the range it's given.
     RefPtr<StyleRuleBase> consumeAtRule(CSSParserTokenRange&, AllowedRules);
 
-    static void parseDeclarationListForInspector(const String&, const CSSParserContext&, CSSParserObserver&);
-    static void parseStyleSheetForInspector(const String&, const CSSParserContext&, StyleSheetContents&, CSSParserObserver&);
+    static void parseDeclarationListForInspector(StringView, const CSSParserContext&, CSSParserObserver&);
+    static void parseStyleSheetForInspector(StringView, const CSSParserContext&, StyleSheetContents&, CSSParserObserver&);
 
     static IsImportant consumeTrailingImportantAndWhitespace(CSSParserTokenRange&);
 
-    static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
-
+    const CSSParserContext& context() const LIFETIME_BOUND { return m_context; }
     const CSSTokenizer* tokenizer() const LIFETIME_BOUND { return m_tokenizer.get(); }
 
 private:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -270,7 +270,7 @@ bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important
     return parseSuccess;
 }
 
-RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID property, const String& string, const CSSParserContext& context)
+RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID property, StringView string, const CSSParserContext& context)
 {
     ASSERT(!WebCore::isShorthand(property));
 
@@ -324,7 +324,7 @@ RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID pro
     return value;
 }
 
-RefPtr<CSSValue> CSSPropertyParser::parseCounterStyleDescriptor(CSSPropertyID property, const String& string, const CSSParserContext& context)
+RefPtr<CSSValue> CSSPropertyParser::parseCounterStyleDescriptor(CSSPropertyID property, StringView string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -57,11 +57,11 @@ public:
     static bool parseValue(CSSPropertyID, IsImportant, CSSParserTokenRange, const CSSParserContext&, Vector<CSSProperty, 256>& result, StyleRuleType, const CSSNamespacePrefixMap& = { });
 
     // Parses a longhand style property.
-    static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, const String&, const CSSParserContext&);
+    static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, StringView, const CSSParserContext&);
     static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, CSSParserTokenRange, const CSSParserContext&);
 
     // Parses a @counter-style descriptor.
-    static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, const String&, const CSSParserContext&);
+    static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, StringView, const CSSParserContext&);
 
     static RefPtr<const Style::CustomProperty> parseTypedCustomPropertyInitialValue(const AtomString&, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&);
     static std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&, Style::IsAttrTainted);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -87,7 +87,7 @@ Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParse
     }
 }
 
-Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String& string, const CSSParserContext& context)
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(StringView string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
@@ -47,7 +47,7 @@ Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParse
 
 // MARK: <keyframe-selector> parsing
 // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
-Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String&, const CSSParserContext&);
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(StringView, const CSSParserContext&);
 
 // MARK: <keyframes-name> consuming
 // https://drafts.csswg.org/css-animations/#typedef-keyframes-name

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -918,7 +918,7 @@ Color consumeColorRaw(CSSParserTokenRange& range, CSS::PropertyParserState& prop
 
 // MARK: - Raw parsing entry points
 
-Color parseColorRawGeneral(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
+Color parseColorRawGeneral(StringView string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
 {
     CSSTokenizer tokenizer(string);
     CSSParserTokenRange range(tokenizer.tokenRange());
@@ -938,7 +938,7 @@ Color parseColorRawGeneral(const String& string, const CSSParserContext& context
     return createColor(*result, eagerResolutionState);
 }
 
-Color deprecatedParseColorRawWithoutContext(const String& string, const CSSColorParsingOptions& options)
+Color deprecatedParseColorRawWithoutContext(StringView string, const CSSColorParsingOptions& options)
 {
     auto& context = strictCSSParserContext();
     if (auto color = CSSParserFastPaths::parseSimpleColor(string, context))

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -69,19 +69,19 @@ WebCore::Color consumeColorRaw(CSSParserTokenRange&, CSS::PropertyParserState&, 
 
 // Parse with default options.
 // NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
-WebCore::Color parseColorRaw(const String&, const CSSParserContext&, ScriptExecutionContext&);
+WebCore::Color parseColorRaw(StringView, const CSSParserContext&, ScriptExecutionContext&);
 
 // Fast variant to be used when ScriptExecutionContext is expensive to obtain or when need to pass parsing options.
 // If the result is invalid, callers should call parseColorRawGeneral().
 // NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
-WebCore::Color parseColorRawSimple(const String&, const CSSParserContext&);
+WebCore::Color parseColorRawSimple(StringView, const CSSParserContext&);
 
 // Parse with specific options.
-WEBCORE_EXPORT WebCore::Color parseColorRawGeneral(const String&, const CSSParserContext&, ScriptExecutionContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
+WEBCORE_EXPORT WebCore::Color parseColorRawGeneral(StringView, const CSSParserContext&, ScriptExecutionContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // FIXME: All callers are not getting the right Settings, keyword resolution and calc resolution
 // when using this function and should switch to parseColorRaw().
-WEBCORE_EXPORT WebCore::Color deprecatedParseColorRawWithoutContext(const String&, const CSSColorParsingOptions& = { });
+WEBCORE_EXPORT WebCore::Color deprecatedParseColorRawWithoutContext(StringView, const CSSColorParsingOptions& = { });
 
 // MARK: <dynamic-range-limit> (unresolved)
 std::optional<CSS::DynamicRangeLimit> consumeUnresolvedDynamicRangeLimit(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
@@ -110,7 +110,7 @@ std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange
     return result;
 }
 
-std::optional<CSS::ColorScheme> parseUnresolvedColorScheme(const String& string, const CSSParserContext& context)
+std::optional<CSS::ColorScheme> parseUnresolvedColorScheme(StringView string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.h
@@ -49,7 +49,7 @@ namespace CSSPropertyParserHelpers {
 std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <'color-scheme'> parsing (unresolved)
-std::optional<CSS::ColorScheme> parseUnresolvedColorScheme(const String&, const CSSParserContext&);
+std::optional<CSS::ColorScheme> parseUnresolvedColorScheme(StringView, const CSSParserContext&);
 
 // MARK: <'color-scheme'> consuming (CSSValue)
 RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
@@ -33,12 +33,12 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: <color> parsing (raw)
 
-inline WebCore::Color parseColorRawSimple(const String& string, const CSSParserContext& context)
+inline WebCore::Color parseColorRawSimple(StringView string, const CSSParserContext& context)
 {
     return CSSParserFastPaths::parseSimpleColor(string, context);
 }
 
-inline WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext)
+inline WebCore::Color parseColorRaw(StringView string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext)
 {
     auto color = parseColorRawSimple(string, context);
     if (color.isValid())

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.cpp
@@ -367,7 +367,7 @@ RefPtr<CSSValue> consumeEasingFunction(CSSParserTokenRange& range, CSS::Property
     return { };
 }
 
-RefPtr<TimingFunction> parseEasingFunctionDeprecated(const String& string, const CSSParserContext& context)
+RefPtr<TimingFunction> parseEasingFunctionDeprecated(StringView string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h
@@ -52,7 +52,7 @@ std::optional<CSS::EasingFunction> consumeUnresolvedEasingFunction(CSSParserToke
 RefPtr<CSSValue> consumeEasingFunction(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <easing-function> parsing (raw)
-RefPtr<TimingFunction> parseEasingFunctionDeprecated(const String&, const CSSParserContext&);
+RefPtr<TimingFunction> parseEasingFunctionDeprecated(StringView, const CSSParserContext&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
@@ -455,7 +455,7 @@ RefPtr<CSSValue> consumeAppleColorFilter(CSSParserTokenRange& range, CSS::Proper
     return nullptr;
 }
 
-std::optional<Style::Filter> parseFilterValueListOrNoneRaw(const String& string, const CSSParserContext& context, const Document& document, Style::ComputedStyle& style)
+std::optional<Style::Filter> parseFilterValueListOrNoneRaw(StringView string, const CSSParserContext& context, const Document& document, Style::ComputedStyle& style)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.h
@@ -64,7 +64,7 @@ std::optional<CSS::Filter> consumeUnresolvedFilter(CSSParserTokenRange&, CSS::Pr
 std::optional<CSS::AppleColorFilter> consumeUnresolvedAppleColorFilter(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <'filter'> parsing (raw)
-std::optional<Style::Filter> parseFilterValueListOrNoneRaw(const String&, const CSSParserContext&, const Document&, Style::ComputedStyle&);
+std::optional<Style::Filter> parseFilterValueListOrNoneRaw(StringView, const CSSParserContext&, const Document&, Style::ComputedStyle&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -455,7 +455,7 @@ static std::optional<UnresolvedFont> consumeUnresolvedFont(CSSParserTokenRange& 
     };
 }
 
-std::optional<UnresolvedFont> parseUnresolvedFont(const String& string, ScriptExecutionContext& context, std::optional<CSSParserMode> parserModeOverride)
+std::optional<UnresolvedFont> parseUnresolvedFont(StringView string, ScriptExecutionContext& context, std::optional<CSSParserMode> parserModeOverride)
 {
     auto parserContext = CSSParserContext(parserModeOverride ? *parserModeOverride : parserMode(context));
     auto tokenizer = CSSTokenizer(string);
@@ -633,7 +633,7 @@ RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange& range, CSS::Propert
     return CSSValueList::createCommaSeparated(WTF::move(values));
 }
 
-RefPtr<CSSValueList> parseFontFaceSrc(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValueList> parseFontFaceSrc(StringView string, ScriptExecutionContext& context)
 {
     RefPtr document = dynamicDowncast<Document>(context);
     CSSParserContext parserContext = document ? CSSParserContext(*document) : CSSParserContext(HTMLStandardMode);
@@ -655,7 +655,7 @@ RefPtr<CSSValueList> parseFontFaceSrc(const String& string, ScriptExecutionConte
 
 // MARK: @font-face 'size-adjust'
 
-RefPtr<CSSValue> parseFontFaceSizeAdjust(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceSizeAdjust(StringView string, ScriptExecutionContext& context)
 {
     // <'size-adjust'> = <percentage [0,∞]>
     // https://www.w3.org/TR/css-fonts-5/#descdef-font-face-size-adjust
@@ -677,7 +677,7 @@ RefPtr<CSSValue> parseFontFaceSizeAdjust(const String& string, ScriptExecutionCo
     return parsedValue;
 }
 
-static RefPtr<CSSValue> parseFontFaceMetricOverride(const String& string, ScriptExecutionContext& context,
+static RefPtr<CSSValue> parseFontFaceMetricOverride(StringView string, ScriptExecutionContext& context,
     NOESCAPE const Function<RefPtr<CSSValue>(CSSParserTokenRange&, CSS::PropertyParserState&)>& consumeMetricOverride)
 {
     // <font-metrics-override> = normal | <percentage [0,∞]>
@@ -700,24 +700,24 @@ static RefPtr<CSSValue> parseFontFaceMetricOverride(const String& string, Script
     return parsedValue;
 }
 
-RefPtr<CSSValue> parseFontFaceAscentOverride(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceAscentOverride(StringView string, ScriptExecutionContext& context)
 {
     return parseFontFaceMetricOverride(string, context, CSSPropertyParsing::consumeFontFaceAscentOverride);
 }
 
-RefPtr<CSSValue> parseFontFaceDescentOverride(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceDescentOverride(StringView string, ScriptExecutionContext& context)
 {
     return parseFontFaceMetricOverride(string, context, CSSPropertyParsing::consumeFontFaceDescentOverride);
 }
 
-RefPtr<CSSValue> parseFontFaceLineGapOverride(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceLineGapOverride(StringView string, ScriptExecutionContext& context)
 {
     return parseFontFaceMetricOverride(string, context, CSSPropertyParsing::consumeFontFaceLineGapOverride);
 }
 
 // MARK: @font-face 'unicode-range'
 
-RefPtr<CSSValueList> parseFontFaceUnicodeRange(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValueList> parseFontFaceUnicodeRange(StringView string, ScriptExecutionContext& context)
 {
     // <'unicode-range'> = <unicode-range-token>#
     // https://drafts.csswg.org/css-fonts/#descdef-font-face-unicode-range
@@ -740,7 +740,7 @@ RefPtr<CSSValueList> parseFontFaceUnicodeRange(const String& string, ScriptExecu
 
 // MARK: @font-face 'font-display'
 
-RefPtr<CSSValue> parseFontFaceDisplay(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceDisplay(StringView string, ScriptExecutionContext& context)
 {
     // <'font-display'> = auto | block | swap | fallback | optional
     // https://drafts.csswg.org/css-fonts/#descdef-font-face-font-display
@@ -763,7 +763,7 @@ RefPtr<CSSValue> parseFontFaceDisplay(const String& string, ScriptExecutionConte
 
 // MARK: @font-face 'font-style'
 
-RefPtr<CSSValue> parseFontFaceFontStyle(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceFontStyle(StringView string, ScriptExecutionContext& context)
 {
     // <'font-style'> = auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?
     // https://drafts.csswg.org/css-fonts/#descdef-font-face-font-style
@@ -915,7 +915,7 @@ RefPtr<CSSValue> consumeFeatureTagValue(CSSParserTokenRange& range, CSS::Propert
     return CSSFontFeatureValue::create(WTF::move(*tag), WTF::move(*tagValue));
 }
 
-RefPtr<CSSValue> parseFontFaceFeatureSettings(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceFeatureSettings(StringView string, ScriptExecutionContext& context)
 {
     // <'font-feature-settings'> = normal | <feature-tag-value>#
     // https://drafts.csswg.org/css-fonts/#descdef-font-face-font-feature-settings
@@ -961,7 +961,7 @@ RefPtr<CSSValue> consumeVariationTagValue(CSSParserTokenRange& range, CSS::Prope
 
 // MARK: @font-face 'font-width'
 
-RefPtr<CSSValue> parseFontFaceFontWidth(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceFontWidth(StringView string, ScriptExecutionContext& context)
 {
     // <font-width> = auto | <'font-width'>{1,2}
     // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-width
@@ -985,7 +985,7 @@ RefPtr<CSSValue> parseFontFaceFontWidth(const String& string, ScriptExecutionCon
 
 // MARK: @font-face 'font-weight'
 
-RefPtr<CSSValue> parseFontFaceFontWeight(const String& string, ScriptExecutionContext& context)
+RefPtr<CSSValue> parseFontFaceFontWeight(StringView string, ScriptExecutionContext& context)
 {
     // <'font-weight'> = auto | <font-weight-absolute>{1,2}
     // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-weight

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -100,7 +100,7 @@ struct UnresolvedFont {
 
 // MARK: 'font' (shorthand)
 // https://drafts.csswg.org/css-fonts-4/#font-prop
-std::optional<UnresolvedFont> parseUnresolvedFont(const String&, ScriptExecutionContext&, std::optional<CSSParserMode> parserModeOverride = std::nullopt);
+std::optional<UnresolvedFont> parseUnresolvedFont(StringView, ScriptExecutionContext&, std::optional<CSSParserMode> parserModeOverride = std::nullopt);
 
 // MARK: 'font-style'
 // https://drafts.csswg.org/css-fonts-4/#font-style-prop
@@ -125,7 +125,7 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange&, CSS::PropertyParser
 
 // MARK: @font-face 'src'
 // https://drafts.csswg.org/css-fonts-4/#src-desc
-RefPtr<CSSValueList> parseFontFaceSrc(const String&, ScriptExecutionContext&);
+RefPtr<CSSValueList> parseFontFaceSrc(StringView, ScriptExecutionContext&);
 RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange&, CSS::PropertyParserState&);
 // Sub-production of 'src: <font-tech>
 // https://drafts.csswg.org/css-fonts-4/#font-tech-values
@@ -136,31 +136,31 @@ String consumeFontFormat(CSSParserTokenRange&, CSS::PropertyParserState&, bool r
 
 // MARK: @font-face 'size-adjust'
 // https://drafts.csswg.org/css-fonts-5/#descdef-font-face-size-adjust
-RefPtr<CSSValue> parseFontFaceSizeAdjust(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceSizeAdjust(StringView, ScriptExecutionContext&);
 
 // MARK: @font-face 'unicode-range'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-unicode-range
-RefPtr<CSSValueList> parseFontFaceUnicodeRange(const String&, ScriptExecutionContext&);
+RefPtr<CSSValueList> parseFontFaceUnicodeRange(StringView, ScriptExecutionContext&);
 
 // MARK: @font-face 'font-display'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-display
-RefPtr<CSSValue> parseFontFaceDisplay(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceDisplay(StringView, ScriptExecutionContext&);
 
 // MARK: @font-face metric override descriptors
 // https://drafts.csswg.org/css-fonts-4/#font-metrics-override-desc
-RefPtr<CSSValue> parseFontFaceAscentOverride(const String&, ScriptExecutionContext&);
-RefPtr<CSSValue> parseFontFaceDescentOverride(const String&, ScriptExecutionContext&);
-RefPtr<CSSValue> parseFontFaceLineGapOverride(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceAscentOverride(StringView, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceDescentOverride(StringView, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceLineGapOverride(StringView, ScriptExecutionContext&);
 
 // MARK: @font-face 'font-style'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-style
-RefPtr<CSSValue> parseFontFaceFontStyle(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceFontStyle(StringView, ScriptExecutionContext&);
 RefPtr<CSSValue> consumeFontFaceFontStyle(CSSParserTokenRange&, CSS::PropertyParserState&);
 std::optional<CSS::FontStyleRange> consumeUnresolvedFontFaceFontStyle(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: @font-face 'font-feature-settings'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-feature-settings
-RefPtr<CSSValue> parseFontFaceFeatureSettings(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceFeatureSettings(StringView, ScriptExecutionContext&);
 // Sub-production of 'font-feature-settings': <feature-tag-value>
 // https://drafts.csswg.org/css-fonts-4/#feature-tag-value
 RefPtr<CSSValue> consumeFeatureTagValue(CSSParserTokenRange&, CSS::PropertyParserState&);
@@ -174,11 +174,11 @@ RefPtr<CSSValue> consumeVariationTagValue(CSSParserTokenRange&, CSS::PropertyPar
 
 // MARK: @font-face 'font-width'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-width
-RefPtr<CSSValue> parseFontFaceFontWidth(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceFontWidth(StringView, ScriptExecutionContext&);
 
 // MARK: @font-face 'font-weight'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-weight
-RefPtr<CSSValue> parseFontFaceFontWeight(const String&, ScriptExecutionContext&);
+RefPtr<CSSValue> parseFontFaceFontWeight(StringView, ScriptExecutionContext&);
 
 // MARK: - @font-feature-values descriptor consumers
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -68,7 +68,7 @@ static RefPtr<CSSValue> consumeTimelineRangeName(CSSParserTokenRange& range)
     return nullptr;
 }
 
-std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameRaw(const String& rangeString)
+std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameRaw(StringView rangeString)
 {
     if (rangeString == "cover"_s)
         return Style::SingleAnimationRangeName::Cover;
@@ -87,7 +87,7 @@ std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameRaw(const S
     return std::nullopt;
 }
 
-std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameOrNormalRaw(const String& rangeString)
+std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameOrNormalRaw(StringView rangeString)
 {
     if (rangeString == "normal"_s)
         return Style::SingleAnimationRangeName::Normal;
@@ -170,7 +170,7 @@ RefPtr<CSSValue> consumeSingleViewTimelineInsetItem(CSSParserTokenRange& range, 
     return startInset;
 }
 
-std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(const String& string, const CSSParserContext& context, const Document& document)
+std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(StringView string, const CSSParserContext& context, const Document& document)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
@@ -242,7 +242,7 @@ RefPtr<CSSValue> consumeSingleAnimationRangeEnd(CSSParserTokenRange& range, CSS:
 }
 
 template<typename T>
-static std::optional<T> parseAbsoluteSingleAnimationRangeEdgeRaw(const String& string, const CSSParserContext& context, const Document& document)
+static std::optional<T> parseAbsoluteSingleAnimationRangeEdgeRaw(StringView string, const CSSParserContext& context, const Document& document)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
@@ -269,12 +269,12 @@ static std::optional<T> parseAbsoluteSingleAnimationRangeEdgeRaw(const String& s
     return Style::toStyleFromCSSValue<T>(*CheckedPtr { dummyState.ptr() }, *parsedValue);
 }
 
-std::optional<Style::SingleAnimationRangeStart> parseAbsoluteSingleAnimationRangeStartRaw(const String& string, const CSSParserContext& context, const Document& document)
+std::optional<Style::SingleAnimationRangeStart> parseAbsoluteSingleAnimationRangeStartRaw(StringView string, const CSSParserContext& context, const Document& document)
 {
     return parseAbsoluteSingleAnimationRangeEdgeRaw<Style::SingleAnimationRangeStart>(string, context, document);
 }
 
-std::optional<Style::SingleAnimationRangeEnd> parseAbsoluteSingleAnimationRangeEndRaw(const String& string, const CSSParserContext& context, const Document& document)
+std::optional<Style::SingleAnimationRangeEnd> parseAbsoluteSingleAnimationRangeEndRaw(StringView string, const CSSParserContext& context, const Document& document)
 {
     return parseAbsoluteSingleAnimationRangeEdgeRaw<Style::SingleAnimationRangeEnd>(string, context, document);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
@@ -50,8 +50,8 @@ struct ViewTimelineInsetItem;
 namespace CSSPropertyParserHelpers {
 
 bool NODELETE isTimelineRangeName(CSSValueID);
-std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameRaw(const String&);
-std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameOrNormalRaw(const String&);
+std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameRaw(StringView);
+std::optional<Style::SingleAnimationRangeName> parseTimelineRangeNameOrNormalRaw(StringView);
 
 // MARK: - Consumer functions
 
@@ -67,7 +67,7 @@ RefPtr<CSSValue> consumeAnimationTimelineView(CSSParserTokenRange&, CSS::Propert
 // https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
 RefPtr<CSSValue> consumeSingleViewTimelineInsetItem(CSSParserTokenRange&, CSS::PropertyParserState&);
 
-std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(const String&, const CSSParserContext&, const Document&);
+std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(StringView, const CSSParserContext&, const Document&);
 
 // <single-animation-range> = normal | <length-percentage> | <timeline-range-name> <length-percentage>?
 // https://drafts.csswg.org/scroll-animations-1/#propdef-animation-range-start
@@ -75,8 +75,8 @@ RefPtr<CSSValue> consumeSingleAnimationRange(CSSParserTokenRange&, CSS::Property
 RefPtr<CSSValue> consumeSingleAnimationRangeStart(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeSingleAnimationRangeEnd(CSSParserTokenRange&, CSS::PropertyParserState&);
 
-std::optional<Style::SingleAnimationRangeStart> parseAbsoluteSingleAnimationRangeStartRaw(const String&, const CSSParserContext&, const Document&);
-std::optional<Style::SingleAnimationRangeEnd> parseAbsoluteSingleAnimationRangeEndRaw(const String&, const CSSParserContext&, const Document&);
+std::optional<Style::SingleAnimationRangeStart> parseAbsoluteSingleAnimationRangeStartRaw(StringView, const CSSParserContext&, const Document&);
+std::optional<Style::SingleAnimationRangeEnd> parseAbsoluteSingleAnimationRangeEndRaw(StringView, const CSSParserContext&, const Document&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -410,7 +410,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, CSS::PropertyParserSta
     return CSSValueList::createSpaceSeparated(x.releaseNonNull());
 }
 
-std::optional<Style::Transform> parseTransformRaw(const String& string, const CSSParserContext& context, const Document& document)
+std::optional<Style::Transform> parseTransformRaw(StringView string, const CSSParserContext& context, const Document& document)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
@@ -61,7 +61,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeRotate(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <'transform'> parsing (raw)
-std::optional<Style::Transform> parseTransformRaw(const String&, const CSSParserContext&, const Document&);
+std::optional<Style::Transform> parseTransformRaw(StringView, const CSSParserContext&, const Document&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1472,7 +1472,7 @@ static std::optional<Style::PseudoElementIdentifier> NODELETE pseudoElementIdent
 
 // FIXME: It's probably worth investigating if more logic can be shared with
 // CSSSelectorParser::consumePseudo(), though note that the requirements are subtly different.
-std::optional<Style::PseudoElementIdentifier> CSSSelectorParser::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
+std::optional<Style::PseudoElementIdentifier> CSSSelectorParser::parsePseudoElement(StringView input, const CSSSelectorParserContext& context)
 {
     auto tokenizer = CSSTokenizer { input };
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -61,7 +61,7 @@ public:
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
     static CSSSelectorList makeHasScopeSelector(const Vector<const CSSSelector*>& compoundSelectors);
     static CSSSelectorList makeHasArgumentWithScope(const CSSSelector& hasArgument, const CSSSelector& scopeSelector);
-    static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(StringView, const CSSSelectorParserContext&);
 
 private:
     template<typename ConsumeSelector> MutableCSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -60,7 +60,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParser
     return supportsParser.consumeSupportsFeatureOrGeneralEnclosed(range);
 }
 
-CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(const String& condition, const CSSParserContext& context, ParsingMode mode)
+CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(StringView condition, const CSSParserContext& context, ParsingMode mode)
 {
     CSSParser parser(context, condition);
     if (!parser.tokenizer())

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -52,7 +52,7 @@ public:
     };
 
     static SupportsResult supportsCondition(CSSParserTokenRange, CSSParser&, ParsingMode);
-    static SupportsResult supportsCondition(const String&, const CSSParserContext&, ParsingMode);
+    static SupportsResult supportsCondition(StringView, const CSSParserContext&, ParsingMode);
 
 private:
     CSSSupportsParser(CSSParser& parser)

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-SizesAttributeParser::SizesAttributeParser(const String& attribute, const Document& document)
+SizesAttributeParser::SizesAttributeParser(StringView attribute, const Document& document)
     : m_document(document)
 {
     if (!attribute.isEmpty())

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -44,7 +44,7 @@ struct CSSParserContext;
 
 class SizesAttributeParser {
 public:
-    SizesAttributeParser(const String&, const Document&);
+    SizesAttributeParser(StringView attribute LIFETIME_BOUND, const Document&);
 
     std::optional<float> effectiveSize();
     bool isAuto() const { return m_isAuto; }

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -166,15 +166,17 @@ static ASCIILiteral atRuleIdentifierForType(StyleRuleType styleRuleType)
 
 static bool isValidRuleHeaderText(const String& headerText, StyleRuleType styleRuleType, Document* document, CSSParserEnum::NestedContext nestedContext = { })
 {
-    auto isValidAtRuleHeaderText = [&] (const String& atRuleIdentifier) {
+    auto isValidAtRuleHeaderText = [&](const String& atRuleIdentifier) {
         if (headerText.isEmpty())
             return false;
+
+        auto parseText = makeString(atRuleIdentifier, ' ', headerText, " {}"_s);
 
         // Make sure the engine can parse the provided `@` rule, even if it only uses unsupported features. As long as
         // the rule text is entirely consumed and it creates a rule of the expected type, we consider it valid because
         // we will be able to continue to edit the rule in the future.
         CSSParserContext context(parserContextForDocument(document)); // CSSParser holds a reference to this.
-        CSSParser parser(context, makeString(atRuleIdentifier, ' ', headerText, " {}"_s));
+        CSSParser parser(context, parseText);
         if (!parser.tokenizer())
             return false;
 

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -108,7 +108,7 @@ static inline SVGAngleValue::Type NODELETE cssAngleUnitToSVGAngleType(CSS::Angle
     return SVGAngleValue::SVG_ANGLETYPE_UNKNOWN;
 }
 
-ExceptionOr<void> SVGAngleValue::setValueAsString(const String& value)
+ExceptionOr<void> SVGAngleValue::setValueAsString(StringView value)
 {
     if (value.isEmpty()) {
         m_unitType = SVG_ANGLETYPE_UNSPECIFIED;

--- a/Source/WebCore/svg/SVGAngleValue.h
+++ b/Source/WebCore/svg/SVGAngleValue.h
@@ -49,7 +49,7 @@ public:
     void setValueInSpecifiedUnits(float valueInSpecifiedUnits) { m_valueInSpecifiedUnits = valueInSpecifiedUnits; }
     float valueInSpecifiedUnits() const { return m_valueInSpecifiedUnits; }
 
-    ExceptionOr<void> setValueAsString(const String&);
+    ExceptionOr<void> setValueAsString(StringView);
     String valueAsString() const;
 
     ExceptionOr<void> newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);


### PR DESCRIPTION
#### c119008088192c83b7861bcbaf24a675f9d7e837
<pre>
Use StringView for more CSS parsing functions now that CSSTokenizer supports it
<a href="https://bugs.webkit.org/show_bug.cgi?id=322904">https://bugs.webkit.org/show_bug.cgi?id=322904</a>

Reviewed by Darin Adler.

Replaces use of `const String&amp;` for input to CSS parsing functions with StringView
to allow callers more options for how they store the input.

* Source/WebCore/css/CSSGroupingRule.cpp:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/parser/CSSParser.cpp:
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
* Source/WebCore/css/parser/CSSSupportsParser.h:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
* Source/WebCore/css/parser/SizesAttributeParser.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
* Source/WebCore/svg/SVGAngleValue.cpp:
* Source/WebCore/svg/SVGAngleValue.h:

Canonical link: <a href="https://commits.webkit.org/320120@main">https://commits.webkit.org/320120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19e1086c6c4db0746adf53776f88ee0e0de5b5d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194009 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148079 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143448 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99616 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44148 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43728 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5191 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57381 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152986 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40987 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58085 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152670 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47210 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130365 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56593 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18739 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->