### PR TITLE
Reduce IPC encoded size of TransformationMatrix

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1796,6 +1796,57 @@ AffineTransform TransformationMatrix::toAffineTransform() const
                            m_matrix[1][1], m_matrix[3][0], m_matrix[3][1]);
 }
 
+auto TransformationMatrix::ipcData() const -> IPCData
+{
+    if (isIdentity())
+        return std::monostate { };
+
+    if (isIdentityOrTranslation()) {
+        if (!m43())
+            return Translation2DIPCData { m41(), m42() };
+        return Translation3DIPCData { m41(), m42(), m43() };
+    }
+
+    if (isAffine())
+        return toAffineTransform();
+
+    return FullIPCData { { {
+        m11(), m12(), m13(), m14(),
+        m21(), m22(), m23(), m24(),
+        m31(), m32(), m33(), m34(),
+        m41(), m42(), m43(), m44(),
+    } } };
+}
+
+TransformationMatrix TransformationMatrix::fromIPCData(IPCData&& data)
+{
+    return WTF::switchOn(WTF::move(data),
+        [] (std::monostate) {
+            return TransformationMatrix { };
+        }, [] (const Translation2DIPCData& translation) {
+            TransformationMatrix matrix;
+            matrix.setM41(translation.m41);
+            matrix.setM42(translation.m42);
+            return matrix;
+        }, [] (const Translation3DIPCData& translation) {
+            TransformationMatrix matrix;
+            matrix.setM41(translation.m41);
+            matrix.setM42(translation.m42);
+            matrix.setM43(translation.m43);
+            return matrix;
+        }, [] (const AffineTransform& affineTransform) {
+            return TransformationMatrix { affineTransform };
+        }, [] (const FullIPCData& full) {
+            auto& values = full.values;
+            return TransformationMatrix {
+                values[0], values[1], values[2], values[3],
+                values[4], values[5], values[6], values[7],
+                values[8], values[9], values[10], values[11],
+                values[12], values[13], values[14], values[15]
+            };
+        });
+}
+
 static inline void NODELETE blendFloat(double& from, double to, double progress, CompositeOperation compositeOperation)
 {
     switch (compositeOperation) {

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/AffineTransform.h>
 #include <WebCore/CompositeOperation.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatPoint3D.h>
@@ -35,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 
 #if USE(CA)
 typedef struct CATransform3D CATransform3D;
@@ -362,6 +364,23 @@ public:
     WEBCORE_EXPORT void NODELETE flatten();
 
     WEBCORE_EXPORT AffineTransform NODELETE toAffineTransform() const;
+
+    struct Translation2DIPCData {
+        double m41 { 0 };
+        double m42 { 0 };
+    };
+    struct Translation3DIPCData {
+        double m41 { 0 };
+        double m42 { 0 };
+        double m43 { 0 };
+    };
+    struct FullIPCData {
+        std::array<double, 16> values { };
+    };
+    using IPCData = Variant<std::monostate /* identity */, Translation2DIPCData, Translation3DIPCData, AffineTransform, FullIPCData>;
+
+    WEBCORE_EXPORT IPCData ipcData() const;
+    WEBCORE_EXPORT static TransformationMatrix fromIPCData(IPCData&&);
 
     bool operator==(const TransformationMatrix& m2) const
     {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -252,23 +252,25 @@ enum class WebCore::ScrollGranularity : uint8_t {
     Pixel
 };
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::TransformationMatrix {
-    double m11()
-    double m12()
-    double m13()
-    double m14()
-    double m21()
-    double m22()
-    double m23()
-    double m24()
-    double m31()
-    double m32()
-    double m33()
-    double m34()
-    double m41()
-    double m42()
-    double m43()
-    double m44()
+webkit_platform_headers: <WebCore/TransformationMatrix.h>
+
+[CustomHeader, Nested, AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] struct WebCore::TransformationMatrix::Translation2DIPCData {
+    double m41;
+    double m42;
+};
+
+[CustomHeader, Nested, AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] struct WebCore::TransformationMatrix::Translation3DIPCData {
+    double m41;
+    double m42;
+    double m43;
+};
+
+[CustomHeader, Nested, AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] struct WebCore::TransformationMatrix::FullIPCData {
+    std::array<double, 16> values;
+};
+
+[AdditionalEncoder=StreamConnectionEncoder, CreateUsing=fromIPCData, WebKitPlatform] class WebCore::TransformationMatrix {
+    Variant<std::monostate, WebCore::TransformationMatrix::Translation2DIPCData, WebCore::TransformationMatrix::Translation3DIPCData, WebCore::AffineTransform, WebCore::TransformationMatrix::FullIPCData> ipcData();
 }
 
 struct WebCore::CacheQueryOptions {
@@ -282,7 +284,9 @@ struct WebCore::CharacterRange {
     [Validator='!(CheckedUint64 { *location } + *length).hasOverflowed()'] uint64_t length
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::AffineTransform {
+webkit_platform_headers: <WebCore/AffineTransform.h>
+
+[AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] class WebCore::AffineTransform {
     std::span<const double, 6> span();
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -35,6 +35,7 @@
 #include "StreamConnectionEncoder.h"
 #include "Helpers/Test.h"
 #include <WebCore/ShareableResource.h>
+#include <WebCore/TransformationMatrix.h>
 #include <limits>
 #include <wtf/StdLibExtras.h>
 
@@ -830,6 +831,62 @@ TEST(ArgumentCoderSecurityFlags, BitBelongingToNoFlagIsRejectedNotCrashed)
         auto flags = decoder->decode<WebKit::SecurityFlags>();
         EXPECT_FALSE(flags.has_value());
     }
+}
+
+template<size_t expectedDoubleCount>
+static void testTransformationMatrixCoding(const WebCore::TransformationMatrix& matrix)
+{
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
+    encoder << matrix;
+
+    constexpr size_t messageHeaderSize = 16;
+    size_t expectedSize = calculateEncodedSize(messageHeaderSize, EncodedValue<uint8_t, 1> { });
+    if constexpr (expectedDoubleCount)
+        expectedSize = calculateEncodedSize(expectedSize, EncodedValue<double, expectedDoubleCount> { });
+    EXPECT_EQ(expectedSize, encoder.span().size());
+
+    auto decoder = IPC::Decoder::create(encoder.span(), { });
+    ASSERT_TRUE(decoder);
+    auto decoded = decoder->decode<WebCore::TransformationMatrix>();
+    ASSERT_TRUE(decoded.has_value());
+
+    EXPECT_TRUE(matrix == *decoded);
+}
+
+TEST(ArgumentCoderTransformationMatrix, IdentityCostsOnlyTheVariantTag)
+{
+    testTransformationMatrixCoding<0>(WebCore::TransformationMatrix { });
+}
+
+TEST(ArgumentCoderTransformationMatrix, Translation2DCostsTwoDoubles)
+{
+    testTransformationMatrixCoding<2>(WebCore::TransformationMatrix { 10.5, -20.25 });
+
+    WebCore::TransformationMatrix zeroZ;
+    zeroZ.translate3d(1.0, 2.0, 0.0);
+    testTransformationMatrixCoding<2>(zeroZ);
+}
+
+TEST(ArgumentCoderTransformationMatrix, Translation3DCostsThreeDoubles)
+{
+    WebCore::TransformationMatrix translated3D;
+    translated3D.translate3d(1.0, 2.0, 3.0);
+    testTransformationMatrixCoding<3>(translated3D);
+}
+
+TEST(ArgumentCoderTransformationMatrix, AffineCostsSixDoubles)
+{
+    testTransformationMatrixCoding<6>(WebCore::TransformationMatrix { 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 });
+}
+
+TEST(ArgumentCoderTransformationMatrix, NonAffineCostsSixteenDoubles)
+{
+    testTransformationMatrixCoding<16>(WebCore::TransformationMatrix {
+        16.0, 15.0, 14.0, 13.0,
+        12.0, 11.0, 10.0, 9.0,
+        8.0, 7.0, 6.0, 5.0,
+        4.0, 3.0, 2.0, 1.0
+    });
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp
@@ -1341,4 +1341,86 @@ TEST(TransformationMatrix, IdentityDecomposition)
     EXPECT_DOUBLE_EQ(1.0, decomp.quaternion.w);
 }
 
+enum class ExpectedIPCDataAlternative : size_t {
+    Identity = 0,
+    Translation2D = 1,
+    Translation3D = 2,
+    Affine = 3,
+    Full = 4
+};
+
+static void testIPCDataRoundTrip(const WebCore::TransformationMatrix& matrix, ExpectedIPCDataAlternative expectedAlternative)
+{
+    auto ipcData = matrix.ipcData();
+    EXPECT_EQ(static_cast<size_t>(expectedAlternative), ipcData.index());
+    EXPECT_TRUE(matrix == WebCore::TransformationMatrix::fromIPCData(WTF::move(ipcData)));
+}
+
+TEST(TransformationMatrix, IPCDataIdentity)
+{
+    testIPCDataRoundTrip(WebCore::TransformationMatrix { }, ExpectedIPCDataAlternative::Identity);
+}
+
+TEST(TransformationMatrix, IPCDataTranslation2D)
+{
+    testIPCDataRoundTrip(WebCore::TransformationMatrix { 10.5, -20.25 }, ExpectedIPCDataAlternative::Translation2D);
+
+    WebCore::TransformationMatrix translated;
+    translated.translate(1.0, 2.0);
+    testIPCDataRoundTrip(translated, ExpectedIPCDataAlternative::Translation2D);
+
+    WebCore::TransformationMatrix zeroZ;
+    zeroZ.translate3d(1.0, 2.0, 0.0);
+    testIPCDataRoundTrip(zeroZ, ExpectedIPCDataAlternative::Translation2D);
+}
+
+TEST(TransformationMatrix, IPCDataTranslation3D)
+{
+    WebCore::TransformationMatrix translated3D;
+    translated3D.translate3d(1.0, 2.0, 3.0);
+    testIPCDataRoundTrip(translated3D, ExpectedIPCDataAlternative::Translation3D);
+
+    WebCore::TransformationMatrix translatedNegativeZ;
+    translatedNegativeZ.translate3d(0.0, 0.0, -4.5);
+    testIPCDataRoundTrip(translatedNegativeZ, ExpectedIPCDataAlternative::Translation3D);
+}
+
+TEST(TransformationMatrix, IPCDataAffine)
+{
+    testIPCDataRoundTrip(WebCore::TransformationMatrix { 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 }, ExpectedIPCDataAlternative::Affine);
+
+    WebCore::TransformationMatrix scaled;
+    scaled.scale(2.0);
+    testIPCDataRoundTrip(scaled, ExpectedIPCDataAlternative::Affine);
+
+    WebCore::TransformationMatrix rotated;
+    rotated.rotate(45.0);
+    testIPCDataRoundTrip(rotated, ExpectedIPCDataAlternative::Affine);
+}
+
+TEST(TransformationMatrix, IPCDataFull)
+{
+    testIPCDataRoundTrip(WebCore::TransformationMatrix {
+        16.0, 15.0, 14.0, 13.0,
+        12.0, 11.0, 10.0, 9.0,
+        8.0, 7.0, 6.0, 5.0,
+        4.0, 3.0, 2.0, 1.0
+    }, ExpectedIPCDataAlternative::Full);
+
+    WebCore::TransformationMatrix rotatedInX;
+    rotatedInX.rotate3d(45.0, 0.0, 0.0);
+    ASSERT_FALSE(rotatedInX.isAffine());
+    testIPCDataRoundTrip(rotatedInX, ExpectedIPCDataAlternative::Full);
+
+    WebCore::TransformationMatrix withPerspective {
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, -1.0 / 500.0,
+        0.0, 0.0, 0.0, 1.0
+    };
+    ASSERT_TRUE(withPerspective.hasPerspective());
+    ASSERT_FALSE(withPerspective.isAffine());
+    testIPCDataRoundTrip(withPerspective, ExpectedIPCDataAlternative::Full);
+}
+
 }


### PR DESCRIPTION
#### fd86b54293b5d6c3e9b9a07b5373afa488456f66
<pre>
Reduce IPC encoded size of TransformationMatrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=322906">https://bugs.webkit.org/show_bug.cgi?id=322906</a>
<a href="https://rdar.apple.com/186162772">rdar://186162772</a>

Reviewed by Kiet Ho and Per Arne Vollan.

With Site Isolation, we now broadcast multiple TransformationMatrix instances at frame rate to
remote frame processes, so it makes sense to add some code to reduce the size of those matrices over
the wire.

This adds some specializations for common TransformationMatrix types that don&apos;t require the full 4x4
matrix (specifically identity, 2D transforms, 3D transforms, and affine transforms). The added
ArgumentCoder tests ensure that these matrices use fewer bytes over the wire as intended.

Tests: Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
   Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp

* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::ipcData const):
(WebCore::TransformationMatrix::fromIPCData):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::testTransformationMatrixCoding):
(TestWebKitAPI::TEST(ArgumentCoderTransformationMatrix, IdentityCostsOnlyTheVariantTag)):
(TestWebKitAPI::TEST(ArgumentCoderTransformationMatrix, Translation2DCostsTwoDoubles)):
(TestWebKitAPI::TEST(ArgumentCoderTransformationMatrix, Translation3DCostsThreeDoubles)):
(TestWebKitAPI::TEST(ArgumentCoderTransformationMatrix, AffineCostsSixDoubles)):
(TestWebKitAPI::TEST(ArgumentCoderTransformationMatrix, NonAffineCostsSixteenDoubles)):
* Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp:
(TestWebKitAPI::testIPCDataRoundTrip):
(TestWebKitAPI::TEST(TransformationMatrix, IPCDataIdentity)):
(TestWebKitAPI::TEST(TransformationMatrix, IPCDataTranslation2D)):
(TestWebKitAPI::TEST(TransformationMatrix, IPCDataTranslation3D)):
(TestWebKitAPI::TEST(TransformationMatrix, IPCDataAffine)):
(TestWebKitAPI::TEST(TransformationMatrix, IPCDataFull)):

Canonical link: <a href="https://commits.webkit.org/320258@main">https://commits.webkit.org/320258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6225b99eb27c628e73b4a03fbc750a35477a95ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148468 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/471442c9-8cdb-4afc-9b26-cc2ca371111b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143780 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99922 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba0d1d5e-6dea-4c64-8d0a-31962bdcc870) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124199 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c4b15ac-8305-4d82-b941-834d840e3d95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44474 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156659 "Found 3 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPINamespace.NoWebNavigationObjectWithoutPermission, TestWebKitAPI.WKWebExtensionAPIWebNavigation.CommittedEvent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44055 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5581 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196337 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57770 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41076 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153010 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47545 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130765 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56982 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19067 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56353 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56592 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->