### PR TITLE
Range.getBoundingClientRect() returns empty rects for content inside a content-visibility: hidden subtree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-content-visibility-hidden-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-content-visibility-hidden-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL assert_not_equals(rectLeaf.width, 0, "leaf rect width should not be zero") assert_not_equals: leaf rect width should not be zero got disallowed value 0
-FAIL assert_not_equals(rectLeaf.height, 0, "leaf rect height should not be zero") assert_not_equals: leaf rect height should not be zero got disallowed value 0
+PASS assert_not_equals(rectLeaf.width, 0, "leaf rect width should not be zero")
+PASS assert_not_equals(rectLeaf.height, 0, "leaf rect height should not be zero")
 PASS assert_not_equals(rectRoot.width, 0, "root rect width should not be zero")
 PASS assert_not_equals(rectRoot.height, 0, "root rect height should not be zero")
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -1106,10 +1106,25 @@ ExceptionOr<void> Range::expand(const String& unit)
     return setEnd(endContainer.releaseNonNull(), end.deepEquivalent().computeOffsetInContainerNode());
 }
 
+static void updateLayoutForRangeBoundingRect(const SimpleRange& simpleRange)
+{
+    OptionSet<LayoutOptions> layoutOptions;
+    RefPtr<const Element> context;
+    if (RefPtr commonAncestor = commonInclusiveAncestor<ComposedTree>(simpleRange)) {
+        context = dynamicDowncast<Element>(commonAncestor.get());
+        if (!context)
+            context = commonAncestor->parentElementInComposedTree();
+        if (context)
+            layoutOptions = { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible };
+    }
+    protect(simpleRange.start.document())->updateLayoutIgnorePendingStylesheets(layoutOptions, context.get());
+}
+
 Ref<DOMRectList> Range::getClientRects() const
 {
-    protect(startContainer().document())->updateLayout();
-    return DOMRectList::create(RenderObject::clientBorderAndTextRects(makeSimpleRange(*this)));
+    auto simpleRange = makeSimpleRange(*this);
+    updateLayoutForRangeBoundingRect(simpleRange);
+    return DOMRectList::create(RenderObject::clientBorderAndTextRects(simpleRange));
 }
 
 Ref<DOMRect> Range::getBoundingClientRect() const
@@ -1119,7 +1134,7 @@ Ref<DOMRect> Range::getBoundingClientRect() const
 
 Ref<DOMRect> Range::boundingClientRect(const SimpleRange& simpleRange)
 {
-    protect(simpleRange.startContainer().document())->updateLayout();
+    updateLayoutForRangeBoundingRect(simpleRange);
     return DOMRect::create(unionRectIgnoringZeroRects(RenderObject::clientBorderAndTextRects(simpleRange)));
 }
 


### PR DESCRIPTION
#### 3879cf34f64b139ded2b1775638af62bb6ad868e
<pre>
Range.getBoundingClientRect() returns empty rects for content inside a content-visibility: hidden subtree
<a href="https://bugs.webkit.org/show_bug.cgi?id=322910">https://bugs.webkit.org/show_bug.cgi?id=322910</a>
<a href="https://rdar.apple.com/186165755">rdar://186165755</a>

Reviewed by NOBODY (OOPS!).

A Range&apos;s getBoundingClientRect()/getClientRects() ran a plain layout update
before collecting rects. Content inside a content-visibility: hidden subtree is
skipped during layout, so its text has no line boxes and the range geometry
collapsed to a zero-sized rect.

Element.getBoundingClientRect() already handles this by updating layout with
LayoutOptions::TreatContentVisibilityHiddenAsVisible (and ...AutoAsVisible),
which forces the skipped subtree to lay out, scoped to the queried element.

Route both Range geometry entry points through a shared helper that passes those
same options, scoped to the range&apos;s nearest ancestor element. Document::updateLayout()
only forces a skipped subtree when the context element is itself skipped content,
so this is a no-op for ordinary ranges.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-content-visibility-hidden-expected.txt: Progression
* Source/WebCore/dom/Range.cpp:
(WebCore::updateLayoutForRangeBoundingRect):
(WebCore::Range::getClientRects const):
(WebCore::Range::boundingClientRect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3879cf34f64b139ded2b1775638af62bb6ad868e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148088 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143455 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99624 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123876 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45925 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44152 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43734 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5199 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50374 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48420 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 343 new passes 14 flakes 6 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57389 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152677 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47214 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130373 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126753 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56601 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55972 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->