### PR TITLE
Replace references to a font's "computedSize" with "usedSize"

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -786,7 +786,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         }
 
         addAttributeIfNeeded("family-name"_s, style.fontCascade().firstFamily().name);
-        addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
+        addAttributeIfNeeded("size"_s, makeString(std::round(style.usedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
         addAttributeIfNeeded("style"_s, style.fontCascade().fontStyleSlope() ? "italic"_s : "normal"_s);
         addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine().hasLineThrough() ? "true"_s : "false"_s);

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2219,7 +2219,7 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
         return { };
 
     auto fontSizeChanged = [&]() {
-        return previousUnanimatedStyle && previousUnanimatedStyle->computedFontSize() != unanimatedStyle.computedFontSize();
+        return previousUnanimatedStyle && previousUnanimatedStyle->usedFontSize() != unanimatedStyle.usedFontSize();
     };
 
     auto fontWeightChanged = [&]() {

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -200,7 +200,7 @@ void CSSFontFaceSource::load(DownloadableBinaryFontTrustedTypes trustedTypes, Do
             // null if it wasn't going to otherwise (and vice-versa).
             FontCascadeDescription fontDescription;
             fontDescription.setOneFamily(m_fontFaceName);
-            fontDescription.setComputedSize(1);
+            fontDescription.setUsedSize(1);
             fontDescription.setShouldAllowUserInstalledFonts(cssFontFace().allowUserInstalledFonts());
             success = protect(FontCache::forCurrentThread())->fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
             if (document && document->settings().webAPIStatisticsEnabled())

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11667,7 +11667,7 @@ const Style::ComputedStyle& Document::initialStyle() const
 
         auto initialFontFamily = FontFamily { standardFamily, FontFamilyKind::Generic };
         auto initialSpecifiedFontSize = Style::fontSizeForKeyword(CSSValueMedium, false, settingsValues(), inQuirksMode());
-        auto initialComputedFontSize = Style::computedFontSizeFromSpecifiedSize(initialSpecifiedFontSize, false, zoomForFontDescription, Style::MinimumFontSizeRule::AbsoluteAndRelative, settingsValues());
+        auto initialUsedFontSize = Style::usedFontSizeFromSpecifiedSize(initialSpecifiedFontSize, false, zoomForFontDescription, Style::MinimumFontSizeRule::AbsoluteAndRelative, settingsValues());
         auto allowUserInstalledFonts = settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
 
         FontCascadeDescription fontDescription;
@@ -11675,7 +11675,7 @@ const Style::ComputedStyle& Document::initialStyle() const
         fontDescription.setOneFamily(WTF::move(initialFontFamily));
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         fontDescription.setSpecifiedSize(initialSpecifiedFontSize);
-        fontDescription.setComputedSize(initialComputedFontSize, zoomForFontDescription);
+        fontDescription.setUsedSize(initialUsedFontSize, zoomForFontDescription);
         fontDescription.setShouldAllowUserInstalledFonts(allowUserInstalledFonts);
 
         m_cachedInitialStyle->setFontDescription(WTF::move(fontDescription));

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1058,7 +1058,7 @@ static bool shouldEmitExtraNewlineForNode(Node& node, bool emitsNewlinesPerInner
         return false;
 
     auto bottomMargin = renderBox->collapsedMarginAfter();
-    auto fontSize = renderBox->style().fontDescription().computedSize();
+    auto fontSize = renderBox->style().fontDescription().usedSize();
     return bottomMargin * 2 >= fontSize;
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -236,7 +236,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
         static NeverDestroyed<AtomString> family = DefaultFontFamily;
         fontDescription.setOneFamily(family.get());
         fontDescription.setSpecifiedSize(DefaultFontSize);
-        fontDescription.setComputedSize(DefaultFontSize);
+        fontDescription.setUsedSize(DefaultFontSize);
     }
 
     if (newFont == state().unparsedFont && state().font.realized() && fontDescription == state().fontResolutionBase)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -415,7 +415,7 @@ String CanvasRenderingContext2DBase::State::fontString() const
         serializedFont.append("bold "_s);
     else if (weight != normalWeightValue())
         serializedFont.append(weight, " "_s);
-    serializedFont.append(font.computedSize(), "px"_s);
+    serializedFont.append(font.usedSize(), "px"_s);
 
     for (unsigned i = 0; i < font.familyCount(); ++i) {
         auto fontFamily = font.familyAt(i);

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -116,7 +116,7 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily(DefaultFontFamily);
     fontDescription.setSpecifiedSize(DefaultFontSize);
-    fontDescription.setComputedSize(DefaultFontSize);
+    fontDescription.setUsedSize(DefaultFontSize);
 
     if (auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTF::move(fontDescription), context)) {
         ASSERT(context->cssFontSelector());

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -994,7 +994,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     {
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
-        fontDescription.setComputedSize(10);
+        fontDescription.setUsedSize(10);
 
         FontCascade font(WTF::move(fontDescription));
         font.update(nullptr);
@@ -1084,7 +1084,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     {
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
-        fontDescription.setComputedSize(12);
+        fontDescription.setUsedSize(12);
 
         FontCascade font(WTF::move(fontDescription));
         font.update(nullptr);

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -68,7 +68,7 @@ static FontCascade systemFont()
     FontCascadeDescription fontDescription;
     fontDescription.setFamilies({ { "system-ui"_s, FontFamilyKind::Generic } });
     fontDescription.setWeight(FontSelectionValue(500));
-    fontDescription.setComputedSize(12);
+    fontDescription.setUsedSize(12);
 
     FontCascade font(WTF::move(fontDescription));
     font.update(nullptr);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -54,7 +54,7 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const WebCore::Style
     , m_isFirstWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::First))
     , m_isLastWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::Last))
     , m_type(type)
-    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().computedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
+    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().usedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -42,7 +42,7 @@ namespace Layout {
 static inline InlineLayoutUnit NODELETE fullWidthAdvance(const Box& box)
 {
     // A fullwidth character (including fullwidth punctuation) advances one em.
-    return box.style().computedFontSize();
+    return box.style().usedFontSize();
 }
 
 static inline InlineLayoutUnit NODELETE halfOfAFullWidthCharacter(const Box& annotationBox)

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -69,7 +69,7 @@ RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, c
 FontPlatformData CachedSVGFont::platformDataFromCustomData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     if (m_externalSVGDocument)
-        return FontPlatformData(fontDescription.computedSize(), computeSyntheticBold(false, fontDescription, fontCreationContext), computeSyntheticItalic(false, fontDescription, fontCreationContext)); // FIXME: Why are we creating a bogus font here?
+        return FontPlatformData(fontDescription.usedSize(), computeSyntheticBold(false, fontDescription, fontCreationContext), computeSyntheticItalic(false, fontDescription, fontCreationContext)); // FIXME: Why are we creating a bogus font here?
     return CachedFont::platformDataFromCustomData(fontDescription, fontCreationContext);
 }
 

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -225,7 +225,7 @@ void NonFastScrollableRegionOverlay::drawRect(PageOverlay& pageOverlay, Graphics
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
     fontDescription.setSpecifiedSize(12);
-    fontDescription.setComputedSize(12);
+    fontDescription.setUsedSize(12);
     fontDescription.setWeight(FontSelectionValue(500));
     FontCascade font(WTF::move(fontDescription));
     font.update(nullptr);
@@ -506,7 +506,7 @@ void InteractionRegionOverlay::drawSettings(GraphicsContext& context)
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
     fontDescription.setSpecifiedSize(12);
-    fontDescription.setComputedSize(12);
+    fontDescription.setUsedSize(12);
     fontDescription.setWeight(FontSelectionValue(500));
     FontCascade font(WTF::move(fontDescription));
     font.update(nullptr);
@@ -621,7 +621,7 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily("Helvetica"_s);
         fontDescription.setSpecifiedSize(10);
-        fontDescription.setComputedSize(10);
+        fontDescription.setUsedSize(10);
         fontDescription.setWeight(FontSelectionValue(500));
         FontCascade font(WTF::move(fontDescription));
         font.update(nullptr);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -878,7 +878,7 @@ void LocalFrameViewLayoutContext::applyTextSizingIfNeeded(RenderElement& layoutR
         textAutosizingWidth = overrideWidth;
     if (!idempotentMode && !textAutosizingWidth)
         return;
-    layoutRoot.adjustComputedFontSizesOnBlocks(minimumZoomFontSize, textAutosizingWidth);
+    layoutRoot.adjustFontSizesOnBlocks(minimumZoomFontSize, textAutosizingWidth);
     if (!layoutRoot.needsLayout())
         return;
     LOG(TextAutosizing, "Text Autosizing: minimumZoomFontSize=%.2f textAutosizingWidth=%.2f", minimumZoomFontSize, textAutosizingWidth);

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -412,7 +412,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
         );
     }
     if (propertyName == "font-size"_s)
-        return makeString(style->fontDescription().computedSize());
+        return makeString(style->fontDescription().usedSize());
     if (propertyName == "font-family"_s)
         return style->fontDescription().firstFamily().name;
     if (propertyName == "size"_s) {

--- a/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
@@ -83,7 +83,7 @@ public:
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily(systemFontDatabase.systemFontShorthandFamily(messageBox));
         fontDescription.setWeight(systemFontDatabase.systemFontShorthandWeight(messageBox));
-        fontDescription.setComputedSize(gFontSize);
+        fontDescription.setUsedSize(gFontSize);
         m_textFont = FontCascade(WTF::move(fontDescription));
         m_textFont.update(nullptr);
     }

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -82,7 +82,7 @@ Ref<Font> Font::create(Ref<SharedBuffer>&& fontFaceData, Font::Origin origin, fl
     bool wrapping;
     auto customFontData = CachedFont::createCustomFontData(fontFaceData.get(), { }, wrapping, trustedType);
     FontDescription description;
-    description.setComputedSize(fontSize);
+    description.setUsedSize(fontSize);
     // FIXME: Why doesn't this pass in any meaningful data for the last few arguments?
     auto platformData = CachedFont::platformDataFromCustomData(*customFontData, description, { });
     return Font::create(WTF::move(platformData), origin);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -446,7 +446,7 @@ float FontCascade::zeroWidth() const
     // This represents the advance measure of the glyph 0 (zero, the Unicode character U+0030)
     // in the element's font. In cases where it is impossible or impractical to determine the measure of the 0 glyph,
     // it must be assumed to be 0.5em
-    auto defaultZeroWidthValue = fontDescription().computedSize() / 2;
+    auto defaultZeroWidthValue = fontDescription().usedSize() / 2;
     if (!metricsOfPrimaryFont().zeroWidth())
         return defaultZeroWidthValue;
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -108,7 +108,7 @@ public:
     const FontCascadeDescription& fontDescription() const LIFETIME_BOUND { return m_fontDescription; }
     FontCascadeDescription& mutableFontDescription() const LIFETIME_BOUND { return m_fontDescription; }
 
-    float size() const { return fontDescription().computedSize(); }
+    float size() const { return fontDescription().usedSize(); }
 
     bool isCurrent(const FontSelector&) const;
     void updateFonts(Ref<FontCascadeFonts>&&) const;

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -111,7 +111,7 @@ struct FontDescriptionKey {
     FontDescriptionKey() = default;
 
     FontDescriptionKey(const FontDescription& description)
-        : m_size(description.computedSize())
+        : m_size(description.usedSize())
         , m_fontSelectionRequest(description.fontSelectionRequest())
         , m_flags(makeFlagsKey(description))
         , m_locale(description.computedLocale())

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -156,7 +156,7 @@ void FontCascadeDescription::resolveFontSizeAdjustFromFontIfNeeded(const Font& f
     if (!fontSizeAdjust.shouldResolveFromFont())
         return;
 
-    auto aspectValue = fontSizeAdjust.resolve(computedSize(), font.fontMetrics());
+    auto aspectValue = fontSizeAdjust.resolve(usedSize(), font.fontMetrics());
     setFontSizeAdjust({ fontSizeAdjust.metric, FontSizeAdjust::ValueType::FromFont, aspectValue });
 }
 
@@ -179,7 +179,7 @@ TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascade
     }
 
     ts << ", specified size "_s << fontCascadeDescription.specifiedSize();
-    ts << ", computed size "_s << fontCascadeDescription.computedSize();
+    ts << ", used size "_s << fontCascadeDescription.usedSize();
     ts << ", is absolute size "_s << fontCascadeDescription.isAbsoluteSize();
     if (fontCascadeDescription.kerning() != Kerning::Auto)
         ts << ", kerning "_s << fontCascadeDescription.kerning();

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -121,7 +121,7 @@ AtomString FontDescription::platformResolveGenericFamily(UScriptCode, const Atom
 float FontDescription::adjustedSizeForFontFace(float fontFaceSizeAdjust) const
 {
     // It is not worth modifying the used size with @font-face size-adjust if we are to re-adjust it later with font-size-adjust. This is because font-size-adjust will overrule this change, since size-adjust also modifies the font's metric values and thus, keeps the aspect-value unchanged.
-    return fontSizeAdjust().value ? computedSize() : fontFaceSizeAdjust * computedSize();
+    return fontSizeAdjust().value ? usedSize() : fontFaceSizeAdjust * usedSize();
 }
 
 FontVariantEastAsianValues FontDescription::variantEastAsian() const

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -46,9 +46,9 @@ public:
 
     bool operator==(const FontDescription&) const = default;
 
-    float computedSize() const { return m_computedSize; }
+    float usedSize() const { return m_usedSize; }
     float usedZoomFactor() const { return m_usedZoomFactor; }
-    float unzoomedComputedSize() const { return m_computedSize / m_usedZoomFactor; }
+    float unzoomedUsedSize() const { return m_usedSize / m_usedZoomFactor; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
     float NODELETE adjustedSizeForFontFace(float) const;
     std::optional<FontSelectionValue> fontStyleSlope() const { return m_fontSelectionRequest.slope; }
@@ -107,7 +107,7 @@ public:
     const FontPalette& fontPalette() const LIFETIME_BOUND { return m_fontPalette; }
     FontSizeAdjust fontSizeAdjust() const { return m_sizeAdjust; }
 
-    void setComputedSize(float s, float zoom = 1.0f) { m_computedSize = clampToFloat(s); m_usedZoomFactor = zoom; }
+    void setUsedSize(float s, float zoom = 1.0f) { m_usedSize = clampToFloat(s); m_usedZoomFactor = zoom; }
     void setTextSpacingTrim(TextSpacingTrim v) { m_textSpacingTrim = v; }
     void setTextAutospace(TextAutospace v) { m_textAutospace = v; }
     void setFontStyleAxis(FontStyleAxis axis) { m_fontSelectionRequest.slopeAxis = axis; updatePenalizeObliqueFontSelection(); }
@@ -171,7 +171,7 @@ private:
     FontSelectionRequest m_fontSelectionRequest;
     TextSpacingTrim m_textSpacingTrim;
     TextAutospace m_textAutospace;
-    float m_computedSize { 0 }; // Computed size adjusted for the minimum font size and the zoom factor.
+    float m_usedSize { 0 }; // Size adjusted for the minimum font size and the zoom factor.
     float m_usedZoomFactor { 1.0 };
 
     PREFERRED_TYPE(FontOrientation) unsigned m_orientation : 1; // Whether the font is rendering on a horizontal line or a vertical line.

--- a/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
+++ b/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
@@ -117,7 +117,7 @@ FontCascade FrameProcessIndicators::makeFont()
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
     fontDescription.setSpecifiedSize(fontSize);
-    fontDescription.setComputedSize(fontSize);
+    fontDescription.setUsedSize(fontSize);
 
     FontCascade font(WTF::move(fontDescription));
     font.update(nullptr);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -88,7 +88,7 @@ void PlatformCALayer::drawRepaintIndicator(GraphicsContext& graphicsContext, Pla
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
     fontDescription.setSpecifiedSize(fontSize);
-    fontDescription.setComputedSize(fontSize);
+    fontDescription.setUsedSize(fontSize);
 
     FontCascade cascade(WTF::move(fontDescription));
     cascade.update(nullptr);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -740,7 +740,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 
     FontPlatformData platformData(font.get(), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), fontCreationContext.metricsOverrides());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.usedSize());
     return makeUnique<FontPlatformData>(platformData);
 }
 
@@ -960,9 +960,9 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
 
     // LastResort is guaranteed to be non-null.
     auto fontDescriptor = adoptCF(CTFontDescriptorCreateLastResort());
-    auto font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), fontDescription.computedSize(), nullptr));
+    auto font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), fontDescription.usedSize(), nullptr));
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription).boldObliquePair();
-    FontPlatformData platformData(font.get(), fontDescription.computedSize(), syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
+    FontPlatformData platformData(font.get(), fontDescription.usedSize(), syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
     return fontForPlatformData(platformData);
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -48,7 +48,7 @@ FontFamilySpecificationCoreText::~FontFamilySpecificationCoreText() = default;
 
 FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fontDescription) const
 {
-    auto size = fontDescription.computedSize();
+    auto size = fontDescription.usedSize();
     auto& originalPlatformData = FontFamilySpecificationCoreTextCache::forCurrentThread().ensure(FontFamilySpecificationKey(m_fontDescriptor.get(), fontDescription), [&]() {
         // FIXME: Stop creating this unnecessary CTFont once rdar://problem/105508842 is fixed.
         UnrealizedCoreTextFont unrealizedFont = { adoptCF(CTFontCreateWithFontDescriptor(m_fontDescriptor.get(), size, nullptr)) };
@@ -59,7 +59,7 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
         auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription, { }, ShouldComputePhysicalTraits::Yes).boldObliquePair();
 
         auto platformData = makeUnique<FontPlatformData>(font.get(), size, false, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
-        platformData->updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+        platformData->updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.usedSize());
         return platformData;
     });
 

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -234,7 +234,7 @@ SystemFontDatabaseCoreText::CascadeListParameters SystemFontDatabaseCoreText::sy
 {
     CascadeListParameters result;
     result.locale = description.computedLocale();
-    result.size = description.computedSize();
+    result.size = description.usedSize();
     result.italic = isItalic(description.fontStyleSlope());
     result.allowUserInstalledFonts = allowUserInstalledFonts;
 

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -50,7 +50,7 @@ FontCascade::FontCascade(const FontPlatformData& fontData, FontSmoothingMode fon
     RetainPtr ctFont = fontData.ctFont();
 
     m_fontDescription.setSpecifiedSize(CTFontGetSize(ctFont.get()));
-    m_fontDescription.setComputedSize(CTFontGetSize(ctFont.get()));
+    m_fontDescription.setUsedSize(CTFontGetSize(ctFont.get()));
     m_fontDescription.setIsItalic(CTFontGetSymbolicTraits(ctFont.get()) & kCTFontTraitItalic);
     m_fontDescription.setWeight((CTFontGetSymbolicTraits(ctFont.get()) & kCTFontTraitBold) ? boldWeightValue() : normalWeightValue());
 }

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -62,7 +62,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, fontDescription, fontCreationContext);
     FontPlatformData platformData(font.get(), size, syntheticBold, syntheticItalic, orientation, widthVariant, fontDescription.textRenderingMode(), fontCreationContext.metricsOverrides(), this);
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.usedSize());
     return platformData;
 }
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -87,7 +87,7 @@ bool FontCache::configurePatternForFontDescription(FcPattern* pattern, const Fon
         return false;
     if (!FcPatternAddInteger(pattern, FC_WEIGHT, fontWeightToFontconfigWeight(fontDescription.weight())))
         return false;
-    if (!FcPatternAddDouble(pattern, FC_PIXEL_SIZE, fontDescription.computedSize()))
+    if (!FcPatternAddDouble(pattern, FC_PIXEL_SIZE, fontDescription.usedSize()))
         return false;
     return true;
 }
@@ -135,7 +135,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     getFontPropertiesFromPattern(resultPattern.get(), description, { }, fixedWidth, syntheticBold, syntheticOblique);
 
     RefPtr<cairo_font_face_t> fontFace = adoptRef(cairo_ft_font_face_create_for_pattern(resultPattern.get()));
-    FontPlatformData alternateFontData(fontFace.get(), WTF::move(resultPattern), description.computedSize(), fixedWidth, syntheticBold, syntheticOblique, description.orientation());
+    FontPlatformData alternateFontData(fontFace.get(), WTF::move(resultPattern), description.usedSize(), fixedWidth, syntheticBold, syntheticOblique, description.orientation());
     return fontForPlatformData(alternateFontData);
 }
 
@@ -468,7 +468,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     FontPlatformData platformData(fontFace.get(), WTF::move(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation(), fontCreationContext.metricsOverrides());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.usedSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);
 
     // Verify that this font has an encoding compatible with Fontconfig. Fontconfig currently

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -114,7 +114,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation(), fontCreationContext.metricsOverrides());
 
-    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.usedSize());
     return platformData;
 }
 

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -151,7 +151,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
     // @font-face size-adjust does not affect fallback font sizes, but font-size-adjust does.
     // We initialize FontPlatformData with the computed size, then apply font-size-adjust if required.
-    auto size = description.computedSize();
+    auto size = description.usedSize();
     FontPlatformData alternateFontData(WTF::move(typeface), size, syntheticBold, syntheticOblique, description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features));
     alternateFontData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), size);
 
@@ -195,7 +195,7 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
     }
 
     auto [syntheticBold, syntheticOblique] = computeSynthesisProperties(*typeface, fontDescription, { });
-    FontPlatformData platformData(WTF::move(typeface), fontDescription.computedSize(), syntheticBold, syntheticOblique,
+    FontPlatformData platformData(WTF::move(typeface), fontDescription.usedSize(), syntheticBold, syntheticOblique,
         fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), computeFeatures(fontDescription, { }));
     return fontForPlatformData(platformData);
 }
@@ -426,7 +426,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     auto [syntheticBold, syntheticOblique] = computeSynthesisProperties(*typeface, fontDescription, options);
     FontPlatformData platformData(WTF::move(typeface), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), WTF::move(features), fontCreationContext.metricsOverrides());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.usedSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);
 
     return platformDataUniquePtr;

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -95,7 +95,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto features = FontCache::computeFeatures(description, fontCreationContext);
 
     FontPlatformData platformData(WTF::move(typeface), size, computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext), computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext), description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features), fontCreationContext.metricsOverrides(), this);
-    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
+    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.usedSize());
     return platformData;
 }
 

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -407,7 +407,7 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
     }
 
     auto hFont = adoptGDIObject(static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT)));
-    FontPlatformData platformData(WTF::move(hFont), fontDescription.computedSize(), false, false);
+    FontPlatformData platformData(WTF::move(hFont), fontDescription.usedSize(), false, false);
     return fontForPlatformData(platformData);
 }
 

--- a/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 {
     LONG weight = adjustedGDIFontWeight(toGDIFontWeight(fontDescription.weight()), family);
     auto hfont = createGDIFont(family, weight, isItalic(fontDescription.fontStyleSlope()),
-        fontDescription.computedSize() * cWindowsFontScaleFactor);
+        fontDescription.usedSize() * cWindowsFontScaleFactor);
 
     if (!hfont)
         return nullptr;
@@ -55,7 +55,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     bool synthesizeItalic = !options.contains(FontLookupOptions::DisallowObliqueSynthesis)
         && isItalic(fontDescription.fontStyleSlope()) && !logFont.lfItalic;
 
-    auto result = makeUnique<FontPlatformData>(WTF::move(hfont), fontDescription.computedSize(), synthesizeBold, synthesizeItalic, fontCreationContext.metricsOverrides());
+    auto result = makeUnique<FontPlatformData>(WTF::move(hfont), fontDescription.usedSize(), synthesizeBold, synthesizeItalic, fontCreationContext.metricsOverrides());
 
     bool fontCreationFailed = !result->scaledFont();
 

--- a/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
@@ -33,7 +33,7 @@ cairo_font_face_t* createCairoDWriteFontFace(HFONT);
 
 FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
-    auto size = fontDescription.computedSize();
+    auto size = fontDescription.usedSize();
 
     bool syntheticBold = computeSyntheticBold(false, fontDescription, fontCreationContext);
     bool syntheticItalic = computeSyntheticItalic(false, fontDescription, fontCreationContext);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -105,7 +105,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::timeFont()
 
     auto& description = fontDescription();
     description.setSpecifiedSize(m_baseFontSize);
-    description.setComputedSize(m_baseFontSize);
+    description.setUsedSize(m_baseFontSize);
     m_timeFont = { FontCascadeDescription { description } };
     m_timeFont->update(nullptr);
 
@@ -119,7 +119,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::bipBopFont()
 
     auto& description = fontDescription();
     description.setSpecifiedSize(m_bipBopFontSize);
-    description.setComputedSize(m_bipBopFontSize);
+    description.setUsedSize(m_bipBopFontSize);
     m_bipBopFont = { FontCascadeDescription { description } };
     m_bipBopFont->update(nullptr);
 
@@ -133,7 +133,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::statsFont()
 
     auto& description = fontDescription();
     description.setSpecifiedSize(m_statsFontSize);
-    description.setComputedSize(m_statsFontSize);
+    description.setUsedSize(m_statsFontSize);
     m_statsFont = { FontCascadeDescription { description } };
     m_statsFont->update(nullptr);
 

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -243,7 +243,7 @@ static FontCascade dragLabelFont(int size, bool bold)
     description.setWeight(bold ? boldWeightValue() : normalWeightValue());
     description.setOneFamily(metrics.lfSmCaptionFont.lfFaceName);
     description.setSpecifiedSize((float)size);
-    description.setComputedSize((float)size);
+    description.setUsedSize((float)size);
     result = FontCascade(WTF::move(description));
     result.update();
     return result;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -428,7 +428,7 @@ bool RenderBlockFlow::recomputeLogicalWidthAndColumnWidth()
 LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
-        return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
+        return LayoutUnit(style().fontDescription().usedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
     return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), style().usedZoomForLength());
 }
 
@@ -4616,9 +4616,9 @@ static inline float textMultiplier(RenderObject& renderer, float specifiedSize)
     return std::max((1.0f / log10f(specifiedSize) * coefficient), 1.0f);
 }
 
-void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
+void RenderBlockFlow::adjustFontSizes(float size, float visibleWidth)
 {
-    LOG(TextAutosizing, "RenderBlockFlow %p adjustComputedFontSizes, size=%f visibleWidth=%f, borderBoxWidth()=%f. Bailing: %d", this, size, visibleWidth, borderBoxWidth().toFloat(), visibleWidth >= borderBoxWidth());
+    LOG(TextAutosizing, "RenderBlockFlow %p adjustFontSizes, size=%f visibleWidth=%f, borderBoxWidth()=%f. Bailing: %d", this, size, visibleWidth, borderBoxWidth().toFloat(), visibleWidth >= borderBoxWidth());
 
     // Don't do any work if the block is smaller than the visible area.
     if (visibleWidth >= borderBoxWidth())
@@ -4685,7 +4685,7 @@ void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
             float lineTextMultiplier = lineCount == ONE_LINE ? oneLineTextMultiplier(text, specifiedSize) : textMultiplier(text, specifiedSize);
             float candidateNewSize = roundf(std::min(minFontSize, specifiedSize * lineTextMultiplier));
 
-            if (candidateNewSize > specifiedSize && candidateNewSize != fontDescription.computedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
+            if (candidateNewSize > specifiedSize && candidateNewSize != fontDescription.usedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
                 protect(document())->textAutoSizing().addTextNode(*protect(text.textNode()), candidateNewSize);
         }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -558,8 +558,8 @@ public:
     void resetInlineContentCache();
 
 #if ENABLE(TEXT_AUTOSIZING)
-    void adjustComputedFontSizes(float size, float visibleWidth);
-    void resetComputedFontSize()
+    void adjustFontSizes(float size, float visibleWidth);
+    void resetFontSize()
     {
         m_widthForTextAutosizing = -1;
         m_lineCountForTextAutosizing = NOT_SET;

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -115,7 +115,7 @@ void RenderCombineText::combineTextIfNeeded()
         return;
 
     auto description = originalFont().fontDescription();
-    float emWidth = description.computedSize() * textCombineMargin;
+    float emWidth = description.usedSize() * textCombineMargin;
 
     RefPtr fontSelector = style().fontCascade().fontSelector();
 
@@ -169,10 +169,10 @@ void RenderCombineText::combineTextIfNeeded()
 
     if (!m_isCombined) {
         float scaleFactor = std::max(0.4f, emWidth / (emWidth + bestFitDelta));
-        float originalSize = bestFitDescription.computedSize();
+        float originalSize = bestFitDescription.usedSize();
         do {
             float computedSize = originalSize * scaleFactor;
-            bestFitDescription.setComputedSize(computedSize);
+            bestFitDescription.setUsedSize(computedSize);
             m_combineFontStyle->setFontDescription(FontCascadeDescription { bestFitDescription });
         
             FontCascade compressedFont(FontCascadeDescription { bestFitDescription }, style().fontCascade());

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2638,7 +2638,7 @@ static RenderObject::BlockContentHeightType includeNonFixedHeight(const RenderOb
     return RenderObject::FlexibleHeight;
 }
 
-void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWidth)
+void RenderElement::adjustFontSizesOnBlocks(float size, float visibleWidth)
 {
     RefPtr document = view().frameView().frame().document();
     if (!document)
@@ -2660,7 +2660,7 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
 
         int stackSize = depthStack.size();
         if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(*descendant); blockFlow && !blockFlow->isRenderListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
-            blockFlow->adjustComputedFontSizes(size, visibleWidth);
+            blockFlow->adjustFontSizes(size, visibleWidth);
         newFixedDepth = 0;
     }
 
@@ -2690,7 +2690,7 @@ void RenderElement::resetTextAutosizing()
 
         int stackSize = depthStack.size();
         if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(*descendant); blockFlow && !blockFlow->isRenderListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
-            blockFlow->resetComputedFontSize();
+            blockFlow->resetFontSize();
         newFixedDepth = 0;
     }
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -260,7 +260,7 @@ public:
     void setHasCounterNodeMap(bool f) { m_hasCounterNodeMap = f; }
 
 #if ENABLE(TEXT_AUTOSIZING)
-    void adjustComputedFontSizesOnBlocks(float size, float visibleWidth);
+    void adjustFontSizesOnBlocks(float size, float visibleWidth);
     WEBCORE_EXPORT void resetTextAutosizing();
 #endif
 

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -319,7 +319,7 @@ void RenderEmbeddedObject::getReplacementTextGeometry(const LayoutPoint& accumul
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily(SystemFontDatabase::singleton().systemFontShorthandFamily(SystemFontDatabase::FontShorthand::WebkitSmallControl));
     fontDescription.setWeight(boldWeightValue());
-    fontDescription.setComputedSize(12);
+    fontDescription.setUsedSize(12);
     font = FontCascade(WTF::move(fontDescription));
     font.update(nullptr);
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -608,7 +608,7 @@ static GridLanesLayout::ResolvedFitTolerance resolveFitTolerance(const RenderGri
     return tolerance.switchOn(
         [&](const CSS::Keyword::Normal&) -> LayoutUnit {
             // Normal resolves to 1em
-            return LayoutUnit { grid.style().computedFontSize() };
+            return LayoutUnit { grid.style().usedFontSize() };
         },
         [&](const Style::FitTolerance::Fixed& fixed) -> LayoutUnit {
             return LayoutUnit { fixed.resolveZoom(grid.style().usedZoomForLength()) };

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4468,7 +4468,7 @@ static RefPtr<Pattern> patternForDescription(PatternDescription description, Flo
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily("Helvetica"_s);
         fontDescription.setSpecifiedSize(10);
-        fontDescription.setComputedSize(10);
+        fontDescription.setUsedSize(10);
         fontDescription.setWeight(FontSelectionValue(500));
         FontCascade font(WTF::move(fontDescription));
         font.update(nullptr);

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -448,7 +448,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlock = downcast<RenderBlockFlow>(*parent());
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
-        return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
+        return LayoutUnit(parentBlock.style().fontDescription().usedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
     return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), parentBlock.style().usedZoomForLength());
 }
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -836,7 +836,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderElement& re
     CheckedRef style = renderer->style();
     return {
         extractControlStyleStatesForRendererInternal(*renderer),
-        style->computedFontSize(),
+        style->usedFontSize(),
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorApplyingColorFilter(),

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -220,7 +220,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
     bool firstPass = true;
     for (auto& node : m_autoSizedNodes) {
         auto& renderer = *node->renderer();
-        if (renderer.style().fontDescription().computedSize() == averageSize)
+        if (renderer.style().fontDescription().usedSize() == averageSize)
             continue;
 
         float specifiedSize = renderer.style().fontDescription().specifiedSize();
@@ -238,7 +238,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
 
         auto style = cloneRenderStyleWithState(renderer.style());
         auto fontDescription = style.fontDescription();
-        fontDescription.setComputedSize(averageSize);
+        fontDescription.setUsedSize(averageSize);
         style.setFontDescription(FontCascadeDescription { fontDescription });
         parentRenderer->setStyle(WTF::move(style));
 
@@ -297,7 +297,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             if (!firstLetterStyle)
                 continue;
             auto fontDescription = firstLetterStyle->fontDescription();
-            fontDescription.setComputedSize(averageSize * fontDescription.specifiedSize() / parentStyle.fontDescription().specifiedSize());
+            fontDescription.setUsedSize(averageSize * fontDescription.specifiedSize() / parentStyle.fontDescription().specifiedSize());
             firstLetterStyle->setFontDescription(FontCascadeDescription { fontDescription });
         }
 
@@ -326,8 +326,8 @@ void TextAutoSizingValue::reset()
         // Reset the font size back to the original specified size
         auto fontDescription = renderer->style().fontDescription();
         float originalSize = fontDescription.specifiedSize();
-        if (fontDescription.computedSize() != originalSize) {
-            fontDescription.setComputedSize(originalSize);
+        if (fontDescription.usedSize() != originalSize) {
+            fontDescription.setUsedSize(originalSize);
             auto style = cloneRenderStyleWithState(renderer->style());
             style.setFontDescription(FontCascadeDescription { fontDescription });
             parentRenderer->setStyle(WTF::move(style));

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -991,7 +991,7 @@ static float autoTextDecorationInset(const Style::ComputedStyle& style)
     // A small UA-chosen inset (relative to font size) so that two adjacent identical underlined
     // elements do not appear to share a single continuous underline (important for e.g. Chinese,
     // where underlining is a form of punctuation).
-    return style.computedFontSize() / 8;
+    return style.usedFontSize() / 8;
 }
 
 struct DecoratingBoxFragmentInlineSizes {
@@ -1133,7 +1133,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
                 overlineOffset(),
                 computedLinethroughCenter(decoratingBox.style.get(), textDecorationThickness, autoTextDecorationThickness),
                 decoratingBox.style->metricsOfPrimaryFont().ascent() + 2.f,
-                wavyStrokeParameters(decoratingBox.style->computedFontSize())
+                wavyStrokeParameters(decoratingBox.style->usedFontSize())
             };
         };
 
@@ -1219,7 +1219,7 @@ void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decoratio
             , insetWidth
             , textDecorationThickness
             , linethroughCenter
-            , wavyStrokeParameters(decoratingBox.style->computedFontSize()) }, decoratingBox.textDecorationStyles);
+            , wavyStrokeParameters(decoratingBox.style->usedFontSize()) }, decoratingBox.textDecorationStyles);
     }
 
     if (m_isCombinedText)

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3327,8 +3327,10 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(Style::ComputedSt
     constexpr auto controlBaseHeight = 20.0f;
     constexpr auto controlBaseFontSize = 11.0f;
 
+    // FIXME: unzoomedUsedSize() doesn't quite match 1em due to minimum font size restrictions. Likely this should use `Style::emToPx<int>(controlBaseHeight / controlBaseFontSize, style)` instead.
+
     if (!style.logicalWidth().isSpecified() || style.logicalHeight().isAuto()) {
-        auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().unzoomedComputedSize();
+        auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().unzoomedUsedSize();
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
             minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomFactor::none()));
         // FIXME: This may need to be a layout time adjustment to support various
@@ -3377,8 +3379,10 @@ bool RenderThemeCocoa::adjustMenuListButtonStyleForVectorBasedControls(Style::Co
     const float menuListBaseHeight = 20;
     const float menuListBaseFontSize = 11;
 
+    // FIXME: unzoomedUsedSize() doesn't quite match 1em due to minimum font size restrictions. Likely this should use `Style::emToPx<int>(menuListBaseHeight / menuListBaseFontSize, style)` instead.
+
     if (style.logicalHeight().isAuto())
-        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(menuListMinHeight, static_cast<int>(menuListBaseHeight / menuListBaseFontSize * style.fontDescription().unzoomedComputedSize()))) });
+        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(menuListMinHeight, static_cast<int>(menuListBaseHeight / menuListBaseFontSize * style.fontDescription().unzoomedUsedSize()))) });
     else
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(menuListMinHeight) });
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -139,7 +139,8 @@ void RenderThemeIOS::adjustCheckboxStyle(Style::ComputedStyle& style, const Elem
     if (!style.width().isSizingKeywordOrAuto() && !style.height().isAuto())
         return;
 
-    auto size = Style::PreferredSize::Fixed { std::max(style.computedFontSize(), 10.f) };
+    // FIXME: usedFontSize() includes zoom, if it is used, zoom will applied twice to width and height, once now, and once at layout / use time. Likely this should use `Style::emToPx<float>(1, style)`.
+    auto size = Style::PreferredSize::Fixed { std::max(style.usedFontSize(), 10.f) };
     style.setWidth(size);
     style.setHeight(size);
 }
@@ -240,7 +241,8 @@ void RenderThemeIOS::adjustRadioStyle(Style::ComputedStyle& style, const Element
     if (!style.width().isSizingKeywordOrAuto() && !style.height().isAuto())
         return;
 
-    auto size = std::max(style.computedFontSize(), 10.0f);
+    // FIXME: usedFontSize() includes zoom meaning zoom will applied twice to width and height, once now, and once at layout / use time. Likely this should use `Style::emToPx<float>(1, style)`.
+    auto size = std::max(style.usedFontSize(), 10.0f);
     style.setWidth(Style::PreferredSize::Fixed { size });
     style.setHeight(Style::PreferredSize::Fixed { size });
 
@@ -532,9 +534,11 @@ void RenderThemeIOS::adjustMenuListButtonStyle(Style::ComputedStyle& style, cons
     }
 #endif
 
+    // FIXME: fontDescription().usedSize() includes zoom meaning zoom will applied twice to logical min-height, once now, and once at layout / use time. Likely this should use `Style::emToPx<int>(MenuListBaseHeight / MenuListBaseFontSize, style)`.
+
     // Set the min-height to be at least MenuListMinHeight.
     if (style.logicalHeight().isAuto())
-        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(MenuListMinHeight, static_cast<int>(MenuListBaseHeight / MenuListBaseFontSize * style.fontDescription().computedSize()))) });
+        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(MenuListMinHeight, static_cast<int>(MenuListBaseHeight / MenuListBaseFontSize * style.fontDescription().usedSize()))) });
     else
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(MenuListMinHeight) });
 
@@ -958,11 +962,13 @@ void RenderThemeIOS::adjustButtonStyle(Style::ComputedStyle& style, const Elemen
     }
 #endif
 
+    // FIXME: fontDescription().usedSize() includes zoom meaning zoom will applied twice to logical min-height, once now, and once at layout / use time. Likely this should use `Style::emToPx<int>(ControlBaseHeight / ControlBaseFontSize, style)`.
+
     // If no size is specified, ensure the height of the button matches ControlBaseHeight scaled
     // with the font size. min-height is used rather than height to avoid clipping the contents of
     // the button in cases where the button contains more than one line of text.
     if (style.logicalWidth().isSizingKeywordOrAuto() || style.logicalHeight().isAuto()) {
-        auto minimumHeight = ControlBaseHeight / ControlBaseFontSize * style.fontDescription().computedSize();
+        auto minimumHeight = ControlBaseHeight / ControlBaseFontSize * style.fontDescription().usedSize();
         if (auto fixedLogicalMinHeight = style.logicalMinHeight().tryFixed())
             minimumHeight = std::max(minimumHeight, fixedLogicalMinHeight->resolveZoom(style.usedZoomForLength()));
         // FIXME: This may need to be a layout time adjustment to support various values like fit-content etc.

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1171,7 +1171,7 @@ bool RenderThemeMac::controlSupportsTints(const RenderElement& renderer) const
 
 static NSControlSize controlSizeForSystemFont(const Style::ComputedStyle& style)
 {
-    auto fontSize = style.computedFontSize();
+    auto fontSize = style.usedFontSize();
     if (fontSize >= [NSFont systemFontSizeForControlSize:NSControlSizeLarge] && supportsLargeFormControls())
         return NSControlSizeLarge;
     if (fontSize >= [NSFont systemFontSizeForControlSize:NSControlSizeRegular])
@@ -1183,7 +1183,7 @@ static NSControlSize controlSizeForSystemFont(const Style::ComputedStyle& style)
 
 static NSControlSize controlSizeForFont(const Style::ComputedStyle& style)
 {
-    auto fontSize = style.computedFontSize();
+    auto fontSize = style.usedFontSize();
     if (fontSize >= 21 && supportsLargeFormControls())
         return NSControlSizeLarge;
     if (fontSize >= 16)
@@ -1224,7 +1224,7 @@ static void setFontFromControlSize(Style::ComputedStyle& style, NSControlSize co
 
     NSFont* font = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSize]];
     fontDescription.setOneFamily("-apple-system"_s);
-    fontDescription.setComputedSize([font pointSize] * style.usedZoom(), style.usedZoom());
+    fontDescription.setUsedSize([font pointSize] * style.usedZoom(), style.usedZoom());
     fontDescription.setSpecifiedSize([font pointSize]);
 
     // Reset line height
@@ -1371,7 +1371,7 @@ Style::PaddingBox RenderThemeMac::platformPopupInternalPaddingBox(const Style::C
     }
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
-        float arrowWidth = baseArrowWidth * (style.computedFontSize() / baseFontSize);
+        float arrowWidth = baseArrowWidth * (style.usedFontSize() / baseFontSize);
         float rightPadding = ceilf(arrowWidth + (arrowPaddingBefore + arrowPaddingAfter + paddingBeforeSeparator) * style.usedZoom());
         float leftPadding = styledPopupPaddingLeft;
 
@@ -1413,7 +1413,7 @@ void RenderThemeMac::adjustMenuListButtonStyle(Style::ComputedStyle& style, cons
 #endif
 
     auto usedZoom = style.usedZoomForLength();
-    float fontScale = style.computedFontSize() / baseFontSize / usedZoom.value;
+    float fontScale = style.usedFontSize() / baseFontSize / usedZoom.value;
 
     style.resetPadding();
 
@@ -1637,7 +1637,7 @@ std::optional<FontCascadeDescription> RenderThemeMac::controlFont(StyleAppearanc
 
         NSFont* nsFont = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSizeForFont(font)]];
         fontDescription.setOneFamily("-apple-system"_s);
-        fontDescription.setComputedSize([nsFont pointSize] * zoomFactor, zoomFactor);
+        fontDescription.setUsedSize([nsFont pointSize] * zoomFactor, zoomFactor);
         fontDescription.setSpecifiedSize([nsFont pointSize]);
         return fontDescription;
     }

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -118,7 +118,7 @@ void RenderMathMLRow::stretchVerticalOperatorsAndLayoutChildren()
     }
     if (stretchAscent + stretchDescent <= 0) {
         // We ensure a minimal stretch size.
-        stretchAscent = style().computedFontSize();
+        stretchAscent = style().usedFontSize();
         stretchDescent = 0;
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -269,7 +269,7 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, protect(renderer.document())));
+    fontDescription.setUsedSize(Style::usedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, protect(renderer.document())));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -72,10 +72,10 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         // Set the font to be one line too big and then ratchet back to get to a precise fit. We can't just set the desired font size based off font height metrics
         // because many fonts bake ascent into the font metrics. Therefore we have to look at actual measured cap height values in order to know when we have a good fit.
         auto newFontDescription = firstLetterStyle.fontDescription();
-        float capRatio = firstLetterStyle.metricsOfPrimaryFont().capHeight().value() / firstLetterStyle.computedFontSize();
+        float capRatio = firstLetterStyle.metricsOfPrimaryFont().capHeight().value() / firstLetterStyle.usedFontSize();
         float startingFontSize = ((firstLetterStyle.initialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight()) / capRatio;
         newFontDescription.setSpecifiedSize(startingFontSize);
-        newFontDescription.setComputedSize(startingFontSize);
+        newFontDescription.setUsedSize(startingFontSize);
         firstLetterStyle.setFontDescription(WTF::move(newFontDescription));
 
         int desiredCapHeight = (firstLetterStyle.initialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight();
@@ -83,7 +83,7 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         while (actualCapHeight > desiredCapHeight) {
             auto newFontDescription = firstLetterStyle.fontDescription();
             newFontDescription.setSpecifiedSize(newFontDescription.specifiedSize() - 1);
-            newFontDescription.setComputedSize(newFontDescription.computedSize() -1);
+            newFontDescription.setUsedSize(newFontDescription.usedSize() - 1);
             firstLetterStyle.setFontDescription(WTF::move(newFontDescription));
             actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         }

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -108,7 +108,7 @@ static inline float defaultGap(const Style::ComputedStyle& style)
 {
     // This represents the gap between the baseline and the closest edge of the underline.
     const float textDecorationBaseFontSize = 16.f;
-    return std::max(1.f, ceilf(style.computedFontSize() / textDecorationBaseFontSize / 2.f));
+    return std::max(1.f, ceilf(style.usedFontSize() / textDecorationBaseFontSize / 2.f));
 }
 
 static float computedUnderlineOffset(const UnderlineOffsetArguments& context, const RenderObject* renderer)
@@ -180,7 +180,7 @@ static InkOverflowForDecorations computedInkOverflowForDecorations(const Style::
     InkOverflowForDecorations overflowResult;
 
     if (decorationStyle == TextDecorationStyle::Wavy) {
-        wavyStrokeParameters = WebCore::wavyStrokeParameters(lineStyle.computedFontSize());
+        wavyStrokeParameters = WebCore::wavyStrokeParameters(lineStyle.usedFontSize());
         wavyOffset = wavyOffsetFromDecoration();
         overflowResult.left() = strokeThickness;
         overflowResult.right() = strokeThickness;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -705,7 +705,7 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
     if (shouldAddIntrinsicMarginToFormControls) {
         // Important: Intrinsic margins get added to controls before the theme has adjusted the style, since the theme will
         // alter fonts and heights/widths.
-        if (is<HTMLFormControlElement>(m_element) && style.computedFontSize() >= 11) {
+        if (is<HTMLFormControlElement>(m_element) && style.usedFontSize() >= 11) {
             // Don't apply intrinsic margins to image buttons. The designer knows how big the images are,
             // so we have to treat all image buttons as though they were explicitly sized.
             if (RefPtr input = dynamicDowncast<HTMLInputElement>(*m_element); !input || !input->isImageButton())
@@ -1003,8 +1003,8 @@ void Adjuster::adjustSVGElementStyle(Style::ComputedStyle& style, const SVGEleme
         // children inherit the correct (unzoomed) computed size. The SVG root transform handles
         // the zoom scaling, consistent with other SVG content.
         auto fontDescription = style.fontDescription();
-        auto computedFontSize = computedFontSizeFromSpecifiedSize(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), /*useSVGZoomRules=*/true, style, protect(svgElement.document()));
-        fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+        auto usedFontSize = usedFontSizeFromSpecifiedSize(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), /*useSVGZoomRules=*/true, style, protect(svgElement.document()));
+        fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
         style.setFontDescription(WTF::move(fontDescription));
     }
 
@@ -1389,14 +1389,14 @@ auto Adjuster::adjustmentForTextAutosizing(const Style::ComputedStyle& style, co
         return adjustmentForTextAutosizing;
 
     float initialScale = document->page() ? document->page()->initialScaleIgnoringContentSize() : 1;
-    auto adjustLineHeightIfNeeded = [&](auto computedFontSize) {
+    auto adjustLineHeightIfNeeded = [&](auto usedFontSize) {
         auto lineHeight = style.specifiedLineHeight();
         constexpr static unsigned eligibleFontSize = 12;
-        if (computedFontSize * initialScale >= eligibleFontSize)
+        if (usedFontSize * initialScale >= eligibleFontSize)
             return;
 
         constexpr static float boostFactor = 1.25;
-        auto minimumLineHeight = boostFactor * computedFontSize;
+        auto minimumLineHeight = boostFactor * usedFontSize;
         if (auto fixedLineHeight = lineHeight.tryFixed(); !fixedLineHeight || fixedLineHeight->resolveZoom(ZoomFactor { 1.0f }) >= minimumLineHeight)
             return;
 
@@ -1407,15 +1407,15 @@ auto Adjuster::adjustmentForTextAutosizing(const Style::ComputedStyle& style, co
     };
 
     auto& fontDescription = style.fontDescription();
-    auto initialComputedFontSize = fontDescription.computedSize();
+    auto initialUsedFontSize = fontDescription.usedSize();
     auto specifiedFontSize = fontDescription.specifiedSize();
 
     bool isCandidate = newStatus.isIdempotentTextAutosizingCandidate(style);
-    if (!isCandidate && WTF::areEssentiallyEqual(initialComputedFontSize, specifiedFontSize))
+    if (!isCandidate && WTF::areEssentiallyEqual(initialUsedFontSize, specifiedFontSize))
         return adjustmentForTextAutosizing;
 
     auto adjustedFontSize = AutosizeStatus::idempotentTextSize(fontDescription.specifiedSize(), initialScale);
-    if (isCandidate && WTF::areEssentiallyEqual(initialComputedFontSize, adjustedFontSize))
+    if (isCandidate && WTF::areEssentiallyEqual(initialUsedFontSize, adjustedFontSize))
         return adjustmentForTextAutosizing;
 
     if (!hasTextChild(element))
@@ -1438,7 +1438,7 @@ bool Adjuster::adjustForTextAutosizing(Style::ComputedStyle& style, AdjustmentFo
 
     if (auto newFontSize = adjustment.newFontSize) {
         auto fontDescription = style.fontDescription();
-        fontDescription.setComputedSize(*newFontSize);
+        fontDescription.setUsedSize(*newFontSize);
         style.setFontDescription(WTF::move(fontDescription));
     }
     if (auto newLineHeight = adjustment.newLineHeight)

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -217,7 +217,7 @@ void BuilderState::updateFontForTextSizeAdjust()
     if (auto* frame = document().frame(); frame && m_style.textZoom() != TextZoom::Reset)
         zoomFactor *= frame->textZoomFactor();
     newFontDescription.setSpecifiedSize(baseSize);
-    newFontDescription.setComputedSize(baseSize * zoomFactor, zoomFactor);
+    newFontDescription.setUsedSize(baseSize * zoomFactor, zoomFactor);
 
     m_style.setFontDescriptionWithoutUpdate(WTF::move(newFontDescription));
 }
@@ -297,8 +297,8 @@ void BuilderState::updateFontForSizeChange()
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)
 {
     fontDescription.setSpecifiedSize(size);
-    auto computedFontSize = Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), style(), document());
-    fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+    auto usedFontSize = Style::usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), style(), document());
+    fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 }
 
 CSSPropertyID BuilderState::cssPropertyID() const

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -77,10 +77,10 @@ inline void BuilderState::setFontDescriptionFontSize(float fontSize)
         m_style.mutableFontDescriptionWithoutUpdate().setSpecifiedSize(fontSize);
     }
 
-    SUPPRESS_UNCOUNTED_ARG auto computedSize = Style::computedFontSizeFromSpecifiedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), style(), document());
-    if (m_style.fontDescription().computedSize() != computedSize.size || m_style.fontDescription().usedZoomFactor() != computedSize.usedZoomFactor) {
+    SUPPRESS_UNCOUNTED_ARG auto usedFontSize = Style::usedFontSizeFromSpecifiedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), style(), document());
+    if (m_style.fontDescription().usedSize() != usedFontSize.size || m_style.fontDescription().usedZoomFactor() != usedFontSize.zoomFactor) {
         m_fontDirty = true;
-        m_style.mutableFontDescriptionWithoutUpdate().setComputedSize(computedSize.size, computedSize.usedZoomFactor);
+        m_style.mutableFontDescriptionWithoutUpdate().setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
     }
 }
 

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -114,7 +114,7 @@ RefPtr<CSSValue> Extractor::getFontSizeCSSValuePreferringKeyword() const
     if (auto sizeIdentifier = style->fontDescription().keywordSizeAsIdentifier())
         return CSSKeywordValue::create(sizeIdentifier);
 
-    return CSSPrimitiveValue::create(unapplyingZoom<float>(style->fontDescription().computedSize(), *style), CSSUnitType::Px);
+    return CSSPrimitiveValue::create(unapplyingZoom<float>(style->fontDescription().usedSize(), *style), CSSUnitType::Px);
 }
 
 bool Extractor::useFixedFontDefaultSize() const

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -694,7 +694,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
                 if (state.valueType == ExtractorState::PropertyValueType::Computed)
                     return functor(number);
 
-                return functor(LineHeight::Length { number.value * state.style.fontDescription().unzoomedComputedSize() });
+                return functor(LineHeight::Length { number.value * state.style.fontDescription().unzoomedUsedSize() });
             }
         );
     }
@@ -713,7 +713,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyFontFamily> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyFontSize> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        return functor(Length<CSS::Nonnegative> { state.style.fontDescription().unzoomedComputedSize() });
+        return functor(Length<CSS::Nonnegative> { state.style.fontDescription().unzoomedUsedSize() });
     }
 };
 
@@ -2900,7 +2900,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractFontShorthand(ExtractorState& st
     if (!propertiesResetByShorthandAreExpressible())
         return computedFont;
 
-    computedFont->size = createCSSValue(state.pool, state.style, Length<> { description.unzoomedComputedSize() });
+    computedFont->size = createCSSValue(state.pool, state.style, Length<> { description.unzoomedUsedSize() });
 
     auto computedLineHeight = ExtractorGenerated::extractValue(state, CSSPropertyLineHeight);
     if (computedLineHeight && !isValueID(*computedLineHeight, CSSValueNormal))

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 namespace Style {
 
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule minimumSizeRule, const SettingsValues& settings)
+float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule minimumSizeRule, const SettingsValues& settings)
 {
     // Text with a 0px font size should not be visible and therefore needs to be
     // exempt from minimum font size rules. Acid3 relies on this for pixel-perfect
@@ -90,7 +90,7 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     return std::min(maximumAllowedFontSize, zoomedSize);
 }
 
-ComputedFontSize computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle& style, const Document& document)
+UsedFontSize usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle& style, const Document& document)
 {
     float zoomFactor = 1.0f;
     if (!useSVGZoomRules) {
@@ -99,12 +99,12 @@ ComputedFontSize computedFontSizeFromSpecifiedSize(float specifiedSize, bool isA
         if (frame && style.textZoom() != TextZoom::Reset)
             zoomFactor *= frame->textZoomFactor();
     }
-    return { computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues()), zoomFactor };
+    return { usedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues()), zoomFactor };
 }
 
-float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)
+float usedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)
 {
-    return computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, MinimumFontSizeRule::Absolute, document.settingsValues());
+    return usedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, MinimumFontSizeRule::Absolute, document.settingsValues());
 }
 
 constexpr int fontSizeTableMax = 16;

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -38,14 +38,14 @@ class ComputedStyle;
 
 enum class MinimumFontSizeRule : uint8_t { None, Absolute, AbsoluteAndRelative };
 
-struct ComputedFontSize {
+struct UsedFontSize {
     float size { 0.0f };
-    float usedZoomFactor { 1.0f };
+    float zoomFactor { 1.0f };
 };
 
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
-ComputedFontSize computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle&, const Document&);
-float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
+float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
+UsedFontSize usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle&, const Document&);
+float usedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float NODELETE adjustedFontSize(float size, const WebCore::FontSizeAdjust&, const FontMetrics&);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -287,7 +287,7 @@ class FontSizeWrapper final : public Wrapper<float> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontSizeWrapper, Animation);
 public:
     FontSizeWrapper()
-        : Wrapper<float>(CSSPropertyID::CSSPropertyFontSize, &ComputedStyleProperties::computedFontSize, &ComputedStyleProperties::setFontSize)
+        : Wrapper<float>(CSSPropertyID::CSSPropertyFontSize, &ComputedStyleProperties::usedFontSize, &ComputedStyleProperties::setFontSize)
     {
     }
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -95,8 +95,8 @@ Style::ComputedStyle resolveForDocument(const Document& document)
         int size = fontSizeForKeyword(CSSValueMedium, false, document);
         fontDescription.setSpecifiedSize(size);
         bool useSVGZoomRules = document.isSVGDocument();
-        auto computedFontSize = computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, documentStyle, document);
-        fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+        auto usedFontSize = usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, documentStyle, document);
+        fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 
         auto [fontOrientation, glyphOrientation] = documentStyle.fontAndGlyphOrientation();
         fontDescription.setOrientation(fontOrientation);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -377,7 +377,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
         if (auto sizeIdentifier = fontDescription.keywordSizeAsIdentifier()) {
             auto size = Style::fontSizeForKeyword(sizeIdentifier, !oldFamilyUsedFixedDefaultSize, protectedContext->settingsValues());
             fontDescription.setSpecifiedSize(size);
-            fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), 1.0, MinimumFontSizeRule::None, protectedContext->settingsValues()));
+            fontDescription.setUsedSize(usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), 1.0, MinimumFontSizeRule::None, protectedContext->settingsValues()));
         }
     }
 
@@ -395,7 +395,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     fontDescription.setKeywordSizeFromIdentifier(resolvedSize.keyword);
     if (resolvedSize.size > 0) {
         fontDescription.setSpecifiedSize(resolvedSize.size);
-        fontDescription.setComputedSize(resolvedSize.size);
+        fontDescription.setUsedSize(resolvedSize.size);
     }
 
     // As there is no line-height on FontCascade, there's no need to resolve it, even

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -675,8 +675,8 @@ std::unique_ptr<Style::ComputedStyle> Resolver::defaultStyleForElement(const Ele
 
     auto size = fontSizeForKeyword(CSSValueMedium, false, protect(document()));
     fontDescription.setSpecifiedSize(size);
-    auto computedFontSize = computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), *style, protect(document()));
-    fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+    auto usedFontSize = usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), *style, protect(document()));
+    fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
     style->setFontDescription(WTF::move(fontDescription));

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -310,7 +310,7 @@ bool ComputedStyle::borderAndBackgroundEqual(const ComputedStyle& other) const
 
 float ComputedStyle::computedLineHeight() const
 {
-    return evaluate<float>(lineHeight(), LineHeightEvaluationContext { computedFontSize(), metricsOfPrimaryFont().lineSpacing() }, usedZoomForLength());
+    return evaluate<float>(lineHeight(), LineHeightEvaluationContext { usedFontSize(), metricsOfPrimaryFont().lineSpacing() }, usedZoomForLength());
 }
 
 bool ComputedStyle::scrollSnapDataEquivalent(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -268,9 +268,9 @@ std::pair<FontOrientation, NonCJKGlyphOrientation> ComputedStyleBase::fontAndGly
     }
 }
 
-float ComputedStyleBase::computedFontSize() const
+float ComputedStyleBase::usedFontSize() const
 {
-    return fontDescription().computedSize();
+    return fontDescription().usedSize();
 }
 
 const LineHeight& ComputedStyleBase::specifiedLineHeight() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -655,7 +655,7 @@ public:
     WEBCORE_EXPORT const Font& primaryFont() const LIFETIME_BOUND;
     WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const LIFETIME_BOUND;
     std::pair<FontOrientation, NonCJKGlyphOrientation> NODELETE fontAndGlyphOrientation();
-    float NODELETE computedFontSize() const;
+    float NODELETE usedFontSize() const;
     inline WebkitLocale computedLocale() const;
     const LineHeight& NODELETE specifiedLineHeight() const;
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -138,7 +138,7 @@ inline void ComputedStyleProperties::setFontSize(float size)
 
     auto description = fontDescription();
     description.setSpecifiedSize(size);
-    description.setComputedSize(size, description.usedZoomFactor());
+    description.setUsedSize(size, description.usedZoomFactor());
     setFontDescription(WTF::move(description));
 
     // Whenever the font size changes, letter-spacing and word-spacing, which are dependent on font-size, must be re-synchronized.

--- a/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp
@@ -47,7 +47,7 @@ static constexpr auto defaultMetric = FontSizeAdjust::Metric::ExHeight;
 std::optional<float> FontSizeAdjust::resolvedMetricValue(const Style::ComputedStyle& style) const
 {
     if (m_platform.shouldResolveFromFont())
-        return m_platform.resolve(style.computedFontSize(), style.metricsOfPrimaryFont());
+        return m_platform.resolve(style.usedFontSize(), style.metricsOfPrimaryFont());
     return m_platform.value;
 }
 

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -69,7 +69,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
 
     auto handlePercentage = [&](const auto& percentage) {
         auto textZoomFactor = ZoomFactor { state.zoomWithTextZoomFactor() };
-        auto percentageBasis = state.style().fontDescription().unzoomedComputedSize();
+        auto percentageBasis = state.style().fontDescription().unzoomedUsedSize();
 
         // FIXME: percentage should not be restricted to an integer here.
         auto percentageValue = static_cast<int>(percentage.value);
@@ -81,7 +81,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
 
     auto handleCalc = [&](const auto& calc) {
         auto textZoomFactor = ZoomFactor { state.zoomWithTextZoomFactor() };
-        auto percentageBasis = state.style().fontDescription().unzoomedComputedSize();
+        auto percentageBasis = state.style().fontDescription().unzoomedUsedSize();
 
         return CSS::clampingToRangeOf<LineHeight::Length>(
             evaluate<float>(calc, percentageBasis, textZoomFactor) * multiplier

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -110,7 +110,7 @@ static double resolveIc(const FontCascade& fontCascadeForUnit)
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
     if (!ideogramWidth)
-        return fontDescription.unzoomedComputedSize();
+        return fontDescription.unzoomedUsedSize();
     return unzoomFontMetric(ideogramWidth.value(), fontDescription);
 }
 
@@ -705,7 +705,7 @@ bool equalForLengthResolution(const ComputedStyle& styleA, const ComputedStyle& 
 {
     // These properties affect results of `resolveLength` above.
 
-    if (styleA.fontDescription().computedSize() != styleB.fontDescription().computedSize())
+    if (styleA.fontDescription().usedSize() != styleB.fontDescription().usedSize())
         return false;
     if (styleA.fontDescription().specifiedSize() != styleB.fontDescription().specifiedSize())
         return false;
@@ -732,7 +732,7 @@ double emToPxDouble(double value, const ComputedStyle& style)
 
 double emToPxDoubleZoomed(double value, const ComputedStyle& style)
 {
-    return value * style.fontCascade().fontDescription().computedSize();
+    return value * style.fontCascade().fontDescription().usedSize();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -45,13 +45,13 @@ float TextDecorationThickness::resolve(const Style::ComputedStyle& style) const
 {
     return WTF::switchOn(m_value,
         [&](const CSS::Keyword::Auto&) {
-            return style.computedFontSize() / textDecorationBaseFontSize;
+            return style.usedFontSize() / textDecorationBaseFontSize;
         },
         [&](const CSS::Keyword::FromFont&) {
             return style.metricsOfPrimaryFont().underlineThickness().value_or(0);
         },
         [&](const LengthPercentage& value) {
-            return Style::evaluate<float>(value, style.computedFontSize(), style.usedZoomForLength());
+            return Style::evaluate<float>(value, style.usedFontSize(), style.usedZoomForLength());
         }
     );
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
@@ -43,10 +43,10 @@ float TextUnderlineOffset::resolve(const Style::ComputedStyle& style, float auto
             return Style::evaluate<float>(fixed, style.usedZoomForLength());
         },
         [&](const Calc& calc) -> float {
-            return Style::evaluate<float>(calc, style.computedFontSize(), style.usedZoomForLength());
+            return Style::evaluate<float>(calc, style.usedFontSize(), style.usedZoomForLength());
         },
         [&](const Percentage& percentage) -> float {
-            return Style::evaluate<float>(percentage, style.computedFontSize());
+            return Style::evaluate<float>(percentage, style.usedFontSize());
         }
     );
 }

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -203,7 +203,7 @@ std::optional<std::pair<double, double>> ViewGestureGeometryCollector::computeTe
         if (!textLength || !textNode->renderer() || allTextNodes.contains(*textNode))
             continue;
 
-        unsigned fontSizeBin = fontSizeBinningInterval * round(textNode->renderer()->style().fontDescription().computedSize() / fontSizeBinningInterval);
+        unsigned fontSizeBin = fontSizeBinningInterval * round(textNode->renderer()->style().fontDescription().usedSize() / fontSizeBinningInterval);
         if (!FontSizeCounter::isValidValue(fontSizeBin))
             continue;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2665,7 +2665,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformationWitho
 
     if (CheckedPtr renderer = focusedElement->renderer()) {
         information.interactionRect = rootViewInteractionBounds(*focusedElement);
-        information.nodeFontSize = protect(renderer->style())->fontDescription().computedSize();
+        information.nodeFontSize = protect(renderer->style())->fontDescription().usedSize();
 
         bool inFixed = false;
         renderer->localToContainerPoint(FloatPoint(), nullptr, MapCoordinatesMode::UseTransforms, &inFixed);

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -473,7 +473,7 @@ id<DOMEventTarget> kit(WebCore::EventTarget* target)
     auto* style = core(self)->renderStyle();
     if (!style)
         return 0.0f;
-    return style->fontDescription().computedSize();
+    return style->fontDescription().usedSize();
 }
 
 - (DOMNode *)nextFocusNode

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -50,7 +50,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont().spaceWidth();
@@ -96,7 +96,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -139,7 +139,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
 {
     FontCascadeDescription description;
     description.setOneFamily("LucidaGrande"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont().spaceWidth();
@@ -181,7 +181,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
 {
     FontCascadeDescription description;
     description.setOneFamily("LucidaGrande"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -217,7 +217,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(48);
+    description.setUsedSize(48);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -265,7 +265,7 @@ TEST_F(ComplexTextControllerTest, SubstitutedSpaceAdvanceCompensatesFollowingMar
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont().spaceWidth(Font::SyntheticBoldInclusion::Exclude);
@@ -304,7 +304,7 @@ TEST_F(ComplexTextControllerTest, SubstitutedSpaceAdvanceDoesNotCompensateInRTL)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont().spaceWidth(Font::SyntheticBoldInclusion::Exclude);
@@ -347,7 +347,7 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(48);
+    description.setUsedSize(48);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -376,7 +376,7 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(48);
+    description.setUsedSize(48);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -419,7 +419,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -84,7 +84,7 @@ TEST(FontCascadeTest, EqualityWithNullFonts)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(16);
+    description.setUsedSize(16);
 
     FontCascade a(FontCascadeDescription { description });
     FontCascade b(FontCascadeDescription { description });
@@ -168,7 +168,7 @@ TEST(FontCascadeTest, PurgeInactiveFontDataClearsShapedTextCache)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(16);
+    description.setUsedSize(16);
     FontCascade font(WTF::move(description));
     font.update();
 
@@ -189,7 +189,7 @@ TEST(FontCascadeTest, ComplexTextRetainsSystemFallbackFonts)
 {
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(16);
+    description.setUsedSize(16);
     FontCascade fontCascade(WTF::move(description));
     fontCascade.update();
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
@@ -90,7 +90,7 @@ TEST(BifurcatedGraphicsContextTests, Text)
 
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
-    description.setComputedSize(80);
+    description.setUsedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
 


### PR DESCRIPTION
#### f6a1d35c9ae3555b89ba2d3677b7366efedefcf1
<pre>
Replace references to a font&apos;s &quot;computedSize&quot; with &quot;usedSize&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=322908">https://bugs.webkit.org/show_bug.cgi?id=322908</a>

Reviewed by Darin Adler.

Part 1 of <a href="https://bugs.webkit.org/show_bug.cgi?id=319263">https://bugs.webkit.org/show_bug.cgi?id=319263</a>

FontDescription and Style::ComputedStyleBase reference a font&apos;s &quot;computed size&quot;,
but the value they currently associate with that is closer to CSS concept of a
used style size than a computed one. It is a transformation of the computed size,
which is incorrectly currently referred to as the &quot;specified&quot; size and will be
addressed next, with zoom and preference driven minimum size clamps applied.

* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/css/CSSFontFaceSource.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
* Source/WebCore/page/DebugPageOverlays.cpp:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/platform/graphics/Font.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
* Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp:
* Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderCombineText.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/InlineTextBoxStyle.cpp:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractor.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
* Source/WebCore/style/StyleFontSizeFunctions.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolver.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
* Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
* Source/WebKitLegacy/mac/DOM/DOM.mm:
* Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp:

Canonical link: <a href="https://commits.webkit.org/320257@main">https://commits.webkit.org/320257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0ac6825a9e63109b3b2905b638d699e4f5cc488

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184244 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143845 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99978 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124256 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46330 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44119 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5650 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57840 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41074 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153075 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47606 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130844 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57052 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->