### PR TITLE
[list-marker] Marker text should not be filled in lazily from RenderListMarker::layout()

### DIFF
--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -296,7 +296,7 @@ static RenderListItem* previousListItem(const Element& list, const RenderListIte
 void RenderListItem::updateItemValuesForOrderedList(const HTMLOListElement& list)
 {
     for (auto* listItem = firstListItem(list); listItem; listItem = nextListItem(list, *listItem))
-        listItem->updateValue();
+        listItem->updateValueAndMarkerContent();
 }
 
 unsigned RenderListItem::itemCountForOrderedList(const HTMLOListElement& list)
@@ -387,6 +387,15 @@ void RenderListItem::updateValue()
     }
 }
 
+void RenderListItem::updateValueAndMarkerContent()
+{
+    updateValue();
+    // Nothing is changing the render tree here, so there is nothing to wait for: fill the marker's text in right away
+    // rather than leave it to layout (see RenderTreeBuilder::updateListMarkerContents()).
+    if (m_marker)
+        m_marker->updateInlineMarginsAndContent();
+}
+
 void RenderListItem::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
 {
     RenderBlockFlow::styleDidChange(diff, oldStyle);
@@ -397,15 +406,6 @@ void RenderListItem::styleDidChange(Style::Difference diff, const Style::Compute
         if (m_marker && m_marker->excludedPosition())
             m_marker->invalidateExcludedMarkerContainer();
     }
-}
-
-void RenderListItem::computeIntrinsicLogicalWidthContributions()
-{
-    // FIXME: RenderListMarker::updateInlineMargins() mutates margin style which affects preferred widths.
-    if (m_marker && m_marker->hasInvalidContentLogicalWidths())
-        m_marker->updateInlineMarginsAndContent();
-
-    RenderBlockFlow::computeIntrinsicLogicalWidthContributions();
 }
 
 RenderListMarker* RenderListItem::excludedMarker() const
@@ -475,20 +475,20 @@ void RenderListItem::usedCounterDirectivesChanged()
     if (m_marker)
         m_marker->setNeedsLayoutAndInvalidateContentLogicalWidths();
 
-    updateValue();
+    updateValueAndMarkerContent();
     RefPtr list = enclosingList(*this);
     if (!list)
         return;
     auto* item = this;
     while ((item = nextListItem(*list, *item)))
-        item->updateValue();
+        item->updateValueAndMarkerContent();
 }
 
-void RenderListItem::updateListMarkerNumbers()
+Vector<CheckedRef<RenderListMarker>> RenderListItem::updateListMarkerNumbers()
 {
     RefPtr list = enclosingList(*this);
     if (!list)
-        return;
+        return { };
 
     bool isInReversedOrderedList = false;
     if (auto* orderedList = dynamicDowncast<HTMLOListElement>(*list)) {
@@ -498,10 +498,15 @@ void RenderListItem::updateListMarkerNumbers()
 
     // If an item has been marked for update before, we know that all following items have, too.
     // This gives us the opportunity to stop and avoid marking the same nodes again.
+    Vector<CheckedRef<RenderListMarker>> markersNeedingContentUpdate;
     auto* item = this;
     auto subsequentListItem = isInReversedOrderedList ? previousListItem : nextListItem;
-    while ((item = subsequentListItem(*list, *item)) && item->m_value)
+    while ((item = subsequentListItem(*list, *item)) && item->m_value) {
         item->updateValue();
+        if (CheckedPtr marker = item->m_marker.get())
+            markersNeedingContentUpdate.append(*marker);
+    }
+    return markersNeedingContentUpdate;
 }
 
 bool RenderListItem::isInReversedOrderedList() const

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -41,7 +41,9 @@ public:
 
     WEBCORE_EXPORT String markerText(RenderListMarker::IncludeSuffix = RenderListMarker::IncludeSuffix::Yes) const;
 
-    void updateListMarkerNumbers();
+    // Returns the markers whose text the renumbering invalidated, for the caller to fill in once it is done changing
+    // the tree (RenderTreeBuilder::addListMarkerNeedingContentUpdate).
+    Vector<CheckedRef<RenderListMarker>> updateListMarkerNumbers();
 
     static void updateItemValuesForOrderedList(const HTMLOListElement&);
     static unsigned itemCountForOrderedList(const HTMLOListElement&);
@@ -77,8 +79,8 @@ private:
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
 
-    void computeIntrinsicLogicalWidthContributions() final;
 
+    void updateValueAndMarkerContent();
     void updateValueNow() const;
     void usedCounterDirectivesChanged();
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -193,7 +193,27 @@ RenderTreeBuilder::RenderTreeBuilder(RenderView& view)
 
 RenderTreeBuilder::~RenderTreeBuilder()
 {
+    // Normally a no-op: RenderTreeUpdater::commit() has already done this. It is here for the tree changes that run
+    // with no render tree update in flight, tearing renderers down for a subtree that is leaving the composed tree
+    // (ContainerNode::destroyRenderTreeIfNeeded()), since those build a RenderTreeBuilder of their own.
+    // FIXME: Remove once those sites are driven by the render tree update, see RenderTreeBuilder::current().
+    updateListMarkerContents();
     s_current = m_previous;
+}
+
+void RenderTreeBuilder::addListMarkerNeedingContentUpdate(RenderListMarker& marker)
+{
+    m_listMarkersNeedingContentUpdate.add(marker);
+}
+
+void RenderTreeBuilder::updateListMarkerContents()
+{
+    // A marker's text is made of its list item's list-item counter value, which is only settled once the tree is done
+    // changing: inserting or removing a list item renumbers every item after it.
+    while (!m_listMarkersNeedingContentUpdate.isEmptyIgnoringNullReferences()) {
+        for (auto& marker : std::exchange(m_listMarkersNeedingContentUpdate, { }))
+            marker.updateInlineMarginsAndContent();
+    }
 }
 
 bool RenderTreeBuilder::isRebuildRootForChildren(const RenderElement& renderer)
@@ -485,8 +505,10 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
         newChild->initializeFragmentedFlowStateOnInsertion();
         if (CheckedPtr fragmentedFlow = dynamicDowncast<RenderMultiColumnFlow>(newChild->enclosingFragmentedFlow()))
             multiColumnBuilder().multiColumnDescendantInserted(*fragmentedFlow, *newChild);
-        if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(*newChild))
-            listItemRenderer->updateListMarkerNumbers();
+        if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(*newChild)) {
+            for (auto& marker : listItemRenderer->updateListMarkerNumbers())
+                addListMarkerNeedingContentUpdate(marker);
+        }
     }
 
     newChild->setNeedsLayoutAndInvalidateContentLogicalWidths();
@@ -1004,7 +1026,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderGrid(RenderGrid& pare
     return takenChild;
 }
 
-static void resetRendererStateOnDetach(RenderElement& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed willBeDestroyed, RenderTreeBuilder::IsInternalMove isInternalMove)
+static void resetRendererStateOnDetach(RenderElement& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed willBeDestroyed)
 {
     if (child.isFloatingOrOutOfFlowPositioned())
         downcast<RenderBox>(child).removeFloatingOrOutOfFlowChildFromBlockLists();
@@ -1020,8 +1042,6 @@ static void resetRendererStateOnDetach(RenderElement& parent, RenderObject& chil
     if (CheckedPtr textRenderer = dynamicDowncast<RenderSVGInlineText>(child))
         textRenderer->removeAndDestroyLegacyTextBoxes();
 
-    if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(child); listItemRenderer && isInternalMove == RenderTreeBuilder::IsInternalMove::No)
-        listItemRenderer->updateListMarkerNumbers();
 }
 
 RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed willBeDestroyed)
@@ -1039,7 +1059,12 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     }
 
     if (child.everHadLayout())
-        resetRendererStateOnDetach(parent, child, willBeDestroyed, m_internalMovesType);
+        resetRendererStateOnDetach(parent, child, willBeDestroyed);
+
+    if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(child); listItemRenderer && child.everHadLayout() && m_internalMovesType == IsInternalMove::No) {
+        for (auto& marker : listItemRenderer->updateListMarkerNumbers())
+            addListMarkerNeedingContentUpdate(marker);
+    }
 
     if (m_tearDownType == RenderTreeBuilder::TearDownType::Root || is<RenderInline>(m_subtreeDestroyRoot)) {
         // In case of partial damage on the inline content (the block root is not going away), we need to initiate inline layout invalidation on leaf renderers too.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -27,10 +27,12 @@
 
 #include "RenderTreePosition.h"
 #include "RenderWidget.h"
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
 class RenderGrid;
+class RenderListMarker;
 class RenderTreeUpdater;
 
 class RenderTreeBuilder {
@@ -68,7 +70,14 @@ public:
     void destroyAndCleanUpAnonymousWrappers(RenderObject& child, const RenderElement* destroyRoot);
     void normalizeTreeAfterStyleChange(RenderElement&, Style::ComputedStyle& oldStyle);
 
+    // Fills in what the marker registration below collected. Called from RenderTreeUpdater::GeneratedContent.
+    void updateListMarkerContents();
+
 private:
+    // Collected while the tree is being built: a marker's text is made of its list item's list-item counter value,
+    // which is only settled once the tree is done changing.
+    void addListMarkerNeedingContentUpdate(RenderListMarker&);
+
     static void markBoxForRelayoutAfterSplit(RenderBoxModelObject&);
 
     void attachInternal(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild);
@@ -131,6 +140,7 @@ private:
 
     WidgetHierarchyUpdatesSuspensionScope m_widgetHierarchyUpdatesSuspensionScope;
     RenderView& m_view;
+    SingleThreadWeakHashSet<RenderListMarker> m_listMarkersNeedingContentUpdate;
     RenderTreeBuilder* m_previous { nullptr };
     static RenderTreeBuilder* s_current;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -140,6 +140,8 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         // unicode-bidi, so rebuild on that too, to carry the new value into it.
         auto contentChanged = markerRenderer->style().content() != newStyle.content() || markerRenderer->style().unicodeBidi() != newStyle.unicodeBidi() || markerRenderer->style().listStyleType() != newStyle.listStyleType();
         markerRenderer->setStyle(WTF::move(newStyle));
+        // list-style-type, the counter style it resolves to and the writing mode all decide the marker's text.
+        m_builder.addListMarkerNeedingContentUpdate(*markerRenderer);
 
         // Recomputing this here rather than diffing the style properties it is made of also picks up
         // what is not the marker's own style: its direction, and what the document's counter style
@@ -193,6 +195,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
 
     RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
+    m_builder.addListMarkerNeedingContentUpdate(*newMarkerRenderer);
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
     auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
     auto shouldCollapseAnonymousBlockParent = !searchResult.parent && !newMarkerRenderer->isInside() && searchResult.shouldCollapseAnonymousBlockParent;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -143,6 +143,7 @@ void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
 
     generatedContent().updateRemainingQuotes();
     generatedContent().updateCounters();
+    generatedContent().updateListMarkers();
 
     m_builder.updateAfterDescendants(renderView());
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -127,6 +127,13 @@ void RenderTreeUpdater::GeneratedContent::updateCounters()
     update();
 }
 
+void RenderTreeUpdater::GeneratedContent::updateListMarkers()
+{
+    // The markers were collected by the builder as it changed the tree, since a marker's text is made of its list
+    // item's list-item counter value and that is only settled once the tree is done changing.
+    m_updater.m_builder.updateListMarkerContents();
+}
+
 static KeyframeEffectStack* NODELETE keyframeEffectStackForPseudoElement(const Element& element, PseudoElementType pseudoElementType)
 {
     if (!element.mayHaveKeyframeEffects())

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -44,6 +44,7 @@ public:
     void updateBeforeOrAfterPseudoElement(Element&, const Style::ElementUpdate&, PseudoElementType);
     void updateRemainingQuotes();
     void updateCounters();
+    void updateListMarkers();
     void updateWritingSuggestionsRenderer(RenderElement&, Style::DifferenceResult minimalStyleDifference);
 
     static void removeBeforePseudoElement(Element&, RenderTreeBuilder&);


### PR DESCRIPTION
#### fdc812b2d80ba8e3472ebe39795f68fe2444a65e
<pre>
[list-marker] Marker text should not be filled in lazily from RenderListMarker::layout()
<a href="https://bugs.webkit.org/show_bug.cgi?id=322915">https://bugs.webkit.org/show_bug.cgi?id=322915</a>
&lt;<a href="https://rdar.apple.com/problem/186180196">rdar://problem/186180196</a>&gt;

Reviewed by Antti Koivisto.

A marker&apos;s text is made of its list item&apos;s list-item counter value, which is only settled once the tree is done changing, so it was left to layout to fill in.
Have the marker register with the RenderTreeBuilder in charge of the change instead, which fills in what it collected when it is finished,
and drop the two call sites that had to reach into the marker before it was measured.

No behavior change.

Canonical link: <a href="https://commits.webkit.org/320127@main">https://commits.webkit.org/320127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dda82778afbe3ec145f85b381b20d4d98e160de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148145 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef75e975-4032-417c-8d3e-08149728684e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57511 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143502 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99675 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d47afcca-5360-438d-833c-92d3302cfa6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186807 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47272 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure(s) based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123924 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/224da794-629e-480d-9e00-82cc948aa2c8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45973 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44205 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43787 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5256 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50431 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 26986 issues") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48472 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196012 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57446 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58150 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152726 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47267 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130430 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126879 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56658 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18798 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->