### PR TITLE
Resync `webaudio` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/flac-builder.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/flac-builder.js
@@ -1,0 +1,233 @@
+/**
+ * In-memory FLAC file synthesizer for Web Audio decode tests.
+ *
+ * buildFlac(options) returns an ArrayBuffer holding a spec-valid FLAC stream made
+ * of silent CONSTANT-subframe frames, so a test can synthesize FLAC with a chosen
+ * sample rate, block size, frame count and channel layout without shipping a binary
+ * asset. Samples are always 16-bit (BITS_PER_SAMPLE).
+ */
+
+(function () {
+  "use strict";
+
+  // "fLaC" stream marker that opens every FLAC file.
+  const FLAC_STREAM_MARKER = [0x66, 0x4c, 0x61, 0x43];
+  // Metadata block header byte: last-metadata-block flag (0x80) | block type 0 (STREAMINFO).
+  const METADATA_BLOCK_HEADER_STREAMINFO_LAST = 0x80;
+  // STREAMINFO payload length in bytes (fixed at 34).
+  const STREAMINFO_LENGTH = 34;
+  // Length of the trailing MD5 signature field (left zero = unset).
+  const MD5_SIGNATURE_LENGTH = 16;
+  // Frame sync: 14-bit sync code with fixed blocking strategy.
+  const FRAME_SYNC = [0xff, 0xf8];
+  // Frame-header block-size code (top nibble 0b0111): a 16-bit (blockSize-1) follows the header.
+  const BLOCKSIZE_CODE_16BIT_MINUS1 = 0x70;
+  // Sample-size nibble for 16-bit samples in the frame-header channel/bps byte.
+  const SAMPLE_SIZE_CODE_16BIT = 0x08;
+  // Subframe header byte: CONSTANT subframe type with 0 wasted bits.
+  const SUBFRAME_HEADER_CONSTANT = 0x00;
+  // Generator polynomials for the header CRC-8 and the frame CRC-16.
+  const CRC8_POLY = 0x07;
+  const CRC16_POLY = 0x8005;
+  // Samples are emitted as 16-bit constants. To support other depths in the
+  // future, make this a per-call option and update three byte-packed sites: the
+  // (bps - 1) field in buildStreamInfo, the sample-size nibble in buildFrame's
+  // header (SAMPLE_SIZE_CODE_16BIT), and the per-sample byte width written into
+  // each CONSTANT subframe (currently a fixed big-endian 16-bit value).
+  const BITS_PER_SAMPLE = 16;
+  // FLAC independent-channel assignments encode 1..8 channels as (channels - 1).
+  const MAX_CHANNELS = 8;
+  // STREAMINFO sample-rate code (index into the FLAC fixed sample-rate table).
+  const SAMPLE_RATE_CODES = {
+    88200: 1,
+    176400: 2,
+    192000: 3,
+    8000: 4,
+    16000: 5,
+    22050: 6,
+    24000: 7,
+    32000: 8,
+    44100: 9,
+    48000: 10,
+    96000: 11,
+  };
+  // Splits the 36-bit STREAMINFO total-samples field.
+  const TWO_POW_32 = 2 ** 32;
+
+  // CRC-8 (polynomial 0x07, MSB-first) over the frame header bytes; the result
+  // is the last byte of every FLAC frame header.
+  function crc8(bytes) {
+    let c = 0;
+    for (const b of bytes) {
+      c ^= b;
+      for (let i = 0; i < 8; i++) {
+        c = c & 0x80 ? ((c << 1) ^ CRC8_POLY) & 0xff : (c << 1) & 0xff;
+      }
+    }
+    return c;
+  }
+
+  // CRC-16 (polynomial 0x8005, MSB-first) over the whole frame up to the
+  // checksum; the result is the two trailing bytes of every FLAC frame.
+  function crc16(bytes) {
+    let c = 0;
+    for (const b of bytes) {
+      c ^= b << 8;
+      for (let i = 0; i < 8; i++) {
+        c = c & 0x8000 ? ((c << 1) ^ CRC16_POLY) & 0xffff : (c << 1) & 0xffff;
+      }
+    }
+    return c;
+  }
+
+  // Encodes a frame number as FLAC's UTF-8-like variable-length integer (the
+  // "coded number" in a fixed-blocksize frame header): 1-4 bytes whose length
+  // grows with the value's magnitude, mirroring UTF-8 byte sequences.
+  function utf8FrameNumber(n) {
+    if (n < 0x80) {
+      return [n];
+    }
+    if (n < 0x800) {
+      return [0xc0 | (n >> 6), 0x80 | (n & 0x3f)];
+    }
+    if (n < 0x10000) {
+      return [0xe0 | (n >> 12), 0x80 | ((n >> 6) & 0x3f), 0x80 | (n & 0x3f)];
+    }
+    return [
+      0xf0 | (n >> 18),
+      0x80 | ((n >> 12) & 0x3f),
+      0x80 | ((n >> 6) & 0x3f),
+      0x80 | (n & 0x3f),
+    ];
+  }
+
+  function buildStreamInfo(blockSize, sampleRate, channels, totalSamples) {
+    // The packed field after the block-size and frame-size fields holds, in order:
+    //   20 bits sample rate | 3 bits (channels - 1) | 5 bits (bps - 1) | 36 bits total samples.
+    const bpsMinus1 = BITS_PER_SAMPLE - 1;
+    const totalHi = Math.floor(totalSamples / TWO_POW_32); // top 4 bits of the 36-bit total
+    const totalLo = totalSamples % TWO_POW_32; // low 32 bits of the total
+    return [
+      ...FLAC_STREAM_MARKER,
+      METADATA_BLOCK_HEADER_STREAMINFO_LAST,
+      0x00,
+      0x00,
+      STREAMINFO_LENGTH,
+      (blockSize >> 8) & 0xff,
+      blockSize & 0xff, // min block size
+      (blockSize >> 8) & 0xff,
+      blockSize & 0xff, // max block size
+      0x00,
+      0x00,
+      0x00, // min frame size (unknown)
+      0x00,
+      0x00,
+      0x00, // max frame size (unknown)
+      (sampleRate >> 12) & 0xff,
+      (sampleRate >> 4) & 0xff,
+      ((sampleRate & 0x0f) << 4) |
+        (((channels - 1) & 0x07) << 1) |
+        ((bpsMinus1 >> 4) & 0x01),
+      ((bpsMinus1 & 0x0f) << 4) | (totalHi & 0x0f),
+      (totalLo >>> 24) & 0xff,
+      (totalLo >>> 16) & 0xff,
+      (totalLo >>> 8) & 0xff,
+      totalLo & 0xff,
+      ...new Array(MD5_SIGNATURE_LENGTH).fill(0),
+    ];
+  }
+
+  function buildFrame(
+    frameIndex,
+    blockSize,
+    sampleRate,
+    channels,
+    sampleValue
+  ) {
+    const blockSizeMinus1 = blockSize - 1;
+    const header = [
+      ...FRAME_SYNC,
+      BLOCKSIZE_CODE_16BIT_MINUS1 | SAMPLE_RATE_CODES[sampleRate],
+      (((channels - 1) & 0x07) << 4) | SAMPLE_SIZE_CODE_16BIT,
+      ...utf8FrameNumber(frameIndex),
+      (blockSizeMinus1 >> 8) & 0xff,
+      blockSizeMinus1 & 0xff,
+    ];
+    header.push(crc8(header));
+
+    const frame = header.slice();
+    const sampleHi = (sampleValue >> 8) & 0xff;
+    const sampleLo = sampleValue & 0xff;
+    for (let c = 0; c < channels; c++) {
+      frame.push(SUBFRAME_HEADER_CONSTANT, sampleHi, sampleLo);
+    }
+    const crc = crc16(frame);
+    frame.push((crc >> 8) & 0xff, crc & 0xff);
+    return frame;
+  }
+
+  /**
+   * options:
+   *   sampleRate   : FLAC fixed-table rate (8000/16000/22050/24000/32000/44100/
+   *                  48000/88200/96000/176400/192000)                    [required]
+   *   blockSize    : samples per FLAC frame (e.g. 65535)                  [required]
+   *   frameCount   : number of FLAC frames to emit                        [required]
+   *   totalSamples : value written to the STREAMINFO total-samples field
+   *                  (defaults to blockSize * frameCount; kept separate so a
+   *                  test can declare an oversized total on purpose)      [optional]
+   *   channels     : 1..8 independent channels                           [required]
+   *   sampleValue  : constant 16-bit sample emitted in every subframe
+   *                  (default 0 = silence)                                [optional]
+   * returns: ArrayBuffer of the encoded FLAC file.
+   */
+  function buildFlac(options) {
+    const {
+      sampleRate,
+      blockSize,
+      frameCount,
+      totalSamples = blockSize * frameCount,
+      channels,
+      sampleValue = 0,
+    } = options;
+
+    if (!(sampleRate in SAMPLE_RATE_CODES)) {
+      throw new Error(
+        `buildFlac: sampleRate ${sampleRate} is not a FLAC fixed-table rate`
+      );
+    }
+    if (
+      !Number.isInteger(channels) ||
+      channels < 1 ||
+      channels > MAX_CHANNELS
+    ) {
+      throw new Error(
+        `buildFlac: channels must be an integer in 1..${MAX_CHANNELS}`
+      );
+    }
+
+    const streamInfo = buildStreamInfo(
+      blockSize,
+      sampleRate,
+      channels,
+      totalSamples
+    );
+    let length = streamInfo.length;
+    const frames = [];
+    for (let i = 0; i < frameCount; i++) {
+      const frame = buildFrame(i, blockSize, sampleRate, channels, sampleValue);
+      frames.push(frame);
+      length += frame.length;
+    }
+
+    const out = new Uint8Array(length);
+    out.set(streamInfo, 0);
+    let offset = streamInfo.length;
+    for (const frame of frames) {
+      out.set(frame, offset);
+      offset += frame.length;
+    }
+    return out.buffer;
+  }
+
+  window.buildFlac = buildFlac;
+})();

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/w3c-import.log
@@ -24,6 +24,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/convolution-testing.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/delay-testing.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/distance-model-testing.js
+/LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/flac-builder.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/merger-testing.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/mix-testing.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/mixing-rules.js

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https-expected.txt
@@ -1,62 +1,62 @@
 
-PASS OscillatorNode smoke test at 3000Hz & hint 1
-FAIL OscillatorNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS OscillatorNode smoke test at 48000Hz & hint 128
+PASS OscillatorNode smoke test at 3000Hz & hint 1
+FAIL OscillatorNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS OscillatorNode smoke test at 48000Hz & hint 100
-PASS AudioBufferSourceNode smoke test at 3000Hz & hint 1
-FAIL AudioBufferSourceNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS AudioBufferSourceNode smoke test at 48000Hz & hint 128
+PASS AudioBufferSourceNode smoke test at 3000Hz & hint 1
+FAIL AudioBufferSourceNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS AudioBufferSourceNode smoke test at 48000Hz & hint 100
-PASS ConstantSourceNode smoke test at 3000Hz & hint 1
-FAIL ConstantSourceNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ConstantSourceNode smoke test at 48000Hz & hint 128
+PASS ConstantSourceNode smoke test at 3000Hz & hint 1
+FAIL ConstantSourceNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ConstantSourceNode smoke test at 48000Hz & hint 100
-PASS GainNode smoke test at 3000Hz & hint 1
-FAIL GainNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS GainNode smoke test at 48000Hz & hint 128
+PASS GainNode smoke test at 3000Hz & hint 1
+FAIL GainNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS GainNode smoke test at 48000Hz & hint 100
-PASS BiquadFilterNode smoke test at 3000Hz & hint 1
-FAIL BiquadFilterNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS BiquadFilterNode smoke test at 48000Hz & hint 128
+PASS BiquadFilterNode smoke test at 3000Hz & hint 1
+FAIL BiquadFilterNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS BiquadFilterNode smoke test at 48000Hz & hint 100
-PASS DelayNode smoke test at 3000Hz & hint 1
-FAIL DelayNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS DelayNode smoke test at 48000Hz & hint 128
+PASS DelayNode smoke test at 3000Hz & hint 1
+FAIL DelayNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS DelayNode smoke test at 48000Hz & hint 100
-PASS DynamicsCompressorNode smoke test at 3000Hz & hint 1
-FAIL DynamicsCompressorNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS DynamicsCompressorNode smoke test at 48000Hz & hint 128
+PASS DynamicsCompressorNode smoke test at 3000Hz & hint 1
+FAIL DynamicsCompressorNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS DynamicsCompressorNode smoke test at 48000Hz & hint 100
-PASS WaveShaperNode smoke test at 3000Hz & hint 1
-FAIL WaveShaperNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS WaveShaperNode smoke test at 48000Hz & hint 128
+PASS WaveShaperNode smoke test at 3000Hz & hint 1
+FAIL WaveShaperNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS WaveShaperNode smoke test at 48000Hz & hint 100
-PASS PannerNode smoke test at 3000Hz & hint 1
-FAIL PannerNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS PannerNode smoke test at 48000Hz & hint 128
+PASS PannerNode smoke test at 3000Hz & hint 1
+FAIL PannerNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS PannerNode smoke test at 48000Hz & hint 100
-PASS StereoPannerNode smoke test at 3000Hz & hint 1
-FAIL StereoPannerNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS StereoPannerNode smoke test at 48000Hz & hint 128
+PASS StereoPannerNode smoke test at 3000Hz & hint 1
+FAIL StereoPannerNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS StereoPannerNode smoke test at 48000Hz & hint 100
-PASS AnalyserNode smoke test at 3000Hz & hint 1
-FAIL AnalyserNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS AnalyserNode smoke test at 48000Hz & hint 128
+PASS AnalyserNode smoke test at 3000Hz & hint 1
+FAIL AnalyserNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS AnalyserNode smoke test at 48000Hz & hint 100
-PASS IIRFilterNode smoke test at 3000Hz & hint 1
-FAIL IIRFilterNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS IIRFilterNode smoke test at 48000Hz & hint 128
+PASS IIRFilterNode smoke test at 3000Hz & hint 1
+FAIL IIRFilterNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS IIRFilterNode smoke test at 48000Hz & hint 100
-PASS ConvolverNode smoke test at 3000Hz & hint 1
-FAIL ConvolverNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ConvolverNode smoke test at 48000Hz & hint 128
+PASS ConvolverNode smoke test at 3000Hz & hint 1
+FAIL ConvolverNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ConvolverNode smoke test at 48000Hz & hint 100
-PASS ChannelMergerNode smoke test at 3000Hz & hint 1
-FAIL ChannelMergerNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ChannelMergerNode smoke test at 48000Hz & hint 128
+PASS ChannelMergerNode smoke test at 3000Hz & hint 1
+FAIL ChannelMergerNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ChannelMergerNode smoke test at 48000Hz & hint 100
-PASS ChannelSplitterNode smoke test at 3000Hz & hint 1
-FAIL ChannelSplitterNode smoke test at 768000Hz & hint 4608000 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ChannelSplitterNode smoke test at 48000Hz & hint 128
+PASS ChannelSplitterNode smoke test at 3000Hz & hint 1
+FAIL ChannelSplitterNode smoke test at 768000Hz & hint 256 promise_test: Unhandled rejection with value: object "NotSupportedError: sampleRate is not in range"
 PASS ChannelSplitterNode smoke test at 48000Hz & hint 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https.html
@@ -4,12 +4,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 const TEST_CONFIGS = [
-  // Stress test very low rate & tiny block sizes.
-  {sampleRate: 3000, renderSizeHint: 1, length: 128},
-  // Stress test very high rate & massive block sizes.
-  {sampleRate: 768000, renderSizeHint: 4608000, length: 4608000},
   // Standard baseline verification.
   {sampleRate: 48000, renderSizeHint: 128, length: 128},
+  // Stress test very low rate & tiny block sizes.
+  {sampleRate: 3000, renderSizeHint: 1, length: 128},
+  // Stress test very high rate & larger than default block size.
+  {sampleRate: 768000, renderSizeHint: 256, length: 256},
   // Non-power-of-two block size verification.
   {sampleRate: 48000, renderSizeHint: 100, length: 200}
 ];

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/w3c-import.log
@@ -28,6 +28,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-dynamic-direction.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-zero.html
+/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-start-null-buffer.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-start.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended.html

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL error callback is invoked with DataCloneError promise_rejects_dom: function "function() { throw e; }" threw object "EncodingError: Decoding failed" that is not a DOMException DataCloneError: property "code" is equal to 0, expected 25
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test to verify decodeAudioData() invokes the error callback for a detached ArrayBuffer</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body></body>
+<script>
+promise_test(async t => {
+  const context = new AudioContext();
+  t.add_cleanup(() => context.close());
+
+  // create a detached ArrayBuffer
+  const audioData = new ArrayBuffer(4);
+  structuredClone({}, { transfer: [audioData] });
+
+  // save a reference to the promise res
+  let resolve;
+  const errorInvoked = new Promise(res => { resolve = res; });
+
+  // create decodeAudioData() promise with success and error callbacks
+  const success = t.unreached_func('success callback should not run');
+  const error = t.step_func(err => { resolve(err); });
+  const promise = context.decodeAudioData(audioData, success, error);
+
+  // assert promise rejects with DataCloneError and await pending errorInvoked promise
+  const [, err] = await Promise.all([
+    promise_rejects_dom(t, 'DataCloneError', promise),
+    errorInvoked,
+  ]);
+
+  // err must be a DataCloneError DOMException
+  assert_true(err instanceof DOMException, 'error callback argument is a DOMException');
+  assert_equals(err.name, 'DataCloneError');
+
+}, 'error callback is invoked with DataCloneError');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/w3c-import.log
@@ -26,6 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume-close.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html
+/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/constructor-allowed-to-start.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/context-time-monotonic-on-setsinkid.https.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/processing-after-resume.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections-expected.txt
@@ -3,5 +3,5 @@ PASS Verify k-rate 'attack' with input on DynamicsCompressorNode
 PASS Verify k-rate 'knee' with input on DynamicsCompressorNode
 PASS Verify k-rate 'ratio' with input on DynamicsCompressorNode
 PASS Verify k-rate 'release' with input on DynamicsCompressorNode
-FAIL Verify k-rate 'threshold' with input on DynamicsCompressorNode assert_equals: threshold: Sample[512] must match exactly expected 0.004096666816622019 but got 0.004097588360309601
+PASS Verify k-rate 'threshold' with input on DynamicsCompressorNode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/w3c-import.log
@@ -29,6 +29,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurveAtTime.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-summingjunction.html
+/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/automation-rate-testing.js
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/automation-rate.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.html

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https-expected.txt
@@ -1,7 +1,8 @@
 
-FAIL AudioWorkletGlobalScope: message via shared port promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'context.audioWorklet.port.onmessage = (event) => {
-            resolve(event.data);
-          }')"
+Harness Error (FAIL), message = Unhandled rejection: undefined is not an object (evaluating 'port.addEventListener')
+
+FAIL AudioWorklet: shared port exists before addModule() assert_true: AudioWorklet.port must exist before addModule() expected true got false
+FAIL AudioWorkletGlobalScope: shared port is available at module evaluation time and supports message passing promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'port.addEventListener')"
 PASS AudioWorkletProcessor: initialization message
 PASS AudioWorkletProcessor: message via instance port
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html
@@ -11,67 +11,87 @@
     <script>
       const filePath = 'processors/port-processor.js';
 
-      // Global-to-worklet via shared port test
-      promise_test(async (t) => {
+      function createContext(t) {
         const context = new AudioContext();
         t.add_cleanup(() => context.close());
+        return context;
+      }
+
+      async function createPortProcessorNode(context) {
         await context.audioWorklet.addModule(filePath);
+        return new AudioWorkletNode(context, 'port-processor');
+      }
 
-        const globalOnMessagePromise = new Promise((resolve) => {
-          context.audioWorklet.port.onmessage = (event) => {
-            resolve(event.data);
+      // Waits until `port` receives a message whose payload satisfies
+      // `predicate`, then resolves with that payload.
+      function waitForPortMessage(port, predicate) {
+        return new Promise((resolve) => {
+          const onMessage = (event) => {
+            if (predicate(event.data)) {
+              port.removeEventListener('message', onMessage);
+              resolve(event.data);
+            }
           };
-          context.audioWorklet.port.postMessage('hello world');
+          port.addEventListener('message', onMessage);
+          // addEventListener() path requires an explicit start().
+          port.start();
         });
+      }
 
+      promise_test(async (t) => {
+        const context = createContext(t);
+        assert_true(
+            context.audioWorklet.port instanceof MessagePort,
+            'AudioWorklet.port must exist before addModule()');
+      }, 'AudioWorklet: shared port exists before addModule()');
+
+      promise_test(async (t) => {
+        const context = createContext(t);
+        const globalInitializationPromise = waitForPortMessage(
+            context.audioWorklet.port,
+            (data) => data?.type === 'module-evaluation');
+
+        await context.audioWorklet.addModule(filePath);
         assert_equals(
-            await globalOnMessagePromise,
+            (await globalInitializationPromise).type,
+            'module-evaluation',
+            'AudioWorkletGlobalScope shared port is available during module evaluation');
+
+        const globalEchoPromise = waitForPortMessage(
+            context.audioWorklet.port, (data) => data === 'hello world');
+        context.audioWorklet.port.postMessage('hello world');
+        assert_equals(
+            await globalEchoPromise,
             'hello world',
             'The response from AudioWorkletGlobalScope');
-      }, 'AudioWorkletGlobalScope: message via shared port');
+      }, 'AudioWorkletGlobalScope: shared port is available at module evaluation time and supports message passing');
 
-      // Worklet-to-node (initialization message from Worklet constructor) test
       promise_test(async (t) => {
-        const context = new AudioContext();
-        t.add_cleanup(() => context.close());
-        await context.audioWorklet.addModule(filePath);
+        const context = createContext(t);
+        const node = await createPortProcessorNode(context);
 
-        // Creates an AudioWorkletNode and sets an EventHandler on MessagePort
-        // object. The associated PortProcessor will post a message upon its
-        // construction. Test if the message is received correctly.
-        const nodeCreationOnMessagePromise = new Promise((resolve) => {
-          const node = new AudioWorkletNode(context, 'port-processor');
-          node.port.onmessage = (event) => {
-            resolve(event.data.state);
-          };
-        });
+        // PortProcessor emits a constructor-time "created" message.
+        const nodeCreationOnMessagePromise = waitForPortMessage(
+            node.port, (data) => data?.state === 'created');
 
         assert_equals(
-            await nodeCreationOnMessagePromise,
+            (await nodeCreationOnMessagePromise).state,
             'created',
             'The initial message from PortProcessor');
       }, 'AudioWorkletProcessor: initialization message');
 
-      // Node-to-worklet echo test
       promise_test(async (t) => {
-        const context = new AudioContext();
-        t.add_cleanup(() => context.close());
-        await context.audioWorklet.addModule(filePath);
+        const context = createContext(t);
+        const node = await createPortProcessorNode(context);
 
-        const nodeOnMessagePromise = new Promise((resolve) => {
-          const node = new AudioWorkletNode(context, 'port-processor');
-          node.port.onmessage = (event) => {
-            if (!event.data.state) {
-              // Ignore if the delivered message has |state|. This is already
-              // tested in the previous task.
-              resolve(event.data.message);
-            }
-          };
-          node.port.postMessage('hello');
-        });
+        const nodeOnMessagePromise = waitForPortMessage(
+            node.port,
+            // Ignore constructor-time state message; wait for echo payload.
+            (data) => data?.message === 'hello');
+        node.port.postMessage('hello');
 
         assert_equals(
-            await nodeOnMessagePromise,
+            (await nodeOnMessagePromise).message,
             'hello',
             'The response from PortProcessor');
       }, 'AudioWorkletProcessor: message via instance port');

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/port-processor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/port-processor.js
@@ -33,4 +33,5 @@ class PortProcessor extends AudioWorkletProcessor {
 
 registerProcessor('port-processor', PortProcessor);
 
+port.postMessage({type: 'module-evaluation'});
 port.onmessage = (event) => port.postMessage(event.data);

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL decodeAudioData rejects when the resampled length exceeds AudioBuffer.length sampleRate is not in range
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>
+  decodeAudioData rejects when the resampled length would exceed AudioBuffer.length
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/webaudio/resources/flac-builder.js"></script>
+<body>
+<script>
+// Decoding into an OfflineAudioContext whose rate is far above the source rate
+// must reject: the fully-resampled result is longer than an AudioBuffer can
+// represent. The Web Audio spec defines no truncation for this case, so
+// decodeAudioData must reject with EncodingError.
+
+const SRC_RATE = 8000;
+const DEST_RATE = 768000;
+const BLOCK = 65535;
+const NFRAMES = 683;  // Chosen so the upsampled length is not representable.
+const sampleCount = NFRAMES * BLOCK;
+
+promise_test(t => {
+  const flac = buildFlac({
+    sampleRate: SRC_RATE,
+    blockSize: BLOCK,
+    frameCount: NFRAMES,
+    totalSamples: sampleCount,
+    channels: 1,
+  });
+  const ctx = new OfflineAudioContext(1, 128, DEST_RATE);
+  return promise_rejects_dom(
+    t, "EncodingError", ctx.decodeAudioData(flac),
+    "decodeAudioData must reject when the resampled length exceeds AudioBuffer.length");
+}, "decodeAudioData rejects when the resampled length exceeds AudioBuffer.length");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/w3c-import.log
@@ -15,6 +15,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/ctor-offlineaudiocontext.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/current-time-block-size.html
+/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-detached-execution-context.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-rendersizehint.html
 /LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-suspend-rendersizehint.https.html

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4633,6 +4633,7 @@ webkit.org/b/210374 http/tests/media/user-gesture-preserved-across-xmlhttpreques
 
 webkit.org/b/213331 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_volumeChange.html [ Skip ] # timeout
+imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html [ Skip ] # timeout
 
 webkit.org/b/213783 webanimations/accelerated-animation-with-easing.html [ Pass ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1925,7 +1925,6 @@ webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/237415 webgl/1.0.x/conformance/rendering/clipping-wide-points.html [ Pass Failure ]
 
 # webkit.org/b/255427 [ Ventura ] 4/13 batch mark expectations and branch bugs
-imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections.html [ Failure ]
 [ arm64 ] webaudio/ScriptProcessor/scriptprocessor-offlineaudiocontext.html [ Failure ]
 
 # webkit.org/b/275963 -- these tests have slight differences on x86_64 and arm64


### PR DESCRIPTION
#### 0b6951eacdd2f18bcd46910f739f3ea58a2ca134
<pre>
Resync `webaudio` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=322917">https://bugs.webkit.org/show_bug.cgi?id=322917</a>
<a href="https://rdar.apple.com/186181479">rdar://186181479</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6efb1b12b95725c026cb1f5a451138345cfca937">https://github.com/web-platform-tests/wpt/commit/6efb1b12b95725c026cb1f5a451138345cfca937</a>

* LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/flac-builder.js: Added.
(crc8):
(crc16):
(utf8FrameNumber):
(buildStreamInfo):
(buildFrame):
(buildFlac):
* LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/rendersizehint-smoke-tests.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/port-processor.js:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/decodeAudioData-oversized-resample.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/w3c-import.log:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320164@main">https://commits.webkit.org/320164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86d795ed44ed3f1c4ee92728303db03abc632a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148136 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57502 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143496 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99668 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123917 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44199 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5886 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43779 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5247 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196003 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57437 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41011 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58141 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152719 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47261 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126866 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56649 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18791 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56020 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->