### PR TITLE
[GLib] Support alpha channel in color choosers

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -298,9 +298,6 @@ fast/history/page-cache-indexed-closed-db.html [ Pass ]
 
 fast/multicol/multicol-with-child-renderLayer-for-input.html [ Pass ]
 
-# Enhanced <input type=color>
-accessibility/color-well.html [ Skip ]
-
 # permessage-deflate WebSocket extension.
 http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-comp-bit-onoff.html [ Pass ]
 http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-parameter.html [ Pass ]
@@ -1707,8 +1704,6 @@ imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollIntoView-in-onscroll-to-sticky.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-composed.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html [ Skip ]
-
-fast/forms/color/display-none-input-color-chooser-shown.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Events-related bugs

--- a/LayoutTests/platform/glib/accessibility/color-well-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/color-well-expected.txt
@@ -1,0 +1,13 @@
+This test checks the role of ColorWellRole on an input with type=color
+
+Role of input type=color is: AXRole: AXButton
+Value of empty color well: AXValue: rgb 0.00000 0.00000 0.00000 1
+Value of good color well: AXValue: rgb 1.00000 0.00000 0.00000 1
+Value of bad color well: AXValue: rgb 0.00000 0.00000 0.00000 1
+Value of alpha color well: AXValue: rgb 0.23137 0.23529 0.23137 0.40000
+Value of p3 color well: AXValue: rgb 1.00000 0.26667 0.60000 0.25882
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4437,9 +4437,11 @@ InputTypeColorEnhancementsEnabled:
       default: false
     WebKit:
       "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
   sharedPreferenceForWebProcess: true
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -279,7 +279,7 @@ String AccessibilityObjectAtspi::text() const
 
     if (m_coreObject->role() == AccessibilityRole::ColorWell) {
         auto color = convertColor<SRGBA<float>>(m_coreObject->colorValue()).resolved();
-        GUniquePtr<char> colorString(g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue));
+        GUniquePtr<char> colorString(color.alpha == 1 ? g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue) : g_strdup_printf("rgb %7.5f %7.5f %7.5f %7.5f", color.red, color.green, color.blue, color.alpha));
         return String::fromUTF8(colorString.get());
     }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.cpp
@@ -39,6 +39,7 @@
 enum {
     PROP_0,
     PROP_COLOR,
+    PROP_SUPPORTS_ALPHA,
     N_PROPERTIES,
 };
 
@@ -59,6 +60,7 @@ struct _WebKitColorChooserRequestPrivate {
 #elif PLATFORM(WPE)
     WebKitColor color;
 #endif
+    WebKit::ColorControlSupportsAlpha supportsAlpha;
     bool handled;
 };
 
@@ -94,6 +96,9 @@ static void webkitColorChooserRequestGetProperty(GObject* object, guint property
 #elif PLATFORM(WPE)
         g_value_set_boxed(value, &request->priv->color);
 #endif
+        break;
+    case PROP_SUPPORTS_ALPHA:
+        g_value_set_boolean(value, webkit_color_chooser_request_get_supports_alpha(request));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyID, paramSpec);
@@ -151,6 +156,19 @@ static void webkit_color_chooser_request_class_init(WebKitColorChooserRequestCla
             WEBKIT_TYPE_COLOR,
             WEBKIT_PARAM_READWRITE);
 #endif
+
+    /**
+     * WebKitColorChooserRequest:supports-alpha:
+     *
+     * Whether the color input element accepts colors with an alpha channel.
+     *
+     * Since: 2.56
+     */
+    sObjProperties[PROP_SUPPORTS_ALPHA] =
+        g_param_spec_boolean("supports-alpha",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
 
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
@@ -261,6 +279,27 @@ void webkit_color_chooser_request_get_element_rectangle(WebKitColorChooserReques
 }
 #endif
 
+/**
+ * webkit_color_chooser_request_get_supports_alpha:
+ * @request: a [class@ColorChooserRequest]
+ *
+ * Gets whether the color input element accepts colors with an alpha channel.
+ *
+ * This is %TRUE when the input element has the `alpha` attribute. When it is
+ * %FALSE, the alpha component of the selected color is ignored and the element
+ * always uses an opaque color.
+ *
+ * Returns: %TRUE if the element accepts an alpha channel, or %FALSE otherwise
+ *
+ * Since: 2.56
+ */
+gboolean webkit_color_chooser_request_get_supports_alpha(WebKitColorChooserRequest* request)
+{
+    g_return_val_if_fail(WEBKIT_IS_COLOR_CHOOSER_REQUEST(request), FALSE);
+
+    return request->priv->supportsAlpha == WebKit::ColorControlSupportsAlpha::Yes;
+}
+
 void webkit_color_chooser_request_finish(WebKitColorChooserRequest* request)
 {
     g_return_if_fail(WEBKIT_IS_COLOR_CHOOSER_REQUEST(request));
@@ -285,12 +324,13 @@ void webkit_color_chooser_request_cancel(WebKitColorChooserRequest* request)
     g_signal_emit(request, signals[FINISHED], 0);
 }
 
-WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKit::WebColorPicker& colorPicker, const WebCore::Color& initialColor, const WebCore::IntRect& elementRect)
+WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKit::WebColorPicker& colorPicker, const WebCore::Color& initialColor, const WebCore::IntRect& elementRect, WebKit::ColorControlSupportsAlpha supportsAlpha)
 {
     WebKitColorChooserRequest* request = WEBKIT_COLOR_CHOOSER_REQUEST(g_object_new(WEBKIT_TYPE_COLOR_CHOOSER_REQUEST, nullptr));
     request->priv->colorPicker = colorPicker;
     request->priv->initialColor = initialColor;
     request->priv->elementRect = elementRect;
+    request->priv->supportsAlpha = supportsAlpha;
 #if PLATFORM(GTK)
     request->priv->rgba = WebKit::colorToGdkRGBA(initialColor);
 #elif PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.h.in
@@ -225,6 +225,9 @@ WEBKIT_API void
 webkit_color_chooser_request_cancel                (WebKitColorChooserRequest *request);
 #endif
 
+WEBKIT_API gboolean
+webkit_color_chooser_request_get_supports_alpha    (WebKitColorChooserRequest *request);
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequestPrivate.h
@@ -26,10 +26,11 @@
 
 #pragma once
 
+#include "ColorControlSupportsAlpha.h"
 #include "WebColorPicker.h"
 #include "WebKitColorChooserRequest.h"
 #include <WebCore/Color.h>
 #include <WebCore/IntRect.h>
 #include <wtf/WeakPtr.h>
 
-WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKit::WebColorPicker&, const WebCore::Color& initialColor, const WebCore::IntRect& elementRect);
+WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKit::WebColorPicker&, const WebCore::Color& initialColor, const WebCore::IntRect& elementRect, WebKit::ColorControlSupportsAlpha);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -291,11 +291,11 @@ Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& pa
 }
 #endif // ENABLE(CONTEXT_MENUS)
 
-RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color& color, const WebCore::IntRect& rect, ColorControlSupportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier> frameID)
+RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color& color, const WebCore::IntRect& rect, ColorControlSupportsAlpha supportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier> frameID)
 {
     if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
-        return WebKitColorChooser::create(page, color, rect, frameID);
-    return WebColorPickerGtk::create(page, color, rect, frameID);
+        return WebKitColorChooser::create(page, color, rect, supportsAlpha, frameID);
+    return WebColorPickerGtk::create(page, color, rect, supportsAlpha, frameID);
 }
 
 RefPtr<WebDateTimePicker> PageClientImpl::createDateTimePicker(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
@@ -29,13 +29,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebKitColorChooser> WebKitColorChooser::create(WebPageProxy& page, const WebCore::Color& initialColor, const WebCore::IntRect& rect, std::optional<WebCore::FrameIdentifier> frameID)
+Ref<WebKitColorChooser> WebKitColorChooser::create(WebPageProxy& page, const WebCore::Color& initialColor, const WebCore::IntRect& rect, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
 {
-    return adoptRef(*new WebKitColorChooser(page, initialColor, rect, frameID));
+    return adoptRef(*new WebKitColorChooser(page, initialColor, rect, supportsAlpha, frameID));
 }
 
-WebKitColorChooser::WebKitColorChooser(WebPageProxy& page, const Color& initialColor, const IntRect& rect, std::optional<WebCore::FrameIdentifier> frameID)
-    : WebColorPickerGtk(page, initialColor, rect, frameID)
+WebKitColorChooser::WebKitColorChooser(WebPageProxy& page, const Color& initialColor, const IntRect& rect, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
+    : WebColorPickerGtk(page, initialColor, rect, supportsAlpha, frameID)
     , m_elementRect(rect)
 {
 }
@@ -63,7 +63,7 @@ void WebKitColorChooser::colorChooserRequestFinished(WebKitColorChooserRequest*,
 void WebKitColorChooser::showColorPicker(const Color& color, const IntRect& rect)
 {
     m_initialColor = colorToGdkRGBA(color);
-    GRefPtr<WebKitColorChooserRequest> request = adoptGRef(webkitColorChooserRequestCreate(*this, color, m_elementRect));
+    GRefPtr<WebKitColorChooserRequest> request = adoptGRef(webkitColorChooserRequestCreate(*this, color, m_elementRect, m_supportsAlpha));
     g_signal_connect(request.get(), "finished", G_CALLBACK(WebKitColorChooser::colorChooserRequestFinished), this);
 
     if (webkitWebViewEmitRunColorChooser(WEBKIT_WEB_VIEW(m_webView), request.get()))

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
@@ -33,11 +33,11 @@ namespace WebKit {
 
 class WebKitColorChooser final : public WebColorPickerGtk {
 public:
-    static Ref<WebKitColorChooser> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    static Ref<WebKitColorChooser> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier> = std::nullopt);
     virtual ~WebKitColorChooser();
 
 private:
-    WebKitColorChooser(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, std::optional<WebCore::FrameIdentifier>);
+    WebKitColorChooser(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier>);
 
     void endPicker() override;
     void showColorPicker(const WebCore::Color&, const WebCore::IntRect&) override;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -328,11 +328,11 @@ Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& pa
 }
 #endif
 
-RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier> frameID)
+RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha supportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier> frameID)
 {
     if (!m_view.client().isGLibBasedAPI())
         return nullptr;
-    return WebKitColorChooser::create(m_view, page, frameID);
+    return WebKitColorChooser::create(m_view, page, supportsAlpha, frameID);
 }
 
 RefPtr<WebDataListSuggestionsDropdown> PageClientImpl::createDataListSuggestionsDropdown(WebPageProxy&)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.cpp
@@ -29,15 +29,16 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebKitColorChooser> WebKitColorChooser::create(WKWPE::View& view, WebPageProxy& page, std::optional<WebCore::FrameIdentifier> frameID)
+Ref<WebKitColorChooser> WebKitColorChooser::create(WKWPE::View& view, WebPageProxy& page, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
 {
     ASSERT(view.client().isGLibBasedAPI());
-    return adoptRef(*new WebKitColorChooser(view, page, frameID));
+    return adoptRef(*new WebKitColorChooser(view, page, supportsAlpha, frameID));
 }
 
-WebKitColorChooser::WebKitColorChooser(WKWPE::View& view, WebPageProxy& page, std::optional<WebCore::FrameIdentifier> frameID)
+WebKitColorChooser::WebKitColorChooser(WKWPE::View& view, WebPageProxy& page, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
     : WebColorPicker(&page.colorPickerClient(), frameID)
     , m_view(view)
+    , m_supportsAlpha(supportsAlpha)
 {
 }
 
@@ -65,7 +66,7 @@ void WebKitColorChooser::colorChooserRequestFinished(WebKitColorChooserRequest*,
 
 void WebKitColorChooser::showColorPicker(const Color& color, const IntRect& rect)
 {
-    GRefPtr<WebKitColorChooserRequest> request = adoptGRef(webkitColorChooserRequestCreate(*this, color, rect));
+    GRefPtr<WebKitColorChooserRequest> request = adoptGRef(webkitColorChooserRequestCreate(*this, color, rect, m_supportsAlpha));
     g_signal_connect(request.get(), "finished", G_CALLBACK(WebKitColorChooser::colorChooserRequestFinished), this);
     m_request = request;
 

--- a/Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "ColorControlSupportsAlpha.h"
 #include "WebColorPicker.h"
 #include <wtf/glib/GRefPtr.h>
 
@@ -32,11 +33,11 @@ namespace WebKit {
 
 class WebKitColorChooser final : public WebColorPicker {
 public:
-    static Ref<WebKitColorChooser> create(WKWPE::View&, WebPageProxy&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    static Ref<WebKitColorChooser> create(WKWPE::View&, WebPageProxy&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier> = std::nullopt);
     ~WebKitColorChooser();
 
 private:
-    WebKitColorChooser(WKWPE::View&, WebPageProxy&, std::optional<WebCore::FrameIdentifier>);
+    WebKitColorChooser(WKWPE::View&, WebPageProxy&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier>);
 
     void endPicker() override;
     void showColorPicker(const WebCore::Color&, const WebCore::IntRect&) override;
@@ -44,6 +45,7 @@ private:
     static void colorChooserRequestFinished(WebKitColorChooserRequest*, WebKitColorChooser*);
 
     WKWPE::View& m_view;
+    ColorControlSupportsAlpha m_supportsAlpha;
     GRefPtr<WebKitColorChooserRequest> m_request;
 };
 

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
@@ -35,15 +35,16 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebColorPickerGtk> WebColorPickerGtk::create(WebPageProxy& page, const Color& initialColor, const IntRect& rect, std::optional<WebCore::FrameIdentifier> frameID)
+Ref<WebColorPickerGtk> WebColorPickerGtk::create(WebPageProxy& page, const Color& initialColor, const IntRect& rect, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
 {
-    return adoptRef(*new WebColorPickerGtk(page, initialColor, rect, frameID));
+    return adoptRef(*new WebColorPickerGtk(page, initialColor, rect, supportsAlpha, frameID));
 }
 
-WebColorPickerGtk::WebColorPickerGtk(WebPageProxy& page, const Color& initialColor, const IntRect&, std::optional<WebCore::FrameIdentifier> frameID)
+WebColorPickerGtk::WebColorPickerGtk(WebPageProxy& page, const Color& initialColor, const IntRect&, ColorControlSupportsAlpha supportsAlpha, std::optional<WebCore::FrameIdentifier> frameID)
     : WebColorPicker(&page.colorPickerClient(), frameID)
     , m_initialColor(colorToGdkRGBA(initialColor))
     , m_webView(page.viewWidget())
+    , m_supportsAlpha(supportsAlpha)
     , m_colorChooser(nullptr)
 {
 }
@@ -95,6 +96,7 @@ void WebColorPickerGtk::showColorPicker(const Color& color, const IntRect&)
     if (!m_colorChooser) {
         GtkWidget* toplevel = gtk_widget_get_toplevel(m_webView);
         m_colorChooser = gtk_color_chooser_dialog_new(_("Select Color"), widgetIsOnscreenToplevelWindow(toplevel) ? GTK_WINDOW(toplevel) : nullptr);
+        gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(m_colorChooser), m_supportsAlpha == ColorControlSupportsAlpha::Yes);
         gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_colorChooser), &m_initialColor);
         g_signal_connect(m_colorChooser, "notify::rgba", G_CALLBACK(WebColorPickerGtk::colorChooserDialogRGBAChangedCallback), this);
         g_signal_connect(m_colorChooser, "response", G_CALLBACK(WebColorPickerGtk::colorChooserDialogResponseCallback), this);

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ColorControlSupportsAlpha.h"
 #include "WebColorPicker.h"
 #include <gdk/gdk.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 
 class WebColorPickerGtk : public WebColorPicker {
 public:
-    static Ref<WebColorPickerGtk> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    static Ref<WebColorPickerGtk> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier> = std::nullopt);
     virtual ~WebColorPickerGtk();
 
     void endPicker() override;
@@ -50,12 +51,13 @@ public:
     const GdkRGBA* initialColor() const LIFETIME_BOUND { return &m_initialColor; }
 
 protected:
-    WebColorPickerGtk(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    WebColorPickerGtk(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, ColorControlSupportsAlpha, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     void didChooseColor(const WebCore::Color&);
 
     GdkRGBA m_initialColor;
     GtkWidget* m_webView;
+    ColorControlSupportsAlpha m_supportsAlpha;
 
 private:
     static void colorChooserDialogRGBAChangedCallback(GtkColorChooser*, GParamSpec*, WebColorPickerGtk*);

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -515,6 +515,7 @@ static gboolean runColorChooserCallback(WebKitWebView *webView, WebKitColorChoos
     gtk_popover_set_pointing_to(GTK_POPOVER(popover), &rectangle);
 
     GtkWidget *colorChooser = gtk_color_chooser_widget_new();
+    gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(colorChooser), webkit_color_chooser_request_get_supports_alpha(request));
     GdkRGBA rgba;
     webkit_color_chooser_request_get_rgba(request, &rgba);
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(colorChooser), &rgba);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp
@@ -1574,6 +1574,7 @@ static void testWebViewColorChooserRequest(ColorChooserTest* test, gconstpointer
     test->loadHtml(defaultColorHTML.get(), nullptr);
     test->waitUntilLoadFinished();
     WebKitColorChooserRequest* request = test->clickMouseButtonAndWaitForColorChooserRequest(5, 5);
+    g_assert_false(webkit_color_chooser_request_get_supports_alpha(request));
 
 #if PLATFORM(GTK)
     // Default color is black (#000000).
@@ -1652,6 +1653,41 @@ static void testWebViewColorChooserRequest(ColorChooserTest* test, gconstpointer
 #endif
     GUniquePtr<char> value(WebViewTest::javascriptResultToCString(test->runJavaScriptAndWaitUntilFinished("document.querySelector('input').value", nullptr)));
     g_assert_cmpstr(value.get(), ==, "#000000");
+
+    // The alpha attribute makes the element accept colors with an alpha channel.
+    GUniquePtr<char> alphaColorHTML(g_strdup_printf(colorChooserHTMLFormat, "alpha value='#ff000000'"));
+    test->loadHtml(alphaColorHTML.get(), nullptr);
+    test->waitUntilLoadFinished();
+    request = test->clickMouseButtonAndWaitForColorChooserRequest(5, 5);
+    g_assert_true(webkit_color_chooser_request_get_supports_alpha(request));
+#if PLATFORM(GTK)
+    webkit_color_chooser_request_get_rgba(request, &rgba1);
+    GdkRGBA rgba4 = { 1., 0., 0., 0. };
+    g_assert_true(gdk_rgba_equal(&rgba1, &rgba4));
+    rgba4 = { 0., 1., 0., 0.5 };
+    webkit_color_chooser_request_set_rgba(request, &rgba4);
+#elif PLATFORM(WPE)
+    webkit_color_chooser_request_get_color(request, &color);
+    assertColorIsEqual(&color, 1., 0., 0., 0.);
+    color = { 0., 1., 0., 0.5 };
+    webkit_color_chooser_request_set_color(request, &color);
+#endif
+    value.reset(WebViewTest::javascriptResultToCString(test->runJavaScriptAndWaitUntilFinished("document.querySelector('input').value", nullptr)));
+    g_assert_cmpstr(value.get(), ==, "color(srgb 0 1 0 / 0.501961)");
+    test->finishRequest();
+
+    // Without the alpha attribute the alpha channel of the selected color is dropped.
+    test->loadHtml(defaultColorHTML.get(), nullptr);
+    test->waitUntilLoadFinished();
+    request = test->clickMouseButtonAndWaitForColorChooserRequest(5, 5);
+#if PLATFORM(GTK)
+    webkit_color_chooser_request_set_rgba(request, &rgba4);
+#elif PLATFORM(WPE)
+    webkit_color_chooser_request_set_color(request, &color);
+#endif
+    value.reset(WebViewTest::javascriptResultToCString(test->runJavaScriptAndWaitUntilFinished("document.querySelector('input').value", nullptr)));
+    g_assert_cmpstr(value.get(), ==, "#00ff00");
+    test->finishRequest();
 
 #if PLATFORM(WPE)
     test->loadHtml(defaultColorHTML.get(), nullptr);


### PR DESCRIPTION
#### dc960d597efc24a379dabcf1d39b4edc241b851b
<pre>
[GLib] Support alpha channel in color choosers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322918">https://bugs.webkit.org/show_bug.cgi?id=322918</a>

Reviewed by Claudio Saavedra and Carlos Garcia Campos.

This was already exposed on Apple ports.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/accessibility/color-well-expected.txt: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::text const):
* Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.cpp:
(webkitColorChooserRequestGetProperty):
(webkit_color_chooser_request_class_init):
(webkit_color_chooser_request_get_supports_alpha):
(webkitColorChooserRequestCreate):
* Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitColorChooserRequestPrivate.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::createColorPicker):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp:
(WebKit::WebKitColorChooser::create):
(WebKit::WebKitColorChooser::WebKitColorChooser):
(WebKit::WebKitColorChooser::showColorPicker):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::createColorPicker):
* Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.cpp:
(WebKit::WebKitColorChooser::create):
(WebKit::WebKitColorChooser::WebKitColorChooser):
(WebKit::WebKitColorChooser::showColorPicker):
* Source/WebKit/UIProcess/API/wpe/WebKitColorChooser.h:
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp:
(WebKit::WebColorPickerGtk::create):
(WebKit::WebColorPickerGtk::WebColorPickerGtk):
(WebKit::WebColorPickerGtk::showColorPicker):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(runColorChooserCallback):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp:
(testWebViewColorChooserRequest):

Canonical link: <a href="https://commits.webkit.org/320149@main">https://commits.webkit.org/320149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ad4e7309d176056e908e65b9ea0cc546edeacd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143467 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99637 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44166 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5857 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12689 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43747 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45085 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57402 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41001 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152689 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47228 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130386 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126792 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56614 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18758 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->