### PR TITLE
REGRESSION(320030@main): [WPE] ENABLE_WPE_LEGACY_API=0 can't build due to undefined reference to `WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent(WebKit::WebKeyboardEventInit&&)'

### DIFF
--- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
@@ -131,7 +131,10 @@ private:
     MSG m_nativeEvent;
     Vector<MSG> m_pendingCharEvents;
 #else
-    explicit NativeWebKeyboardEvent(WebKeyboardEventInit&&);
+    explicit NativeWebKeyboardEvent(WebKeyboardEventInit&& init)
+        : WebKeyboardEvent(WTF::move(init.event), WTF::move(init.keyboard))
+    {
+    }
 #endif
 };
 

--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -126,7 +126,10 @@ private:
 
     MSG m_nativeEvent;
 #else
-    explicit NativeWebMouseEvent(WebMouseEventInit&&);
+    explicit NativeWebMouseEvent(WebMouseEventInit&& init)
+        : WebMouseEvent(WTF::move(init.event), WTF::move(init.mouse))
+    {
+    }
 #endif
 };
 

--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -108,7 +108,10 @@ private:
 
     MSG m_nativeEvent;
 #else
-    explicit NativeWebWheelEvent(WebWheelEventInit&&);
+    explicit NativeWebWheelEvent(WebWheelEventInit&& init)
+        : WebWheelEvent(WTF::move(init.event), WTF::move(init.wheel))
+    {
+    }
 #endif
 };
 

--- a/Source/WebKit/Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
+++ b/Source/WebKit/Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
@@ -39,11 +39,6 @@ Ref<NativeWebKeyboardEvent> NativeWebKeyboardEvent::create(struct wpe_input_keyb
     return adoptRef(*new NativeWebKeyboardEvent(WebEventFactory::createWebKeyboardEvent(event, text, isAutoRepeat, handledByInputMethod == HandledByInputMethod::Yes, WTF::move(preeditUnderlines), WTF::move(preeditSelectionRange))));
 }
 
-NativeWebKeyboardEvent::NativeWebKeyboardEvent(WebKeyboardEventInit&& init)
-    : WebKeyboardEvent(WTF::move(init.event), WTF::move(init.keyboard))
-{
-}
-
 } // namespace WebKit
 
 #endif // USE(LIBWPE)

--- a/Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp
+++ b/Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp
@@ -39,11 +39,6 @@ Ref<NativeWebMouseEvent> NativeWebMouseEvent::create(struct wpe_input_pointer_ev
     return adoptRef(*new NativeWebMouseEvent(WebEventFactory::createWebMouseEvent(event, deviceScaleFactor, syntheticClickType)));
 }
 
-NativeWebMouseEvent::NativeWebMouseEvent(WebMouseEventInit&& init)
-    : WebMouseEvent(WTF::move(init.event), WTF::move(init.mouse))
-{
-}
-
 } // namespace WebKit
 
 #endif // USE(LIBWPE)

--- a/Source/WebKit/Shared/libwpe/NativeWebWheelEventLibWPE.cpp
+++ b/Source/WebKit/Shared/libwpe/NativeWebWheelEventLibWPE.cpp
@@ -40,11 +40,6 @@ Ref<NativeWebWheelEvent> NativeWebWheelEvent::create(struct wpe_input_axis_event
     return adoptRef(*new NativeWebWheelEvent(WebEventFactory::createWebWheelEvent(event, deviceScaleFactor, phase, momentumPhase)));
 }
 
-NativeWebWheelEvent::NativeWebWheelEvent(WebWheelEventInit&& init)
-    : WebWheelEvent(WTF::move(init.event), WTF::move(init.wheel))
-{
-}
-
 } // namespace WebKit
 
 #endif // USE(LIBWPE)


### PR DESCRIPTION
#### e6b841d2ce6ba690906486cb70fb393f0611fcaf
<pre>
REGRESSION(320030@main): [WPE] ENABLE_WPE_LEGACY_API=0 can&apos;t build due to undefined reference to `WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent(WebKit::WebKeyboardEventInit&amp;&amp;)&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=322919">https://bugs.webkit.org/show_bug.cgi?id=322919</a>

Reviewed by Adrian Perez de Castro.

build-webkit --wpe --cmakeargs=-DENABLE_WPE_LEGACY_API=0 couldn&apos;t link libWPEWebKit-2.0.so:

&gt; undefined reference to `WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent(WebKit::WebKeyboardEventInit&amp;&amp;)&apos;
&gt; undefined reference to `WebKit::NativeWebMouseEvent::NativeWebMouseEvent(WebKit::WebMouseEventInit&amp;&amp;)&apos;
&gt; undefined reference to `WebKit::NativeWebWheelEvent::NativeWebWheelEvent(WebKit::WebWheelEventInit&amp;&amp;)&apos;

Moved the ctors from libwpe/*.cpp to *.h to share them between legacy libwpe
code path and modern wpe platform code path.

* Source/WebKit/Shared/NativeWebKeyboardEvent.h:
(WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent):
* Source/WebKit/Shared/NativeWebMouseEvent.h:
(WebKit::NativeWebMouseEvent::NativeWebMouseEvent):
* Source/WebKit/Shared/NativeWebWheelEvent.h:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent):
* Source/WebKit/Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp:
(WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent): Deleted.
* Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp:
(WebKit::NativeWebMouseEvent::NativeWebMouseEvent): Deleted.
* Source/WebKit/Shared/libwpe/NativeWebWheelEventLibWPE.cpp:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent): Deleted.

Canonical link: <a href="https://commits.webkit.org/320123@main">https://commits.webkit.org/320123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8310798a702ee8b1fd41938cf594d567a9b99b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194031 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148102 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143468 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99640 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47238 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164225 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 2 api tests failed or timed out; 2 api tests failed or timed out; 1 api test failed or timed out; Passed API tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44167 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43749 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5213 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48435 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195969 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57403 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153008 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58107 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152691 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47229 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130387 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56615 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18760 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->