### PR TITLE
Web Inspector: Log Message breakpoint actions should log objects as rich console arguments

### DIFF
--- a/LayoutTests/inspector/debugger/breakpoint-action-log-object-expected.txt
+++ b/LayoutTests/inspector/debugger/breakpoint-action-log-object-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: [object Object]
+Testing that a "Log" breakpoint action logs an object as a rich console argument.
+
+
+== Running test suite: Debugger.BreakpointAction.Log.Object
+-- Running test case: LogObjectAsRichConsoleArgument
+inside breakpointActions a:(42) b:([object Object])
+PASS: Should log exactly one console argument.
+PASS: Logged argument should be a rich object, not a string.
+PASS: Logged argument should describe the original object.
+

--- a/LayoutTests/inspector/debugger/breakpoint-action-log-object.html
+++ b/LayoutTests/inspector/debugger/breakpoint-action-log-object.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/script-for-breakpoint-actions.js"></script>
+<script>
+function runBreakpointActions()
+{
+    breakpointActions(42, {x:1, y:2});
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.BreakpointAction.Log.Object");
+
+    suite.addTestCase({
+        name: "LogObjectAsRichConsoleArgument",
+        description: "A `${object}` log message should be logged as a rich, inspectable console object instead of the string `[object Object]`.",
+        async test() {
+            let objectMessagePromise = new Promise((resolve) => {
+                let listener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                    let message = event.data.message;
+                    if (message.parameters && message.parameters.some((parameter) => parameter.type === "object")) {
+                        WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+                        resolve(message);
+                    }
+                });
+            });
+
+            let breakpointPromise = new Promise((resolve) => {
+                WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ScriptAdded, (event) => {
+                    let scriptObject = event.data.script;
+                    if (!/script\-for\-breakpoint\-actions\.js$/.test(scriptObject.url))
+                        return;
+
+                    let location = scriptObject.createSourceCodeLocation(4, 0);
+                    let breakpoint = new WI.JavaScriptBreakpoint(location);
+                    breakpoint.autoContinue = true;
+                    breakpoint.addAction(new WI.BreakpointAction(WI.BreakpointAction.Type.Log, {data: "${b}"}));
+                    WI.debuggerManager.addBreakpoint(breakpoint);
+                    resolve();
+                });
+            });
+
+            let reloadPromise = InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            InspectorTest.reloadPage();
+
+            await Promise.all([reloadPromise, breakpointPromise]);
+            await InspectorTest.evaluateInPage("runBreakpointActions()");
+
+            let message = await objectMessagePromise;
+            InspectorTest.expectEqual(message.parameters.length, 1, "Should log exactly one console argument.");
+            InspectorTest.expectEqual(message.parameters[0].type, "object", "Logged argument should be a rich object, not a string.");
+            InspectorTest.expectEqual(message.parameters[0].description, "Object", "Logged argument should describe the original object.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that a "Log" breakpoint action logs an object as a rich console argument.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/Breakpoint.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Breakpoint.js
@@ -283,15 +283,16 @@ WI.Breakpoint = class Breakpoint extends WI.Object
                 if (!tokens)
                     return false;
 
-                let templateLiteral = tokens.reduce((text, token) => {
-                    if (token.type === WI.BreakpointLogMessageLexer.TokenType.PlainText)
-                        return text + token.data.escapeCharacters("`\\");
-                    if (token.type === WI.BreakpointLogMessageLexer.TokenType.Expression)
-                        return text + "${" + token.data + "}";
-                    return text;
-                }, "");
+                let args = [];
+                for (let token of tokens) {
+                    if (token.type === WI.BreakpointLogMessageLexer.TokenType.PlainText) {
+                        if (token.data)
+                            args.push("`" + token.data.escapeCharacters("`\\") + "`");
+                    } else if (token.type === WI.BreakpointLogMessageLexer.TokenType.Expression)
+                        args.push("(" + token.data + ")");
+                }
 
-                action.data = "console.log(`" + templateLiteral + "`)";
+                action.data = "console.log(" + args.join(", ") + ")";
                 action.type = WI.BreakpointAction.Type.Evaluate;
                 return true;
             });


### PR DESCRIPTION
#### 841620db349c805b2b3126ce7feb336a042b2294
<pre>
Web Inspector: Log Message breakpoint actions should log objects as rich console arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=263110">https://bugs.webkit.org/show_bug.cgi?id=263110</a>

Reviewed by NOBODY (OOPS!).

A Log Message breakpoint action containing a `${expression}` placeholder was compiled into a single `console.log` template literal.

Coercing every placeholder to a string meant that logging an object showed `[object Object]` instead of the rich value.

Compile each placeholder into its own `console.log` argument so objects are logged as rich values.

* Source/WebInspectorUI/UserInterface/Models/Breakpoint.js:
(WI.Breakpoint.prototype.optionsToProtocol):

* LayoutTests/inspector/debugger/breakpoint-action-log-object.html: Added.
* LayoutTests/inspector/debugger/breakpoint-action-log-object-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/841620db349c805b2b3126ce7feb336a042b2294

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148165 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59141 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143518 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99692 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164277 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123940 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45989 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44221 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156384 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.UserGestureLogsUserInteraction (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43801 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5276 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153062 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58170 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152744 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47282 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130450 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126903 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56678 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->