### PR TITLE
SMIL animation of a presentation attribute is never released when the element is detached mid-animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute-expected.txt
@@ -1,0 +1,6 @@
+
+PASS teardown while connected releases the animated fill (control)
+PASS detaching mid-animation then tearing down releases the animated fill
+PASS moving an animating element to a new parent then tearing down releases the animated fill
+PASS detaching and reattaching the parent group then tearing down releases the animated fill
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>SMIL: detaching an element releases its animated presentation attribute</title>
+<link rel="help" href="https://svgwg.org/specs/animations/#AnimateElement">
+<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="stage" width="300" height="40" aria-hidden="true"></svg>
+
+<script>
+const SVG_NS = "http://www.w3.org/2000/svg";
+const BASE_FILL = "rgb(0, 0, 0)";
+const ANIM_FILL = "rgb(243, 243, 243)";
+
+const stage = document.getElementById("stage");
+
+function nextFrame() {
+    return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
+function computedFill(node) {
+    return getComputedStyle(node).fill;
+}
+
+async function waitForFill(node, expected, frames = 60) {
+    for (let i = 0; i < frames; i++) {
+        if (computedFill(node) === expected)
+            return expected;
+        await nextFrame();
+    }
+    return computedFill(node);
+}
+
+function makeGroup() {
+    const g = document.createElementNS(SVG_NS, "g");
+    stage.appendChild(g);
+    return g;
+}
+
+function makeNode(parent) {
+    const node = document.createElementNS(SVG_NS, "rect");
+    node.setAttribute("x", "4");
+    node.setAttribute("y", "4");
+    node.setAttribute("width", "32");
+    node.setAttribute("height", "32");
+    node.setAttribute("fill", "#000000");
+    parent.appendChild(node);
+    return node;
+}
+
+function animate(node) {
+    const anim = document.createElementNS(SVG_NS, "animate");
+    anim.setAttribute("attributeName", "fill");
+    anim.setAttribute("begin", "0s");
+    anim.setAttribute("dur", "10s");
+    anim.setAttribute("repeatCount", "indefinite");
+    anim.setAttribute("values", "#f3f3f3;#f3f3f3");
+    node.appendChild(anim);
+    return anim;
+}
+
+function teardown(node) {
+    node.querySelectorAll("animate").forEach(a => a.remove());
+    node.setAttribute("fill", "#000000");
+}
+
+function detachCase(name, body) {
+    promise_test(async t => {
+        const group = makeGroup();
+        t.add_cleanup(() => group.remove());
+
+        const node = await body(group);
+
+        assert_equals(node._fillDuring, ANIM_FILL,
+            "precondition: animation applied its value before teardown");
+
+        if (!node.isConnected)
+            stage.appendChild(node);
+
+        const after = await waitForFill(node, BASE_FILL);
+        assert_equals(after, BASE_FILL, "animated value released after teardown");
+        assert_equals(node.querySelector("animate"), null,
+            "no <animate> child remains");
+    }, name);
+}
+
+detachCase("teardown while connected releases the animated fill (control)",
+    async group => {
+        const node = makeNode(group);
+        animate(node);
+        node._fillDuring = await waitForFill(node, ANIM_FILL);
+        teardown(node);
+        return node;
+    });
+
+detachCase("detaching mid-animation then tearing down releases the animated fill",
+    async group => {
+        const node = makeNode(group);
+        animate(node);
+        node._fillDuring = await waitForFill(node, ANIM_FILL);
+        node.remove();
+        teardown(node);
+        return node;
+    });
+
+detachCase("moving an animating element to a new parent then tearing down releases the animated fill",
+    async group => {
+        const node = makeNode(group);
+        animate(node);
+        node._fillDuring = await waitForFill(node, ANIM_FILL);
+        makeGroup().appendChild(node);
+        teardown(node);
+        return node;
+    });
+
+detachCase("detaching and reattaching the parent group then tearing down releases the animated fill",
+    async group => {
+        const node = makeNode(group);
+        animate(node);
+        node._fillDuring = await waitForFill(node, ANIM_FILL);
+        group.remove();
+        stage.appendChild(group);
+        await waitForFill(node, ANIM_FILL);
+        teardown(node);
+        return node;
+    });
+</script>

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
@@ -80,17 +80,16 @@ void SVGAttributeAnimator::removeAnimatedStyleProperty(SVGElement& element, CSSP
     ASSERT(!element.deletionHasBegun());
     ASSERT(id != CSSPropertyInvalid);
 
-    protect(element.ensureAnimatedSMILStyleProperties())->removeProperty(id);
+    RefPtr animatedSMILStyleProperties = element.animatedSMILStyleProperties();
+    if (!animatedSMILStyleProperties)
+        return;
+    animatedSMILStyleProperties->removeProperty(id);
     element.invalidateStyle();
 }
 
 void SVGAttributeAnimator::removeAnimatedStyleProperty(SVGElement& targetElement)
 {
     ASSERT(m_attributeName != anyQName());
-
-    // FIXME: Do we really need to check both isConnected and !parentNode?
-    if (!targetElement.isConnected() || !targetElement.parentNode())
-        return;
 
     CSSPropertyID id = cssPropertyID(m_attributeName.localName());
 


### PR DESCRIPTION
#### d6e2e670e84753c4fd93a700868105d80be12567
<pre>
SMIL animation of a presentation attribute is never released when the element is detached mid-animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322922">https://bugs.webkit.org/show_bug.cgi?id=322922</a>
<a href="https://rdar.apple.com/185452156">rdar://185452156</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

A SMIL &lt;animate&gt; on a presentation attribute (e.g. fill) applies its value
through the element&apos;s animated SMIL style block, which the cascade injects at
inline-style priority and thus outranks the attribute (the base value). That
value is released only by SVGAttributeAnimator::removeAnimatedStyleProperty(),
via the animator&apos;s stop() during teardown.

That method early-returned when the target was disconnected -- but teardown
fires exactly when the element leaves the document, so the guard tripped, the
property was left in animatedSMILStyleProperties, and it re-applied on every
later style resolution. A reinserted (e.g. pooled and reused) element then
painted the frozen animated value permanently.

Drop the guard from the removal path so the value is released regardless of
connection state. This is safe: invalidateStyle() is already a no-op on a
disconnected element, and reinsertion triggers a fresh style resolution that no
longer sees the property. The apply paths keep their guard.

Test: imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-detach-releases-animated-presentation-attribute.html: Added.
* Source/WebCore/svg/properties/SVGAttributeAnimator.cpp:
(WebCore::SVGAttributeAnimator::removeAnimatedStyleProperty):

Canonical link: <a href="https://commits.webkit.org/320199@main">https://commits.webkit.org/320199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b71dbc213ab38ab1a9c2dc4abd0fa2442188798

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58019 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194319 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57754 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47484 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124125 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46191 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5501 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196257 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57690 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41032 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58394 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152939 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130685 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56902 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56273 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->