### PR TITLE
[JSC] `Temporal.ZonedDateTime.prototype.round` resolves the rounded wall-clock time with a minute-rounded offset

### DIFF
--- a/JSTests/stress/temporal-zoned-date-time-round-sub-minute-offset-fold.js
+++ b/JSTests/stress/temporal-zoned-date-time-round-sub-minute-offset-fold.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+// Pacific/Niue moved from LMT -11:19:40 to -11:20 at local midnight on 1952-10-16,
+// so 23:59:40-23:59:59 on 1952-10-15 happen twice, 20 seconds apart. round() must
+// resolve the rounded wall-clock time with the exact current offset, not one
+// rounded to minutes, otherwise the result slides to the earlier occurrence.
+
+{
+    const zdt = Temporal.Instant.from("1952-10-16T11:19:50Z").toZonedDateTimeISO("Pacific/Niue");
+    shouldBe(zdt.offset, "-11:20");
+    const rounded = zdt.round({ smallestUnit: "second" });
+    shouldBe(rounded.epochNanoseconds, zdt.epochNanoseconds);
+    shouldBe(rounded.offset, "-11:20");
+}
+
+{
+    const zdt = Temporal.Instant.from("1952-10-16T11:19:50.400Z").toZonedDateTimeISO("Pacific/Niue");
+    shouldBe(zdt.offset, "-11:20");
+    const rounded = zdt.round({ smallestUnit: "second" });
+    shouldBe(rounded.epochNanoseconds, Temporal.Instant.from("1952-10-16T11:19:50Z").epochNanoseconds);
+    shouldBe(rounded.offset, "-11:20");
+}
+
+{
+    const zdt = Temporal.Instant.from("1952-10-16T11:19:30Z").toZonedDateTimeISO("Pacific/Niue");
+    shouldBe(zdt.offset, "-11:19:40");
+    const rounded = zdt.round({ smallestUnit: "second" });
+    shouldBe(rounded.epochNanoseconds, zdt.epochNanoseconds);
+    shouldBe(rounded.offset, "-11:19:40");
+}
+
+{
+    const zdt = Temporal.Instant.from("1952-10-16T11:19:59Z").toZonedDateTimeISO("Pacific/Niue");
+    const rounded = zdt.round({ smallestUnit: "minute" });
+    shouldBe(rounded.epochNanoseconds, Temporal.Instant.from("1952-10-16T11:20:00Z").epochNanoseconds);
+    shouldBe(rounded.toString(), "1952-10-16T00:00:00-11:20[Pacific/Niue]");
+}

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -539,7 +539,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
         auto epochNsResult = TemporalCore::interpretISODateTimeOffset(
             roundedDate, roundedTime, TemporalCore::UseStartOfDay::No,
             OffsetBehaviour::Option, TemporalOffsetDisambiguation::Prefer,
-            *curOffsetResult, TemporalCore::MatchBehaviour::MatchMinutes,
+            *curOffsetResult, TemporalCore::MatchBehaviour::MatchExactly,
             zdt->timeZone(), TemporalDisambiguation::Compatible);
         if (!epochNsResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, epochNsResult.error());


### PR DESCRIPTION
#### 56241cc1137f1aa6923b80e59522406084e20637
<pre>
[JSC] `Temporal.ZonedDateTime.prototype.round` resolves the rounded wall-clock time with a minute-rounded offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=322923">https://bugs.webkit.org/show_bug.cgi?id=322923</a>

Reviewed by Yusuke Suzuki.

round() re-interprets the rounded wall-clock time through
InterpretISODateTimeOffset with the receiver&apos;s current offset, and the
spec passes match-exactly there: the offset came from the time zone, not
from a string that only carries minutes. JSC passed match-minutes, so
inside a sub-minute fold (Pacific/Niue moved from LMT -11:19:40 to -11:20
in 1952) a candidate whose offset merely rounds to the current one is
accepted first, and rounding a time in the second occurrence slid 20
seconds back into the first.

Pass match-exactly like with() and the property-bag path already do.

Test: JSTests/stress/temporal-zoned-date-time-round-sub-minute-offset-fold.js

* JSTests/stress/temporal-zoned-date-time-round-sub-minute-offset-fold.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/320217@main">https://commits.webkit.org/320217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cabe07af540b53f7a5d41df2f3e654e08c94456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143473 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99644 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123894 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44172 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5863 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12695 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43753 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5218 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45091 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57408 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153012 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152695 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47235 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130392 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126810 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56620 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->