### PR TITLE
[JSC] Reject when search-string is longer than the target-string early

### DIFF
--- a/JSTests/stress/string-index-of-search-longer-than-subject.js
+++ b/JSTests/stress/string-index-of-search-longer-than-subject.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} got ${actual}`);
+}
+
+// A needle that cannot fit in the remaining subject must report "not found" without disturbing any
+// of the other cases, including the empty needle, which matches at the start position.
+const nonLatin1 = "—";
+
+function indexOf(subject, search) { return subject.indexOf(search); }
+noInline(indexOf);
+function indexOfAt(subject, search, position) { return subject.indexOf(search, position); }
+noInline(indexOfAt);
+function includes(subject, search) { return subject.includes(search); }
+noInline(includes);
+function includesAt(subject, search, position) { return subject.includes(search, position); }
+noInline(includesAt);
+
+const subjects = ["", "a", "abc", "abcabcabc", "abc" + nonLatin1, nonLatin1 + "abc"];
+const searches = ["", "a", "c", "abc", "abcd", "abcabcabc", "abcabcabca", nonLatin1, "x"];
+
+// Compute expectations with a straightforward reference implementation.
+function referenceIndexOf(subject, search, position) {
+    const start = Math.min(Math.max(position | 0, 0), subject.length);
+    for (let i = start; i + search.length <= subject.length; ++i) {
+        let match = true;
+        for (let j = 0; j < search.length; ++j) {
+            if (subject[i + j] !== search[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+    return -1;
+}
+
+const positions = [0, 1, 2, 3, 100];
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const subject of subjects) {
+        for (const search of searches) {
+            const expected = referenceIndexOf(subject, search, 0);
+            shouldBe(indexOf(subject, search), expected);
+            shouldBe(includes(subject, search), expected !== -1);
+            for (const position of positions) {
+                const expectedAt = referenceIndexOf(subject, search, position);
+                shouldBe(indexOfAt(subject, search, position), expectedAt);
+                shouldBe(includesAt(subject, search, position), expectedAt !== -1);
+            }
+        }
+    }
+}
+
+// Ropes: the length check must not consult a resolved view.
+function indexOfRope(a, b, search) { return (a + b).indexOf(search); }
+noInline(indexOfRope);
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    shouldBe(indexOfRope("abc", "def", "cd"), 2);
+    shouldBe(indexOfRope("abc", "def", "abcdefg"), -1);
+    shouldBe(indexOfRope("abc", "def", "f"), 5);
+    shouldBe(indexOfRope("abc", nonLatin1, nonLatin1), 3);
+}

--- a/JSTests/stress/string-last-index-of-search-longer-than-subject.js
+++ b/JSTests/stress/string-last-index-of-search-longer-than-subject.js
@@ -1,0 +1,150 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} got ${actual}`);
+}
+
+// A needle that cannot fit in the searched range must report "not found" without disturbing any of
+// the other cases, including the empty needle, which always matches.
+const nonLatin1 = "\u2014";
+
+function lastIndexOf(subject, search) { return subject.lastIndexOf(search); }
+noInline(lastIndexOf);
+function lastIndexOfAt(subject, search, position) { return subject.lastIndexOf(search, position); }
+noInline(lastIndexOfAt);
+function startsWith(subject, search) { return subject.startsWith(search); }
+noInline(startsWith);
+function startsWithAt(subject, search, position) { return subject.startsWith(search, position); }
+noInline(startsWithAt);
+function endsWith(subject, search) { return subject.endsWith(search); }
+noInline(endsWith);
+function endsWithAt(subject, search, position) { return subject.endsWith(search, position); }
+noInline(endsWithAt);
+
+// Compute expectations with straightforward reference implementations.
+function matchesAt(subject, search, index) {
+    if (index < 0 || index + search.length > subject.length)
+        return false;
+    for (let i = 0; i < search.length; ++i) {
+        if (subject[index + i] !== search[i])
+            return false;
+    }
+    return true;
+}
+
+function referenceLastIndexOf(subject, search, position) {
+    const maxStart = subject.length - search.length;
+    if (maxStart < 0)
+        return -1;
+    let start = maxStart;
+    if (position !== undefined)
+        start = Math.min(Math.max(position | 0, 0), maxStart);
+    for (let i = start; i >= 0; --i) {
+        if (matchesAt(subject, search, i))
+            return i;
+    }
+    return -1;
+}
+
+function referenceStartsWith(subject, search, position) {
+    const start = Math.min(Math.max((position === undefined ? 0 : position) | 0, 0), subject.length);
+    return matchesAt(subject, search, start);
+}
+
+function referenceEndsWith(subject, search, position) {
+    const end = position === undefined ? subject.length : Math.min(Math.max(position | 0, 0), subject.length);
+    return matchesAt(subject, search, end - search.length);
+}
+
+const subjects = ["", "a", "abc", "abcabcabc", "abc" + nonLatin1, nonLatin1 + "abc"];
+const searches = ["", "a", "c", "abc", "abcd", "abcabcabc", "abcabcabca", nonLatin1, "x"];
+const positions = [0, 1, 2, 3, 100];
+
+const cases = [];
+for (const subject of subjects) {
+    for (const search of searches) {
+        cases.push({
+            subject, search,
+            lastIndexOf: referenceLastIndexOf(subject, search, undefined),
+            startsWith: referenceStartsWith(subject, search, undefined),
+            endsWith: referenceEndsWith(subject, search, undefined),
+            at: positions.map(position => ({
+                position,
+                lastIndexOf: referenceLastIndexOf(subject, search, position),
+                startsWith: referenceStartsWith(subject, search, position),
+                endsWith: referenceEndsWith(subject, search, position),
+            })),
+        });
+    }
+}
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const c of cases) {
+        shouldBe(lastIndexOf(c.subject, c.search), c.lastIndexOf);
+        shouldBe(startsWith(c.subject, c.search), c.startsWith);
+        shouldBe(endsWith(c.subject, c.search), c.endsWith);
+        for (const at of c.at) {
+            shouldBe(lastIndexOfAt(c.subject, c.search, at.position), at.lastIndexOf);
+            shouldBe(startsWithAt(c.subject, c.search, at.position), at.startsWith);
+            shouldBe(endsWithAt(c.subject, c.search, at.position), at.endsWith);
+        }
+    }
+}
+
+// Ropes: the length checks must not consult a resolved view, on either the subject or the needle.
+// "long" is longer than JSString::minLengthForRopeWalk, so it also exercises the rope-walking paths.
+const long = "abcdefgh".repeat(38);
+
+function lastIndexOfRopeSubject(a, b, search) { return (a + b).lastIndexOf(search); }
+noInline(lastIndexOfRopeSubject);
+function startsWithRopeSubject(a, b, search) { return (a + b).startsWith(search); }
+noInline(startsWithRopeSubject);
+function endsWithRopeSubject(a, b, search) { return (a + b).endsWith(search); }
+noInline(endsWithRopeSubject);
+function lastIndexOfRopeSearch(subject, c, d) { return subject.lastIndexOf(c + d); }
+noInline(lastIndexOfRopeSearch);
+function startsWithRopeSearch(subject, c, d) { return subject.startsWith(c + d); }
+noInline(startsWithRopeSearch);
+function endsWithRopeSearch(subject, c, d) { return subject.endsWith(c + d); }
+noInline(endsWithRopeSearch);
+function lastIndexOfRopeSubjectAt(a, b, search, position) { return (a + b).lastIndexOf(search, position); }
+noInline(lastIndexOfRopeSubjectAt);
+
+const ropeCases = [
+    ["abc", "def", "cd"],
+    ["abc", "def", "abcdefg"],
+    ["abc", nonLatin1, nonLatin1],
+    ["abc", "def", ""],
+    [long, "abc", "c"],
+    [long, "abc", "cd"],
+    ["abc", long, long + "x"],
+    ["", "abc", "abcd"],
+].map(([a, b, search]) => {
+    const joined = a + b;
+    return {
+        a, b, search,
+        lastIndexOf: referenceLastIndexOf(joined, search, undefined),
+        startsWith: referenceStartsWith(joined, search, undefined),
+        endsWith: referenceEndsWith(joined, search, undefined),
+        lastIndexOfAtFour: referenceLastIndexOf(joined, search, 4),
+        lastIndexOfAtMinusOne: referenceLastIndexOf(joined, search, -1),
+    };
+});
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const c of ropeCases) {
+        shouldBe(lastIndexOfRopeSubject(c.a, c.b, c.search), c.lastIndexOf);
+        shouldBe(startsWithRopeSubject(c.a, c.b, c.search), c.startsWith);
+        shouldBe(endsWithRopeSubject(c.a, c.b, c.search), c.endsWith);
+        shouldBe(lastIndexOfRopeSubjectAt(c.a, c.b, c.search, 4), c.lastIndexOfAtFour);
+        shouldBe(lastIndexOfRopeSubjectAt(c.a, c.b, c.search, -1), c.lastIndexOfAtMinusOne);
+    }
+
+    // The needle is a rope that is longer than the subject, so it must be rejected without being
+    // resolved.
+    shouldBe(lastIndexOfRopeSearch("abc", long, long), -1);
+    shouldBe(startsWithRopeSearch("abc", long, long), false);
+    shouldBe(endsWithRopeSearch("abc", long, long), false);
+    shouldBe(lastIndexOfRopeSearch("abcabc", "ab", "c"), 3);
+    shouldBe(startsWithRopeSearch("abcabc", "ab", "c"), true);
+    shouldBe(endsWithRopeSearch("abcabc", "ab", "c"), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3977,13 +3977,16 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObjec
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned baseLength = base->length();
+    unsigned argumentLength = argument->length();
+    if (baseLength < argumentLength)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
     auto otherView = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
-    unsigned argumentLength = otherView->length();
-
     unsigned pos = 0;
-    if (argumentLength == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+    if (argumentLength == 1 && base->isRope() && baseLength >= JSString::minLengthForRopeWalk) {
         if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
             if (*result != notFound)
                 OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
@@ -4036,11 +4039,8 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto otherView = argument->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
     int32_t length = base->length();
-    unsigned argumentLength = otherView->length();
+    unsigned argumentLength = argument->length();
     unsigned pos = 0;
     if (position >= 0)
         pos = std::min<uint32_t>(position, length);
@@ -4048,7 +4048,10 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
     if (static_cast<unsigned>(length) < static_cast<uint64_t>(argumentLength) + pos)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
 
-    if (argumentLength == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    if (argumentLength == 1 && base->isRope() && static_cast<unsigned>(length) >= JSString::minLengthForRopeWalk) {
         if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
             if (*result != notFound)
                 OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
@@ -4131,13 +4134,13 @@ JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOf, UCPUStrictInt32, (JSGlobalO
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto otherView = argument->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
     unsigned length = base->length();
-    unsigned argumentLength = otherView->length();
+    unsigned argumentLength = argument->length();
     if (length < argumentLength)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     unsigned startPosition = length - argumentLength;
 
@@ -4181,11 +4184,8 @@ JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOfWithIndex, UCPUStrictInt32, (
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto otherView = argument->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
     unsigned length = base->length();
-    unsigned argumentLength = otherView->length();
+    unsigned argumentLength = argument->length();
     if (length < argumentLength)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
 
@@ -4195,6 +4195,9 @@ JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOfWithIndex, UCPUStrictInt32, (
         startPosition = 0;
     else
         startPosition = std::min<uint32_t>(position, maxStart);
+
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     if (argumentLength == 1)
         OPERATION_RETURN(scope, stringLastIndexOfOneCharOperation(globalObject, scope, base, otherView[0], startPosition));
@@ -4242,10 +4245,15 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject* globa
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned length = base->length();
+    unsigned prefixLength = prefix->length();
+    if (length < prefixLength)
+        OPERATION_RETURN(scope, false);
+
     auto prefixView = prefix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    if (prefixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+    if (prefixLength == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
         if (auto character = base->tryGetCharAt(globalObject, 0))
             OPERATION_RETURN(scope, *character == prefixView[0]);
     }
@@ -4264,17 +4272,19 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObje
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto prefixView = prefix->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, false);
-
     unsigned length = base->length();
     unsigned start = 0;
     if (position >= 0)
         start = std::min<uint32_t>(position, length);
 
-    if (prefixView->length() == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
-        if (start >= length)
-            OPERATION_RETURN(scope, false);
+    unsigned prefixLength = prefix->length();
+    if (length - start < prefixLength)
+        OPERATION_RETURN(scope, false);
+
+    auto prefixView = prefix->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    if (prefixLength == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
         if (auto character = base->tryGetCharAt(globalObject, start))
             OPERATION_RETURN(scope, *character == prefixView[0]);
     }
@@ -4293,11 +4303,16 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject* globalO
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned length = base->length();
+    unsigned suffixLength = suffix->length();
+    if (length < suffixLength)
+        OPERATION_RETURN(scope, false);
+
     auto suffixView = suffix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    if (suffixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
-        if (auto character = base->tryGetCharAt(globalObject, base->length() - 1))
+    if (suffixLength == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (auto character = base->tryGetCharAt(globalObject, length - 1))
             OPERATION_RETURN(scope, *character == suffixView[0]);
     }
 
@@ -4315,27 +4330,23 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobal
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned length = base->length();
+    unsigned end = endPosition >= 0 ? std::min<uint32_t>(endPosition, length) : 0;
+
+    unsigned suffixLength = suffix->length();
+    if (end < suffixLength)
+        OPERATION_RETURN(scope, false);
+
     auto suffixView = suffix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    if (suffixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
-        unsigned length = base->length();
-        unsigned end = endPosition >= 0 ? std::min<uint32_t>(endPosition, length) : 0;
-        if (!end)
-            OPERATION_RETURN(scope, false);
+    if (suffixLength == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
         if (auto character = base->tryGetCharAt(globalObject, end - 1))
             OPERATION_RETURN(scope, *character == suffixView[0]);
     }
 
     auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
-
-    int32_t length = baseView->length();
-    unsigned end = length;
-    if (endPosition >= 0)
-        end = std::min<uint32_t>(endPosition, length);
-    else
-        end = 0;
 
     OPERATION_RETURN(scope, baseView->hasInfixEndingAt(suffixView, end));
 }

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -921,9 +921,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
     JSString* otherJSString = a0.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto otherView = otherJSString->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     // 5. Let numPos be ? ToNumber(position).
     // 6. Assert: If position is undefined, then numPos is NaN.
     // 7. If numPos is NaN, let pos be +∞; else let pos be ! ToIntegerOrInfinity(numPos).
@@ -935,7 +932,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
     RETURN_IF_EXCEPTION(scope, { });
 
     unsigned len = thisJSString->length();
-    unsigned otherLen = otherView->length();
+    unsigned otherLen = otherJSString->length();
     if (len < otherLen)
         return JSValue::encode(jsNumber(-1));
 
@@ -947,6 +944,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
         startPosition = maxStart;
     else
         startPosition = static_cast<unsigned>(numPos);
+
+    auto otherView = otherJSString->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
     // Now, startPosition is in [0, maxStart(len - otherLen)].
     if (otherLen == 1) {
@@ -1979,13 +1979,14 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
+    auto searchLength = search->length();
+    if (length - start < searchLength)
+        return JSValue::encode(jsBoolean(false));
+
     auto searchString = search->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
-        if (start >= length)
-            return JSValue::encode(jsBoolean(false));
-
+    if (searchLength == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
         if (auto character = string->tryGetCharAt(globalObject, start))
             return JSValue::encode(jsBoolean(*character == searchString[0]));
     }
@@ -2029,13 +2030,14 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
+    auto searchLength = search->length();
+    if (end < searchLength)
+        return JSValue::encode(jsBoolean(false));
+
     auto searchString = search->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
-        if (!end)
-            return JSValue::encode(jsBoolean(false));
-
+    if (searchLength == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
         if (auto character = string->tryGetCharAt(globalObject, end - 1))
             return JSValue::encode(jsBoolean(*character == searchString[0]));
     }
@@ -2058,7 +2060,11 @@ static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, J
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
-    if (search->length() == 1 && string->isRope() && string->length() >= JSString::minLengthForRopeWalk) {
+    auto searchLength = search->length();
+    if (length - start < searchLength)
+        return JSValue::encode(jsBoolean(false));
+
+    if (searchLength == 1 && string->isRope() && string->length() >= JSString::minLengthForRopeWalk) {
         auto searchView = search->view(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
 

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -138,6 +138,9 @@ SUPPRESS_NODELETE size_t StringView::find(AdaptiveStringSearcherTables& tables, 
     if (!matchLength)
         return start;
 
+    if (matchLength > subjectLength - start)
+        return notFound;
+
     if (subjectLength > INT32_MAX || matchLength > INT32_MAX) [[unlikely]]
         return find(matchString, start);
 


### PR DESCRIPTION
#### 27eb122967d3188a3ea63a018bcff533df3d88e0
<pre>
[JSC] Reject when search-string is longer than the target-string early
<a href="https://bugs.webkit.org/show_bug.cgi?id=322924">https://bugs.webkit.org/show_bug.cgi?id=322924</a>
<a href="https://rdar.apple.com/186187306">rdar://186187306</a>

Reviewed by Marcus Plutowski.

For String#indexOf / String#includes / StringView::find, reject when
search-string is longer than the target-string early before constructing
adaptive string searcher table. We apply the same thing to reverseFind /
lastIndexOf etc. Also doing the same fast path rejection for startsWith
and endsWith.

Test: JSTests/stress/string-index-of-search-longer-than-subject.js

* JSTests/stress/string-index-of-search-longer-than-subject.js: Added.
(shouldBe):
(indexOf):
(indexOfAt):
(includes):
(includesAt):
(referenceIndexOf):
(indexOfRope):
* JSTests/stress/string-last-index-of-search-longer-than-subject.js: Added.
(shouldBe):
(lastIndexOf):
(lastIndexOfAt):
(startsWith):
(startsWithAt):
(endsWith):
(endsWithAt):
(matchesAt):
(referenceLastIndexOf):
(referenceStartsWith):
(referenceEndsWith):
(lastIndexOfRopeSubject):
(startsWithRopeSubject):
(endsWithRopeSubject):
(lastIndexOfRopeSearch):
(startsWithRopeSearch):
(endsWithRopeSearch):
(lastIndexOfRopeSubjectAt):
(map):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringIncludesImpl):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):

Canonical link: <a href="https://commits.webkit.org/320177@main">https://commits.webkit.org/320177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/651ad90ee64dcfaccd639fdf44cfccb88d460e04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194042 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148113 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79a627d6-0c07-4e2e-a0de-29c1cff4e61c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143478 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99648 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c2a22cb-45d5-486d-8399-2ab020b8b737) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123899 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/501bb41b-57c4-4b7b-b18f-120cb0e267ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44177 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5868 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12696 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43754 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5224 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45097 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57414 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153017 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58118 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40383 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152700 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27930 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47243 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130398 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126818 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56626 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18765 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->