### PR TITLE
Refactor EventSenderSyntheticEvent to be shareable across TWKAPI and WKTR

### DIFF
--- a/Tools/TestRunnerShared/mac/SyntheticNSEvent.h
+++ b/Tools/TestRunnerShared/mac/SyntheticNSEvent.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import <AppKit/AppKit.h>
+#import <wtf/Forward.h>
+
+@interface SyntheticNSEvent : NSEvent
+
+- (id)initPressureEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation stage:(NSInteger)stage pressure:(float)pressure stageTransition:(float)stageTransition phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
+- (id)initMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation magnification:(CGFloat)magnification phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
+- (id)initSmartMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
+
+- (NSTimeInterval)timestamp;
+
+@end
+
+void dispatchSyntheticEvent(NSEvent *, NSView *, NSString *description, void (^)(NSView *, NSEvent *));
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestRunnerShared/mac/SyntheticNSEvent.mm
+++ b/Tools/TestRunnerShared/mac/SyntheticNSEvent.mm
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SyntheticNSEvent.h"
+
+#if PLATFORM(MAC)
+
+#import "CoreGraphicsTestSPI.h"
+#import <pal/spi/cocoa/IOKitSPI.h>
+#import <wtf/Assertions.h>
+#import <wtf/Function.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/text/WTFString.h>
+
+@interface NSApplication (SyntheticNSEventDetails)
+- (void)_setCurrentEvent:(NSEvent *)event;
+@end
+
+@interface NSEvent (SyntheticNSEventDetails)
+- (instancetype)_initWithCGEvent:(CGEventRef)event eventRef:(void *)eventRef;
+@end
+
+static CGSGesturePhase gesturePhaseFromNSEventPhase(NSEventPhase phase)
+{
+    switch (phase) {
+    case NSEventPhaseMayBegin:
+        return kCGSGesturePhaseMayBegin;
+
+    case NSEventPhaseBegan:
+        return kCGSGesturePhaseBegan;
+
+    case NSEventPhaseChanged:
+        return kCGSGesturePhaseChanged;
+
+    case NSEventPhaseCancelled:
+        return kCGSGesturePhaseCancelled;
+
+    case NSEventPhaseEnded:
+        return kCGSGesturePhaseEnded;
+
+    case NSEventPhaseNone:
+    default:
+        return kCGSGesturePhaseNone;
+    }
+}
+
+@implementation SyntheticNSEvent {
+    NSPoint _syntheticGlobalLocation;
+    NSPoint _syntheticLocationInWindow;
+    NSInteger _syntheticStage;
+    float _syntheticPressure;
+    CGFloat _syntheticMagnification;
+    CGFloat _syntheticStageTransition;
+    NSEventPhase _syntheticPhase;
+    NSEventPhase _syntheticMomentumPhase;
+    NSTimeInterval _syntheticTimestamp;
+    NSInteger _syntheticEventNumber;
+    short _syntheticSubtype;
+    NSEventType _syntheticType;
+    NSWindow *_syntheticWindow;
+}
+
+- (instancetype)initPressureEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation stage:(NSInteger)stage pressure:(float)pressure stageTransition:(float)stageTransition phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
+{
+    RetainPtr cgEvent = adoptCF(CGEventCreate(nullptr));
+    CGEventSetType(cgEvent, (CGEventType)kCGSEventGesture);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGestureHIDType, kIOHIDEventTypeForce);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGesturePhase, gesturePhaseFromNSEventPhase(phase));
+    CGEventSetDoubleValueField(cgEvent, kCGEventStagePressure, pressure);
+    CGEventSetDoubleValueField(cgEvent, kCGEventTransitionProgress, pressure);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGestureStage, stageTransition);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGestureBehavior, kCGSGestureBehaviorDeepPress);
+
+    self = [super _initWithCGEvent:cgEvent eventRef:nullptr];
+
+    if (!self)
+        return nil;
+
+    _syntheticLocationInWindow = location;
+    _syntheticGlobalLocation = globalLocation;
+    _syntheticStage = stage;
+    _syntheticPressure = pressure;
+    _syntheticStageTransition = stageTransition;
+    _syntheticPhase = phase;
+    _syntheticTimestamp = time;
+    _syntheticEventNumber = eventNumber;
+    _syntheticWindow = window;
+    _syntheticType = NSEventTypePressure;
+
+    return self;
+}
+
+- (id)initMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation magnification:(CGFloat)magnification phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
+{
+    RetainPtr cgEvent = adoptCF(CGEventCreate(nullptr));
+    CGEventSetType(cgEvent, (CGEventType)kCGSEventGesture);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGestureHIDType, kIOHIDEventTypeZoom);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGesturePhase, gesturePhaseFromNSEventPhase(phase));
+    CGEventSetDoubleValueField(cgEvent, kCGEventGestureZoomValue, magnification);
+
+    if (!(self = [super _initWithCGEvent:cgEvent eventRef:nullptr]))
+        return nil;
+
+    _syntheticLocationInWindow = location;
+    _syntheticGlobalLocation = globalLocation;
+    _syntheticMagnification = magnification;
+    _syntheticPhase = phase;
+    _syntheticTimestamp = time;
+    _syntheticEventNumber = eventNumber;
+    _syntheticWindow = window;
+    _syntheticType = NSEventTypeMagnify;
+
+    return self;
+}
+
+- (id)initSmartMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
+{
+    RetainPtr cgEvent = adoptCF(CGEventCreate(nullptr));
+    CGEventSetType(cgEvent, (CGEventType)kCGSEventGesture);
+    CGEventSetIntegerValueField(cgEvent, kCGEventGestureHIDType, kIOHIDEventTypeZoomToggle);
+
+    if (!(self = [super _initWithCGEvent:cgEvent eventRef:nullptr]))
+        return nil;
+
+    _syntheticType = NSEventTypeSmartMagnify;
+    _syntheticLocationInWindow = location;
+    _syntheticGlobalLocation = globalLocation;
+    _syntheticTimestamp = time;
+    _syntheticWindow = window;
+
+    return self;
+}
+
+
+- (CGFloat)stageTransition
+{
+    return _syntheticStageTransition;
+}
+
+- (NSTimeInterval)timestamp
+{
+    return _syntheticTimestamp;
+}
+
+- (NSEventType)type
+{
+    return _syntheticType;
+}
+
+- (NSEventSubtype)subtype
+{
+    return (NSEventSubtype)_syntheticSubtype;
+}
+
+- (NSPoint)locationInWindow
+{
+    return _syntheticLocationInWindow;
+}
+
+- (NSPoint)location
+{
+    return _syntheticGlobalLocation;
+}
+
+- (NSInteger)stage
+{
+    return _syntheticStage;
+}
+
+- (float)pressure
+{
+    return _syntheticPressure;
+}
+
+- (CGFloat)magnification
+{
+    return _syntheticMagnification;
+}
+
+- (NSEventPhase)phase
+{
+    return _syntheticPhase;
+}
+
+- (NSEventPhase)momentumPhase
+{
+    return _syntheticMomentumPhase;
+}
+
+- (NSInteger)eventNumber
+{
+    return _syntheticEventNumber;
+}
+
+- (BOOL)_isTouchesEnded
+{
+    return false;
+}
+
+- (NSWindow *)window
+{
+    return _syntheticWindow;
+}
+
+@end
+
+void dispatchSyntheticEvent(NSEvent *event, NSView *platformView, NSString *description, void (^dispatch)(NSView *, NSEvent *))
+{
+    NSPoint locationInWindow = [event locationInWindow];
+    RetainPtr targetView = [platformView hitTest:locationInWindow];
+    if (!targetView) {
+        LOG_ERROR("%@ failed to find the target view at %@\n", description, NSStringFromPoint(locationInWindow));
+        return;
+    }
+
+    [NSApp _setCurrentEvent:event];
+    dispatch(targetView, event);
+    [NSApp _setCurrentEvent:nil];
+}
+
+#endif

--- a/Tools/WebKitTestRunner/PlatformCocoa.cmake
+++ b/Tools/WebKitTestRunner/PlatformCocoa.cmake
@@ -159,6 +159,7 @@ list(APPEND WebKitTestRunner_SOURCES
     ${WebKitTestRunner_DIR}/mac/main.mm
 
     ${WebKitTestRunner_SHARED_DIR}/mac/NSPasteboardAdditions.mm
+    ${WebKitTestRunner_SHARED_DIR}/mac/SyntheticNSEvent.mm
 
     ${WebKitTestRunner_SHARED_DIR}/cocoa/ClassMethodSwizzler.mm
     ${WebKitTestRunner_SHARED_DIR}/cocoa/InstanceMethodSwizzler.mm

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		F474EE3D2B82B65100DE5F41 /* WKTextExtractionTestingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F474EE3A2B82B65100DE5F41 /* WKTextExtractionTestingHelpers.h */; };
 		F4C3578C20E8444600FA0748 /* LayoutTestSpellChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C3578A20E8444000FA0748 /* LayoutTestSpellChecker.mm */; };
 		F4FED324235823A3003C139C /* NSPasteboardAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */; };
+		1A2B3C4D2E5F60718293A4B3 /* SyntheticNSEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D2E5F60718293A4B2 /* SyntheticNSEvent.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -530,6 +531,8 @@
 		F4F2894B2AC4ED290084A38D /* UIKitSPIForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIKitSPIForTesting.h; path = ../TestRunnerShared/spi/UIKitSPIForTesting.h; sourceTree = "<group>"; };
 		F4FED3212358215E003C139C /* NSPasteboardAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSPasteboardAdditions.h; path = ../TestRunnerShared/mac/NSPasteboardAdditions.h; sourceTree = "<group>"; };
 		F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = NSPasteboardAdditions.mm; path = ../TestRunnerShared/mac/NSPasteboardAdditions.mm; sourceTree = "<group>"; };
+		1A2B3C4D2E5F60718293A4B1 /* SyntheticNSEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyntheticNSEvent.h; path = ../TestRunnerShared/mac/SyntheticNSEvent.h; sourceTree = "<group>"; };
+		1A2B3C4D2E5F60718293A4B2 /* SyntheticNSEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SyntheticNSEvent.mm; path = ../TestRunnerShared/mac/SyntheticNSEvent.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1100,6 +1103,8 @@
 			children = (
 				F4FED3212358215E003C139C /* NSPasteboardAdditions.h */,
 				F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */,
+				1A2B3C4D2E5F60718293A4B1 /* SyntheticNSEvent.h */,
+				1A2B3C4D2E5F60718293A4B2 /* SyntheticNSEvent.mm */,
 			);
 			name = mac;
 			sourceTree = "<group>";
@@ -1411,6 +1416,7 @@
 				BC793400118F7C84005EA8E2 /* main.mm in Sources */,
 				F4FED324235823A3003C139C /* NSPasteboardAdditions.mm in Sources */,
 				BC7934E811906846005EA8E2 /* PlatformWebViewMac.mm in Sources */,
+				1A2B3C4D2E5F60718293A4B3 /* SyntheticNSEvent.mm in Sources */,
 				BC8C795C11D2785D004535A1 /* TestControllerMac.mm in Sources */,
 				0F87B6131BACAD82004EC572 /* UIScriptControllerMac.mm in Sources */,
 				E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */,

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -27,10 +27,10 @@
 #import "config.h"
 #import "EventSenderProxy.h"
 
-#import "CoreGraphicsTestSPI.h"
 #import "ModifierKeys.h"
 #import "PlatformWebView.h"
 #import "StringFunctions.h"
+#import "SyntheticNSEvent.h"
 #import "TestController.h"
 #import "TestRunnerWKWebView.h"
 #import "WebKitTestRunnerWindow.h"
@@ -41,7 +41,6 @@
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
-#import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -53,202 +52,6 @@
 
 @interface NSEvent (ForTestRunner)
 - (void)_postDelayed;
-- (instancetype)_initWithCGEvent:(CGEventRef)event eventRef:(void *)eventRef;
-@end
-
-@interface EventSenderSyntheticEvent : NSEvent {
-@public
-    NSPoint _eventSender_locationInWindow;
-    NSPoint _eventSender_location;
-    NSInteger _eventSender_stage;
-    float _eventSender_pressure;
-    CGFloat _eventSender_magnification;
-    CGFloat _eventSender_stageTransition;
-    NSEventPhase _eventSender_phase;
-    NSEventPhase _eventSender_momentumPhase;
-    NSTimeInterval _eventSender_timestamp;
-    NSInteger _eventSender_eventNumber;
-    short _eventSender_subtype;
-    NSEventType _eventSender_type;
-    NSWindow *_eventSender_window;
-}
-
-- (id)initPressureEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation stage:(NSInteger)stage pressure:(float)pressure stageTransition:(float)stageTransition phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
-- (id)initMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation magnification:(CGFloat)magnification phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
-- (id)initSmartMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window;
-
-- (NSTimeInterval)timestamp;
-
-@end
-
-static CGSGesturePhase EventSenderCGGesturePhaseFromNSEventPhase(NSEventPhase phase)
-{
-    switch (phase) {
-    case NSEventPhaseMayBegin:
-        return kCGSGesturePhaseMayBegin;
-
-    case NSEventPhaseBegan:
-        return kCGSGesturePhaseBegan;
-
-    case NSEventPhaseChanged:
-        return kCGSGesturePhaseChanged;
-
-    case NSEventPhaseCancelled:
-        return kCGSGesturePhaseCancelled;
-
-    case NSEventPhaseEnded:
-        return kCGSGesturePhaseEnded;
-
-    case NSEventPhaseNone:
-    default:
-        return kCGSGesturePhaseNone;
-    }
-}
-
-@implementation EventSenderSyntheticEvent
-
-- (instancetype)initPressureEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation stage:(NSInteger)stage pressure:(float)pressure stageTransition:(float)stageTransition phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
-{
-    auto cgEvent = adoptCF(CGEventCreate(nullptr));
-    CGEventSetType(cgEvent.get(), (CGEventType)kCGSEventGesture);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGestureHIDType, kIOHIDEventTypeForce);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGesturePhase, EventSenderCGGesturePhaseFromNSEventPhase(phase));
-    CGEventSetDoubleValueField(cgEvent.get(), kCGEventStagePressure, pressure);
-    CGEventSetDoubleValueField(cgEvent.get(), kCGEventTransitionProgress, pressure);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGestureStage, stageTransition);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGestureBehavior, kCGSGestureBehaviorDeepPress);
-
-    self = [super _initWithCGEvent:cgEvent.get() eventRef:nullptr];
-
-    if (!self)
-        return nil;
-
-    _eventSender_location = location;
-    _eventSender_locationInWindow = globalLocation;
-    _eventSender_stage = stage;
-    _eventSender_pressure = pressure;
-    _eventSender_stageTransition = stageTransition;
-    _eventSender_phase = phase;
-    _eventSender_timestamp = time;
-    _eventSender_eventNumber = eventNumber;
-    _eventSender_window = window;
-    _eventSender_type = NSEventTypePressure;
-
-    return self;
-}
-
-- (id)initMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation magnification:(CGFloat)magnification phase:(NSEventPhase)phase time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
-{
-    auto cgEvent = adoptCF(CGEventCreate(nullptr));
-    CGEventSetType(cgEvent.get(), (CGEventType)kCGSEventGesture);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGestureHIDType, kIOHIDEventTypeZoom);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGesturePhase, EventSenderCGGesturePhaseFromNSEventPhase(phase));
-    CGEventSetDoubleValueField(cgEvent.get(), kCGEventGestureZoomValue, magnification);
-
-    if (!(self = [super _initWithCGEvent:cgEvent.get() eventRef:nullptr]))
-        return nil;
-
-    _eventSender_location = location;
-    _eventSender_locationInWindow = globalLocation;
-    _eventSender_magnification = magnification;
-    _eventSender_phase = phase;
-    _eventSender_timestamp = time;
-    _eventSender_eventNumber = eventNumber;
-    _eventSender_window = window;
-    _eventSender_type = NSEventTypeMagnify;
-
-    return self;
-}
-
-- (id)initSmartMagnifyEventAtLocation:(NSPoint)location globalLocation:(NSPoint)globalLocation time:(NSTimeInterval)time eventNumber:(NSInteger)eventNumber window:(NSWindow *)window
-{
-    auto cgEvent = adoptCF(CGEventCreate(nullptr));
-    CGEventSetType(cgEvent.get(), (CGEventType)kCGSEventGesture);
-    CGEventSetIntegerValueField(cgEvent.get(), kCGEventGestureHIDType, kIOHIDEventTypeZoomToggle);
-
-    if (!(self = [super _initWithCGEvent:cgEvent.get() eventRef:nullptr]))
-        return nil;
-
-    _eventSender_type = NSEventTypeSmartMagnify;
-    _eventSender_location = location;
-    _eventSender_locationInWindow = globalLocation;
-    _eventSender_timestamp = time;
-    _eventSender_window = window;
-
-    return self;
-}
-
-
-- (CGFloat)stageTransition
-{
-    return _eventSender_stageTransition;
-}
-
-- (NSTimeInterval)timestamp
-{
-    return _eventSender_timestamp;
-}
-
-- (NSEventType)type
-{
-    return _eventSender_type;
-}
-
-- (NSEventSubtype)subtype
-{
-    return (NSEventSubtype)_eventSender_subtype;
-}
-
-- (NSPoint)locationInWindow
-{
-    return _eventSender_location;
-}
-
-- (NSPoint)location
-{
-    return _eventSender_locationInWindow;
-}
-
-- (NSInteger)stage
-{
-    return _eventSender_stage;
-}
-
-- (float)pressure
-{
-    return _eventSender_pressure;
-}
-
-- (CGFloat)magnification
-{
-    return _eventSender_magnification;
-}
-
-- (NSEventPhase)phase
-{
-    return _eventSender_phase;
-}
-
-- (NSEventPhase)momentumPhase
-{
-    return _eventSender_momentumPhase;
-}
-
-- (NSInteger)eventNumber
-{
-    return _eventSender_eventNumber;
-}
-
-- (BOOL)_isTouchesEnded
-{
-    return false;
-}
-
-- (NSWindow *)window
-{
-    return _eventSender_window;
-}
-
 @end
 
 namespace WTR {
@@ -477,7 +280,7 @@ static void handleForceEventSynchronously(NSEvent *event)
 
 RetainPtr<NSEvent> EventSenderProxy::beginPressureEvent(int stage)
 {
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initPressureEventAtLocation:NSMakePoint(m_position.x, m_position.y)
+    RetainPtr event = adoptNS([[SyntheticNSEvent alloc] initPressureEventAtLocation:NSMakePoint(m_position.x, m_position.y)
         globalLocation:([m_testController->mainWebView()->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
         stage:stage
         pressure:0.5
@@ -492,7 +295,7 @@ RetainPtr<NSEvent> EventSenderProxy::beginPressureEvent(int stage)
 
 RetainPtr<NSEvent> EventSenderProxy::pressureChangeEvent(int stage, float pressure, EventSenderProxy::PressureChangeDirection direction)
 {
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initPressureEventAtLocation:NSMakePoint(m_position.x, m_position.y)
+    RetainPtr event = adoptNS([[SyntheticNSEvent alloc] initPressureEventAtLocation:NSMakePoint(m_position.x, m_position.y)
         globalLocation:([m_testController->mainWebView()->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
         stage:stage
         pressure:pressure
@@ -815,14 +618,9 @@ void EventSenderProxy::mouseScrollBy(int x, int y)
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     NSEvent *event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
-    if (NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event];
-        [targetView scrollWheel:event];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint location = [event locationInWindow];
-        WTFLogAlways("mouseScrollBy failed to find the target view at %f,%f\n", location.x, location.y);
-    }
+    dispatchSyntheticEvent(event, m_testController->mainWebView()->platformView(), @"mouseScrollBy", ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView scrollWheel:syntheticEvent];
+    });
 }
 
 void EventSenderProxy::continuousMouseScrollBy(int x, int y, bool paged)
@@ -850,14 +648,9 @@ void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int x, int y, int
     NSEvent* event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
 
     // Our event should have the correct settings:
-    if (NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event];
-        [targetView scrollWheel:event];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("mouseScrollByWithWheelAndMomentumPhases failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    dispatchSyntheticEvent(event, m_testController->mainWebView()->platformView(), @"mouseScrollByWithWheelAndMomentumPhases", ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView scrollWheel:syntheticEvent];
+    });
 }
 
 static CGGesturePhase cgScrollPhaseFromPhase(EventSenderProxy::WheelEventPhase phase)
@@ -927,14 +720,9 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
 
     NSEvent* event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
     // Our event should have the correct settings:
-    if (NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event];
-        [targetView scrollWheel:event];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("EventSenderProxy::sendWheelEvent failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    dispatchSyntheticEvent(event, m_testController->mainWebView()->platformView(), @"EventSenderProxy::sendWheelEvent", ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView scrollWheel:syntheticEvent];
+    });
 }
 
 void EventSenderProxy::smartMagnify()
@@ -942,91 +730,50 @@ void EventSenderProxy::smartMagnify()
     auto* mainWebView = m_testController->mainWebView();
     NSView *platformView = mainWebView->platformView();
 
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initSmartMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
+    RetainPtr event = adoptNS([[SyntheticNSEvent alloc] initSmartMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
         globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
         time:absoluteTimeForEventTime(currentEventTime())
         eventNumber:++m_eventNumber
         window:platformView.window]);
 
-    if (NSView *targetView = [platformView hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event.get()];
-        [targetView smartMagnifyWithEvent:event.get()];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("gestureStart failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    dispatchSyntheticEvent(event, platformView, @"smartMagnify", ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView smartMagnifyWithEvent:syntheticEvent];
+    });
 }
 
 #if ENABLE(MAC_GESTURE_EVENTS)
 
+static void sendMagnifyEvent(TestController& testController, WKPoint position, NSInteger eventNumber, NSTimeInterval time, double scale, NSEventPhase phase, const String& description)
+{
+    auto* mainWebView = testController.mainWebView();
+    RetainPtr platformView = mainWebView->platformView();
+
+    RetainPtr event = adoptNS([[SyntheticNSEvent alloc] initMagnifyEventAtLocation:NSMakePoint(position.x, position.y)
+        globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(position.x, position.y, 1, 1)].origin)
+        magnification:scale
+        phase:phase
+        time:time
+        eventNumber:eventNumber
+        window:[platformView window]]);
+
+    dispatchSyntheticEvent(event, platformView, description.createNSString(), ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView magnifyWithEvent:syntheticEvent];
+    });
+}
+
 void EventSenderProxy::scaleGestureStart(double scale)
 {
-    auto* mainWebView = m_testController->mainWebView();
-    NSView *platformView = mainWebView->platformView();
-
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
-        globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
-        magnification:scale
-        phase:NSEventPhaseBegan
-        time:absoluteTimeForEventTime(currentEventTime())
-        eventNumber:++m_eventNumber
-        window:platformView.window]);
-
-    if (NSView *targetView = [platformView hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event.get()];
-        [targetView magnifyWithEvent:event.get()];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("gestureStart failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    sendMagnifyEvent(*m_testController, m_position, ++m_eventNumber, absoluteTimeForEventTime(currentEventTime()), scale, NSEventPhaseBegan, "scaleGestureStart"_s);
 }
 
 void EventSenderProxy::scaleGestureChange(double scale)
 {
-    auto* mainWebView = m_testController->mainWebView();
-    NSView *platformView = mainWebView->platformView();
-
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
-        globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
-        magnification:scale
-        phase:NSEventPhaseChanged
-        time:absoluteTimeForEventTime(currentEventTime())
-        eventNumber:++m_eventNumber
-        window:platformView.window]);
-
-    if (NSView *targetView = [platformView hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event.get()];
-        [targetView magnifyWithEvent:event.get()];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("gestureStart failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    sendMagnifyEvent(*m_testController, m_position, ++m_eventNumber, absoluteTimeForEventTime(currentEventTime()), scale, NSEventPhaseChanged, "scaleGestureChange"_s);
 }
 
 void EventSenderProxy::scaleGestureEnd(double scale)
 {
-    auto* mainWebView = m_testController->mainWebView();
-    NSView *platformView = mainWebView->platformView();
-
-    auto event = adoptNS([[EventSenderSyntheticEvent alloc] initMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
-        globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
-        magnification:scale
-        phase:NSEventPhaseEnded
-        time:absoluteTimeForEventTime(currentEventTime())
-        eventNumber:++m_eventNumber
-        window:platformView.window]);
-
-    if (NSView *targetView = [platformView hitTest:[event locationInWindow]]) {
-        [NSApp _setCurrentEvent:event.get()];
-        [targetView magnifyWithEvent:event.get()];
-        [NSApp _setCurrentEvent:nil];
-    } else {
-        NSPoint windowLocation = [event locationInWindow];
-        WTFLogAlways("gestureStart failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
-    }
+    sendMagnifyEvent(*m_testController, m_position, ++m_eventNumber, absoluteTimeForEventTime(currentEventTime()), scale, NSEventPhaseEnded, "scaleGestureEnd"_s);
 }
 
 #endif // ENABLE(MAC_GESTURE_EVENTS)


### PR DESCRIPTION
#### 58c2111ae9464868fee99051f4aa25e58b610f5c
<pre>
Refactor EventSenderSyntheticEvent to be shareable across TWKAPI and WKTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=322925">https://bugs.webkit.org/show_bug.cgi?id=322925</a>
<a href="https://rdar.apple.com/186187575">rdar://186187575</a>

Reviewed by Richard Robinson.

EventSenderSyntheticEvent was a privately defined NSEvent subclass used
by EventSenderProxy to synthesize pressure/magnification events. In this
patch, we move the class to TestRunnerShared as SyntheticNSEvent, which
will allow TestWebKitAPI to do the same synthesis without duplicating the
requisite support.

We also take this opportunity to add a `dispatchSyntheticEvent()` helper.
Previously, each call site repeated a sequence of hit test against
platform view -&gt; -_setCurrentEvent: -&gt; some form of AppKit dispatch,
which this shared helper can now manage for callers.

This refactor is in anticipation of a forthcoming change where we will
add API tests to verify WKWebView.magnification when driven with
NSResponder-based magnify events.

Canonical link: <a href="https://commits.webkit.org/320131@main">https://commits.webkit.org/320131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c463b0ec48546e6065430ec5df2431f9545bac8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183850 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148143 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a80d20b0-e10a-47a8-a261-b974f313fccc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143501 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99673 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9e0b690-9abc-4e9c-af06-e766d5e06ea8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186805 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47274 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 2 new passes 3 flakes 2 failures; Uploaded test results; Ignored 1 pre-existing failure(s) based on results-db") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123923 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fc5570b-a81c-4cce-a0f2-cdf50b0d54be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44203 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43785 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5254 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196010 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57444 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153042 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58148 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40414 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/contentextensions/text-track-blocked.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/log-delayed-client-side-redirects.html, http/tests/security/cached-svg-image-with-css-cross-domain.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-https-to-http-script-in-iframe-UpgradeMixedContent.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152725 "Found 1 new API test failure: TestWTF.WTF_ThreadSafeWeakPtr.GetRacingWithLastWeakReferenceRelease (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47265 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126874 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56656 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18797 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56027 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->