### PR TITLE
[modern-media-controls] Pinch gesture recognizer references undefined this._targetTouches

### DIFF
--- a/LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures-expected.txt
+++ b/LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures-expected.txt
@@ -1,0 +1,14 @@
+This test checks that PinchGestureRecognizer computes the distance between the two active pointers on platforms that do not natively support GestureEvent, reading from the base class's _targetPointers map rather than a non-existent _targetTouches property.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.dispatchEvent(pointerEvent("pointerdown", 2, 30, 40)) did not throw exception.
+PASS recognizer._startDistance is 50
+PASS states.includes('began') is true
+PASS recognizer.scale is 2
+PASS states.includes('changed') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures.html
+++ b/LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../../Source/WebCore/Modules/modern-media-controls/gesture-recognizers/gesture-recognizer.js" type="text/javascript"></script>
+<script src="../../../../Source/WebCore/Modules/modern-media-controls/gesture-recognizers/pinch.js" type="text/javascript"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<script src="../../../resources/js-test.js"></script>
+<script type="text/javascript">
+
+description("This test checks that PinchGestureRecognizer computes the distance between the two active pointers on platforms that do not natively support GestureEvent, reading from the base class's _targetPointers map rather than a non-existent _targetTouches property.");
+
+if (window.testRunner)
+    window.testRunner.dumpAsText();
+
+// Force the code path used on touch platforms that don't provide native gesture events.
+GestureRecognizer.SupportsGestures = false;
+
+const target = document.createElement("div");
+document.body.appendChild(target);
+
+let states = [];
+const delegate = {
+    gestureRecognizerShouldBegin() { return true; },
+    gestureRecognizerStateDidChange(gestureRecognizer) { states.push(gestureRecognizer.state); }
+};
+
+const recognizer = new PinchGestureRecognizer(target, delegate);
+
+function pointerEvent(type, pointerId, x, y)
+{
+    return new PointerEvent(type, { pointerId, clientX: x, clientY: y, bubbles: true });
+}
+
+// The first finger touches down: not enough touches to start tracking yet.
+target.dispatchEvent(pointerEvent("pointerdown", 1, 0, 0));
+
+// The second finger touches down: the recognizer now has 2 pointers and must
+// compute the starting distance. This used to throw because _distance() read
+// from the undefined this._targetTouches instead of this._targetPointers.
+shouldNotThrow('target.dispatchEvent(pointerEvent("pointerdown", 2, 30, 40))');
+
+// The initial distance between (0, 0) and (30, 40) is 50.
+shouldBe("recognizer._startDistance", "50");
+shouldBeTrue("states.includes('began')");
+
+// Moving the second finger to double the distance should yield a scale of 2.
+recognizer._captureTarget.dispatchEvent(pointerEvent("pointermove", 2, 60, 80));
+shouldBe("recognizer.scale", "2");
+shouldBeTrue("states.includes('changed')");
+
+target.remove();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/pinch.js
+++ b/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/pinch.js
@@ -193,10 +193,12 @@ class PinchGestureRecognizer extends GestureRecognizer
     {
         console.assert(this.numberOfTouches === 2);
 
-        const firstTouch = this._targetTouches[0];
+        const pointers = Array.from(this._targetPointers.values());
+
+        const firstTouch = pointers[0];
         const firstTouchPoint = new DOMPoint(firstTouch.pageX, firstTouch.pageY);
 
-        const secondTouch = this._targetTouches[1];
+        const secondTouch = pointers[1];
         const secondTouchPoint = new DOMPoint(secondTouch.pageX, secondTouch.pageY);
 
         return Math.sqrt(Math.pow(firstTouchPoint.x - secondTouchPoint.x, 2) + Math.pow(firstTouchPoint.y - secondTouchPoint.y, 2));


### PR DESCRIPTION
#### ec6ccd304e0f171242d64435b36476f5fcbf4050
<pre>
[modern-media-controls] Pinch gesture recognizer references undefined this._targetTouches
<a href="https://bugs.webkit.org/show_bug.cgi?id=322927">https://bugs.webkit.org/show_bug.cgi?id=322927</a>

Reviewed by NOBODY (OOPS!).

PinchGestureRecognizer._distance() read the two active touches from
this._targetTouches, which does not exist. The base GestureRecognizer
tracks active pointers in this._targetPointers, and that is a Map, so
neither the old property name nor integer indexing ([0]/[1]) would work.

On platforms with a native GestureEvent (real iOS) the recognizer takes
the gesture* code path and never calls _distance(), which masked the bug.
On touch platforms without native gesture events the pointer path is used,
so _distance() threw a TypeError, breaking pinch-to-fullscreen.

Read the pointers from this._targetPointers via Array.from(...values())
and index into that array instead.

Test: media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures.html

* LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures-expected.txt: Added.
* LayoutTests/media/modern-media-controls/gesture-recognizers/pinch-computes-distance-without-native-gestures.html: Added.
* Source/WebCore/Modules/modern-media-controls/gesture-recognizers/pinch.js:
(PinchGestureRecognizer.prototype._distance):
(PinchGestureRecognizer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec6ccd304e0f171242d64435b36476f5fcbf4050

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67690ecc-fa9a-4167-850b-f846e3e448f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99653 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60a9286e-fc42-44ad-849b-6b7210a2e6ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f12cb00a-ca15-48cc-8240-14ab53ac31f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44182 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43760 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5228 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195984 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153020 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58122 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40389 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152703 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47244 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130402 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56630 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18771 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56001 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->