### PR TITLE
MediaController leaks its MutationObserver by never disconnecting it in deinitialize()

### DIFF
--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer-expected.txt
@@ -1,0 +1,21 @@
+Testing that MediaController.deinitialize() disconnects the MutationObserver watching the media element's "controls" attribute, so mutating that attribute no longer updates controls availability once the controls have been torn down.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mediaController is an instance of MediaController
+PASS mediaController.controls.visible is true
+
+Sanity check: while the controls are live, removing the "controls" attribute updates availability.
+PASS mediaController.controls.visible is false
+PASS mediaController.controls.visible is true
+
+Tearing down the controls with deinitialize().
+
+Removing the "controls" attribute again. A leaked MutationObserver would flip controls.visible back to false.
+PASS mediaController.controls.visible is true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer.html
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<body>
+<video src="../../content/test.mp4" controls></video>
+<div id="shadow"></div>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<script type="text/javascript">
+
+window.jsTestIsAsync = true;
+
+description("Testing that MediaController.deinitialize() disconnects the MutationObserver watching the media element's \"controls\" attribute, so mutating that attribute no longer updates controls availability once the controls have been torn down.");
+
+const shadowRoot = document.querySelector("div#shadow").attachShadow({ mode: "open" });
+const media = document.querySelector("video");
+const mediaController = createControls(shadowRoot, media, null);
+
+shouldBeType("mediaController", "MediaController");
+shouldBeTrue("mediaController.controls.visible");
+
+debug("");
+debug("Sanity check: while the controls are live, removing the \"controls\" attribute updates availability.");
+media.removeAttribute("controls");
+
+// MutationObserver callbacks are delivered as a microtask, so we assert on the next turn.
+setTimeout(() => {
+    shouldBeFalse("mediaController.controls.visible");
+
+    media.setAttribute("controls", "");
+    setTimeout(() => {
+        shouldBeTrue("mediaController.controls.visible");
+
+        debug("");
+        debug("Tearing down the controls with deinitialize().");
+        mediaController.deinitialize();
+
+        debug("");
+        debug("Removing the \"controls\" attribute again. A leaked MutationObserver would flip controls.visible back to false.");
+        media.removeAttribute("controls");
+
+        setTimeout(() => {
+            shouldBeTrue("mediaController.controls.visible");
+
+            shadowRoot.host.remove();
+            media.remove();
+            debug("");
+            finishJSTest();
+        }, 0);
+    }, 0);
+}, 0);
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -112,7 +112,8 @@ class MediaController
 
         window.addEventListener("keydown", this);
 
-        new MutationObserver(this._updateControlsAvailability.bind(this)).observe(this.media, { attributes: true, attributeFilter: ["controls"] });
+        this._controlsAttributeObserver = new MutationObserver(this._updateControlsAvailability.bind(this));
+        this._controlsAttributeObserver.observe(this.media, { attributes: true, attributeFilter: ["controls"] });
     }
 
     // Public
@@ -357,6 +358,7 @@ class MediaController
 
     deinitialize()
     {
+        this._controlsAttributeObserver.disconnect();
         this.shadowRoot.removeChild(this.container);
         window.removeEventListener("keydown", this);
         if (this.controls)
@@ -374,6 +376,7 @@ class MediaController
         window.addEventListener("keydown", this);
         if (this.controls)
             this.controls.reenable();
+        this._controlsAttributeObserver.observe(this.media, { attributes: true, attributeFilter: ["controls"] });
         return true;
     }
 


### PR DESCRIPTION
#### c29d080cbc848273847c4c378e1cb2838c696e5d
<pre>
MediaController leaks its MutationObserver by never disconnecting it in deinitialize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=322928">https://bugs.webkit.org/show_bug.cgi?id=322928</a>

Reviewed by NOBODY (OOPS!).

The MediaController constructor created a MutationObserver inline to watch the
media element&apos;s &quot;controls&quot; attribute, but kept no reference to it and never
disconnected it. Because the observed node (the media element) retains its
registered observers, and the observer retains its bound callback, which in
turn retains the MediaController, the media element kept the MediaController
alive for as long as the element itself lived. This defeats the WeakRef held
in mediaWeakRef and left the observer firing _updateControlsAvailability() even
after the controls had been torn down via deinitialize().

Store the observer on the instance, disconnect it in deinitialize(), and
re-observe the (possibly replaced) media element in reinitialize() so the
&quot;controls&quot; attribute continues to be tracked across a fullscreen round-trip.

Test: media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer.html

* LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer-expected.txt: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-deinitialize-disconnects-controls-observer.html: Added.
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
(MediaController.prototype.deinitialize):
(MediaController.prototype.reinitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29d080cbc848273847c4c378e1cb2838c696e5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148118 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99654 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123902 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45955 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Passed layout tests; Running layout-tests; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44197 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43763 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5229 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50404 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48451 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; Ignored 3 pre-existing failure(s) based on results-db; Uploaded test results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195985 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153021 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58123 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40392 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/popup-from-iframe-same-site-with-post-form.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/postredirect-basic.html, http/tests/resourceLoadStatistics/enable-debug-mode.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-redirect-allowed.html, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html, http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152704 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47246 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130403 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126825 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56631 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18774 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->