### PR TITLE
[NewCodable] Add the ability to decode more primitive types

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift
@@ -46,18 +46,26 @@ enum JavaScriptEvaluationCodableValue<ID: Hashable & Sendable>: Sendable, Hashab
     case object([ObjectEntry])
 }
 
+extension JavaScriptEvaluationCodableValue.EmptyType {
+    fileprivate init(_ emptyType: WebKit.JavaScriptEvaluationResult.EmptyType) {
+        self = emptyType == .Null ? .null : .undefined
+    }
+}
+
 extension JavaScriptEvaluationCodableValue {
     init(_ value: borrowing WebKit.JavaScriptEvaluationResult.Value) {
+        typealias Cxx = WebKit.CxxInteropSupport
+
         self =
             switch unsafe value.index() {
-            case 0: // EmptyType
-                fatalError("not yet implemented")
-            case WebKit.CxxInteropSupport.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: CBool.self):
-                unsafe .bool(WebKit.CxxInteropSupport.alternativeForVariant(value, Alternative: CBool.self))
-            case 2: // double
-                fatalError("not yet implemented")
-            case 3: // String
-                fatalError("not yet implemented")
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: WebKit.JavaScriptEvaluationResult.EmptyType.self):
+                unsafe .empty(.init(Cxx.alternativeForVariant(value)))
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: CBool.self):
+                unsafe .bool(Cxx.alternativeForVariant(value))
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: CDouble.self):
+                unsafe .number(Cxx.alternativeForVariant(value))
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: WTF.String.self):
+                unsafe .string((Cxx.alternativeForVariant(value) as WTF.String).description)
             case 4: // Seconds
                 fatalError("not yet implemented")
             case 5: // Vector<JSObjectID>

--- a/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
@@ -50,32 +50,7 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
         self.codingPath = codingPath
     }
 
-    private func decodePrimitive<T>(
-        _ type: T.Type = T.self,
-        resolve: (JavaScriptEvaluationCodableValue<ID>) -> T?
-    ) throws(CodingError.Decoding) -> T {
-        guard let value = storage.value.map[id] else {
-            throw CodingError.dataCorrupted(
-                at: codingPath,
-                debugDescription: "No entry for \(id)."
-            )
-        }
-
-        guard let resolvedValue = resolve(value) else {
-            throw CodingError.typeMismatch(
-                expectedTypeDescription: "\(T.self)",
-                actualValueDescription: "\(value)",
-                at: codingPath
-            )
-        }
-
-        return resolvedValue
-    }
-
-    @_lifetime(self: copy self)
-    mutating func decode<T: CommonDecodable>(_: T.Type) throws(CodingError.Decoding) -> T {
-        fatalError("\(#function) is not implemented")
-    }
+    // Intentionally does not implement the `mutating func decode<T: CommonDecodable>(_: T.Type) throws(CodingError.Decoding) -> T` requirement; the default implementation is sound.
 
     @_lifetime(self: copy self)
     mutating func decodeStruct<T: ~Copyable>(
@@ -132,94 +107,127 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int.Type) throws(CodingError.Decoding) -> Int {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int8.Type) throws(CodingError.Decoding) -> Int8 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int16.Type) throws(CodingError.Decoding) -> Int16 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int32.Type) throws(CodingError.Decoding) -> Int32 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int64.Type) throws(CodingError.Decoding) -> Int64 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Int128.Type) throws(CodingError.Decoding) -> Int128 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt.Type) throws(CodingError.Decoding) -> UInt {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt8.Type) throws(CodingError.Decoding) -> UInt8 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt16.Type) throws(CodingError.Decoding) -> UInt16 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt32.Type) throws(CodingError.Decoding) -> UInt32 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt64.Type) throws(CodingError.Decoding) -> UInt64 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: UInt128.Type) throws(CodingError.Decoding) -> UInt128 {
-        fatalError("\(#function) is not implemented")
+        try decodeInteger()
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Float.Type) throws(CodingError.Decoding) -> Float {
-        fatalError("\(#function) is not implemented")
+        let double = try decodeNumber(narrowingTo: Float.self)
+        let float = Float(double)
+
+        func isOrdinary(_ value: some FloatingPoint) -> Bool {
+            value.isFinite && !value.isZero
+        }
+
+        // A finite, nonzero value is the only kind narrowing can damage; +/-0, +/-infinity and
+        // NaN all convert exactly.
+        guard isOrdinary(float) || !isOrdinary(double) else {
+            throw CodingError.dataCorrupted(
+                at: codingPath,
+                debugDescription: "\(double) is not representable in Float."
+            )
+        }
+
+        return float
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_ hint: Double.Type) throws(CodingError.Decoding) -> Double {
-        fatalError("\(#function) is not implemented")
+        try decodeNumber(narrowingTo: Double.self)
     }
 
     @_lifetime(self: copy self)
     mutating func decode(_: String.Type) throws(CodingError.Decoding) -> String {
-        fatalError("\(#function) is not implemented")
+        try decodePrimitive {
+            guard case .string(let value) = $0 else {
+                return nil
+            }
+
+            return value
+        }
     }
 
     @_lifetime(self: copy self)
     mutating func decodeString<V: DecodingStringVisitor & ~Copyable>(
         _ visitor: borrowing V
     ) throws(CodingError.Decoding) -> V.DecodedValue {
-        fatalError("\(#function) is not implemented")
+        try visitor.visitString(decode(String.self))
     }
 
     @_lifetime(self: copy self)
     mutating func decodeNil() throws(CodingError.Decoding) -> Bool {
-        fatalError("\(#function) is not implemented")
+        try decodePrimitive {
+            guard case .empty = $0 else {
+                return false
+            }
+
+            // `undefined` counts as nil alongside `null`.
+            return true
+        }
     }
 
     @_lifetime(self: copy self)
     mutating func decodeOptional(_ closure: (inout Self) throws(CodingError.Decoding) -> Void) throws(CodingError.Decoding) {
-        fatalError("\(#function) is not implemented")
+        if try decodeNil() {
+            return
+        }
+
+        try closure(&self)
     }
 
     @_lifetime(self: copy self)
@@ -236,6 +244,63 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
     @_lifetime(self: copy self)
     mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D {
         fatalError("\(#function) is not implemented")
+    }
+}
+
+extension JavaScriptEvaluationGraphDecoder {
+    private func codableValue() throws(CodingError.Decoding) -> JavaScriptEvaluationCodableValue<ID> {
+        guard let value = storage.value.map[id] else {
+            throw CodingError.dataCorrupted(
+                at: codingPath,
+                debugDescription: "No entry for \(id)."
+            )
+        }
+
+        return value
+    }
+
+    private func decodePrimitive<T>(
+        _ type: T.Type = T.self,
+        resolve: (JavaScriptEvaluationCodableValue<ID>) -> T?
+    ) throws(CodingError.Decoding) -> T {
+        let value = try codableValue()
+
+        guard let resolvedValue = resolve(value) else {
+            throw CodingError.typeMismatch(
+                expectedTypeDescription: "\(T.self)",
+                actualValueDescription: "\(value)",
+                at: codingPath
+            )
+        }
+
+        return resolvedValue
+    }
+
+    private func decodeNumber<T>(narrowingTo type: T.Type) throws(CodingError.Decoding) -> Double {
+        let value = try codableValue()
+
+        guard case .number(let number) = value else {
+            throw CodingError.typeMismatch(
+                expectedTypeDescription: "\(T.self)",
+                actualValueDescription: "\(value)",
+                at: codingPath
+            )
+        }
+
+        return number
+    }
+
+    private func decodeInteger<T: FixedWidthInteger>(_ type: T.Type = T.self) throws(CodingError.Decoding) -> T {
+        let value = try decodeNumber(narrowingTo: T.self)
+
+        guard let integer = T(exactly: value) else {
+            throw CodingError.dataCorrupted(
+                at: codingPath,
+                debugDescription: "\(value) is not representable in \(T.self)."
+            )
+        }
+
+        return integer
     }
 }
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h
@@ -95,7 +95,7 @@ namespace WebKit::CxxInteropSupport {
 
 // FIXME: Generalize this once rdar://186426517 is fixed.
 template<typename Alternative>
-inline bool alternativeForVariant(const JavaScriptEvaluationResult::Value& value)
+inline Alternative alternativeForVariant(const JavaScriptEvaluationResult::Value& value)
 {
     return std::get<Alternative>(value);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
@@ -25,18 +25,232 @@
 
 @_spi(Experimental_NewCodable) import WebKit
 import Testing
+import NewCodable
+import struct Swift.String
 
 @MainActor
 struct JavaScriptEvaluationTests {
+    let page = WebPage()
+
     @Test
-    func evaluateBool() async throws {
-        let page = WebPage()
+    func decodingBool() async throws {
+        try await testDecoding(true) { "return true;" }
+        try await testDecoding(false) { "return false;" }
+        try await testDecoding(true) { "return 1 === 1;" }
 
-        let trueResult = try await page.callJavaScriptv0(returning: Bool.self) { "return true;" }
-        #expect(trueResult)
+        await testTypeMismatch(decoding: Bool.self) { "return 1;" }
+        await testTypeMismatch(decoding: Bool.self) { "return 0;" }
+        await testTypeMismatch(decoding: Bool.self) { #"return "true";"# }
+    }
 
-        let falseResult = try await page.callJavaScriptv0(returning: Bool.self) { "return false;" }
-        #expect(!falseResult)
+    @Test
+    func decodingDouble() async throws {
+        try await testDecoding(42.5) { "return 42.5;" }
+        try await testDecoding(-0.25) { "return -0.25;" }
+        try await testDecoding(0.0) { "return 0;" }
+        try await testDecoding(3.0) { "return 1 + 2;" }
+        try await testDecoding(9_007_199_254_740_991.0) { "return Number.MAX_SAFE_INTEGER;" }
+        try await testDecoding(Double.greatestFiniteMagnitude) { "return Number.MAX_VALUE;" }
+        try await testDecoding(Double.leastNonzeroMagnitude) { "return Number.MIN_VALUE;" }
+        try await testDecoding(Double.infinity) { "return Infinity;" }
+        try await testDecoding(-Double.infinity) { "return -Infinity;" }
+
+        // NaN is not equal to itself, so it cannot use the equality-based helper.
+        let nan = try await page.callJavaScriptv0(returning: Double.self) { "return NaN;" }
+        #expect(nan.isNaN)
+
+        await testTypeMismatch(decoding: Double.self) { #"return "42.5";"# }
+        await testTypeMismatch(decoding: Double.self) { "return true;" }
+    }
+
+    @Test
+    func decodingFloat() async throws {
+        try await testDecoding(Float(0.5)) { "return 0.5;" }
+        try await testDecoding(Float(-1.25)) { "return -1.25;" }
+        try await testDecoding(Float(0)) { "return 0;" }
+
+        // Rounding to the nearest Float loses precision, not the value, so it is allowed.
+        try await testDecoding(Float(0.1)) { "return 0.1;" }
+
+        // Infinity and NaN are exactly representable, so they are passed through rather than
+        // treated as an overflow.
+        try await testDecoding(Float.infinity) { "return Infinity;" }
+        try await testDecoding(-Float.infinity) { "return -Infinity;" }
+
+        let nan = try await page.callJavaScriptv0(returning: Float.self) { "return NaN;" }
+        #expect(nan.isNaN)
+
+        // The largest and smallest magnitudes Float can hold are fine, but a finite value
+        // past either one keeps none of its magnitude, so it is rejected instead of becoming
+        // infinity or zero.
+        try await testDecoding(Float.greatestFiniteMagnitude) { "return 3.4028234663852886e38;" }
+        try await testDecoding(-Float.greatestFiniteMagnitude) { "return -3.4028234663852886e38;" }
+        try await testDecoding(Float.leastNonzeroMagnitude) { "return 1.401298464324817e-45;" }
+
+        await testDataCorrupted(decoding: Float.self) { "return 1e39;" }
+        await testDataCorrupted(decoding: Float.self) { "return -1e39;" }
+        await testDataCorrupted(decoding: Float.self) { "return Number.MAX_VALUE;" }
+        await testDataCorrupted(decoding: Float.self) { "return 1e-46;" }
+        await testDataCorrupted(decoding: Float.self) { "return Number.MIN_VALUE;" }
+
+        await testTypeMismatch(decoding: Float.self) { #"return "0.5";"# }
+        await testTypeMismatch(decoding: Float.self) { "return false;" }
+    }
+
+    @Test
+    func decodingInt() async throws {
+        try await testDecoding(42) { "return 42;" }
+        try await testDecoding(-42) { "return -42;" }
+        try await testDecoding(0) { "return 0;" }
+        try await testDecoding(3) { "return 1 + 2;" }
+        try await testDecoding(9_007_199_254_740_991) { "return Number.MAX_SAFE_INTEGER;" }
+        try await testDecoding(-9_007_199_254_740_991) { "return Number.MIN_SAFE_INTEGER;" }
+
+        // A value which is not integral, or which is out of range, is rejected rather than
+        // truncated or wrapped. The value arrived with the right type, so this is corrupt
+        // data rather than a type mismatch.
+        await testDataCorrupted(decoding: Int.self) { "return 1.5;" }
+        await testDataCorrupted(decoding: Int.self) { "return -1.5;" }
+        await testDataCorrupted(decoding: Int.self) { "return NaN;" }
+        await testDataCorrupted(decoding: Int.self) { "return Infinity;" }
+        await testDataCorrupted(decoding: Int.self) { "return Number.MAX_VALUE;" }
+
+        await testTypeMismatch(decoding: Int.self) { #"return "42";"# }
+        await testTypeMismatch(decoding: Int.self) { "return true;" }
+    }
+
+    @Test
+    func decodingSignedIntegers() async throws {
+        try await testDecoding(Int8.max) { "return 127;" }
+        try await testDecoding(Int8.min) { "return -128;" }
+        await testDataCorrupted(decoding: Int8.self) { "return 128;" }
+        await testDataCorrupted(decoding: Int8.self) { "return -129;" }
+
+        try await testDecoding(Int16.max) { "return 32767;" }
+        try await testDecoding(Int16.min) { "return -32768;" }
+        await testDataCorrupted(decoding: Int16.self) { "return 32768;" }
+
+        try await testDecoding(Int32.max) { "return 2147483647;" }
+        try await testDecoding(Int32.min) { "return -2147483648;" }
+        await testDataCorrupted(decoding: Int32.self) { "return 2147483648;" }
+
+        try await testDecoding(Int64(9_007_199_254_740_991)) { "return Number.MAX_SAFE_INTEGER;" }
+        await testDataCorrupted(decoding: Int64.self) { "return 2 ** 63;" }
+
+        try await testDecoding(Int128(-12345)) { "return -12345;" }
+        await testDataCorrupted(decoding: Int128.self) { "return 1.5;" }
+    }
+
+    @Test
+    func decodingUnsignedIntegers() async throws {
+        try await testDecoding(UInt(42)) { "return 42;" }
+        try await testDecoding(UInt(0)) { "return 0;" }
+        await testDataCorrupted(decoding: UInt.self) { "return -1;" }
+
+        try await testDecoding(UInt8.max) { "return 255;" }
+        await testDataCorrupted(decoding: UInt8.self) { "return 256;" }
+
+        try await testDecoding(UInt16.max) { "return 65535;" }
+        await testDataCorrupted(decoding: UInt16.self) { "return 65536;" }
+
+        try await testDecoding(UInt32.max) { "return 4294967295;" }
+        await testDataCorrupted(decoding: UInt32.self) { "return 4294967296;" }
+
+        try await testDecoding(UInt64(9_007_199_254_740_991)) { "return Number.MAX_SAFE_INTEGER;" }
+        await testDataCorrupted(decoding: UInt64.self) { "return 2 ** 64;" }
+
+        try await testDecoding(UInt128(12345)) { "return 12345;" }
+        await testDataCorrupted(decoding: UInt128.self) { "return -12345;" }
+    }
+
+    @Test
+    func decodingString() async throws {
+        try await testDecoding("hello") { #"return "hello";"# }
+        try await testDecoding("") { #"return "";"# }
+        try await testDecoding("foo1") { #"return "foo" + 1;"# }
+        try await testDecoding("42") { "return String(42);" }
+        try await testDecoding("a\nb\tc\"d") { #"return "a\nb\tc\"d";"# }
+        try await testDecoding(String(repeating: "x", count: 1000)) { #"return "x".repeat(1000);"# }
+
+        await testTypeMismatch(decoding: String.self) { "return 42;" }
+        await testTypeMismatch(decoding: String.self) { "return true;" }
+    }
+
+    @Test
+    func decodingNonASCIIString() async throws {
+        try await testDecoding("héllo wörld") { #"return "héllo wörld";"# }
+        try await testDecoding("日本語") { #"return "日本語";"# }
+        try await testDecoding("👩‍👩‍👧‍👦🇨🇦") { #"return "👩‍👩‍👧‍👦🇨🇦";"# }
+
+        // Unpaired surrogates are not representable in UTF-8, and are replaced during conversion.
+        try await testDecoding("\u{FFFD}") { #"return "\uD800";"# }
+    }
+
+    @Test
+    func decodingOptional() async throws {
+        try await testDecoding(Int?.none) { "return null;" }
+        try await testDecoding(String?.none) { "return null;" }
+        try await testDecoding(Bool?.none) { "return null;" }
+
+        // `undefined` is a missing value too, however it was produced.
+        try await testDecoding(Int?.none) { "return undefined;" }
+        try await testDecoding(Int?.none) { "return ({}).missingProperty;" }
+        try await testDecoding(Int?.none) { "let unused = 1;" }
+
+        try await testDecoding(Int?.some(0)) { "return 0;" }
+        try await testDecoding(String?.some("hello")) { #"return "hello";"# }
+        try await testDecoding(String?.some("")) { #"return "";"# }
+        try await testDecoding(Bool?.some(false)) { "return false;" }
+        try await testDecoding(Double?.some(2.5)) { "return 2.5;" }
+
+        // A value present but of the wrong type is still a mismatch, not a nil.
+        await testTypeMismatch(decoding: Int?.self) { #"return "42";"# }
+
+        // A missing value is only acceptable where the Swift type is optional.
+        await testTypeMismatch(decoding: Int.self) { "return null;" }
+        await testTypeMismatch(decoding: String.self) { "return null;" }
+        await testTypeMismatch(decoding: Double.self) { "return undefined;" }
+    }
+}
+
+extension JavaScriptEvaluationTests {
+    private func testDecoding<T: CommonDecodable & Equatable>(
+        _ expectedValue: T,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ source: () -> String
+    ) async throws {
+        let actual = try await page.callJavaScriptv0(returning: T.self, source)
+        #expect(actual == expectedValue, sourceLocation: sourceLocation)
+    }
+
+    private func testTypeMismatch<T: CommonDecodable>(
+        decoding type: T.Type,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ source: () -> String
+    ) async {
+        let error = await #expect(throws: CodingError.Decoding.self, sourceLocation: sourceLocation) {
+            _ = try await page.callJavaScriptv0(returning: T.self, source)
+        }
+
+        guard case .typeMismatch = error?.kind else {
+            Issue.record("Unexpected CodingError.Decoding type: \(error)", sourceLocation: sourceLocation)
+            return
+        }
+    }
+
+    private func testDataCorrupted<T: CommonDecodable>(
+        decoding type: T.Type,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ source: () -> String
+    ) async {
+        let error = await #expect(throws: CodingError.Decoding.self, sourceLocation: sourceLocation) {
+            _ = try await page.callJavaScriptv0(returning: T.self, source)
+        }
+
+        guard case .dataCorrupted = error?.kind else {
+            Issue.record("Unexpected CodingError.Decoding type: \(error)", sourceLocation: sourceLocation)
+            return
+        }
     }
 }
 


### PR DESCRIPTION
#### 2d6042742a7eb23c1b092e2d2235857c116f712c
<pre>
[NewCodable] Add the ability to decode more primitive types
<a href="https://bugs.webkit.org/show_bug.cgi?id=322932">https://bugs.webkit.org/show_bug.cgi?id=322932</a>
<a href="https://rdar.apple.com/186193259">rdar://186193259</a>

Reviewed by Wenson Hsieh.

Decode numbers and strings and optionals too!

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift

* Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift:
* Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift:
(JavaScriptEvaluationGraphDecoder.decode(_:)):
(JavaScriptEvaluationGraphDecoder.codableValue() throws(CodingError.Decoding:)):
(JavaScriptEvaluationGraphDecoder.decodeNil() throws(CodingError.Decoding:)):
(JavaScriptEvaluationGraphDecoder.decodeOptional(_:)):
* Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h:
(WebKit::CxxInteropSupport::alternativeForVariant):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift:
(JavaScriptEvaluationTests.decodingBool):
(JavaScriptEvaluationTests.decodingDouble):
(JavaScriptEvaluationTests.decodingFloat):
(JavaScriptEvaluationTests.decodingInt):
(JavaScriptEvaluationTests.decodingSignedIntegers):
(JavaScriptEvaluationTests.decodingUnsignedIntegers):
(JavaScriptEvaluationTests.decodingString):
(JavaScriptEvaluationTests.decodingNonASCIIString):
(JavaScriptEvaluationTests.decodingOptional):
(JavaScriptEvaluationTests.evaluateBool): Deleted.

Canonical link: <a href="https://commits.webkit.org/320525@main">https://commits.webkit.org/320525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4609efdce94191db5a88bb32be9689e7f97a8f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184939 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195274 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144519 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124811 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45016 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44681 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6326 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197222 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58527 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154002 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59233 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153659 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48173 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131527 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128144 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57729 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19699 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->