### PR TITLE
[AppKit Gestures] WKMouseTrackingGestureRecognizer should not be exposed using @objc

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -411,6 +411,12 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module WKMouseTrackingGestureRecognizer {
+        requires objc
+        header "../../UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.h"
+        export *
+    }
+
     module WKUserContentControllerInternal {
         requires cplusplus20,objc
         header "../../UIProcess/API/Cocoa/WKUserContentControllerInternal.h"

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -41,6 +41,7 @@
 #import "TextRecognitionUpdateResult.h"
 #import "ViewGestureController.h"
 #import "WKDeferringGestureRecognizer.h"
+#import "WKMouseTrackingGestureRecognizer.h"
 #import "WKWebView.h"
 #import "WKWebViewInternal.h"
 #import "WebEventFactory.h"
@@ -793,7 +794,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     case NSGestureRecognizerStateBegan:
         _activeMouseTrackingGestureRecognizer = mouseTrackingGesture.get();
         if (_mouseTrackingHasSentMouseDown)
-            [mouseTrackingGesture beginTrackingMouseInheritedFromLocationInWindow:_mouseTrackingStartLocationInWindow];
+            [mouseTrackingGesture beginTrackingMouseInheritedFromWindowLocation:_mouseTrackingStartLocationInWindow];
         else
             [mouseTrackingGesture beginTrackingMouse];
         break;

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <wtf/Platform.h>
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+
+#import <AppKit/AppKit.h>
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+NS_SWIFT_UI_ACTOR
+@interface WKMouseTrackingGestureRecognizer : NSPressGestureRecognizer
+
+// Where the press began, as opposed to -locationInView:, which is the current location.
+@property (nonatomic, readonly) NSPoint startLocationInWindow;
+
+// The current location, rebased onto the location tracking was inherited from, if any.
+@property (nonatomic, readonly) NSPoint mouseLocationInWindow;
+
+@property (nonatomic, readonly) NSSize movementInWindowSinceStart;
+
+// Tracks from this recognizer's own start location.
+- (void)beginTrackingMouse;
+
+// Tracks as the continuation of a recognizer that stopped tracking at `windowLocation`, so that
+// `mouseLocationInWindow` remains continuous across the handoff.
+- (void)beginTrackingMouseInheritedFromWindowLocation:(NSPoint)windowLocation;
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKMouseTrackingGestureRecognizer.swift
@@ -24,37 +24,36 @@
 #if HAVE_APPKIT_GESTURES_SUPPORT
 
 import AppKit
+import WebKit_Internal
 private import AppKit_Private.NSPressGestureRecognizer_Private
 
-@objc(WKMouseTrackingGestureRecognizer)
-final class WKMouseTrackingGestureRecognizer: NSPressGestureRecognizer {
+@objc
+@implementation
+extension WKMouseTrackingGestureRecognizer {
+    @nonobjc
     private var mouseLocationOffsetInWindow: CGSize = .zero
 
-    override func reset() {
+    final override func reset() {
         mouseLocationOffsetInWindow = .zero
         super.reset()
     }
 
-    @objc(beginTrackingMouse)
     func beginTrackingMouse() {
         mouseLocationOffsetInWindow = .zero
     }
 
-    @objc(beginTrackingMouseInheritedFromLocationInWindow:)
-    func beginTrackingMouse(inheritedFromLocationInWindow locationInWindow: CGPoint) {
+    func beginTrackingMouseInherited(fromWindowLocation windowLocation: CGPoint) {
         let start = startLocationInWindow
         mouseLocationOffsetInWindow = CGSize(
-            width: start.x - locationInWindow.x,
-            height: start.y - locationInWindow.y
+            width: start.x - windowLocation.x,
+            height: start.y - windowLocation.y
         )
     }
 
-    @objc
     var startLocationInWindow: CGPoint {
         _startLocation(in: nil)
     }
 
-    @objc
     var mouseLocationInWindow: CGPoint {
         let location = self.location(in: nil)
         return CGPoint(
@@ -63,7 +62,6 @@ final class WKMouseTrackingGestureRecognizer: NSPressGestureRecognizer {
         )
     }
 
-    @objc
     var movementInWindowSinceStart: CGSize {
         let location = self.location(in: nil)
         let start = startLocationInWindow

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -994,6 +994,7 @@
 		3326F2672B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		335698F62B19307700C7FEE4 /* WebExtensionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 335698F52B19307700C7FEE4 /* WebExtensionConstants.h */; };
+		336207753044CD74005B0265 /* WKMouseTrackingGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 336207743044CD74005B0265 /* WKMouseTrackingGestureRecognizer.h */; };
 		3365E6733023E5C0003166AA /* WebExtensionAPIOffscreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 3365E6723023E5C0003166AA /* WebExtensionAPIOffscreen.h */; };
 		3366F02F3024FD1B002EEB9A /* WebExtensionOffscreenDocumentParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 3366F02D3024FD10002EEB9A /* WebExtensionOffscreenDocumentParameters.h */; };
 		336E07482EBCC1E400B4D635 /* WKAppKitGestureController.h in Headers */ = {isa = PBXBuildFile; fileRef = 336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */; };
@@ -5423,6 +5424,7 @@
 		33367638130C99DC006C9DE2 /* WKResourceCacheManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKResourceCacheManager.cpp; sourceTree = "<group>"; };
 		33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKResourceCacheManager.h; sourceTree = "<group>"; };
 		335698F52B19307700C7FEE4 /* WebExtensionConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionConstants.h; sourceTree = "<group>"; };
+		336207743044CD74005B0265 /* WKMouseTrackingGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKMouseTrackingGestureRecognizer.h; sourceTree = "<group>"; };
 		3365E6723023E5C0003166AA /* WebExtensionAPIOffscreen.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIOffscreen.h; sourceTree = "<group>"; };
 		3365E6743023E75D003166AA /* WebExtensionAPIOffscreenCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIOffscreenCocoa.mm; sourceTree = "<group>"; };
 		3365E6763023EA6F003166AA /* WebExtensionAPIOffscreen.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIOffscreen.idl; sourceTree = "<group>"; };
@@ -9657,6 +9659,7 @@
 				07F0337D3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift */,
 				078074F83029A874005492F5 /* WKDOMDoubleClickGestureRecognizer.swift */,
 				07F0337B30107D3900B69551 /* WKFastScrollTracker.swift */,
+				336207743044CD74005B0265 /* WKMouseTrackingGestureRecognizer.h */,
 				3323520E303EC02F003C7F3B /* WKMouseTrackingGestureRecognizer.swift */,
 			);
 			path = AppKitGestures;
@@ -19627,6 +19630,7 @@
 				411A8DDB20DDD1AC0060D34F /* WKMockMediaDevice.h in Headers */,
 				950F2880252414EA00B74F1C /* WKMouseDeviceObserver.h in Headers */,
 				F4C627E72A7AC17B00F546BF /* WKMouseInteraction.h in Headers */,
+				336207753044CD74005B0265 /* WKMouseTrackingGestureRecognizer.h in Headers */,
 				BC4075FE124FF0270068F20A /* WKMutableArray.h in Headers */,
 				BC407600124FF0270068F20A /* WKMutableDictionary.h in Headers */,
 				C09AE5E9125257C20025825D /* WKNativeEvent.h in Headers */,


### PR DESCRIPTION
#### 6044c47010e248b255da77f28246acc220f06546
<pre>
[AppKit Gestures] WKMouseTrackingGestureRecognizer should not be exposed using @objc
<a href="https://bugs.webkit.org/show_bug.cgi?id=322944">https://bugs.webkit.org/show_bug.cgi?id=322944</a>
<a href="https://rdar.apple.com/186216383">rdar://186216383</a>

Reviewed by Richard Robinson.

This patch is a follow-up to 319879@main.

Exposing a Swift class to Objective-C by annotating the class with @objc
is not properly supported. Instead, in this patch, we go with the
supported direction, which is to declare the class in a header and
implement in Swift with @objc @implementation.

No new tests since this patch does not introduce a behavior change.

Canonical link: <a href="https://commits.webkit.org/320126@main">https://commits.webkit.org/320126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9ac343e9fbe8bbfdc6cdc24a1784099f94c971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148151 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55477ccb-14bf-462e-ba48-199537c12351) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143506 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99679 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07feb9b0-a807-4a36-830a-ebfe193791fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32e39b4e-d7cb-4707-8198-3cc01154f0c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44209 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43789 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5262 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196018 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57452 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58156 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152732 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47271 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130436 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56664 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18800 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56035 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->