### PR TITLE
[JSC] `WebAssembly.Exception` rejects null options and accepts non-object options

### DIFF
--- a/JSTests/wasm/stress/exception-constructor-options-argument.js
+++ b/JSTests/wasm/stress/exception-constructor-options-argument.js
@@ -1,0 +1,37 @@
+//@ requireOptions("--useExecutableAllocationFuzz=false")
+import * as assert from "../assert.js";
+
+const tag = new WebAssembly.Tag({ parameters: ["i32"] });
+
+// The options argument is a WebIDL dictionary: undefined and null mean an empty
+// dictionary, and anything else that is not an object is a TypeError.
+
+function testUndefinedAndNull() {
+    for (const options of [undefined, null]) {
+        const e = new WebAssembly.Exception(tag, [0], options);
+        assert.truthy(e instanceof WebAssembly.Exception);
+        assert.eq(e.stack, undefined);
+    }
+}
+
+function testNonObjects() {
+    for (const options of [5, 0, "traceStack", "", true, false, 1n, Symbol("s")]) {
+        assert.throws(() => new WebAssembly.Exception(tag, [0], options), TypeError,
+            "WebAssembly.Exception expects its third argument to be an object");
+    }
+}
+
+function testObjects() {
+    for (const options of [{}, [], () => {}, Object.create(null), { traceStack: false }]) {
+        const e = new WebAssembly.Exception(tag, [0], options);
+        assert.eq(e.stack, undefined);
+    }
+    for (const options of [{ traceStack: true }, { traceStack: 1 }, { traceStack: "yes" }, Object.assign(() => {}, { traceStack: true })]) {
+        const e = new WebAssembly.Exception(tag, [0], options);
+        assert.eq(typeof e.stack, "string");
+    }
+}
+
+testUndefinedAndNull();
+testNonObjects();
+testObjects();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -84,7 +84,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
 
     bool traceStack = false;
     JSValue optionsValue = callFrame->argument(2);
-    if (!optionsValue.isUndefined()) {
+    if (!optionsValue.isUndefinedOrNull()) {
+        if (!optionsValue.isObject())
+            return throwVMTypeError(globalObject, scope, "WebAssembly.Exception expects its third argument to be an object"_s);
         JSValue traceStackValue = optionsValue.get(globalObject, Identifier::fromString(vm, "traceStack"_s));
         RETURN_IF_EXCEPTION(scope, { });
         traceStack = traceStackValue.toBoolean(globalObject);


### PR DESCRIPTION
#### 5faef46275e1a37fc9924d252f3cd9e59fa8a7b4
<pre>
[JSC] `WebAssembly.Exception` rejects null options and accepts non-object options
<a href="https://bugs.webkit.org/show_bug.cgi?id=322948">https://bugs.webkit.org/show_bug.cgi?id=322948</a>

Reviewed by Keith Miller.

The third argument of the WebAssembly.Exception constructor is a WebIDL
dictionary, so null must be treated like undefined and any other
non-object must be a TypeError. The constructor only skipped undefined,
so null threw while reading traceStack and a number or string was read
as an object.

Treat undefined and null as the empty dictionary and throw for other
non-objects.

Test: JSTests/wasm/stress/exception-constructor-options-argument.js

* JSTests/wasm/stress/exception-constructor-options-argument.js: Added.
(testUndefinedAndNull):
(testNonObjects):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/320215@main">https://commits.webkit.org/320215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f5674ee359c69ffcd919fa5e9424188e92657c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143556 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99730 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44261 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5945 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12782 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43841 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5318 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45190 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196074 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57507 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153104 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41045 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58211 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152784 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47324 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130491 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126944 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56719 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18852 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->