### PR TITLE
[JSC] Inline `RegExp#test` for unicode patterns and patterns with a Yarr frame

### DIFF
--- a/JSTests/microbenchmarks/regexp-test-inline-quantifier.js
+++ b/JSTests/microbenchmarks/regexp-test-inline-quantifier.js
@@ -1,0 +1,15 @@
+const re = /^[a-z]+$/;
+
+function isLowerAlpha(s) {
+    return re.test(s);
+}
+noInline(isLowerAlpha);
+
+const words = ["alpha", "beta", "Gamma", "delta", "epsilon", "zeta2", "eta", "theta"];
+let count = 0;
+for (let i = 0; i < 2e6; ++i) {
+    if (isLowerAlpha(words[i & 7]))
+        count++;
+}
+if (count !== 2e6 * 6 / 8)
+    throw new Error("bad count: " + count);

--- a/JSTests/microbenchmarks/regexp-test-inline-unicode-sets.js
+++ b/JSTests/microbenchmarks/regexp-test-inline-unicode-sets.js
@@ -1,0 +1,15 @@
+const re = /^[\p{L}--[A-Z]]+$/v;
+
+function isLowerLetter(s) {
+    return re.test(s);
+}
+noInline(isLowerLetter);
+
+const words = ["alpha", "beta", "Gamma", "delta", "epsilon", "zeta2", "eta", "theta"];
+let count = 0;
+for (let i = 0; i < 2e6; ++i) {
+    if (isLowerLetter(words[i & 7]))
+        count++;
+}
+if (count !== 2e6 * 6 / 8)
+    throw new Error("bad count: " + count);

--- a/JSTests/microbenchmarks/regexp-test-inline-unicode.js
+++ b/JSTests/microbenchmarks/regexp-test-inline-unicode.js
@@ -1,0 +1,15 @@
+const re = /^[a-z]+$/u;
+
+function isLowerAlpha(s) {
+    return re.test(s);
+}
+noInline(isLowerAlpha);
+
+const words = ["alpha", "beta", "Gamma", "delta", "epsilon", "zeta2", "eta", "theta"];
+let count = 0;
+for (let i = 0; i < 2e6; ++i) {
+    if (isLowerAlpha(words[i & 7]))
+        count++;
+}
+if (count !== 2e6 * 6 / 8)
+    throw new Error("bad count: " + count);

--- a/JSTests/stress/regexp-test-inline-empty-iteration-punts-to-interpreter.js
+++ b/JSTests/stress/regexp-test-inline-empty-iteration-punts-to-interpreter.js
@@ -1,0 +1,59 @@
+// A quantified group whose body can match the empty string ((?:x*)+, (?:x*)?, (?:x*){2})
+// makes the Yarr JIT give up in the middle of matching and fall back to the interpreter.
+// Such a pattern must not be inlined into DFG/FTL code: the inlined matcher shares
+// registers with the operands of the slow-path call.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(message + ": expected " + expected + " but got " + actual);
+}
+
+const inputs = ["y", "yx", "yxx", "q", "", "xy", "yxq", "xxx", "yyy", "qy"];
+
+// [regexp, expected result for each input above]
+const cases = [
+    [/y(?:x*)+/,        "1110011011"],
+    [/y(?:x*)*/,        "1110011011"],
+    [/y(?:x*)?/,        "1110011011"],
+    [/y(?:x*|q)?/,      "1110011011"],
+    [/y(?:x*){2}/,      "1110011011"],
+    [/y(?:x*){2,}/,     "1110011011"],
+    [/^(?:x*)+y/,       "1110011010"],
+    [/(?:x*)+q/,        "0001001001"],
+    [/y(?:x*)+/u,       "1110011011"],
+    [/y(?:x*)+/v,       "1110011011"],
+    [/y(?:x*)+$/,       "1110010011"],
+    [/(?:x?y?)+z/,      "0000000000"],
+];
+
+for (const [re, expected] of cases)
+    shouldBe(expected.length, inputs.length, re + " expectation length");
+
+// A RegExp literal inside the function is a NewRegExp node that the strength reduction
+// phase can turn into RegExpTestInline.
+function makeLiteralTest(re) {
+    const test = new Function("s", "return " + re + ".test(s);");
+    noInline(test);
+    return test;
+}
+
+// A RegExp in a global const is folded to a constant cell, so the RegExpObject operand of
+// the slow-path call is materialized differently from the literal case.
+const globalRegExps = cases.map(([re]) => re);
+function makeConstTest(index) {
+    const test = new Function("s", "return globalRegExps[" + index + "].test(s);");
+    noInline(test);
+    return test;
+}
+
+for (let c = 0; c < cases.length; ++c) {
+    const [re, expected] = cases[c];
+    const literalTest = makeLiteralTest(re);
+    const constTest = makeConstTest(c);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const s = inputs[i % inputs.length];
+        const e = expected[i % inputs.length] === "1";
+        shouldBe(literalTest(s), e, re + ".test(" + JSON.stringify(s) + ") literal");
+        shouldBe(constTest(s), e, re + ".test(" + JSON.stringify(s) + ") const");
+    }
+}

--- a/JSTests/stress/regexp-test-inline-frame-in-outgoing-argument-area.js
+++ b/JSTests/stress/regexp-test-inline-frame-in-outgoing-argument-area.js
@@ -1,0 +1,36 @@
+//@ requireOptions("--maximumRegExpTestInlineCodesize=10000")
+
+// The Yarr frame of an inlined RegExp#test lives in the outgoing-argument area of the
+// DFG/FTL frame. Two inlined patterns with different frame sizes, JS calls that lay out
+// their arguments in the same area, and locals live across all of them must not
+// interfere with each other.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(message + ": expected " + expected + " but got " + actual);
+}
+
+function callee(a, b, c, d, e, f, g) {
+    return a + b + c + d + e + f + g;
+}
+noInline(callee);
+
+function test(s, k, args) {
+    let a0 = k + 1, a1 = k + 2, a2 = k + 3, a3 = k + 4, a4 = k + 5, a5 = k + 6, a6 = k + 7, a7 = k + 8;
+    let b0 = k * 1.5, b1 = k * 2.5, b2 = k * 3.5, b3 = k * 4.5;
+    let r = 0;
+    r += /^[a-z]+$/u.test(s) ? 1 : 0;                                                          // 2 frame slots
+    r += /^[a-c][a-c][a-c][a-c][a-c][a-c][a-c][a-c][a-c][a-c][a-c][a-c]$/u.test(s) ? 2 : 0;    // 24 frame slots
+    r += callee(k, k, k, k, k, k, k);
+    r += callee.apply(null, args);
+    shouldBe(a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + b0 + b1 + b2 + b3, 20 * k + 36, "locals for k=" + k);
+    return r;
+}
+noInline(test);
+
+const args = [1, 1, 1, 1, 1, 1, 1];
+for (let i = 0; i < testLoopCount; ++i) {
+    const k = i & 0xff;
+    const s = i & 1 ? "abcabcabcabc" : "abcabcabcabd!";
+    shouldBe(test(s, k, args), 7 * k + 7 + (i & 1 ? 3 : 0), "result for i=" + i);
+}

--- a/JSTests/stress/regexp-test-inline-unicode-and-quantifiers.js
+++ b/JSTests/stress/regexp-test-inline-unicode-and-quantifiers.js
@@ -1,0 +1,61 @@
+// RegExp.prototype.test on a constant RegExp becomes RegExpTestInline in DFG/FTL. The
+// inlined Yarr code now covers u/v-flag patterns and patterns whose terms need frame
+// slots for backtracking (quantifiers, alternations, .-classes in unicode mode).
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(message + ": expected " + expected + " but got " + actual);
+}
+
+const inputs = [
+    "", "hello world", "world", "hello worXd", "woooorld", "abc", "ABC", "K", "k", "\u212a", "\u017f", "s", "S",
+    "xxxyz", "xyz", "z", "yz", "ababe", "cde", "abcde", "aab", "aaaaab", "  #x", "#", "\t#",
+    "\u{1F600}", "a\u{1F600}b", "\ud83d", "\ude00", "\u00e9", "foo", "a foo b", "foobar", "bar", "ab", "ba",
+    "a\nb", "\n", "1", "12 ", " 12", "x", "xy", "xxy", "qqq", "aq", "0", "Z", "zebra", "aeiou",
+    "hello w\u00f6rld", "hello " + "wor" + "ld",
+];
+
+// [regexp, expected result for each input above]
+const cases = [
+    [/world/u,           "0110000000000000000000000000000000000000000000000001"],
+    [/wor.d/u,           "0111000000000000000000000000000000000000000000000001"],
+    [/wor.d/v,           "0111000000000000000000000000000000000000000000000001"],
+    [/wo+rld/,           "0110100000000000000000000000000000000000000000000001"],
+    [/wo+rld/u,          "0110100000000000000000000000000000000000000000000001"],
+    [/x*y?z/u,           "0000000000000111100000000000000000000000000000001000"],
+    [/a{2,4}b/u,         "0000000000000000000011000000000000000000000000000000"],
+    [/^\s*#/u,           "0000000000000000000000111000000000000000000000000000"],
+    [/[k-s]/iu,          "0111100111111000000000000000001111000000000011001111"],
+    [/\p{Lu}/u,          "0001001101001000000000000000000000000000000000010000"],
+    [/[\p{L}--[a-z]]/v,  "0001001101101000000000000000010000000000000000010010"],
+    [/[^\x00-\x7f]/u,    "0000000001100000000000000111110000000000000000000010"],
+    [/\u{1F600}/u,       "0000000000000000000000000110000000000000000000000000"],
+    [/./su,              "0111111111111111111111111111111111111111111111111111"],
+    [/^.$/u,             "0000000111111001000000010101110000000010010000110000"],
+    [/foo|bar/u,         "0000000000000000000000000000001111000000000000000000"],
+    [/\D/u,              "0111111111111111111111111111111111111101111111011111"],
+    [/\W+/u,             "0101000001100000000000111111110100001101100000000011"],
+    [/q*$/u,             "1111111111111111111111111111111111111111111111111111"],
+    [/^/mu,              "1111111111111111111111111111111111111111111111111111"],
+    [/(?:ab|cd)+e/u,     "0000000000000000011100000000000000000000000000000000"],
+    [/[a-c]+|[x-z]{2}/u, "0000010000000110111111000010000111111000001101001100"],
+];
+
+for (const [re, expected] of cases)
+    shouldBe(expected.length, inputs.length, re + " expectation length");
+
+function makeTest(re) {
+    // A RegExp literal inside the function is a NewRegExp node that the strength reduction
+    // phase can turn into RegExpTestInline.
+    const test = new Function("s", "return " + re + ".test(s);");
+    noInline(test);
+    return test;
+}
+
+for (const [re, expected] of cases) {
+    const test = makeTest(re);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const s = inputs[i % inputs.length];
+        shouldBe(test(s), expected[i % inputs.length] === "1", re + ".test(" + JSON.stringify(s) + ")");
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3116,7 +3116,7 @@ void SpeculativeJIT::compileRegExpTestInline(Node* node)
 
         auto commonData = jitCode()->dfgCommon();
         move(TrustedImm32(0), yarrRegisters.index);
-        Yarr::jitCompileInlinedTest(&m_graph.m_stackChecker, regExp->pattern(), regExp->flags(), Yarr::CharSize::Char8, &vm(), commonData->m_boyerMooreData, *this, yarrRegisters);
+        Yarr::jitCompileInlinedTest(&m_graph.m_stackChecker, regExp->pattern(), regExp->flags(), Yarr::CharSize::Char8, &vm(), commonData->m_boyerMooreData, *this, yarrRegisters, m_graph.m_parameterSlots * sizeof(Register));
 
         slowCases.append(branch32(Equal, yarrRegisters.returnRegister, TrustedImm32(static_cast<int32_t>(Yarr::JSRegExpResult::JITCodeFailure))));
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1150,9 +1150,6 @@ private:
                 if (regExp->globalOrSticky())
                     return false;
 
-                if (regExp->eitherUnicode())
-                    return false;
-
                 auto jitCodeBlock = regExp->getRegExpJITCodeBlock();
                 if (!jitCodeBlock)
                     return false;
@@ -1170,7 +1167,7 @@ private:
                 unsigned alignedFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(inlineCodeStats8Bit.stackSize());
 
                 if (alignedFrameSize)
-                    m_graph.m_parameterSlots = std::max(m_graph.m_parameterSlots, argumentCountForStackSize(alignedFrameSize));
+                    m_graph.m_parameterSlots = std::max<unsigned>(m_graph.m_parameterSlots, alignedFrameSize / sizeof(Register));
 
                 NodeOrigin origin = m_node->origin;
                 m_insertionSet.insertNode(m_nodeIndex, SpecNone, Check, origin, m_node->children.justChecks());

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19916,7 +19916,7 @@ IGNORE_CLANG_WARNINGS_END
                 yarrRegisters.returnRegister = returnGPR;
                 yarrRegisters.returnRegister2 = return2GPR;
 
-                Yarr::jitCompileInlinedTest(stackChecker, regExp->pattern(), regExp->flags(), Yarr::CharSize::Char8, vm, commonData->m_boyerMooreData, jit, yarrRegisters);
+                Yarr::jitCompileInlinedTest(stackChecker, regExp->pattern(), regExp->flags(), Yarr::CharSize::Char8, vm, commonData->m_boyerMooreData, jit, yarrRegisters, alignedFrameSize);
 
                 CCallHelpers::JumpList done;
 

--- a/Source/JavaScriptCore/runtime/StackAlignment.h
+++ b/Source/JavaScriptCore/runtime/StackAlignment.h
@@ -63,16 +63,6 @@ constexpr unsigned roundLocalRegisterCountForFramePointerOffset(unsigned localRe
     return WTF::roundUpToMultipleOf(stackAlignmentRegisters(), localRegisterCount + CallerFrameAndPC::sizeInRegisters) - CallerFrameAndPC::sizeInRegisters;
 }
 
-constexpr unsigned argumentCountForStackSize(unsigned sizeInBytes)
-{
-    unsigned sizeInRegisters = sizeInBytes / sizeof(void*);
-
-    if (sizeInRegisters <= CallFrame::headerSizeInRegisters)
-        return 0;
-
-    return sizeInRegisters - CallFrame::headerSizeInRegisters;
-}
-
 inline unsigned logStackAlignmentRegisters()
 {
     return WTF::fastLog2(stackAlignmentRegisters());

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1746,6 +1746,8 @@ class YarrGenerator final : public YarrJITInfo {
 
     CCallHelpers::Address NODELETE frameAddress()
     {
+        if (m_executionMode == ExecutionMode::InlineTest)
+            return CCallHelpers::Address(MacroAssembler::stackPointerRegister);
         size_t stackSizeForCalleeSaves = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(m_calleeSaves.registerCount() * sizeof(UCPURegister));
         return CCallHelpers::Address(GPRInfo::callFrameRegister, -(stackSizeForCalleeSaves + m_callFrameSizeInBytes));
     }
@@ -7209,17 +7211,15 @@ public:
                 return false;
             if (m_pattern.sticky())
                 return false;
-            if (m_pattern.eitherUnicode())
-                return false;
             if (mayCall())
-                return false;
-            if (m_callFrameSizeInBytes)
                 return false;
             if (m_containsNestedSubpatterns)
                 return false;
             if (m_pattern.m_containsBackreferences)
                 return false;
             if (m_pattern.m_saveInitialStartValue)
+                return false;
+            if (!m_abortExecution.empty())
                 return false;
 
             // SIMD search path uses Vector scratch registers which is not assigned from DFG / FTL.
@@ -7272,9 +7272,10 @@ public:
             codeBlock.setFallBackWithFailureReason(*m_failureReason);
     }
 
-    void compileInline(YarrBoyerMooreData& boyerMooreData)
+    void compileInline(YarrBoyerMooreData& boyerMooreData, unsigned reservedFrameSizeInBytes)
     {
         RELEASE_ASSERT(!m_pattern.m_containsBackreferences);
+        RELEASE_ASSERT(m_callFrameSizeInBytes <= reservedFrameSizeInBytes);
 
         // We need to compile before generating code since we set flags based on compilation that
         // are used during generation.
@@ -7303,21 +7304,6 @@ public:
 
         skipToEndAnchoredStart();
 
-        if (m_callFrameSizeInBytes) {
-            // Create space on stack for matching context data.
-            // Note that this stack check cannot clobber m_regs.regT1 as it is needed for the slow path we call if we fail the stack check.
-            m_jit.addPtr(MacroAssembler::TrustedImm32(-m_callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
-            MacroAssembler::Jump stackOk = m_jit.branchPtr(MacroAssembler::LessThanOrEqual, MacroAssembler::AbsoluteAddress(const_cast<VM*>(m_vm)->addressOfSoftStackLimit()), m_regs.regT0);
-
-            // Exceeded stack limit, punt to the interpreter.
-            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(JSRegExpResult::JITCodeFailure)), m_regs.returnRegister);
-            m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.returnRegister2);
-            m_inlinedFailedMatch.append(m_jit.jump());
-
-            stackOk.link(&m_jit);
-            m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
-        }
-
         if (m_decodeSurrogatePairs)
             m_jit.getEffectiveAddress(MacroAssembler::BaseIndex(m_regs.input, m_regs.length, MacroAssembler::TimesTwo), m_regs.endOfStringAddress);
 
@@ -7339,7 +7325,8 @@ public:
         if (m_disassembler)
             m_disassembler->setEndOfBacktrack(m_jit.label());
 
-        generateJITFailReturn();
+        RELEASE_ASSERT(m_abortExecution.empty());
+        RELEASE_ASSERT(m_hitMatchLimit.empty());
 
         if (m_disassembler)
             m_disassembler->setEndOfCode(m_jit.label());
@@ -7830,7 +7817,7 @@ void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSiz
     }
 }
 
-void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringView patternString, OptionSet<Yarr::Flags> flags, CharSize charSize, VM* vm, YarrBoyerMooreData& boyerMooreData, CCallHelpers& jit, YarrJITRegisters& jitRegisters)
+void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringView patternString, OptionSet<Yarr::Flags> flags, CharSize charSize, VM* vm, YarrBoyerMooreData& boyerMooreData, CCallHelpers& jit, YarrJITRegisters& jitRegisters, unsigned reservedFrameSizeInBytes)
 {
     Yarr::ErrorCode errorCode;
     Yarr::YarrPattern pattern(patternString, flags, errorCode, ExecutionMode::InlineTest);
@@ -7845,7 +7832,7 @@ void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringVi
 
     YarrGenerator<YarrJITRegisters> yarrGenerator(jit, vm, &boyerMooreData, jitRegisters, pattern, patternString, charSize, ExecutionMode::InlineTest);
     yarrGenerator.setStackChecker(m_compilationThreadStackChecker);
-    yarrGenerator.compileInline(boyerMooreData);
+    yarrGenerator.compileInline(boyerMooreData, reservedFrameSizeInBytes);
 }
 
 void YarrCodeBlock::dumpSimpleName(PrintStream& out) const

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -438,7 +438,7 @@ void jitCompile(YarrPattern&, StringView patternString, CharSize, std::optional<
 
 class YarrJITRegisters;
 
-void jitCompileInlinedTest(StackCheck*, StringView, OptionSet<Yarr::Flags>, CharSize, VM*, YarrBoyerMooreData&, CCallHelpers&, YarrJITRegisters&);
+void jitCompileInlinedTest(StackCheck*, StringView, OptionSet<Yarr::Flags>, CharSize, VM*, YarrBoyerMooreData&, CCallHelpers&, YarrJITRegisters&, unsigned reservedFrameSizeInBytes);
 
 } } // namespace JSC::Yarr
 


### PR DESCRIPTION
#### 83683abb036df547c679bd13ee7bca7ff64df9f9
<pre>
[JSC] Inline `RegExp#test` for unicode patterns and patterns with a Yarr frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=322949">https://bugs.webkit.org/show_bug.cgi?id=322949</a>

Reviewed by Yusuke Suzuki.

RegExpTestInline emits the Yarr matcher for 8-bit strings directly into
DFG/FTL code, but it refuses any pattern whose terms need Yarr frame slots for
backtracking. That is every quantifier and alternation and, with the u or v
flag, every character class, so almost no real pattern is inlined. The Yarr
frame is addressed relative to the frame pointer, which only works inside
Yarr&apos;s own function frame, and the u/v flags are excluded on top of that even
though the 8-bit matcher does not decode surrogate pairs.

The inlined matcher calls nothing, so the outgoing-argument area at the bottom
of the DFG/FTL frame is free while it runs. This patch places the Yarr frame
there: DFG and FTL reserve the frame size in that area, and in
ExecutionMode::InlineTest the frame is addressed relative to the stack pointer.
The function&apos;s own stack check covers the reservation, so the inlined code
neither moves the stack pointer nor checks the stack limit. With frames
available, the unicode exclusions are dropped.

                                          Baseline                  Patched

regexp-test-inline-quantifier         18.6940+-0.1085     ^     10.7594+-0.1545        ^ definitely 1.7375x faster
regexp-test-inline-unicode-sets       18.8223+-0.0938     ^     11.6284+-0.1800        ^ definitely 1.6186x faster
regexp-test-inline-unicode            18.6505+-0.1107     ^     10.9138+-0.1957        ^ definitely 1.7089x faster

Tests: JSTests/microbenchmarks/regexp-test-inline-quantifier.js
       JSTests/microbenchmarks/regexp-test-inline-unicode-sets.js
       JSTests/microbenchmarks/regexp-test-inline-unicode.js
       JSTests/stress/regexp-test-inline-frame-in-outgoing-argument-area.js
       JSTests/stress/regexp-test-inline-unicode-and-quantifiers.js

* JSTests/microbenchmarks/regexp-test-inline-quantifier.js: Added.
(isLowerAlpha):
* JSTests/microbenchmarks/regexp-test-inline-unicode-sets.js: Added.
(isLowerLetter):
* JSTests/microbenchmarks/regexp-test-inline-unicode.js: Added.
(isLowerAlpha):
* JSTests/stress/regexp-test-inline-frame-in-outgoing-argument-area.js: Added.
(shouldBe):
(callee):
(test):
* JSTests/stress/regexp-test-inline-unicode-and-quantifiers.js: Added.
(shouldBe):
(makeTest):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileRegExpTestInline):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/StackAlignment.h:
(JSC::argumentCountForStackSize): Deleted.
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::jitCompileInlinedTest):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Canonical link: <a href="https://commits.webkit.org/320559@main">https://commits.webkit.org/320559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d07953ef981e9ad7b0db0941b4d50042aa1278

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195246 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44995 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6735 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13591 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44659 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6299 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46177 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197195 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58499 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153974 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59205 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153633 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48151 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131493 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19677 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->