### PR TITLE
[SVG] Additive color animations lose precision from per-layer 8-bit rounding

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Ten additive fill animations accumulate without per-layer 8-bit truncation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Additive SVG color animations accumulate in full precision</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect id="target" width="100" height="100" fill="rgb(0, 0, 0)">
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+        <animate attributeName="fill" additive="sum" from="rgb(0, 0, 0)" to="rgb(1, 1, 1)" begin="0s" dur="10s"/>
+    </rect>
+</svg>
+
+<script>
+async_test(t => {
+    window.onload = () => {
+        const svg = document.querySelector("svg");
+        svg.pauseAnimations();
+        svg.setCurrentTime(4);
+        requestAnimationFrame(t.step_func_done(() => {
+            assert_equals(getComputedStyle(document.getElementById("target")).fill, "rgb(4, 4, 4)");
+        }));
+    };
+}, "Ten additive fill animations accumulate without per-layer 8-bit truncation");
+</script>

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
@@ -87,17 +87,17 @@ public:
 
     void animate(SVGElement&, float progress, unsigned repeatCount, Color& animated)
     {
-        auto simpleAnimated = animated.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-        auto simpleFrom = m_animationMode == AnimationMode::To ? simpleAnimated : m_from.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-        auto simpleTo = m_to.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-        auto simpleToAtEndOfDuration = toAtEndOfDuration().toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+        auto simpleAnimated = animated.toColorTypeLossy<SRGBA<float>>().resolved();
+        auto simpleFrom = m_animationMode == AnimationMode::To ? simpleAnimated : m_from.toColorTypeLossy<SRGBA<float>>().resolved();
+        auto simpleTo = m_to.toColorTypeLossy<SRGBA<float>>().resolved();
+        auto simpleToAtEndOfDuration = toAtEndOfDuration().toColorTypeLossy<SRGBA<float>>().resolved();
 
         float red = Base::animate(progress, repeatCount, simpleFrom.red, simpleTo.red, simpleToAtEndOfDuration.red, simpleAnimated.red);
         float green = Base::animate(progress, repeatCount, simpleFrom.green, simpleTo.green, simpleToAtEndOfDuration.green, simpleAnimated.green);
         float blue = Base::animate(progress, repeatCount, simpleFrom.blue, simpleTo.blue, simpleToAtEndOfDuration.blue, simpleAnimated.blue);
         float alpha = Base::animate(progress, repeatCount, simpleFrom.alpha, simpleTo.alpha, simpleToAtEndOfDuration.alpha, simpleAnimated.alpha);
 
-        animated = makeFromComponentsClamping<SRGBA<uint8_t>>(std::lround(red), std::lround(green), std::lround(blue), std::lround(alpha));
+        animated = makeFromComponentsClamping<SRGBA<float>>(red, green, blue, alpha);
     }
 
     std::optional<float> calculateDistance(SVGElement&, const String& from, const String& to) const override;


### PR DESCRIPTION
#### fad1b146f46c60d3eeaafa8b49f79f4ac77574dc
<pre>
[SVG] Additive color animations lose precision from per-layer 8-bit rounding
<a href="https://bugs.webkit.org/show_bug.cgi?id=322950">https://bugs.webkit.org/show_bug.cgi?id=322950</a>
<a href="https://rdar.apple.com/186223510">rdar://186223510</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVGAnimationColorFunction interpolated and accumulated color channels as
8-bit sRGB (SRGBA&lt;uint8_t&gt;). Every additive/cumulative animation targeting
the same element/attribute stacks its contribution through a single shared
Color value, so rounding each layer to 8 bits before the next layer reads
it discarded the sub-integer remainder. Stacked additive=&quot;sum&quot; color
animations therefore under-counted: ten layers each contributing 0.4 per
channel produced rgb(0, 0, 0) instead of rgb(4, 4, 4), diverging from
other browsers.

Interpolate and accumulate in SRGBA&lt;float&gt; instead, matching the approach
blendWithoutPremultiply() uses for CSS transitions. The result is still
serialized as legacy rgb()/rgba() via serializationForHTML(SRGBA&lt;float&gt;),
so there is no computed-value or rendering-format change for single-layer
animations; only the precision of multi-layer accumulation improves.

Test: imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/additive-color-precision-animation.html: Added.
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h:
(WebCore::SVGAnimationColorFunction::animate):

Canonical link: <a href="https://commits.webkit.org/320166@main">https://commits.webkit.org/320166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/665ea2fb37e7dd37e15e6706055c965e909e48ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51659 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194141 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148211 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e99b6e49-ae03-4841-886f-3bb96917c607) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143563 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99733 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0127e313-0692-4102-9d56-5394ab37042f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123984 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb00eb8e-9ce3-45a4-a96f-3ac1e0b6e603) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44272 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43845 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5323 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196079 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41013 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58216 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152789 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47329 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130496 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18856 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56095 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->