### PR TITLE
[list-marker] Wrap an inside marker in an anonymous inline box so its content is part of the line https://bugs.webkit.org/show_bug.cgi?id=322951 <rdar://problem/186225101>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5775,11 +5775,9 @@ webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/first-letter-
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/first-line-opacity-001.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/grammar-error-001.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-010.html [ ImageOnlyFailure ]
-webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-012.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-017.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-018.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-list-style-position.html [ ImageOnlyFailure ]
-webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-normal.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/spelling-error-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/host-context-specificity-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-expected.txt
@@ -176,30 +176,30 @@ layer at (0,0) size 785x1844
             text run at (26,10) width 68: "Third item"
       RenderBlock {OL} at (0,1686) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "1"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderListMarker at (133,10) size 0x18: "1"
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "1"
           RenderText {#text} at (55,10) size 63x18
             text run at (55,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "2"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderListMarker at (133,10) size 0x18: "2"
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "2"
           RenderText {#text} at (10,10) size 124x36
             text run at (10,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "3"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderListMarker at (133,10) size 0x18: "3"
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "3"
           RenderText {#text} at (49,10) size 69x18
             text run at (49,10) width 69: "Third item"

--- a/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
@@ -176,30 +176,30 @@ layer at (0,0) size 1844x585
             text run at (10,26) width 68: "Third item"
       RenderBlock {OL} at (1686,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "1"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "1"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderListMarker at (10,133) size 18x0: "1"
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "1"
           RenderText {#text} at (10,55) size 18x63
             text run at (10,55) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "2"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "2"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderListMarker at (10,133) size 18x0: "2"
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "2"
           RenderText {#text} at (10,10) size 36x124
             text run at (10,10) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "3"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "3"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderListMarker at (10,133) size 18x0: "3"
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "3"
           RenderText {#text} at (10,49) size 18x69
             text run at (10,49) width 68: "Third item"

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2575,7 +2575,8 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
         }
 
         RenderElement& current = downcast<RenderElement>(*firstLetter);
-        if (is<RenderListMarker>(current))
+        // css-pseudo-4: the contents of a ::marker are ignored by ::first-letter, wherever the marker renders them.
+        if (is<RenderListMarker>(current) || isInlineWrapperForListMarker(current))
             firstLetter = current.nextSibling();
         else if (current.isFloatingOrOutOfFlowPositioned()) {
             if (current.style().pseudoElementType() == PseudoElementType::FirstLetter) {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -82,6 +82,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
+#include "RenderListMarker.h"
 #include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGResourceContainer.h"
@@ -281,7 +282,7 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, Style::Compu
 const Style::ComputedStyle& RenderElement::firstLineStyle() const
 {
     // FIXME: It would be better to just set anonymous block first-line styles correctly.
-    if (isAnonymousBlock()) {
+    if (isAnonymousBlock() || isInlineWrapperForListMarker(*this)) {
         if (!previousInFlowSibling()) {
             if (auto* firstLineStyle = parent()->style().pseudoElementStyle({ PseudoElementType::FirstLine }))
                 return *firstLineStyle;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -35,12 +35,15 @@
 #include "FontCascadeInlines.h"
 #include "FontCascadeDescription.h"
 #include "GraphicsContext.h"
+#include "LocalFrameView.h"
+#include "LocalFrameViewLayoutContext.h"
 #include "InlineIteratorBoxInlines.h"
 #include "PaintInfoInlines.h"
 #include "PseudoElement.h"
 #include "RenderBlockFlow.h"
 #include "RenderBlockInlines.h"
 #include "RenderBoxInlines.h"
+#include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderListItem.h"
 #include "RenderMenuList.h"
@@ -109,6 +112,10 @@ void RenderListMarker::styleDidChange(Style::Difference diff, const Style::Compu
     RenderBox::styleDidChange(diff, oldStyle);
 
     propagateStyleToAnonymousChildren(StylePropagationType::AllChildren);
+
+    // The anonymous inline box around us is our parent, so nothing propagates our style into it.
+    if (CheckedPtr wrapper = inlineWrapper())
+        wrapper->setStyle(styleForInlineWrapper());
 
     if (RefPtr newImage = style().listStyleImage().tryStyleImage(); m_image != newImage) {
         if (m_image)
@@ -203,6 +210,41 @@ RenderBlockFlow* RenderListMarker::contentContainer() const
     return dynamicDowncast<RenderBlockFlow>(firstChild());
 }
 
+RenderInline* RenderListMarker::inlineWrapper() const
+{
+    // The wrapper is put around the marker (and nothing else) by RenderTreeBuilder::List, so the marker is its
+    // first child and the marker's contents follow.
+    auto* wrapper = dynamicDowncast<RenderInline>(parent());
+    if (wrapper && wrapper->isAnonymous() && wrapper->firstChild() == this)
+        return wrapper;
+    return nullptr;
+}
+
+Style::ComputedStyle RenderListMarker::styleForInlineWrapper() const
+{
+    auto wrapperStyle = Style::ComputedStyle::createAnonymousStyleWithDisplay(style(), Style::DisplayType::InlineFlow);
+    // The wrapper is an anonymous child of the list item, which would otherwise hand it a style inheriting from itself
+    // (RenderElement::propagateStyleToAnonymousChildren) and lose what the ::marker sets, tabular figures among it.
+    wrapperStyle.setPseudoElementIdentifier({ { PseudoElementType::Marker } });
+    return wrapperStyle;
+}
+
+RenderElement* RenderListMarker::contentRenderersParent() const
+{
+    if (auto* wrapper = inlineWrapper())
+        return wrapper;
+    return contentContainer();
+}
+
+bool isInlineWrapperForListMarker(const RenderObject& renderer)
+{
+    CheckedPtr wrapper = dynamicDowncast<RenderInline>(renderer);
+    if (!wrapper || !wrapper->isAnonymous())
+        return false;
+    CheckedPtr marker = dynamicDowncast<RenderListMarker>(wrapper->firstChild());
+    return marker && marker->inlineWrapper();
+}
+
 LayoutRect RenderListMarker::localSelectionRect()
 {
     return LayoutRect(LayoutPoint(), borderBoxSize());
@@ -268,6 +310,9 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
         container->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*container, boxOrigin));
         return;
     }
+
+    if (needsInlineWrapper())
+        return;
 
     if (paintInfo.phase != PaintPhase::Foreground && paintInfo.phase != PaintPhase::Accessibility)
         return;
@@ -374,6 +419,11 @@ void RenderListMarker::layout()
         setBorderBoxWidth(image->imageSize(this, style().usedZoom()).width());
         setBorderBoxHeight(image->imageSize(this, style().usedZoom()).height());
         m_layoutBounds = { borderBoxHeight(), 0 };
+    } else if (needsInlineWrapper()) {
+        updateInlineMarginsAndContent();
+        setLogicalWidth({ });
+        setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
+        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     } else {
         setLogicalWidth(minContentLogicalWidthContribution());
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
@@ -516,13 +566,15 @@ void RenderListMarker::updateContent()
 
 void RenderListMarker::updateContentContainerText()
 {
-    CheckedPtr container = contentContainer();
-    if (!container) {
+    CheckedPtr contentParent = contentRenderersParent();
+    if (!contentParent) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    CheckedPtr textRenderer = dynamicDowncast<RenderText>(container->firstChild());
+    CheckedPtr<RenderText> textRenderer;
+    for (CheckedPtr child = contentParent->firstChild(); child && !textRenderer; child = child->nextSibling())
+        textRenderer = dynamicDowncast<RenderText>(child.get());
     if (!textRenderer) {
         ASSERT_NOT_REACHED();
         return;
@@ -540,6 +592,16 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
 {
     ASSERT(hasInvalidContentLogicalWidths());
     updateContent();
+
+    if (needsInlineWrapper()) {
+        // The text renderer next to us is inline content of the list item's own formatting context and already
+        // contributes the marker's width there, so the marker box must not contribute it a second time.
+        m_minContentLogicalWidthContribution = { };
+        m_maxContentLogicalWidthContribution = { };
+        clearContentLogicalWidthsInvalidation();
+        updateInlineMargins();
+        return;
+    }
 
     if (CheckedPtr container = contentContainer()) {
         // The marker is non-wrapping, so its min- and max-content widths are both the
@@ -588,6 +650,11 @@ void RenderListMarker::updateInlineMargins()
     const FontMetrics& fontMetrics = style().metricsOfPrimaryFont();
 
     auto marginsForInsideMarker = [&]() -> std::pair<LayoutUnit, LayoutUnit> {
+        // The text renderer next to us draws the marker and carries its suffix, so the room between marker and
+        // content is that text's, not something the empty marker box has to make.
+        if (needsInlineWrapper())
+            return { };
+
         if (isImage())
             return { 0, markerPadding };
 

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class CSSRegisteredCounterStyle;
 class RenderBlockFlow;
+class RenderInline;
 class RenderListItem;
 class StyleRuleCounterStyle;
 
@@ -73,8 +74,18 @@ public:
     // child (contentContainer()) that this marker lays out and paints itself.
     bool hasContentProperty() const;
     bool needsContentContainer() const;
+    // An inside marker whose contents need renderers of their own puts them in an anonymous inline box around the
+    // marker instead of in a content container, so that they are inline content of the list item's own formatting
+    // context. That is what lets unicode-bidi and direction on the ::marker take effect. The marker box itself then
+    // draws nothing and takes up no room of its own. A synthesized glyph (disc/circle/square) is drawn by the marker,
+    // so it keeps its container.
+    bool needsInlineWrapper() const { return isInside() && !synthesizesGlyph() && needsContentContainer(); }
 
     RenderBlockFlow* contentContainer() const;
+    RenderInline* inlineWrapper() const;
+    Style::ComputedStyle styleForInlineWrapper() const;
+    // The box the marker's contents are attached to, whichever of the two it is.
+    RenderElement* contentRenderersParent() const;
 
     LayoutUnit lineLogicalOffsetForListItem() const { return m_lineLogicalOffsetForListItem; }
     RenderListItem* NODELETE listItem() const;
@@ -145,6 +156,9 @@ private:
     std::optional<ExcludedPosition> m_excludedPosition;
     bool m_shouldCollapseAnonymousBlockParent { false };
 };
+
+// The anonymous inline box an inside marker is wrapped in (see RenderListMarker::needsInlineWrapper).
+bool isInlineWrapperForListMarker(const RenderObject&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -48,7 +48,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::List);
 static RenderObject* firstNonMarkerChild(RenderBlock& parent)
 {
     RenderObject* child = parent.firstChild();
-    while (is<RenderListMarker>(child))
+    // An inside marker may be wrapped in an anonymous inline box, which is the marker as far as this is concerned.
+    while (child && (is<RenderListMarker>(*child) || isInlineWrapperForListMarker(*child)))
         child = child->nextSibling();
     return child;
 }
@@ -131,8 +132,13 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     // excluded and attaches directly to the list item, while an inside one is ordinary inline content that needs an
     // anonymous block when the list item's other children are block level. Only attach() makes that call, and it is not
     // consulted when the marker's parent happens to be unchanged, so rebuild rather than patch the placement in place.
-    if (auto* markerRenderer = listItemRenderer.markerRenderer(); markerRenderer && markerRenderer->style().listStylePosition() != newStyle.listStylePosition())
-        m_builder.destroyAndCleanUpAnonymousWrappers(*markerRenderer, { });
+    if (auto* markerRenderer = listItemRenderer.markerRenderer(); markerRenderer && markerRenderer->style().listStylePosition() != newStyle.listStylePosition()) {
+        // Destroying the anonymous inline box takes the marker with it, and leaves nothing of the inside placement behind.
+        if (CheckedPtr wrapper = markerRenderer->inlineWrapper())
+            m_builder.destroyAndCleanUpAnonymousWrappers(*wrapper, { });
+        else
+            m_builder.destroyAndCleanUpAnonymousWrappers(*markerRenderer, { });
+    }
 
     if (auto* markerRenderer = listItemRenderer.markerRenderer()) {
         // Whether the marker box holds inline content depends on `content` and on list-style-type
@@ -147,17 +153,19 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         // what is not the marker's own style: its direction, and what the document's counter style
         // registry currently resolves list-style-type to.
         auto needsContentContainer = markerRenderer->needsContentContainer();
-        if (contentChanged || needsContentContainer != !!markerRenderer->contentContainer()) {
-            if (auto* existingContainer = markerRenderer->contentContainer())
-                m_builder.destroy(*existingContainer);
+        if (contentChanged || needsContentContainer != !!markerRenderer->contentRenderersParent()) {
+            destroyMarkerContentRenderers(*markerRenderer);
             if (needsContentContainer)
                 buildMarkerContentRenderers(*markerRenderer);
-        } else if (auto* container = markerRenderer->contentContainer()) {
+        } else if (CheckedPtr contentParent = markerRenderer->contentRenderersParent()) {
             // Content unchanged but other style changed: refresh the generated image/quote children
             // (RenderText/RenderCounter are handled by propagateStyleToAnonymousChildren on setStyle).
-            RenderTreeUpdater::GeneratedContent::updateStyleForContentRenderers(*container, markerRenderer->style());
+            RenderTreeUpdater::GeneratedContent::updateStyleForContentRenderers(*contentParent, markerRenderer->style());
         }
-        auto* currentParent = markerRenderer->parent();
+        // What gets placed is the marker, or the anonymous inline box around it when it has one: moving the marker out
+        // of that box on its own would leave its text behind.
+        CheckedRef<RenderElement> markerToPlace = markerRenderer->inlineWrapper() ? static_cast<RenderElement&>(*markerRenderer->inlineWrapper()) : static_cast<RenderElement&>(*markerRenderer);
+        auto* currentParent = markerToPlace->parent();
         if (!currentParent) {
             ASSERT_NOT_REACHED();
             return;
@@ -182,7 +190,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         if (searchResult.parent == currentParent)
             return;
 
-        m_builder.attach(*searchResult.parent, m_builder.detach(*currentParent, *markerRenderer, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*searchResult.parent));
+        m_builder.attach(*searchResult.parent, m_builder.detach(*currentParent, markerToPlace.get(), WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*searchResult.parent));
 
         // If current parent is an anonymous block that has lost all its children, destroy it.
         if (currentParent->isAnonymousBlock() && !currentParent->firstChild()) {
@@ -213,30 +221,77 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         buildMarkerContentRenderers(*listItemRenderer.markerRenderer());
 }
 
+void RenderTreeBuilder::List::wrapInsideMarkerInAnonymousInline(RenderListMarker& marker)
+{
+    ASSERT(marker.needsInlineWrapper());
+    ASSERT(!marker.inlineWrapper());
+
+    // The marker box is atomic and opaque to the bidi algorithm, so putting its contents in an inline box of their
+    // own is what gives the inline formatting context something to read unicode-bidi from (InlineItemsBuilder emits
+    // the bidi control characters on inline box start and end).
+    auto newWrapper = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, marker.document(), marker.styleForInlineWrapper());
+    newWrapper->initializeStyle();
+    CheckedRef wrapper = *newWrapper;
+
+    CheckedRef markerParent = *marker.parent();
+    m_builder.attach(markerParent.get(), WTF::move(newWrapper), &marker);
+    m_builder.attach(wrapper.get(), m_builder.detach(markerParent.get(), marker, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No));
+
+    // Wrapping can happen after the inline content was already laid out once (a style change brings us back here),
+    // and the layout box tree is built from the render tree, so it has to be thrown away for the wrapper to get a box
+    // of its own. Without that the marker's box is left with no parent at all.
+    if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(wrapper->containingBlock()))
+        blockFlow->invalidateLineLayout(RenderBlockFlow::InvalidationReason::InsertionOrRemoval);
+}
+
+void RenderTreeBuilder::List::destroyMarkerContentRenderers(RenderListMarker& marker)
+{
+    if (CheckedPtr container = marker.contentContainer()) {
+        m_builder.destroy(*container);
+        return;
+    }
+
+    // The contents of a wrapped marker are its siblings inside the anonymous inline box, and that box holds a copy of
+    // the marker's style, so it goes with them: move the marker back out and let the wrapper take the rest.
+    CheckedPtr wrapper = marker.inlineWrapper();
+    if (!wrapper)
+        return;
+
+    CheckedRef wrapperParent = *wrapper->parent();
+    m_builder.attach(wrapperParent.get(), m_builder.detach(*wrapper, marker, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), wrapper.get());
+    m_builder.destroyAndCleanUpAnonymousWrappers(*wrapper, { });
+}
+
 void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& marker)
 {
     ASSERT(marker.needsContentContainer());
-    ASSERT(!marker.contentContainer());
+    ASSERT(!marker.contentRenderersParent());
 
-    // css-lists-3 §3.3 generates the marker contents "exactly as for ::before": an anonymous
-    // inline-block box holding the content list (strings, images, counters, quotes). The marker
-    // (RenderListMarker) lays this box out and paints it as a single atomic inline.
-    auto containerStyle = Style::ComputedStyle::createAnonymousStyleWithDisplay(marker.style(), Style::DisplayType::InlineFlowRoot);
-    auto newContainer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, marker.document(), WTF::move(containerStyle));
-    newContainer->initializeStyle();
-    CheckedRef container = *newContainer;
-    m_builder.attach(marker, WTF::move(newContainer));
+    CheckedPtr<RenderElement> contentParent;
+    if (marker.needsInlineWrapper()) {
+        wrapInsideMarkerInAnonymousInline(marker);
+        contentParent = marker.inlineWrapper();
+    } else {
+        // css-lists-3 §3.3 generates the marker contents "exactly as for ::before": an anonymous
+        // inline-block box holding the content list (strings, images, counters, quotes). The marker
+        // (RenderListMarker) lays this box out and paints it as a single atomic inline.
+        auto containerStyle = Style::ComputedStyle::createAnonymousStyleWithDisplay(marker.style(), Style::DisplayType::InlineFlowRoot);
+        auto newContainer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, marker.document(), WTF::move(containerStyle));
+        newContainer->initializeStyle();
+        contentParent = newContainer.get();
+        m_builder.attach(marker, WTF::move(newContainer));
+    }
 
     if (!marker.hasContentProperty()) {
         // list-style-type text that needs renderers of its own, so inline layout can bidi-resolve it.
         // The text itself is only known once counter values resolve, so start empty and let
         // RenderListMarker::updateContent() fill it in at layout time.
         auto textRenderer = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, marker.document(), emptyString());
-        m_builder.attach(container.get(), WTF::move(textRenderer));
+        m_builder.attach(*contentParent, WTF::move(textRenderer));
         return;
     }
 
-    RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, container.get(), marker.style(), PseudoElementType::Marker);
+    RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *contentParent, marker.style(), PseudoElementType::Marker);
 }
 
 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -44,6 +44,8 @@ private:
     // Builds the anonymous inline-block subtree holding the ::marker's generated content
     // (css-lists-3 §3.3). The caller tears down any prior content first.
     void buildMarkerContentRenderers(RenderListMarker&);
+    void destroyMarkerContentRenderers(RenderListMarker&);
+    void wrapInsideMarkerInAnonymousInline(RenderListMarker&);
 
     RenderTreeBuilder& m_builder;
 };


### PR DESCRIPTION
#### 90d86b42428ea988c34bb08587d79f9c01c8a5d3
<pre>
[list-marker] Wrap an inside marker in an anonymous inline box so its content is part of the line <a href="https://bugs.webkit.org/show_bug.cgi?id=322951">https://bugs.webkit.org/show_bug.cgi?id=322951</a> &lt;<a href="https://rdar.apple.com/problem/186225101">rdar://problem/186225101</a>&gt;

The marker box is atomic and opaque to the bidi algorithm, so unicode-bidi and direction on the ::marker had
nothing to act on and an inside marker&apos;s content could not reorder with the list item&apos;s text. Put an inside
marker&apos;s content renderers in an anonymous inline box around the marker instead of in a content container of the
marker&apos;s own, which is what the inline formatting context reads those properties from, and let the marker box
itself draw nothing and take up no room. A synthesized glyph keeps its container, since the marker draws it.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90d86b42428ea988c34bb08587d79f9c01c8a5d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183922 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/185785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/194145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/186877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/5327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/196083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/56728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->