### PR TITLE
[JSC] TypedArray constructor needs to copy JSArray content when its copying may cause side-effect

### DIFF
--- a/JSTests/stress/typedarray-construct-from-array-mutated-by-tonumber.js
+++ b/JSTests/stress/typedarray-construct-from-array-mutated-by-tonumber.js
@@ -1,0 +1,68 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+const constructors = [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float16Array, Float32Array, Float64Array];
+const bigIntConstructors = [BigInt64Array, BigUint64Array];
+
+function shrinkWhileConverting(constructor) {
+    let values = [0, { valueOf() { values.length = 0; return 100; } }, 2];
+    let array = new constructor(values);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 0);
+    shouldBe(array[1], 100);
+    shouldBe(array[2], 2);
+}
+
+function overwriteWhileConverting(constructor) {
+    let values = [0, { valueOf() { values[2] = 42; return 100; } }, 2];
+    let array = new constructor(values);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 0);
+    shouldBe(array[1], 100);
+    shouldBe(array[2], 2);
+}
+
+function growWhileConverting(constructor) {
+    let values = [0, { valueOf() { values.push(42); return 100; } }, 2];
+    let array = new constructor(values);
+    shouldBe(array.length, 3);
+    shouldBe(array[2], 2);
+}
+
+function shrinkWhileConvertingBigInt(constructor) {
+    let values = [0n, { valueOf() { values.length = 0; return 100n; } }, 2n];
+    let array = new constructor(values);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 0n);
+    shouldBe(array[1], 100n);
+    shouldBe(array[2], 2n);
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const constructor of constructors) {
+        shrinkWhileConverting(constructor);
+        overwriteWhileConverting(constructor);
+        growWhileConverting(constructor);
+    }
+    for (const constructor of bigIntConstructors)
+        shrinkWhileConvertingBigInt(constructor);
+
+    shouldBe(new Int32Array([1, 2, 3]).join(), "1,2,3");
+    shouldBe(new Float64Array([1.5, 2.5]).join(), "1.5,2.5");
+    shouldBe(new Int32Array([1, , 3]).join(), "1,0,3");
+    shouldBe(new Int32Array(["1", "2"]).join(), "1,2");
+}
+
+// A sparse index forces array storage, which reaches the same conversion loop.
+{
+    let values = [0, { valueOf() { values.length = 0; return 100; } }, 2];
+    values[100000] = 3;
+    let array = new Uint8Array(values);
+    shouldBe(array.length, 100001);
+    shouldBe(array[0], 0);
+    shouldBe(array[1], 100);
+    shouldBe(array[2], 2);
+    shouldBe(array[100000], 3);
+}

--- a/JSTests/test262/expectations-linux.yaml
+++ b/JSTests/test262/expectations-linux.yaml
@@ -55,9 +55,6 @@ test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
 test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js:
   default: 3
   strict mode: 3
-test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
   default: 3
   strict mode: 3

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -52,9 +52,6 @@ test/built-ins/Proxy/construct/arguments-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 3
   strict mode: 3
-test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
   default: 3
   strict mode: 3

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1974,29 +1974,32 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
 
 void JSArray::fillArgList(JSGlobalObject* globalObject, MarkedArgumentBuffer& args)
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     unsigned i = 0;
     unsigned vectorEnd;
     WriteBarrier<Unknown>* vector;
 
     Butterfly* butterfly = this->butterfly();
-    
+
     switch (indexingType()) {
     case ArrayClass:
         return;
-        
+
     case ArrayWithUndecided: {
         vector = nullptr;
         vectorEnd = 0;
         break;
     }
-        
+
     case ArrayWithInt32:
     case ArrayWithContiguous: {
         vectorEnd = butterfly->publicLength();
         vector = butterfly->contiguous().data();
         break;
     }
-        
+
     case ArrayWithDouble: {
         vector = nullptr;
         vectorEnd = 0;
@@ -2008,15 +2011,15 @@ void JSArray::fillArgList(JSGlobalObject* globalObject, MarkedArgumentBuffer& ar
         }
         break;
     }
-    
+
     case ARRAY_WITH_ARRAY_STORAGE_INDEXING_TYPES: {
         ArrayStorage* storage = butterfly->arrayStorage();
-        
+
         vector = storage->m_vector;
         vectorEnd = std::min(storage->length(), storage->vectorLength());
         break;
     }
-        
+
     default:
         CRASH();
 #if COMPILER_QUIRK(CONSIDERS_UNREACHABLE_CODE)
@@ -2025,7 +2028,7 @@ void JSArray::fillArgList(JSGlobalObject* globalObject, MarkedArgumentBuffer& ar
         break;
 #endif
     }
-    
+
     for (; i < vectorEnd; ++i) {
         WriteBarrier<Unknown>& v = vector[i];
         if (!v)
@@ -2034,8 +2037,11 @@ void JSArray::fillArgList(JSGlobalObject* globalObject, MarkedArgumentBuffer& ar
     }
 
     // FIXME: What prevents this from being called with a RuntimeArray? The length function will always return 0 in that case.
-    for (; i < length(); ++i)
-        args.append(get(globalObject, i));
+    for (; i < length(); ++i) {
+        JSValue value = get(globalObject, i);
+        RETURN_IF_EXCEPTION(scope, void());
+        args.append(value);
+    }
 }
 
 void JSArray::copyToArguments(JSGlobalObject* globalObject, JSValue* firstElementDest, unsigned offset, unsigned length)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -85,6 +85,29 @@ Structure* JSGenericTypedArrayViewConstructor<ViewClass>::createStructure(
         vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
 }
 
+// https://tc39.es/ecma262/#sec-initializetypedarrayfromlist
+template<typename ViewClass>
+inline JSObject* constructGenericTypedArrayViewFromList(JSGlobalObject* globalObject, Structure* structure, const MarkedArgumentBuffer& storage)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_VARIABLE(scope);
+
+    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, storage.size());
+    EXCEPTION_ASSERT(!!scope.exception() == !result);
+    if (!result) [[unlikely]]
+        return nullptr;
+
+    for (unsigned i = 0; i < storage.size(); ++i) {
+        bool success = result->setIndex(globalObject, i, storage.at(i));
+        EXCEPTION_ASSERT(scope.exception() || success);
+        if (!success)
+            return nullptr;
+    }
+
+    return result;
+}
+
 template<typename ViewClass>
 inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* globalObject, Structure* structure, JSObject* iterable, JSValue iteratorMethod)
 {
@@ -101,19 +124,24 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
     });
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, storage.size());
-    EXCEPTION_ASSERT(!!scope.exception() == !result);
-    if (!result) [[unlikely]]
-        return nullptr;
+    RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewFromList<ViewClass>(globalObject, structure, storage));
+}
 
-    for (unsigned i = 0; i < storage.size(); ++i) {
-        bool success = result->setIndex(globalObject, i, storage.at(i));
-        EXCEPTION_ASSERT(scope.exception() || success);
-        if (!success)
-            return nullptr;
+template<typename ViewClass>
+inline JSObject* constructGenericTypedArrayViewFromFastArray(JSGlobalObject* globalObject, Structure* structure, JSArray* array)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    MarkedArgumentBuffer storage;
+    array->fillArgList(globalObject, storage);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (storage.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
     }
 
-    return result;
+    RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewFromList<ViewClass>(globalObject, structure, storage));
 }
 
 constinit const ASCIILiteral typedArrayErrorMessageBufferIsAlreadyDetached = "Buffer is already detached"_s;
@@ -204,9 +232,14 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
         // This getPropertySlot operation should not be observed by the Proxy.
         // So we use VMInquiry. And purge the opaque object cases (proxy and namespace object) by isTaintedByOpaqueObject() guard.
-        if (JSArray* array = dynamicDowncast<JSArray>(object); array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()) [[likely]]
+        if (JSArray* array = dynamicDowncast<JSArray>(object); array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()) [[likely]] {
+            // Every element must be read before any of them is converted, since converting an object
+            // runs valueOf or toString, which can modify the array. Only these shapes can hold an object.
+            IndexingType indexingType = array->indexingType();
+            if (hasContiguous(indexingType) || hasAnyArrayStorage(indexingType))
+                RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewFromFastArray<ViewClass>(globalObject, structure, array));
             length = array->length();
-        else {
+        } else {
             PropertySlot lengthSlot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
             object->getPropertySlot(globalObject, vm.propertyNames->length, lengthSlot);
             RETURN_IF_EXCEPTION(scope, nullptr);


### PR DESCRIPTION
#### 8496050f97ee2ef07bd330b6a49220ed3b93d95c
<pre>
[JSC] TypedArray constructor needs to copy JSArray content when its copying may cause side-effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=322954">https://bugs.webkit.org/show_bug.cgi?id=322954</a>
<a href="https://rdar.apple.com/186227333">rdar://186227333</a>

Reviewed by Yijia Huang.

When constructing a TypedArray from JSArray, we need to copy and convert
the content for the array, which invokes ToNumber operation. And it can
be observable when JSArray is Contiguous or ArrayStorage. In this case,
they may hold an object which has valueOf override and that function can
modify the JSArray. According to the spec, we first need to preserve all
the content of JSArray and then doing ToNumber for each element. Thus we
first need to preserve them somewhere. This patch fixes it by copying
them to MarkedArgumentBuffer first when necessary.

Test: JSTests/stress/typedarray-construct-from-array-mutated-by-tonumber.js

* JSTests/stress/typedarray-construct-from-array-mutated-by-tonumber.js: Added.
(shouldBe):
(shrinkWhileConverting):
(overwriteWhileConverting):
(growWhileConverting):
(shrinkWhileConvertingBigInt):
* JSTests/test262/expectations-linux.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fillArgList):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewFromList):
(JSC::constructGenericTypedArrayViewFromIterator):
(JSC::constructGenericTypedArrayViewFromFastArray):
(JSC::constructGenericTypedArrayViewWithArguments):

Canonical link: <a href="https://commits.webkit.org/320185@main">https://commits.webkit.org/320185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be611360749c37b9e7b23668197c117d403a926

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148335 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af1ea249-641e-495d-8f14-b45af8f878ac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143671 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99832 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2548264-242b-4221-b7bd-e46f799a12ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47446 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124090 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76ccb38b-9342-47ac-a436-7fd5a0f15dfa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46153 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6061 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12886 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43945 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5448 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45319 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57637 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153225 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152899 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47429 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130631 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56849 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56220 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56459 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->