### PR TITLE
[YARR] A character following a class set operand in a `/v` class adds `U+0000`

### DIFF
--- a/JSTests/stress/regexp-v-flag-character-after-set-operand.js
+++ b/JSTests/stress/regexp-v-flag-character-after-set-operand.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrowSyntaxError(source) {
+    try {
+        new RegExp(source, "v");
+    } catch (error) {
+        if (error instanceof SyntaxError)
+            return;
+        throw new Error(`bad error for /${source}/v: ${error}`);
+    }
+    throw new Error(`/${source}/v did not throw`);
+}
+
+// A character following a class set operand (a nested class or a \q{} string
+// disjunction) must add only itself, not a stale cached character.
+for (const [source, matching, nonMatching] of [
+    ["^[\\q{ab}c]$", ["ab", "c"], ["\0", "a", "b", "abc"]],
+    ["^[\\q{ab|cd}e]$", ["ab", "cd", "e"], ["\0", "abe"]],
+    ["^[[ab]c]$", ["a", "b", "c"], ["\0", "d"]],
+    ["^[[\\p{L}]1]$", ["a", "é", "1"], ["\0", "2"]],
+    ["^[[a-c][x]y]$", ["a", "b", "c", "x", "y"], ["\0", "d"]],
+    ["^[a[b]c]$", ["a", "b", "c"], ["\0", "d"]],
+    ["^[\\d\\q{xy}z]$", ["0", "9", "xy", "z"], ["\0", "x"]],
+    ["^[[^a]b]$", ["b", "c", "\0"], ["a"]],
+    ["^[^[a]b]$", ["c", "\0"], ["a", "b"]],
+]) {
+    const regExp = new RegExp(source, "v");
+    for (const string of matching)
+        shouldBe(regExp.test(string), true);
+    for (const string of nonMatching)
+        shouldBe(regExp.test(string), false);
+}
+
+shouldThrowSyntaxError("[\\q{ab}-c]");
+shouldThrowSyntaxError("[[a]-c]");
+shouldThrowSyntaxError("[a&&[b]c]");
+shouldThrowSyntaxError("[a--[b]c]");

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -677,7 +677,6 @@ private:
                 if (ch == '-')
                     m_errorCode = ErrorCode::InvalidClassSetOperation;
                 else {
-                    m_delegate.atomCharacterClassAtom(m_character);
                     switchFromDefaultOpToUnionOpIfNeeded();
                     processCharacter();
                 }


### PR DESCRIPTION
#### 38281d033aee844d56610d9e9b1ea23894f310be
<pre>
[YARR] A character following a class set operand in a `/v` class adds `U+0000`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322962">https://bugs.webkit.org/show_bug.cgi?id=322962</a>

Reviewed by Yusuke Suzuki.

ClassSetParserDelegate holds back the previous character in m_character
until it knows whether it starts a range; m_character is only meaningful
while the state says a character is pending. After a nested class or a
\q{} string disjunction nothing is pending, but atomPatternCharacter()
still emitted m_character before holding back the new one. When no
character had been seen yet that emitted its initial value, so
/^[\q{ab}c]$/v and /^[[\p{L}]a]$/v matched U+0000; otherwise it
re-emitted a character the class already had.

Test: JSTests/stress/regexp-v-flag-character-after-set-operand.js

* JSTests/stress/regexp-v-flag-character-after-set-operand.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):

Canonical link: <a href="https://commits.webkit.org/320216@main">https://commits.webkit.org/320216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b067b2827e5fecd86b204e744bf4526f3a84164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148226 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143572 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99743 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46069 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44281 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5961 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12795 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43854 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5338 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45210 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196094 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57527 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152800 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47341 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130511 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126965 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56739 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18865 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->