### PR TITLE
[NewCodable] Add the ability to decode collections and containers

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift
@@ -26,8 +26,8 @@
 import Foundation
 import WebKit_Internal
 
-enum JavaScriptEvaluationCodableValue<ID: Hashable & Sendable>: Sendable, Hashable {
-    enum EmptyType: Sendable, Hashable {
+enum JavaScriptEvaluationCodableValue<ID: Hashable & Sendable>: Hashable, Sendable {
+    enum EmptyType: Hashable, Sendable {
         case undefined
         case null
     }
@@ -52,30 +52,50 @@ extension JavaScriptEvaluationCodableValue.EmptyType {
     }
 }
 
-extension JavaScriptEvaluationCodableValue {
+extension JavaScriptEvaluationCodableValue<UInt64> {
     init(_ value: borrowing WebKit.JavaScriptEvaluationResult.Value) {
         typealias Cxx = WebKit.CxxInteropSupport
 
         self =
-            switch unsafe value.index() {
+            switch value.index() {
             case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: WebKit.JavaScriptEvaluationResult.EmptyType.self):
-                unsafe .empty(.init(Cxx.alternativeForVariant(value)))
+                .empty(.init(Cxx.alternativeForVariant(value)))
+
             case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: CBool.self):
-                unsafe .bool(Cxx.alternativeForVariant(value))
+                .bool(Cxx.alternativeForVariant(value))
+
             case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: CDouble.self):
-                unsafe .number(Cxx.alternativeForVariant(value))
+                .number(Cxx.alternativeForVariant(value))
+
             case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(Alternative: WTF.String.self):
-                unsafe .string((Cxx.alternativeForVariant(value) as WTF.String).description)
+                .string((Cxx.alternativeForVariant(value) as WTF.String).description)
+
             case 4: // Seconds
                 fatalError("not yet implemented")
-            case 5: // Vector<JSObjectID>
-                fatalError("not yet implemented")
-            case 6: // ObjectMap
-                fatalError("not yet implemented")
+
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(
+                Alternative: WebKit.JavaScriptEvaluationResult.ObjectVector.self
+            ):
+                .array(
+                    Array(Cxx.alternativeForVariant(value) as WebKit.JavaScriptEvaluationResult.ObjectVector).map(Cxx.jsObjectIDRawValue)
+                )
+
+            case Cxx.alternativeIndexForJavaScriptEvaluationResultValue(
+                Alternative: WebKit.JavaScriptEvaluationResult.ObjectMap.self
+            ):
+                .object(
+                    Array(Cxx.alternativeForVariant(value) as WebKit.JavaScriptEvaluationResult.ObjectMap)
+                        .map {
+                            ObjectEntry(key: Cxx.jsObjectIDRawValue($0.key), value: Cxx.jsObjectIDRawValue($0.value))
+                        }
+                )
+
             case 7: // UniqueRef<JSHandleInfo>
                 fatalError("not yet implemented")
+
             case 8: // UniqueRef<WebCore::SerializedNode>
                 fatalError("not yet implemented")
+
             default:
                 fatalError("invalid index")
             }

--- a/Source/WebKit/Shared/JavaScriptEvaluationDecodingGraph.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationDecodingGraph.swift
@@ -24,20 +24,41 @@
 #if HAVE_NEW_CODABLE
 
 import Foundation
+import NewCodable
 import WebKit_Internal
 
 struct JavaScriptEvaluationDecodingGraph<ID: Hashable & Sendable> {
     let map: [ID: JavaScriptEvaluationCodableValue<ID>]
 }
 
+extension JavaScriptEvaluationDecodingGraph {
+    func keyName(for id: ID, at codingPath: CodingPath) throws(CodingError.Decoding) -> String {
+        guard let value = map[id] else {
+            throw CodingError.dataCorrupted(
+                at: codingPath,
+                debugDescription: "No object entry for key reference \(id)."
+            )
+        }
+
+        guard case .string(let name) = value else {
+            throw CodingError.typeMismatch(
+                expectedTypeDescription: "\(String.self)",
+                actualValueDescription: "\(value)",
+                at: codingPath
+            )
+        }
+
+        return name
+    }
+}
+
 extension JavaScriptEvaluationDecodingGraph<UInt64> {
     init(_ result: consuming WebKit.JavaScriptEvaluationOwnedResult) {
         var map: [ID: JavaScriptEvaluationCodableValue<ID>] = [:]
 
-        // swift-format-ignore: Spacing
-        for unsafe entry in unsafe result {
-            let key = unsafe WebKit.CxxInteropSupport.jsObjectIDRawValue(entry.key)
-            let value = unsafe JavaScriptEvaluationCodableValue<ID>(entry.value)
+        for entry in result {
+            let key = WebKit.CxxInteropSupport.jsObjectIDRawValue(entry.key)
+            let value = JavaScriptEvaluationCodableValue<ID>(entry.value)
 
             map[key] = value
         }

--- a/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
@@ -56,21 +56,39 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
     mutating func decodeStruct<T: ~Copyable>(
         _ closure: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
-        fatalError("\(#function) is not implemented")
+        let object = try decodePrimitive([JavaScriptEvaluationCodableValue<ID>.ObjectEntry].self) {
+            guard case .object(let value) = $0 else {
+                return nil
+            }
+
+            return value
+        }
+
+        var decoder = StructDecoder(storage: storage, entries: object, codingPath: codingPath)
+        return try closure(&decoder)
     }
 
     @_lifetime(self: copy self)
     mutating func decodeDictionary<T: ~Copyable>(
         _ closure: (inout DictionaryDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
-        fatalError("\(#function) is not implemented")
+        try decodeStruct(closure)
     }
 
     @_lifetime(self: copy self)
     mutating func decodeArray<T: ~Copyable>(
         _ closure: (inout ArrayDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
-        fatalError("\(#function) is not implemented")
+        let array = try decodePrimitive([ID].self) {
+            guard case .array(let value) = $0 else {
+                return nil
+            }
+
+            return value
+        }
+
+        var decoder = ArrayDecoder(storage: storage, ids: array, codingPath: codingPath)
+        return try closure(&decoder)
     }
 
     @_lifetime(self: copy self)
@@ -78,21 +96,33 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
         _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
         associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
-        fatalError("\(#function) is not implemented")
+        let entries = try decodePrimitive([JavaScriptEvaluationCodableValue<ID>.ObjectEntry].self) {
+            guard case .object(let value) = $0 else {
+                return nil
+            }
+
+            return value
+        }
+
+        guard entries.count == 1, let entry = entries.first else {
+            throw CodingError.dataCorrupted(
+                at: codingPath,
+                debugDescription: "Expected exactly one entry for an enum case, found \(entries.count)."
+            )
+        }
+
+        let name = try storage.value.keyName(for: entry.key, at: codingPath)
+
+        var fieldDecoder = FieldDecoder(string: name)
+        try caseDecoder(&fieldDecoder)
+
+        var associatedValues = Self(storage: storage, id: entry.value, codingPath: codingPath.appending(name))
+        return try associatedValues.decodeStruct(valueDecoder)
     }
 
-    @_lifetime(self: copy self)
-    mutating func decode<Key: CodingStringKeyRepresentable, Value: CommonDecodable>(
-        _: [Key: Value].Type,
-        sizeHint: Int
-    ) throws(CodingError.Decoding) -> [Key: Value] {
-        fatalError("\(#function) is not implemented")
-    }
+    // Intentionally does not implement the `mutating func decode<Key: CodingStringKeyRepresentable, Value: CommonDecodable>(_: [Key: Value].Type, sizeHint: Int) throws(CodingError.Decoding) -> [Key: Value]` requirement; the default implementation is sound.
 
-    @_lifetime(self: copy self)
-    mutating func decode<Element: CommonDecodable>(_: [Element].Type, sizeHint: Int) throws(CodingError.Decoding) -> [Element] {
-        fatalError("\(#function) is not implemented")
-    }
+    // Intentionally does not implement the `mutating func decode<Element: CommonDecodable>(_: [Element].Type, sizeHint: Int) throws(CodingError.Decoding) -> [Element]` requirement; the default implementation is sound.
 
     @_lifetime(self: copy self)
     mutating func decode(_: Bool.Type) throws(CodingError.Decoding) -> Bool {

--- a/Source/WebKit/Shared/JavaScriptEvaluationObjectDecoder.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationObjectDecoder.swift
@@ -53,22 +53,7 @@ struct JavaScriptEvaluationObjectDecoder<ID: Hashable & Sendable>: ~Escapable {
     }
 
     private func keyName(entry: JavaScriptEvaluationCodableValue<ID>.ObjectEntry) throws(CodingError.Decoding) -> String {
-        guard let keyValue = storage.value.map[entry.key] else {
-            throw CodingError.dataCorrupted(
-                at: codingPath,
-                debugDescription: "No object entry for key reference \(entry.key)."
-            )
-        }
-
-        guard case .string(let name) = keyValue else {
-            throw CodingError.typeMismatch(
-                expectedTypeDescription: "\(String.self)",
-                actualValueDescription: "\(keyValue)",
-                at: codingPath
-            )
-        }
-
-        return name
+        try storage.value.keyName(for: entry.key, at: codingPath)
     }
 
     @_lifetime(copy self)

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -61,13 +61,14 @@ class JavaScriptEvaluationResult {
 public:
     enum class EmptyType : bool { Undefined, Null };
     using ObjectMap = HashMap<JSObjectID, JSObjectID>;
+    using ObjectVector = Vector<JSObjectID>;
     using Value = Variant<
         EmptyType,
         bool,
         double,
         String,
         Seconds,
-        Vector<JSObjectID>,
+        ObjectVector,
         ObjectMap,
         UniqueRef<JSHandleInfo>,
         UniqueRef<WebCore::SerializedNode>

--- a/Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h
@@ -56,42 +56,9 @@ private:
 
 #endif
 
-// FIXME: Remove this once rdar://186141869 is fixed.
-class SWIFT_NONCOPYABLE JavaScriptArgumentsBridge {
-public:
-    JavaScriptArgumentsBridge() = default;
-
-    explicit JavaScriptArgumentsBridge(size_t capacity)
-        : m_arguments(std::in_place)
-    {
-        m_arguments->reserveInitialCapacity(capacity);
-    }
-
-    JavaScriptArgumentsBridge(const JavaScriptArgumentsBridge&) = delete;
-    JavaScriptArgumentsBridge& operator=(const JavaScriptArgumentsBridge&) = delete;
-
-    JavaScriptArgumentsBridge(JavaScriptArgumentsBridge&&) = default;
-    JavaScriptArgumentsBridge& operator=(JavaScriptArgumentsBridge&&) = default;
-
-    void append(String&& key, JavaScriptEvaluationResult&& value)
-    {
-        m_arguments->constructAndAppend(WTF::move(key), WTF::move(value));
-    }
-
-    std::optional<Vector<std::pair<String, JavaScriptEvaluationResult>>> consume()
-    {
-        return std::exchange(m_arguments, std::nullopt);
-    }
-
-private:
-    std::optional<Vector<std::pair<String, JavaScriptEvaluationResult>>> m_arguments;
-};
-
 }
 
 namespace WebKit::CxxInteropSupport {
-
-#if defined(HAVE_NEW_CODABLE) && HAVE_NEW_CODABLE
 
 // FIXME: Generalize this once rdar://186426517 is fixed.
 template<typename Alternative>
@@ -111,8 +78,6 @@ inline uint64_t jsObjectIDRawValue(const JSObjectID& id)
 {
     return id.toUInt64();
 }
-
-#endif
 
 inline RunJavaScriptResult::value_type takeValue(RunJavaScriptResult&& expected)
 {

--- a/Source/WebKit/Shared/JavaScriptEvaluationResultDecoder.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResultDecoder.swift
@@ -32,10 +32,10 @@ struct JavaScriptEvaluationResultDecoder {
         _ type: T.Type,
         from result: consuming WebKit.JavaScriptEvaluationResult
     ) throws(CodingError.Decoding) -> T {
-        let rootID = unsafe WebKit.CxxInteropSupport.jsObjectIDRawValue(result.root())
+        let rootID = WebKit.CxxInteropSupport.jsObjectIDRawValue(result.root())
 
-        let owned = unsafe WebKit.JavaScriptEvaluationOwnedResult(consuming: result)
-        let graph = unsafe JavaScriptEvaluationDecodingGraph<UInt64>(owned)
+        let owned = WebKit.JavaScriptEvaluationOwnedResult(consuming: result)
+        let graph = JavaScriptEvaluationDecodingGraph<UInt64>(owned)
 
         var decoder = JavaScriptEvaluationGraphDecoder(
             storage: Ref(graph),

--- a/Source/WebKit/Shared/RunJavaScriptParameters.h
+++ b/Source/WebKit/Shared/RunJavaScriptParameters.h
@@ -39,10 +39,7 @@ enum class RemoveTransientActivation : bool;
 
 namespace WebKit {
 
-// `SWIFT_NONCOPYABLE` is required here because `JavaScriptEvaluationResult` is non-copyable,
-// and `WTF::Vector<T>` doesn't have any requirements on its copy constructor requiring `T` to be copyable.
-// FIXME: Remove `SWIFT_NONCOPYABLE` once rdar://186141869 is fixed.
-struct SWIFT_NONCOPYABLE RunJavaScriptParameters {
+struct RunJavaScriptParameters {
     IPC::TransferString source;
     JSC::SourceTaintedOrigin taintedness;
     URL sourceURL;
@@ -51,5 +48,18 @@ struct SWIFT_NONCOPYABLE RunJavaScriptParameters {
     WebCore::ForceUserGesture forceUserGesture;
     WebCore::RemoveTransientActivation removeTransientActivation;
 };
+
+}
+
+namespace WebKit::CxxInteropSupport {
+
+using RunJavaScriptParametersArguments = Vector<std::pair<String, JavaScriptEvaluationResult>>;
+using OptionalRunJavaScriptParametersArguments = std::optional<RunJavaScriptParametersArguments>;
+
+// FIXME: Remove this once rdar://186106924 is fixed.
+inline OptionalRunJavaScriptParametersArguments makeOptionalArguments(RunJavaScriptParametersArguments&& arguments)
+{
+    return { WTF::move(arguments) };
+}
 
 }

--- a/Source/WebKit/Shared/RunJavaScriptParameters.swift
+++ b/Source/WebKit/Shared/RunJavaScriptParameters.swift
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if compiler(>=6.4) && HAVE_NEW_CODABLE
+
+import WebKit_Internal
+
+extension WebKit.RunJavaScriptParameters {
+    struct JavaScriptArgument: ~Copyable {
+        let key: String
+        let value: WebKit.JavaScriptEvaluationResult
+    }
+
+    init(
+        source: IPC.TransferString,
+        taintedness: JSC.SourceTaintedOrigin,
+        sourceURL: WTF.URL,
+        runAsAsyncFunction: Bool,
+        arguments: consuming UniqueArray<JavaScriptArgument>?,
+        forceUserGesture: Bool,
+        removeTransientActivation: Bool,
+    ) {
+        let argumentsBox = unsafe Self.makeCxxArguments(consume arguments)
+
+        unsafe self.init(
+            source: source,
+            taintedness: taintedness,
+            sourceURL: sourceURL,
+            runAsAsyncFunction: runAsAsyncFunction ? .Yes : .No,
+            arguments: argumentsBox,
+            forceUserGesture: forceUserGesture ? .Yes : .No,
+            removeTransientActivation: removeTransientActivation ? .Yes : .No
+        )
+    }
+}
+
+extension WebKit.RunJavaScriptParameters {
+    fileprivate typealias Cxx = WebKit.CxxInteropSupport
+
+    fileprivate static func makeCxxArguments(
+        _ arguments: consuming UniqueArray<JavaScriptArgument>?
+    ) -> Cxx.OptionalRunJavaScriptParametersArguments {
+        guard var arguments else {
+            return unsafe .init()
+        }
+
+        var vector = unsafe Cxx.RunJavaScriptParametersArguments()
+        unsafe vector.reserveInitialCapacity(arguments.count)
+
+        while let argument = arguments.popLast() {
+            unsafe vector.append(consuming: .init(first: WTF.String(argument.key), second: argument.value))
+        }
+
+        unsafe vector.reverse()
+
+        return unsafe Cxx.makeOptionalArguments(consuming: vector)
+    }
+}
+
+#endif // compiler(>=6.4) && HAVE_NEW_CODABLE

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NewCodable.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NewCodable.swift
@@ -43,23 +43,24 @@ extension WebPage {
             fatalError()
         }
 
-        guard let transferString = unsafe Optional(fromCxx: IPC.TransferString.create(script())) else {
+        guard let transferString = Optional(fromCxx: IPC.TransferString.create(script())) else {
             fatalError()
         }
 
-        let result = unsafe try await page.runJavaScriptInMainFrame(
+        let parameters = unsafe WebKit.RunJavaScriptParameters(
             source: transferString,
             taintedness: .Untainted,
-            url: .init(),
+            sourceURL: .init(),
             runAsAsyncFunction: true,
             arguments: .init(),
             forceUserGesture: true,
             removeTransientActivation: false,
-            wantsResult: true
         )
 
+        let result = unsafe try await page.runJavaScriptInMainFrame(parameters: parameters, wantsResult: true)
+
         let decoder = JavaScriptEvaluationResultDecoder()
-        return unsafe try decoder.decode(Output.self, from: result)
+        return try decoder.decode(Output.self, from: result)
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.swift
+++ b/Source/WebKit/UIProcess/WebPageProxy.swift
@@ -33,62 +33,36 @@ extension WebKit.WebPageProxy.SelectWithGestureCompletionHandler: @unsafe CxxCom
     typealias Argument = WebKit.SelectWithGestureResult
 }
 
+#if HAVE_NEW_CODABLE
 // This is safe because all conformances to the protocol are safe as long as they don't
 // implement any of the requirements themselves.
-extension WebKit.WebPageProxy.RunJavaScriptInFrameCompletionHandler: @unsafe CxxConsumingCompletionHandler {
+extension WebKit.WebPageProxy.RunJavaScriptInFrameCompletionHandler: CxxConsumingCompletionHandler {
     typealias Argument = WebKit.RunJavaScriptResult
 }
+#endif // HAVE_NEW_CODABLE
 
 extension WebKit.WebPageProxy {
-    #if HAVE_SWIFT_STDLIB_6_4
-    @unsafe
-    struct JavaScriptArgument: ~Copyable {
-        let key: String
-        let value: WebKit.JavaScriptEvaluationResult
-    }
-
+    #if HAVE_NEW_CODABLE
     @MainActor
     func runJavaScriptInMainFrame(
-        source: IPC.TransferString,
-        taintedness: JSC.SourceTaintedOrigin,
-        url: WTF.URL,
-        runAsAsyncFunction: Bool,
-        arguments: consuming UniqueArray<JavaScriptArgument>?,
-        forceUserGesture: Bool,
-        removeTransientActivation: Bool,
+        parameters: consuming WebKit.RunJavaScriptParameters,
         wantsResult: Bool
     ) async throws -> WebKit.JavaScriptEvaluationResult {
-        var argumentsBridge = unsafe WebKit.JavaScriptArgumentsBridge()
-        if var arguments = unsafe arguments {
-            unsafe argumentsBridge = unsafe WebKit.JavaScriptArgumentsBridge(arguments.count)
+        let parametersBox = unsafe CopyableBox(value: parameters)
 
-            while unsafe !arguments.isEmpty {
-                let argument = unsafe arguments.remove(at: 0)
-                unsafe argumentsBridge.append(consuming: WTF.String(argument.key), consuming: argument.value)
-            }
-        }
-
-        let box = unsafe try await withCheckedThrowingContinuation { continuation in
-            let parameters = unsafe WebKit.RunJavaScriptParameters(
-                source: source,
-                taintedness: taintedness,
-                sourceURL: url,
-                runAsAsyncFunction: runAsAsyncFunction ? .Yes : .No,
-                arguments: argumentsBridge.consume(),
-                forceUserGesture: forceUserGesture ? .Yes : .No,
-                removeTransientActivation: removeTransientActivation ? .Yes : .No
-            )
-
+        let box = try await withCheckedThrowingContinuation { continuation in
+            // Guaranteed to be non-nil since `take` is only called once, here.
+            // swift-format-ignore: NeverForceUnwrap
             unsafe runJavaScriptInMainFrame(
-                consuming: parameters,
+                consuming: parametersBox.take()!,
                 wantsResult,
                 consuming: .init { result in
                     do {
                         let evaluationResult = try unsafe result.consume()
-                        let box = unsafe CopyableBox(value: evaluationResult)
-                        unsafe continuation.resume(returning: box)
+                        let box = CopyableBox(value: evaluationResult)
+                        continuation.resume(returning: box)
                     } catch {
-                        unsafe continuation.resume(throwing: error)
+                        continuation.resume(throwing: error)
                     }
                 }
             )
@@ -96,9 +70,9 @@ extension WebKit.WebPageProxy {
 
         // Guaranteed to be non-nil since `take` is only called once, here.
         // swift-format-ignore: NeverForceUnwrap
-        return unsafe box.take()!
+        return box.take()!
     }
-    #endif // HAVE_SWIFT_STDLIB_6_4
+    #endif // HAVE_NEW_CODABLE
 
     private borrowing func editorStateCopy() -> WebKit.EditorState {
         unsafe __editorStateUnsafe().pointee

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -164,6 +164,9 @@
 		0735F3202D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */; };
 		0735F3222D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F3212D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift */; };
 		0735F3242D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F3232D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h */; };
+		0738ABBA304BBECF00987FFB /* RunJavaScriptParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7036C32D72882A00083D04 /* RunJavaScriptParameters.h */; };
+		0738ABBB304BBEE100987FFB /* JavaScriptEvaluationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC7C0AF2D70225500E7297E /* JavaScriptEvaluationResult.h */; };
+		0738ABBD304BD9CA00987FFB /* RunJavaScriptParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0738ABBC304BD9CA00987FFB /* RunJavaScriptParameters.swift */; };
 		0739EAF0301562080066ED1B /* WKPDFHUDView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAEA301561FE0066ED1B /* WKPDFHUDView.h */; };
 		0739EAF13015620C0066ED1B /* WKDefaultPDFHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0739EAEC301561FE0066ED1B /* WKDefaultPDFHUDView.swift */; };
 		0739EAF2301562100066ED1B /* WKPDFPageNumberIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAED301561FE0066ED1B /* WKPDFPageNumberIndicator.h */; };
@@ -3511,6 +3514,7 @@
 		0736B75C260D4A4E00E06994 /* RemoteMediaSessionCoordinatorProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionCoordinatorProxy.cpp; sourceTree = "<group>"; };
 		0736B75D260D4A4F00E06994 /* RemoteMediaSessionCoordinatorProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaSessionCoordinatorProxy.messages.in; sourceTree = "<group>"; };
 		0736B75E260D4A5000E06994 /* RemoteMediaSessionCoordinatorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionCoordinatorProxy.h; sourceTree = "<group>"; };
+		0738ABBC304BD9CA00987FFB /* RunJavaScriptParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunJavaScriptParameters.swift; sourceTree = "<group>"; };
 		0739EAEA301561FE0066ED1B /* WKPDFHUDView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPDFHUDView.h; sourceTree = "<group>"; };
 		0739EAEC301561FE0066ED1B /* WKDefaultPDFHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDefaultPDFHUDView.swift; sourceTree = "<group>"; };
 		0739EAED301561FE0066ED1B /* WKPDFPageNumberIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPDFPageNumberIndicator.h; sourceTree = "<group>"; };
@@ -10599,6 +10603,7 @@
 				4149E97C2E95204700DA5303 /* RTCSocketCreationFlags.h */,
 				41B8D85628C9B8D100E5FA37 /* RTCWebKitEncodedFrameInfo.h */,
 				FA7036C32D72882A00083D04 /* RunJavaScriptParameters.h */,
+				0738ABBC304BD9CA00987FFB /* RunJavaScriptParameters.swift */,
 				077DBAFE303AAE74000AA8FC /* RunJavaScriptResult.h */,
 				0782B70B304680930011880F /* RunJavaScriptResult.swift */,
 				AE213B932DDE47AA0043DE0F /* SafeBrowsingCheckOngoing.h */,
@@ -18589,6 +18594,7 @@
 				3A061A313017E09F00F8873B /* IsolatedSiteStore.h in Headers */,
 				46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */,
 				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,
+				0738ABBB304BBEE100987FFB /* JavaScriptEvaluationResult.h in Headers */,
 				0782B70A30467FC10011880F /* JavaScriptEvaluationResultCxxInteropSupport.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
 				1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */,
@@ -18923,6 +18929,7 @@
 				F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */,
 				442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */,
 				410482CE1DDD324F00F006D0 /* RTCNetwork.h in Headers */,
+				0738ABBA304BBECF00987FFB /* RunJavaScriptParameters.h in Headers */,
 				077DBAFF303AAE74000AA8FC /* RunJavaScriptResult.h in Headers */,
 				46F38E8C2416E6730059375A /* RunningBoardServicesSPI.h in Headers */,
 				DDDFE827284699EC006F1EE5 /* SafariServicesSPI.h in Headers */,
@@ -22351,6 +22358,7 @@
 				2DC18FB4218A6E9E0025A88D /* RemoteLayerTreeViews.mm in Sources */,
 				0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */,
 				1AF572302D690813008266F2 /* RemoteScrollingTreeCocoa.mm in Sources */,
+				0738ABBD304BD9CA00987FFB /* RunJavaScriptParameters.swift in Sources */,
 				0782B70C304680930011880F /* RunJavaScriptResult.swift in Sources */,
 				7BCF70DE2615D06E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm in Sources */,
 				9BF622542C3E8559007F7021 /* SecurityFlags.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
@@ -28,6 +28,50 @@ import Testing
 import NewCodable
 import struct Swift.String
 
+// MARK: Supporting types
+
+@CommonDecodable
+private enum Shape: Equatable {
+    case point
+    case circle(radius: Double)
+    case rectangle(width: Double, height: Double)
+    case pair(Int, Int)
+}
+
+@CommonDecodable
+private struct Person: Equatable {
+    let name: String
+    let age: Int
+}
+
+@CommonDecodable
+private struct Item: Equatable {
+    let name: String
+    let rating: Double?
+}
+
+@CommonDecodable
+private struct Post: Equatable {
+    @CodingKey("date_published")
+    let publishDate: String
+    @DecodableAlias("headline")
+    let title: String
+    @CodableDefault(0)
+    let views: Int
+}
+
+@CommonDecodable
+private struct Team: Equatable {
+    let lead: Person
+    let members: [Person]
+    let scoresByName: [String: Int]
+}
+
+@CommonDecodable
+private struct Empty: Equatable {}
+
+// MARK: Tests
+
 @MainActor
 struct JavaScriptEvaluationTests {
     let page = WebPage()
@@ -211,7 +255,217 @@ struct JavaScriptEvaluationTests {
         await testTypeMismatch(decoding: String.self) { "return null;" }
         await testTypeMismatch(decoding: Double.self) { "return undefined;" }
     }
+
+    @Test
+    func decodingArray() async throws {
+        try await testDecoding([1, 2, 3]) { "return [1, 2, 3];" }
+        try await testDecoding([Int]()) { "return [];" }
+        try await testDecoding(["a", "b"]) { #"return ["a", "b"];"# }
+        try await testDecoding([true, false]) { "return [true, false];" }
+        try await testDecoding([1.5, -0.25]) { "return [1.5, -0.25];" }
+        try await testDecoding(Array(0..<100)) { "return Array.from({ length: 100 }, (_, i) => i);" }
+
+        // The element type applies to every element, so a mixed array only decodes as a type
+        // all of them share.
+        try await testDecoding(["1", "two"]) { #"return ["1", "two"];"# }
+        await testTypeMismatch(decoding: [Int].self) { #"return [1, "two", 3];"# }
+
+        // A hole and an explicit null are both missing values, so both need an optional
+        // element type.
+        try await testDecoding([1, nil, 3]) { "return [1, , 3];" }
+        try await testDecoding([1, nil, 3]) { "return [1, null, 3];" }
+        await testTypeMismatch(decoding: [Int].self) { "return [1, null, 3];" }
+
+        // Only a real array decodes as one; an array-like object does not.
+        await testTypeMismatch(decoding: [Int].self) { "return { 0: 1, length: 1 };" }
+        await testTypeMismatch(decoding: [Int].self) { "return 42;" }
+        await testTypeMismatch(decoding: [Int].self) { #"return "abc";"# }
+        await testTypeMismatch(decoding: [Int].self) { "return null;" }
+
+        // Array decodes every element, but a type reading a fixed number of them pulls only
+        // as many as it needs.
+        try await testDecoding(1..<5) { "return [1, 5];" }
+        await testDataCorrupted(decoding: Range<Int>.self) { "return [5, 1];" }
+    }
+
+    @Test
+    func decodingDictionary() async throws {
+        try await testDecoding(["a": 1, "b": 2]) { "return { a: 1, b: 2 };" }
+        try await testDecoding([String: Int]()) { "return {};" }
+        try await testDecoding(["greeting": "hello"]) { #"return { greeting: "hello" };"# }
+        try await testDecoding(["yes": true, "no": false]) { "return { yes: true, no: false };" }
+
+        // Any string is a usable key, including ones which are not identifiers.
+        try await testDecoding(["with space": 1, "": 2]) { #"return { "with space": 1, "": 2 };"# }
+
+        // A JavaScript key is always a string, so an Int key is parsed back out of one.
+        try await testDecoding([1: "one", 2: "two"]) { #"return { 1: "one", 2: "two" };"# }
+        await testDataCorrupted(decoding: [Int: String].self) { #"return { a: "one" };"# }
+
+        // A null value keeps its key, rather than dropping the entry.
+        try await testDecoding(["a": Int?.none, "b": 2]) { "return { a: null, b: 2 };" }
+        await testTypeMismatch(decoding: [String: Int].self) { "return { a: null };" }
+        await testTypeMismatch(decoding: [String: Int].self) { #"return { a: "1" };"# }
+
+        await testTypeMismatch(decoding: [String: Int].self) { "return [1, 2];" }
+        await testTypeMismatch(decoding: [String: Int].self) { "return 42;" }
+        await testTypeMismatch(decoding: [String: Int].self) { "return null;" }
+    }
+
+    @Test
+    func decodingNestedContainers() async throws {
+        try await testDecoding([[1, 2], [3], []]) { "return [[1, 2], [3], []];" }
+        try await testDecoding([["a": 1], ["b": 2]]) { "return [{ a: 1 }, { b: 2 }];" }
+        try await testDecoding(["outer": ["inner": 1]]) { "return { outer: { inner: 1 } };" }
+        try await testDecoding(["values": [1, 2, 3]]) { "return { values: [1, 2, 3] };" }
+        try await testDecoding([["a": [1]], ["b": [2, 3]]]) { "return [{ a: [1] }, { b: [2, 3] }];" }
+        try await testDecoding([[["deep"]]]) { #"return [[["deep"]]];"# }
+
+        // The result is a graph rather than a tree, so one object reached twice is one entry
+        // decoded twice.
+        try await testDecoding([[1], [1]]) { "const shared = [1]; return [shared, shared];" }
+        try await testDecoding(["x": ["n": 1], "y": ["n": 1]]) {
+            "const shared = { n: 1 }; return { x: shared, y: shared };"
+        }
+
+        // A mismatch nested inside a container is reported like any other.
+        await testTypeMismatch(decoding: [[Int]].self) { "return [[1], 2];" }
+        await testTypeMismatch(decoding: [String: [Int]].self) { #"return { a: "x" };"# }
+    }
+
+    @Test
+    func decodingEnum() async throws {
+        try await testDecoding(Shape.point) { "return { point: {} };" }
+        try await testDecoding(Shape.circle(radius: 2.5)) { "return { circle: { radius: 2.5 } };" }
+        try await testDecoding(Shape.rectangle(width: 3, height: 4)) {
+            "return { rectangle: { width: 3, height: 4 } };"
+        }
+
+        // Associated values without a label are keyed by position instead.
+        try await testDecoding(Shape.pair(1, 2)) { "return { pair: { _0: 1, _1: 2 } };" }
+
+        // Exactly one entry names the case, so neither none nor several will do.
+        await testDataCorrupted(decoding: Shape.self) { "return {};" }
+        await testDataCorrupted(decoding: Shape.self) { "return { point: {}, circle: { radius: 1 } };" }
+
+        // The name has to be a case the enum actually has.
+        await testUnknownKey(decoding: Shape.self) { "return { triangle: {} };" }
+
+        // The associated values are an object, and every one the case declares is required.
+        await testTypeMismatch(decoding: Shape.self) { "return { circle: 2.5 };" }
+        await testDataCorrupted(decoding: Shape.self) { "return { circle: {} };" }
+        await testDataCorrupted(decoding: Shape.self) { "return { rectangle: { width: 3 } };" }
+
+        // The enum itself is an object, whatever a case may look like.
+        await testTypeMismatch(decoding: Shape.self) { #"return "point";"# }
+        await testTypeMismatch(decoding: Shape.self) { "return [1, 2];" }
+        await testTypeMismatch(decoding: Shape.self) { "return null;" }
+    }
+
+    @Test
+    func decodingStruct() async throws {
+        let person = Person(name: "Ada", age: 36)
+
+        try await testDecoding(person) { #"return { name: "Ada", age: 36 };"# }
+        try await testDecoding(Empty()) { "return {};" }
+
+        // Fields are matched by name, so the order the object happens to list them in does
+        // not matter.
+        try await testDecoding(person) { #"return { age: 36, name: "Ada" };"# }
+
+        // A field the struct does not declare is ignored rather than rejected.
+        try await testDecoding(person) { #"return { name: "Ada", age: 36, nickname: "A" };"# }
+        try await testDecoding(Empty()) { "return { anything: 1 };" }
+
+        // Every declared field has to be there, and has to be the right type.
+        await testDataCorrupted(decoding: Person.self) { #"return { name: "Ada" };"# }
+        await testDataCorrupted(decoding: Person.self) { "return {};" }
+        await testTypeMismatch(decoding: Person.self) { #"return { name: "Ada", age: "36" };"# }
+
+        // A struct is an object; nothing else stands in for one.
+        await testTypeMismatch(decoding: Person.self) { #"return "Ada";"# }
+        await testTypeMismatch(decoding: Person.self) { #"return ["Ada", 36];"# }
+        await testTypeMismatch(decoding: Person.self) { "return null;" }
+    }
+
+    @Test
+    func decodingStructWithOptionalField() async throws {
+        try await testDecoding(Item(name: "book", rating: 4.5)) {
+            #"return { name: "book", rating: 4.5 };"#
+        }
+
+        // An optional field is satisfied by an explicit null, by undefined, and by the key
+        // being absent altogether.
+        try await testDecoding(Item(name: "book", rating: nil)) {
+            #"return { name: "book", rating: null };"#
+        }
+        try await testDecoding(Item(name: "book", rating: nil)) {
+            #"return { name: "book", rating: undefined };"#
+        }
+        try await testDecoding(Item(name: "book", rating: nil)) { #"return { name: "book" };"# }
+
+        // Optional means the value may be missing, not that it may be anything.
+        await testTypeMismatch(decoding: Item.self) { #"return { name: "book", rating: "4.5" };"# }
+    }
+
+    @Test
+    func decodingStructWithFieldAttributes() async throws {
+        let post = Post(publishDate: "2026-01-01", title: "Hello", views: 10)
+
+        try await testDecoding(post) {
+            #"return { date_published: "2026-01-01", title: "Hello", views: 10 };"#
+        }
+
+        // @DecodableAlias accepts a second spelling of the same field.
+        try await testDecoding(post) {
+            #"return { date_published: "2026-01-01", headline: "Hello", views: 10 };"#
+        }
+
+        // @CodableDefault supplies the value when the field is absent.
+        try await testDecoding(Post(publishDate: "2026-01-01", title: "Hello", views: 0)) {
+            #"return { date_published: "2026-01-01", title: "Hello" };"#
+        }
+
+        // @CodingKey replaces the property name rather than adding to it.
+        await testDataCorrupted(decoding: Post.self) {
+            #"return { publishDate: "2026-01-01", title: "Hello" };"#
+        }
+    }
+
+    @Test
+    func decodingNestedStruct() async throws {
+        let team = Team(
+            lead: Person(name: "Ada", age: 36),
+            members: [Person(name: "Grace", age: 45), Person(name: "Alan", age: 41)],
+            scoresByName: ["Grace": 1, "Alan": 2]
+        )
+
+        try await testDecoding(team) {
+            """
+            return {
+                lead: { name: "Ada", age: 36 },
+                members: [{ name: "Grace", age: 45 }, { name: "Alan", age: 41 }],
+                scoresByName: { Grace: 1, Alan: 2 },
+            };
+            """
+        }
+
+        try await testDecoding([Person(name: "Ada", age: 36)]) { #"return [{ name: "Ada", age: 36 }];"# }
+        try await testDecoding(["lead": Person(name: "Ada", age: 36)]) {
+            #"return { lead: { name: "Ada", age: 36 } };"#
+        }
+
+        // A failure inside a nested struct surfaces the same as one at the top level.
+        await testDataCorrupted(decoding: Team.self) {
+            #"return { lead: { name: "Ada" }, members: [], scoresByName: {} };"#
+        }
+        await testTypeMismatch(decoding: Team.self) {
+            #"return { lead: { name: "Ada", age: 36 }, members: {}, scoresByName: {} };"#
+        }
+    }
 }
+
+// MARK: Helpers
 
 extension JavaScriptEvaluationTests {
     private func testDecoding<T: CommonDecodable & Equatable>(
@@ -223,14 +477,22 @@ extension JavaScriptEvaluationTests {
         #expect(actual == expectedValue, sourceLocation: sourceLocation)
     }
 
+    private func testDecodingFailure<T: CommonDecodable>(
+        decoding type: T.Type,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ source: () -> String
+    ) async -> CodingError.Decoding? {
+        await #expect(throws: CodingError.Decoding.self, sourceLocation: sourceLocation) {
+            _ = try await page.callJavaScriptv0(returning: T.self, source)
+        }
+    }
+
     private func testTypeMismatch<T: CommonDecodable>(
         decoding type: T.Type,
         sourceLocation: SourceLocation = #_sourceLocation,
         _ source: () -> String
     ) async {
-        let error = await #expect(throws: CodingError.Decoding.self, sourceLocation: sourceLocation) {
-            _ = try await page.callJavaScriptv0(returning: T.self, source)
-        }
+        let error = await testDecodingFailure(decoding: type, sourceLocation: sourceLocation, source)
 
         guard case .typeMismatch = error?.kind else {
             Issue.record("Unexpected CodingError.Decoding type: \(error)", sourceLocation: sourceLocation)
@@ -243,11 +505,22 @@ extension JavaScriptEvaluationTests {
         sourceLocation: SourceLocation = #_sourceLocation,
         _ source: () -> String
     ) async {
-        let error = await #expect(throws: CodingError.Decoding.self, sourceLocation: sourceLocation) {
-            _ = try await page.callJavaScriptv0(returning: T.self, source)
-        }
+        let error = await testDecodingFailure(decoding: type, sourceLocation: sourceLocation, source)
 
         guard case .dataCorrupted = error?.kind else {
+            Issue.record("Unexpected CodingError.Decoding type: \(error)", sourceLocation: sourceLocation)
+            return
+        }
+    }
+
+    private func testUnknownKey<T: CommonDecodable>(
+        decoding type: T.Type,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ source: () -> String
+    ) async {
+        let error = await testDecodingFailure(decoding: type, sourceLocation: sourceLocation, source)
+
+        guard case .unknownKey = error?.kind else {
             Issue.record("Unexpected CodingError.Decoding type: \(error)", sourceLocation: sourceLocation)
             return
         }


### PR DESCRIPTION
#### 9ff2da726ecd3cc90e7cef9c8b058ae9ac0c4e8b
<pre>
[NewCodable] Add the ability to decode collections and containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322965">https://bugs.webkit.org/show_bug.cgi?id=322965</a>
<a href="https://rdar.apple.com/186230853">rdar://186230853</a>

Reviewed by Abrar Rahman Protyasha.

Add support for arrays, enums, dictionaries, and structs.

Also clean up some workarounds that are no longer needed.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift

* Source/WebKit/Shared/JavaScriptEvaluationCodableValue.swift:
* Source/WebKit/Shared/JavaScriptEvaluationDecodingGraph.swift:
(JavaScriptEvaluationDecodingGraph.keyName(for:at:)):
* Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift:
(JavaScriptEvaluationGraphDecoder.decode(_:)): Deleted.
(JavaScriptEvaluationGraphDecoder.decodeNil() throws(CodingError.Decoding:)): Deleted.
(JavaScriptEvaluationGraphDecoder.decodeOptional(_:)): Deleted.
* Source/WebKit/Shared/JavaScriptEvaluationObjectDecoder.swift:
(JavaScriptEvaluationObjectDecoder.keyName(_:)):
* Source/WebKit/Shared/JavaScriptEvaluationResultCxxInteropSupport.h:
(WebKit::CxxInteropSupport::vectorFromValue):
(WebKit::CxxInteropSupport::objectMapFromValue):
(): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift:
(JavaScriptEvaluationTests.decodingArray):
(JavaScriptEvaluationTests.decodingDictionary):
(JavaScriptEvaluationTests.decodingNestedContainers):
(JavaScriptEvaluationTests.decodingEnum):
(JavaScriptEvaluationTests.decodingStruct):
(JavaScriptEvaluationTests.decodingStructWithOptionalField):
(JavaScriptEvaluationTests.decodingStructWithFieldAttributes):
(JavaScriptEvaluationTests.decodingNestedStruct):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResultDecoder.swift:
* Source/WebKit/Shared/RunJavaScriptParameters.h:
(WebKit::CxxInteropSupport::makeOptionalArguments):
(): Deleted.
* Source/WebKit/Shared/RunJavaScriptParameters.swift: Added.
* Source/WebKit/UIProcess/API/Swift/WebPage+NewCodable.swift:
* Source/WebKit/UIProcess/WebPageProxy.swift:
(editorStateCopy): Deleted.
(editorState): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/320569@main">https://commits.webkit.org/320569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/897c3c9818a4c59d4e8926d451bb2f47c042c6ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185191 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59103 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58830 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188146 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6574 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51759 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58767 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/197470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59476 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28122 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/48364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131784 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128494 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57955 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->