### PR TITLE
Tolerate generateMipmap failing for float textures in oes-texture-float-linear.html.

### DIFF
--- a/LayoutTests/fast/canvas/webgl/oes-texture-float-linear-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/oes-texture-float-linear-expected.txt
@@ -1,25 +1,3 @@
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
-CONSOLE MESSAGE: WebGL: drawArrays: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete', or it is a float/half-float type with linear filtering and without the relevant float/half-float linear extension enabled.
 This test verifies the functionality of the OES_texture_float_linear extension, if it is available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -35,20 +13,20 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 0,0,0,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
-PASS should be 255,255,255,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST, OES_texture_float_linear is not enabled
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
@@ -59,20 +37,20 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 0,0,0,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST, OES_texture_float_linear is not enabled
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
@@ -83,20 +61,20 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 0,0,0,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
-PASS should be 255,255,255,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST, OES_texture_float_linear is not enabled
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
@@ -107,20 +85,20 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 0,0,0,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is not enabled
-PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should produce [0, 0, 0, 1.0] with NO_ERROR if OES_texture_float_linear isn't enabled
-PASS should be 0,0,0,255
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
+generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST, OES_texture_float_linear is enabled
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
@@ -131,18 +109,22 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
@@ -155,18 +137,22 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_2D, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
@@ -179,18 +165,22 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with non-Linear filter should succeed with NO_ERROR no matter whether OES_texture_float_linear is enabled or not
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: NEAREST, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
@@ -203,18 +193,22 @@ PASS getError was expected value: NO_ERROR : OES_texture_float texture with Line
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: NEAREST_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_NEAREST, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 
 testing target: TEXTURE_CUBE_MAP, testing format: RGBA, magFilter is: LINEAR, minFilter is: LINEAR_MIPMAP_LINEAR, OES_texture_float_linear is enabled
+PASS getError was expected value: NO_ERROR : should be no errors during texture setup
 PASS getError was expected value: NO_ERROR : OES_texture_float texture with Linear filter should succeed with NO_ERROR if OES_texture_float is enabled
 PASS should be 255,255,255,255
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/webgl/resources/oes-texture-float-and-half-float-linear.js
+++ b/LayoutTests/fast/canvas/webgl/resources/oes-texture-float-and-half-float-linear.js
@@ -140,8 +140,14 @@ function generateTest(extensionTypeName, extensionName, pixelType, prologue) {
 
         if (textureTarget == gl.TEXTURE_2D) {
             gl.texImage2D(gl.TEXTURE_2D, 0, format, format, gl[pixelType], canvas2d);
-            if (minFilter != gl.NEAREST && minFilter !=  gl.LINEAR)
-            gl.generateMipmap(gl.TEXTURE_2D);
+            if (minFilter != gl.NEAREST && minFilter != gl.LINEAR) {
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during texture setup");
+                gl.generateMipmap(gl.TEXTURE_2D);
+                if (gl.getError() != gl.NO_ERROR) {
+                    debug("generateMipmap failed for floating-point TEXTURE_2D -- this is legal -- skipping the rest of this test");
+                    return;
+                }
+            }
         }
         else if (textureTarget == gl.TEXTURE_CUBE_MAP) {
             var targets = [
@@ -153,8 +159,14 @@ function generateTest(extensionTypeName, extensionName, pixelType, prologue) {
                 gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
                 for (var tt = 0; tt < targets.length; ++tt)
                     gl.texImage2D(targets[tt], 0, format, format, gl[pixelType], canvas2d);
-                if (minFilter != gl.NEAREST && minFilter !=  gl.LINEAR)
+                if (minFilter != gl.NEAREST && minFilter != gl.LINEAR) {
+                    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during texture setup");
                     gl.generateMipmap(gl.TEXTURE_CUBE_MAP);
+                    if (gl.getError() != gl.NO_ERROR) {
+                        debug("generateMipmap failed for floating-point TEXTURE_CUBE_MAP -- this is legal -- skipping the rest of this test");
+                        return;
+                    }
+                }
         }
         wtu.drawQuad(gl);
         if (!linear) {

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -974,8 +974,6 @@ webkit.org/b/232330 [ Debug ] compositing/video/video-reflection.html [ Pass Tim
 # Flaky on Mac
 webkit.org/b/148435 storage/domstorage/events/basic-body-attribute.html [ Pass Failure ]
 
-webkit.org/b/149930 fast/canvas/webgl/oes-texture-float-linear.html [ Pass Failure ]
-
 # Imported Blink tests which have not been investigated.
 imported/blink/compositing/video/video-controls-layer-creation-squashing.html [ Pass ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 13ea4c03c17ffc75e47cd08d073e1f203588885f
<pre>
Tolerate generateMipmap failing for float textures in oes-texture-float-linear.html.
<a href="https://bugs.webkit.org/show_bug.cgi?id=322957">https://bugs.webkit.org/show_bug.cgi?id=322957</a>
<a href="https://rdar.apple.com/186229937">rdar://186229937</a>

Reviewed by Dan Glastonbury.

Enabling OES_texture_float implicitly enables WEBGL_color_buffer_float, which
makes ANGLE promote RGBA/FLOAT uploads to the sized internal format RGBA32F. A
sized format must be both color-renderable and filterable to be mipmapped, and
RGBA32F is not filterable until OES_texture_float_linear is enabled, so
generateMipmap returns INVALID_OPERATION. The test called generateMipmap
unconditionally, ignored the error, and then attributed it to the following draw.

Khronos rewrote the upstream test in 2019 to skip the rest of the case when
generateMipmap fails, calling that legal. This is a WebKit-local fork frozen at
its 2013 import, so it never picked that up. The maintained conformance version
of the same test already passes on every mac configuration.

The console messages the old baseline expected came from WebKit&apos;s pre-ANGLE
backend, deleted in 254947@main, and are correctly absent now.

* LayoutTests/fast/canvas/webgl/oes-texture-float-linear-expected.txt:
* LayoutTests/fast/canvas/webgl/resources/oes-texture-float-and-half-float-linear.js:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320188@main">https://commits.webkit.org/320188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf595d4d798d0c028efcbf70e4dc1a2bfb29f0a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148234 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09164722-3544-4038-963b-0039fce6b0bd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143580 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99751 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0103698-c244-4c1a-bf7f-5b0b0cf0ba25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03d8e01b-298b-459a-ab18-968895e8827a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46054 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44288 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43863 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5346 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196102 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41027 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58239 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152809 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47348 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126973 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56747 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18874 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->