### PR TITLE
Expect INVALID_VALUE for out-of-bounds compressed texture dimensions

### DIFF
--- a/LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit-expected.txt
@@ -22,7 +22,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 12
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 13
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 14
@@ -44,7 +44,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 12
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 13
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 14
@@ -66,7 +66,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 12
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 13
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 14
@@ -88,7 +88,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 12
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 13
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 12
@@ -108,7 +108,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_X
@@ -124,7 +124,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Y
@@ -140,7 +140,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Y
@@ -156,7 +156,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Z
@@ -172,7 +172,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Z
@@ -188,7 +188,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 12
@@ -208,7 +208,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_X
@@ -224,7 +224,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Y
@@ -240,7 +240,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Y
@@ -256,7 +256,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Z
@@ -272,7 +272,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Z
@@ -288,7 +288,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 12
@@ -308,7 +308,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_X
@@ -324,7 +324,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Y
@@ -340,7 +340,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Y
@@ -356,7 +356,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Z
@@ -372,7 +372,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Z
@@ -388,7 +388,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 num levels: 14, levels used in positive test: 12
@@ -408,7 +408,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_X
@@ -424,7 +424,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Y
@@ -440,7 +440,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Y
@@ -456,7 +456,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_POSITIVE_Z
@@ -472,7 +472,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 
 TEXTURE_CUBE_MAP_NEGATIVE_Z
@@ -488,7 +488,7 @@ PASS getError was expected value: NO_ERROR : uploading compressed texture should
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 9
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 10
 PASS getError was expected value: NO_ERROR : uploading compressed texture should generate NO_ERROR. level is 11
-PASS getError was expected value: INVALID_OPERATION : width or height out of bounds for level 0: should generate INVALID_VALUE.
+PASS getError was expected value: INVALID_VALUE : width or height out of bounds for level 0: should generate INVALID_VALUE.
 PASS getError was expected value: INVALID_VALUE : level out of bounds: should generate INVALID_VALUE. Size is 256x256
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit.html
+++ b/LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit.html
@@ -223,7 +223,7 @@ function testFormatType(t, test) {
       } else {
         var pixelsNegativeTest1 = new test.dataType(sharedArrayBuffer, 0, dataSize);
         gl.compressedTexImage2D(target, 0, test.format, t.maxSize + test.sizeStep, t.maxSize + test.sizeStep, 0, pixelsNegativeTest1);
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "width or height out of bounds for level 0: should generate INVALID_VALUE.");
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bounds for level 0: should generate INVALID_VALUE.");
         //debug("Level is 0, size is " + (t.maxSize + test.sizeStep) + "x" + (t.maxSize + test.sizeStep));
       }
       // level out of bounds

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -570,9 +570,6 @@ webkit.org/b/118153 compositing/repaint/positioned-movement.html [ Pass Failure 
 
 webkit.org/b/131715 transitions/cancel-transition.html [ Pass Failure ]
 
-# <rdar://problem/16696298>
-webkit.org/b/131886 fast/canvas/webgl/webgl-compressed-texture-size-limit.html [ Pass Failure Timeout ]
-
 webkit.org/b/132385 compositing/repaint/repaint-on-layer-grouping-change.html [ Pass Failure ]
 
 # This test, originally written for Chromium, historically was not testing anything on Mac because


### PR DESCRIPTION
#### 76c4d04808578cda9425ec80246098d32a7be83c
<pre>
Expect INVALID_VALUE for out-of-bounds compressed texture dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=322958">https://bugs.webkit.org/show_bug.cgi?id=322958</a>
<a href="https://rdar.apple.com/186229626">rdar://186229626</a>

Reviewed by Dan Glastonbury.

That is the correct error value to check for.

* LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit-expected.txt:
* LayoutTests/fast/canvas/webgl/webgl-compressed-texture-size-limit.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320192@main">https://commits.webkit.org/320192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4de03e16c395a7bfe1a73a210671cf8ccdfb2a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194296 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6849a05a-ffdd-4da3-80a3-538f03da32b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5dd11de-df68-4d5b-bc12-9fe77a69acef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47466 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124112 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a287e91-575f-4d17-811a-033701fb9c9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46173 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43969 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5478 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196234 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163928 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41028 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58371 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152924 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47455 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56879 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18980 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56250 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56489 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56317 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->