### PR TITLE
Read RGB8 color buffers as RGBA and restore console suppression in webgl2-texture-upload-enums.html

### DIFF
--- a/LayoutTests/fast/canvas/webgl/webgl2-texture-upload-enums.html
+++ b/LayoutTests/fast/canvas/webgl/webgl2-texture-upload-enums.html
@@ -8,7 +8,7 @@
 <script>
 description("Test that glTexImage2D and glTexSubImage2D accept new WebGL 2 enum values");
 
-if (window.internal)
+if (window.internals)
     internals.settings.setWebGLErrorsToConsoleEnabled(false);
 
 var canvas = document.getElementById("canvas");
@@ -53,9 +53,13 @@ var count;
 var offset = 0;
 var index;
 var expected;
-function test(uploadArrayFunction, downloadArrayFunction, components, internalFormat, format, uploadType, downloadType) {
+function test(uploadArrayFunction, downloadArrayFunction, components, internalFormat, format, uploadType, downloadType, downloadFormat, downloadComponents) {
 	var width = 4;
 	var height = 4;
+	if (downloadFormat === undefined)
+		downloadFormat = format;
+	if (downloadComponents === undefined)
+		downloadComponents = components;
 	arrayBuffer = new uploadArrayFunction(2 * width * height * components);
 	var count = 0;
 	for (var i = 0; i < height; ++i) {
@@ -69,15 +73,15 @@ function test(uploadArrayFunction, downloadArrayFunction, components, internalFo
 	shouldBe("gl.getError()", "gl.NO_ERROR");
 	gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, format, uploadType, arrayBuffer);
 	shouldBe("gl.getError()", "gl.NO_ERROR");
-	receiver = new downloadArrayFunction(2 * width * height * components);
-	gl.readPixels(0, 0, width, height, format, downloadType, receiver);
+	receiver = new downloadArrayFunction(2 * width * height * downloadComponents);
+	gl.readPixels(0, 0, width, height, downloadFormat, downloadType, receiver);
 	shouldBe("gl.getError()", "gl.NO_ERROR");
 	count = 0;
 	for (var i = 0; i < height; ++i) {
 		for (var j = 0; j < width; ++j) {
 			for (var k = 0; k < components; ++k) {
 				expected = offset + count++;
-				index = (width * i + j) * components + k;
+				index = (width * i + j) * downloadComponents + k;
 				shouldBe("receiver[index]", "expected");
 			}
 		}
@@ -91,7 +95,7 @@ function test(uploadArrayFunction, downloadArrayFunction, components, internalFo
 
 // FIXME: Read from the textures in shaders
 
-test(Uint8Array, Uint8Array, 3, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
+test(Uint8Array, Uint8Array, 3, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE, gl.RGBA, 4);
 test(Uint8Array, Uint8Array, 4, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
 //test(Uint8Array, Uint8Array, 2, gl.LUMINANCE_ALPHA, gl.LUMINANCE_ALPHA, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
 //test(Uint8Array, Uint8Array, 1, gl.LUMINANCE, gl.LUMINANCE, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
@@ -119,7 +123,7 @@ test(Int16Array, Int32Array, 2, gl.RG16I, gl.RG_INTEGER, gl.SHORT, gl.INT);
 test(Uint32Array, Uint32Array, 2, gl.RG32UI, gl.RG_INTEGER, gl.UNSIGNED_INT, gl.UNSIGNED_INT);
 test(Int32Array, Int32Array, 2, gl.RG32I, gl.RG_INTEGER, gl.INT, gl.INT);
 
-test(Uint8Array, Uint8Array, 3, gl.RGB8, gl.RGB, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
+test(Uint8Array, Uint8Array, 3, gl.RGB8, gl.RGB, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE, gl.RGBA, 4);
 test(Uint8Array, Uint8Array, 3, gl.SRGB8, gl.RGB, gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE);
 test(Int8Array, Int8Array, 3, gl.RGB8_SNORM, gl.RGB, gl.BYTE, gl.BYTE);
 test(Float32Array, Float32Array, 3, gl.RGB16F, gl.RGB, gl.FLOAT, gl.FLOAT);

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1697,7 +1697,7 @@ webkit.org/b/223271 [ Debug ] imported/w3c/web-platform-tests/xhr/event-upload-p
 webkit.org/b/223484 [ arm64 ] compositing/style-change/backface-visibility-change.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/223761 media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag.html [ Pass Timeout ]
-webkit.org/b/222239 fast/canvas/webgl/webgl2-texture-upload-enums.html [ Pass Failure ]
+webkit.org/b/322959 [ x86_64 ] fast/canvas/webgl/webgl2-texture-upload-enums.html [ Failure ]
 
 # Note: Even when fixed, this bug needs to be marked as Slow in debug builds.
 webkit.org/b/222239 webgl/2.0.y/conformance2/state/gl-object-get-calls.html [ Pass Failure Slow ]


### PR DESCRIPTION
#### 091cad83074b8af99d15f8c29336fc760ffff24f
<pre>
Read RGB8 color buffers as RGBA and restore console suppression in webgl2-texture-upload-enums.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=322959">https://bugs.webkit.org/show_bug.cgi?id=322959</a>
<a href="https://rdar.apple.com/186229838">rdar://186229838</a>

Reviewed by Dan Glastonbury.

Two independent problems.

279786@main added a `if (window.internals)` guard to eight sibling tests and
`if (window.internal)` to this one, so setWebGLErrorsToConsoleEnabled(false)
never ran and thirty console messages leaked into the output.

Two cases also read an RGB8 color buffer with RGB/UNSIGNED_BYTE. readPixels
accepts the pair implied by the buffer&apos;s component type, which is
RGBA/UNSIGNED_BYTE here, or the implementation-dependent pair reported by
IMPLEMENTATION_COLOR_READ_FORMAT and _TYPE. Metal has no 24-bit color format so
RGB8 is backed by RGBA8 and ANGLE reports RGBA, making RGB/UNSIGNED_BYTE invalid.
The Vulkan backend behaves the same way, and the upstream conformance test reads
an RGB8 framebuffer as RGBA/UNSIGNED_BYTE. These cases have failed since macOS
moved to ANGLE-on-Metal.

No baseline change is needed: with both fixed, the output matches the existing
expectation again.

* LayoutTests/fast/canvas/webgl/webgl2-texture-upload-enums.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320210@main">https://commits.webkit.org/320210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bca190d9cb6ed2400c359a89eaac3b86168329f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148381 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74fd5fd5-aee5-4543-9ecd-4baf24b51748) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143700 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99861 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abff6c6b-0907-4f56-abda-85bfb9b78eb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0d2bfa7-a663-4092-811c-49f2e6b5a533) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46184 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43976 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5494 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196250 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153258 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58387 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152932 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47467 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56895 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18987 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56266 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56333 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->