### PR TITLE
Return transparent black for a placeholder canvas that has no pushed frame

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1545,7 +1545,6 @@ http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-window-bits.ht
 
 webkit.org/b/307136 http/tests/canvas/ctx.2d-canvas-style-pattern-no-document-leak.html [ Failure Pass ]
 
-imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.resize.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/the-offscreen-canvas/size.large.html [ Skip ]
 
 # MSE in worker is only supported on platform with the GPU process active and where MSE is enabled by default

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -96,7 +96,14 @@ RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostPro
     }
     if (!validateArea())
         return nullptr;
-    // Currently we don't cache transparent black bitmaps of canvases that do not have a context.
+    // Transparent black bitmaps are not cached.
+    return createTransparentBlackImageBuffer();
+}
+
+RefPtr<ImageBuffer> CanvasBase::createTransparentBlackImageBuffer() const
+{
+    if (!validateArea())
+        return nullptr;
     return ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
 }
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -76,6 +76,7 @@ public:
     virtual void setSizeForControllingContext(IntSize) = 0;
 
     WEBCORE_EXPORT RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+    RefPtr<ImageBuffer> createTransparentBlackImageBuffer() const;
 
     WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const;
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -159,6 +159,10 @@ PixelFormat PlaceholderRenderingContext::pixelFormat() const
 
 RefPtr<ImageBuffer> PlaceholderRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
 {
+    if (!m_buffer) {
+        // Transparent black bitmaps are not cached.
+        return canvas().createTransparentBlackImageBuffer();
+    }
     return m_buffer;
 }
 


### PR DESCRIPTION
#### a8a0b96619f38d1a9cb165fd57e25c27cee2ef7b
<pre>
Return transparent black for a placeholder canvas that has no pushed frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=322961">https://bugs.webkit.org/show_bug.cgi?id=322961</a>
<a href="https://rdar.apple.com/186229685">rdar://186229685</a>

Reviewed by Said Abou-Hallawa.

CanvasBase::makeRenderingResultsAvailable fabricates a transparent black bitmap
only when a canvas has no rendering context. A placeholder canvas has an internal
PlaceholderRenderingContext, so it took the context path instead, and that
returned nullptr until the OffscreenCanvas pushed its first frame. ImageBitmap
turned the null into &quot;Cannot create ImageBitmap from canvas that can&apos;t be
rendered&quot;, which rejected the promise and timed out two subtests.

HTML&apos;s usability check makes an HTMLCanvasElement source bad only when a
dimension is zero, so a sized placeholder with no pushed frame is good and must
produce a transparent black bitmap. PlaceholderRenderingContext already reports
isSurfaceBufferTransparentBlack() when it has no buffer, so the class modelled
this correctly for painting and simply did not apply it when asked for a buffer.
createPattern, toDataURL, toBlob and toVideoFrame reach the same path.

* LayoutTests/TestExpectations:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
(WebCore::CanvasBase::createTransparentBlackImageBuffer const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::surfaceBufferToImageBuffer):

Canonical link: <a href="https://commits.webkit.org/320202@main">https://commits.webkit.org/320202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cedc75af985128475206b0747a9699251b27cb83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58027 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47495 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124136 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46202 "Exiting early after 10 failures. 10 tests run. 1 failures") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5509 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48690 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196265 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57698 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41036 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58402 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152948 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47482 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130693 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56910 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56281 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56348 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->