### PR TITLE
[visionOS] Log the negotiated cp_layer_renderer_layout in CompositorCoordinator

### DIFF
--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -70,6 +70,19 @@ static std::optional<WebCore::IntSize> sizeFromLayerProperties(cp_layer_renderer
     return WebCore::IntSize { defaultWidth, defaultHeight };
 }
 
+static ASCIILiteral layerRendererLayoutName(cp_layer_renderer_layout layout)
+{
+    switch (layout) {
+    case cp_layer_renderer_layout_dedicated:
+        return "dedicated"_s;
+    case cp_layer_renderer_layout_shared:
+        return "shared"_s;
+    case cp_layer_renderer_layout_layered:
+        return "layered"_s;
+    }
+    return "unknown"_s;
+}
+
 namespace WebKit {
 
 using namespace PAL;
@@ -114,7 +127,13 @@ void CompositorCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoC
     }
 
     m_foveationEnabled = cp_layer_renderer_configuration_get_foveation_enabled(defaultConfiguration.get());
-    m_layeredModeEnabled = cp_layer_renderer_configuration_get_layout(defaultConfiguration.get());
+
+    // FIXME: rdar://183548202 - m_layeredModeEnabled cannot distinguish the shared layout from the
+    // layered one, and the viewport packing in render() assumes the shared layout unconditionally.
+    // Log the negotiated layout so a repro can be attributed without a new build.
+    auto layout = cp_layer_renderer_configuration_get_layout(defaultConfiguration.get());
+    RELEASE_LOG(XR, "CompositorCoordinator: negotiated layer renderer layout is %" PUBLIC_LOG_STRING " (%u), foveation %d", layerRendererLayoutName(layout).characters(), static_cast<unsigned>(layout), m_foveationEnabled);
+    m_layeredModeEnabled = layout;
 
     auto defaultDepthRange = cp_layer_renderer_configuration_get_default_depth_range(defaultConfiguration.get());
     m_depthRange.near = std::min(defaultDepthRange.x, defaultDepthRange.y);


### PR DESCRIPTION
#### 1b080c336e8a7679093e8d9bc0d54623d699b31c
<pre>
[visionOS] Log the negotiated cp_layer_renderer_layout in CompositorCoordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=322967">https://bugs.webkit.org/show_bug.cgi?id=322967</a>
<a href="https://rdar.apple.com/186232387">rdar://186232387</a>

Reviewed by Cameron McCormack.

CompositorCoordinator stores cp_layer_renderer_configuration_get_layout() into a
bool, so the shared and layered layouts both collapse to true and cannot be told
apart. render() then packs the two views side by side unconditionally, which is
only correct for the shared layout; under the others the second view is displaced
by the first viewport&apos;s width inside a texture that is not double width and is
clipped at the texture edge.

Nothing currently records which layout was negotiated, which makes an
intermittent occurrence impossible to attribute after the fact. Log it, along
with the foveation state that determines the viewport widths.

This is behaviour neutral: the layout is captured into a local, logged, and then
assigned to m_layeredModeEnabled exactly as before.

* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(layerRendererLayoutName):
(WebKit::CompositorCoordinator::getPrimaryDeviceInfo):

Canonical link: <a href="https://commits.webkit.org/320141@main">https://commits.webkit.org/320141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b0c2c8d15d0819a71e89319404a9b661064a035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148240 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6067402e-6b79-440b-bdab-f56a9be9198f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143588 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99754 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/191defec-bfc0-4c15-be4c-fed51230d394) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186902 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e01d0c38-72f9-4cd1-a0d0-b1585eb93072) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43869 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5352 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196108 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57541 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40997 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58245 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152814 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47355 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126979 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56753 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18880 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->