### PR TITLE
[SVG] calcMode="paced" is ignored for number, length, and point list animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS calcMode=paced on a length list spaces segments by distance, not uniformly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>calcMode=paced on a length list spaces segments by distance</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">
+    <text id="target" x="0 0" y="20"><animate attributeName="x" calcMode="paced"
+             values="0 0; 0 10; 0 100" begin="0s" dur="10s"/></text>
+</svg>
+
+<script>
+async_test(t => {
+    window.onload = () => {
+        const svg = document.querySelector("svg");
+        svg.pauseAnimations();
+        svg.setCurrentTime(5);
+        requestAnimationFrame(t.step_func_done(() => {
+            assert_approx_equals(document.getElementById("target").x.animVal.getItem(1).value, 50, 1);
+        }));
+    };
+}, "calcMode=paced on a length list spaces segments by distance, not uniformly");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS calcMode=paced on a number list spaces segments by distance, not uniformly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>calcMode=paced on a number list spaces segments by distance</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">
+    <text id="target" x="10" y="20" rotate="0 0"><animate attributeName="rotate" calcMode="paced"
+             values="0 0; 0 10; 0 100" begin="0s" dur="10s"/></text>
+</svg>
+
+<script>
+async_test(t => {
+    window.onload = () => {
+        const svg = document.querySelector("svg");
+        svg.pauseAnimations();
+        svg.setCurrentTime(5);
+        requestAnimationFrame(t.step_func_done(() => {
+            assert_approx_equals(document.getElementById("target").rotate.animVal.getItem(1).value, 50, 1);
+        }));
+    };
+}, "calcMode=paced on a number list spaces segments by distance, not uniformly");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS calcMode=paced on a point list spaces segments by distance, not uniformly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>calcMode=paced on a point list spaces segments by distance</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">
+    <polyline id="target" points="0,0 0,0" fill="none" stroke="black">
+        <animate attributeName="points" calcMode="paced"
+                 values="0,0 0,0; 0,0 5,0; 0,0 100,0" begin="0s" dur="10s"/>
+    </polyline>
+</svg>
+
+<script>
+async_test(t => {
+    window.onload = () => {
+        const svg = document.querySelector("svg");
+        svg.pauseAnimations();
+        svg.setCurrentTime(5);
+        requestAnimationFrame(t.step_func_done(() => {
+            assert_approx_equals(document.getElementById("target").getBBox().width, 50, 1);
+        }));
+    };
+}, "calcMode=paced on a point list spaces segments by distance, not uniformly");
+</script>

--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -193,7 +193,6 @@ void SVGAnimateElementBase::stopAnimation(SVGElement* targetElement)
 
 std::optional<float> SVGAnimateElementBase::calculateDistance(const String& fromString, const String& toString)
 {
-    // FIXME: A return value of float is not enough to support paced animations on lists.
     RefPtr target = targetElement();
     if (!target)
         return { };

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
@@ -27,11 +27,13 @@
 
 #include "SVGAnimationAdditiveListFunction.h"
 #include "SVGElement.h"
+#include "SVGLengthContext.h"
 #include "SVGLengthList.h"
 #include "SVGNumberList.h"
 #include "SVGPointList.h"
 #include "SVGTransformDistance.h"
 #include "SVGTransformList.h"
+#include <cmath>
 
 namespace WebCore {
 
@@ -79,6 +81,25 @@ public:
             value = Base::animate(progress, repeatCount, from, to, toAtEndOfDuration, value);
             animatedItems[i]->value().setValue(lengthContext, value, lengthType, lengthMode);
         }
+    }
+
+    std::optional<float> calculateDistance(SVGElement& targetElement, const String& from, const String& to) const override
+    {
+        auto fromList = SVGLengthList::create(m_from->lengthMode());
+        auto toList = SVGLengthList::create(m_to->lengthMode());
+        if (!fromList->parse(from) || !toList->parse(to))
+            return { };
+
+        auto& fromItems = fromList->items();
+        auto& toItems = toList->items();
+        if (fromItems.isEmpty() || fromItems.size() != toItems.size())
+            return { };
+
+        SVGLengthContext lengthContext(&targetElement);
+        float distance = 0;
+        for (unsigned i = 0; i < fromItems.size(); ++i)
+            distance += std::abs(toItems[i]->value().value(lengthContext) - fromItems[i]->value().value(lengthContext));
+        return distance;
     }
 
 private:
@@ -134,6 +155,24 @@ public:
         }
     }
 
+    std::optional<float> calculateDistance(SVGElement&, const String& from, const String& to) const override
+    {
+        auto fromList = SVGNumberList::create();
+        auto toList = SVGNumberList::create();
+        if (!fromList->parse(from) || !toList->parse(to))
+            return { };
+
+        auto& fromItems = fromList->items();
+        auto& toItems = toList->items();
+        if (fromItems.isEmpty() || fromItems.size() != toItems.size())
+            return { };
+
+        float distance = 0;
+        for (unsigned i = 0; i < fromItems.size(); ++i)
+            distance += std::abs(toItems[i]->value() - fromItems[i]->value());
+        return distance;
+    }
+
 private:
     void addFromAndToValues(SVGElement&) override
     {
@@ -184,6 +223,26 @@ public:
 
             animated = { animatedX, animatedY };
         }
+    }
+
+    std::optional<float> calculateDistance(SVGElement&, const String& from, const String& to) const override
+    {
+        auto fromList = SVGPointList::create();
+        auto toList = SVGPointList::create();
+        if (!fromList->parse(from) || !toList->parse(to))
+            return { };
+
+        auto& fromItems = fromList->items();
+        auto& toItems = toList->items();
+        if (fromItems.isEmpty() || fromItems.size() != toItems.size())
+            return { };
+
+        float distance = 0;
+        for (unsigned i = 0; i < fromItems.size(); ++i) {
+            FloatSize delta = toItems[i]->value() - fromItems[i]->value();
+            distance += delta.diagonalLength();
+        }
+        return distance;
     }
 
 private:


### PR DESCRIPTION
#### 3d07c4b80845385d6269d9c7c2d7d5429b213a99
<pre>
[SVG] calcMode=&quot;paced&quot; is ignored for number, length, and point list animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=322972">https://bugs.webkit.org/show_bug.cgi?id=322972</a>
<a href="https://rdar.apple.com/186242101">rdar://186242101</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox.

Paced calcMode spaces keyTimes proportionally to the distance between
adjacent values, computed via SVGAnimateElementBase::calculateDistance().
The list animation functions never overrode calculateDistance(), so it
returned std::nullopt and calculateKeyTimesForCalcModePaced() bailed out,
silently falling back to uniform timing for number, length, and point
list attributes (e.g. points on &lt;polyline&gt;/&lt;polygon&gt;).

The SVG 2 Animations specification defines calcMode=&quot;paced&quot; as: &quot;Defines
interpolation to produce an even pace of change across the animation.
This is only supported for the data types for which there is an
appropriate distance function defined, which includes only scalar numeric
types plus the types listed in Paced animation and complex types.&quot; Number
lists, length lists, and point lists are among the list types with a
defined distance function, so paced must be honored for them.

Specification (SVG 2), calcMode attribute:
<a href="https://w3c.github.io/svgwg/specs/animations/#CalcModeAttribute">https://w3c.github.io/svgwg/specs/animations/#CalcModeAttribute</a>

Implement calculateDistance() for the numeric list functions, returning
the sum of the per-element distances between the two lists (|delta| for
each scalar in a number or length list, and the Euclidean distance for
each point in a point list). This is the total distance travelled by the
list&apos;s components, which is the quantity the paced key-time computation
consumes, so no interface change is required. calculateDistance() returns
nullopt when the lists fail to parse or differ in length, preserving the
previous fallback. Transform lists and path data have no distance function
defined and continue to fall back to non-paced timing.

Tests: imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation.html
       imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation.html
       imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-lengths-list-animation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-numbers-list-animation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/paced-points-list-animation.html: Added.
* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::calculateDistance):
* Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d07c4b80845385d6269d9c7c2d7d5429b213a99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/896ed4fc-49cf-4b8a-adab-7d87f955bd56) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144313 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100203 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/324473e4-1654-41db-b040-2f0ecf45d6bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124596 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/588ca3e9-e6c0-4a37-a6af-095cbb36fba5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46698 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44838 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44468 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6070 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153781 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153438 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47960 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131262 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57475 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19489 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57084 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->