### PR TITLE
REGRESSION(320051@main): [iOS] fast/quirks/active-quirks-by-domain.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
@@ -80,7 +80,7 @@ https://www.ea.com/
     (none)
 https://www.espn.com/
     AllowLayeredFullscreenVideos
-    NeedsPauseBeforeFullscreenExitQuirk
+    NeedsSuppressedPauseEventOnFullscreenExitQuirk
     ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk
 https://www.facebook.com/
     NeedsFacebookRemoveNotSupportedQuirk


### PR DESCRIPTION
#### 2a3b4f646d3f15fc87e2ffa3a0049756c7546889
<pre>
REGRESSION(320051@main): [iOS] fast/quirks/active-quirks-by-domain.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=322952">https://bugs.webkit.org/show_bug.cgi?id=322952</a>
<a href="https://rdar.apple.com/186225718">rdar://186225718</a>

Reviewed by Cole Carley.

320051@main changed a quirk name from NeedsPauseBeforeFullscreenExitQuirk
to NeedsSuppressedPauseEventOnFullscreenExitQuirk, but test expectations
did not reflect that. We do so with this rebaseline.

* LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320170@main">https://commits.webkit.org/320170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c03ca1496aa3852a45cf6f599d0c9b4ebcbbe16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148260 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23775457-5e8b-4f1b-bf8e-7eb6c6513f5f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143602 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99771 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e601a05-1074-4a82-9a83-303dc48ddb38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124023 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76975e05-bf4a-4064-b832-63afcab8f8c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46090 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44312 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156484 "Found 5 new API test failures: TestWebKitAPI.WebKit.DefaultQuota, TestWebKitAPI.ResourceLoadStatistics.UserGestureLogsUserInteraction, TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.UnifiedPDF.BackgroundAdaptsToColorScheme, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43886 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5372 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153154 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58265 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40517 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152833 "Found 1 new API test failure: TestWTF.WTF_ThreadSafeWeakPtr.GetRacingWithLastWeakReferenceRelease (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47372 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127014 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56773 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56383 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->