### PR TITLE
Cherry-pick(s) a9ffefa3b5d0. rdar://185367233

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -108,6 +108,15 @@ public:
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     std::span<uint8_t> getBufferContents();
 
+<<<<<<< HEAD
+=======
+    bool indirectIndexedBufferRequiresRecomputation(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const;
+    bool indirectBufferRequiresRecomputation(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const;
+
+    void indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool committed = false);
+    void indirectIndexedBufferRecomputed(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool committed = false);
+
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
     std::optional<DrawIndexCacheContainerIterator> canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil) const;
     void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> = nil);
     void skippedDrawIndexedValidation(CommandEncoder&, DrawIndexCacheContainerIterator);
@@ -146,6 +155,11 @@ private:
     void NODELETE setState(State);
     void incrementBufferMapCount();
     void decrementBufferMapCount();
+<<<<<<< HEAD
+=======
+    void takeSlowIndirectIndexValidationPath(CommandBuffer&, Buffer&, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType);
+    void takeSlowIndirectValidationPath(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 
     id<MTLBuffer> m_buffer { nil };
 
@@ -161,8 +175,25 @@ private:
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
     uint32_t m_maxUnsignedIndex { 0 };
     uint16_t m_maxUshortIndex { 0 };
+<<<<<<< HEAD
     uint32_t m_maxValidatedUnsignedIndex { 0 };
     uint16_t m_maxValidatedUshortIndex { 0 };
+=======
+
+    struct IndirectArgsCache {
+        uint64_t indirectOffset { UINT64_MAX };
+        uint64_t indexBufferOffsetInBytes { UINT64_MAX };
+        uint32_t minVertexCount { 0 };
+        uint32_t minInstanceCount { 0 };
+        MTLIndexType indexType { MTLIndexTypeUInt16 };
+        bool committed { false };
+        enum {
+            NoDraw,
+            IndirectDraw,
+            IndirectIndexedDraw
+        } drawType { NoDraw };
+    } m_indirectCache;
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 
     DrawIndexCacheContainer m_drawIndexedCache;
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -547,9 +547,94 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
 #endif
         commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
+<<<<<<< HEAD
             queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
         });
+=======
+
+            queue->writeBuffer(*protectedThis.ptr(), 0, priorData);
+        });
     }
+}
+
+void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, Buffer& apiIndexBuffer, MTLIndexType indexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType primitiveType)
+{
+    WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndexedIndirect calls out of order with submission"); // NOLINT
+    Ref queue = protectedDevice()->getQueue();
+    queue->waitForAllCommitedWorkToComplete();
+    queue->synchronizeResourceAndWait(m_buffer);
+    if (m_buffer.length < indexBufferOffsetInBytes + sizeof(MTLDrawIndexedPrimitivesIndirectArguments))
+        return;
+    auto bufferSubData = span<MTLDrawIndexedPrimitivesIndirectArguments>(m_buffer, indexBufferOffsetInBytes);
+    if (!bufferSubData.data() || !bufferSubData.size())
+        return;
+
+    auto& args = *bufferSubData.data();
+    bool verified = false;
+    auto primitiveOffset = primitiveType == MTLPrimitiveTypeLineStrip || primitiveType == MTLPrimitiveTypeTriangleStrip ? 1u : 0u;
+    if (indexType == MTLIndexTypeUInt16)
+        verified = verifyIndexBufferData<uint16_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
+    else
+        verified = verifyIndexBufferData<uint32_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
+
+    if (!verified) {
+        auto priorData = getBufferContents();
+        queue->clearBuffer(m_buffer, indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
+        queue->finalizeBlitCommandEncoder();
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        if (m_buffer.storageMode == MTLStorageModeManaged)
+            [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
+#endif
+        commandBuffer.addPostCommitHandler([queue, priorData, protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) {
+            [mtlCommandBuffer waitUntilCompleted];
+
+            queue->writeBuffer(*protectedThis.ptr(), 0, priorData);
+        });
+    }
+}
+
+void Buffer::takeSlowIndirectValidationPath(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
+{
+    WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndirect calls out of order with submission"); // NOLINT
+    Ref device { m_device };
+    Ref queue { device->getQueue() };
+    id<MTLRenderPipelineState> renderPipelineState { device->indirectBufferClampPipeline(1) };
+    id<MTLCommandBuffer> commandBuffer { renderPipelineState && m_indirectBuffer && !isDestroyed() ? queue->commandBufferWithDescriptor([MTLCommandBufferDescriptor new]) : nil };
+    if (!commandBuffer) {
+        queue->clearBuffer(m_indirectBuffer, 0, sizeof(MTLDrawPrimitivesIndirectArguments));
+        queue->finalizeBlitCommandEncoder();
+        m_indirectCache = { };
+        return;
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
+    }
+
+    queue->finalizeBlitCommandEncoder();
+    MTLRenderPassDescriptor *renderPassDescriptor { [MTLRenderPassDescriptor new] };
+    renderPassDescriptor.defaultRasterSampleCount = 1;
+    renderPassDescriptor.renderTargetWidth = 1;
+    renderPassDescriptor.renderTargetHeight = 1;
+    id<MTLRenderCommandEncoder> renderCommandEncoder { [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor] };
+    [renderCommandEncoder setRenderPipelineState:renderPipelineState];
+    [renderCommandEncoder setVertexBuffer:m_buffer offset:indirectOffset atIndex:0];
+    [renderCommandEncoder setVertexBuffer:m_indirectBuffer offset:0 atIndex:1];
+    uint32_t minCounts[] { minVertexCount, minInstanceCount };
+    [renderCommandEncoder setVertexBytes:minCounts length:sizeof(minCounts) atIndex:2];
+    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
+    [renderCommandEncoder endEncoding];
+
+    [commandBuffer addCompletedHandler:[device, indirectBuffer = m_indirectBuffer](id<MTLCommandBuffer> completedCommandBuffer) {
+        if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted)
+            return;
+        device->protectedQueue()->scheduleWork([device, indirectBuffer] {
+            if (!indirectBuffer.contents || indirectBuffer.length != sizeof(WebKitMTLDrawPrimitivesIndirectArguments))
+                return;
+            if (static_cast<WebKitMTLDrawPrimitivesIndirectArguments*>(indirectBuffer.contents)->lostOrOOBRead)
+                device->loseTheDevice(WGPUDeviceLostReason_Undefined);
+        });
+    }];
+    queue->commitMTLCommandBuffer(commandBuffer);
+
+    indirectBufferRecomputed(indirectOffset, minVertexCount, minInstanceCount, true);
 }
 
 void Buffer::skippedDrawIndexedValidation(CommandEncoder& commandEncoder, DrawIndexCacheContainerIterator it)
@@ -558,6 +643,54 @@ void Buffer::skippedDrawIndexedValidation(CommandEncoder& commandEncoder, DrawIn
     commandEncoder.skippedDrawIndexedValidation(m_buffer.gpuAddress, it);
 }
 
+<<<<<<< HEAD
+=======
+void Buffer::skippedDrawIndirectIndexedValidation(CommandEncoder& commandEncoder, Buffer* apiIndexBuffer, MTLIndexType indexType, uint32_t indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType primitiveType)
+{
+    if (!apiIndexBuffer)
+        return;
+
+    CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
+    commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, apiIndexBuffer = RefPtr { apiIndexBuffer }, indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount, primitiveType](CommandBuffer& commandBuffer, CommandEncoder& commandEncoder) {
+        if (!weakThis.get())
+            return true;
+
+        RefPtr protectedThis = weakThis.get();
+        protectedThis->m_skippedValidationCommandEncoders.remove(commandEncoder.uniqueId());
+        if (protectedThis->m_mustTakeSlowIndexValidationPath
+            || !protectedThis->m_indirectCache.committed
+            || protectedThis->indirectIndexedBufferRequiresRecomputation(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount)) {
+            protectedThis->takeSlowIndirectIndexValidationPath(commandBuffer, *apiIndexBuffer.get(), indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, primitiveType);
+            commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
+                protectedThis->clearMustTakeSlowIndexValidationPath();
+            });
+        }
+        return true;
+    });
+}
+
+void Buffer::skippedDrawIndirectValidation(CommandEncoder& commandEncoder, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
+{
+    CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
+    commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, indirectOffset, minVertexCount, minInstanceCount](CommandBuffer& commandBuffer, CommandEncoder& commandEncoder) {
+        RefPtr protectedThis { weakThis.get() };
+        if (!protectedThis)
+            return true;
+
+        protectedThis->m_skippedValidationCommandEncoders.remove(commandEncoder.uniqueId());
+        if (protectedThis->m_mustTakeSlowIndexValidationPath
+            || !protectedThis->m_indirectCache.committed
+            || protectedThis->indirectBufferRequiresRecomputation(indirectOffset, minVertexCount, minInstanceCount)) {
+            protectedThis->takeSlowIndirectValidationPath(indirectOffset, minVertexCount, minInstanceCount);
+            commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
+                protectedThis->clearMustTakeSlowIndexValidationPath();
+            });
+        }
+        return true;
+    });
+}
+
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 bool Buffer::didReadOOB(id<MTLIndirectCommandBuffer> icb) const
 {
     auto it = m_didReadOOB.find(icb.gpuResourceID._impl);
@@ -569,6 +702,39 @@ void Buffer::didReadOOB(uint32_t v, id<MTLIndirectCommandBuffer> icb)
     m_didReadOOB.set(icb.gpuResourceID._impl, !!v || didReadOOB(icb));
 }
 
+<<<<<<< HEAD
+=======
+bool Buffer::indirectBufferRequiresRecomputation(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const
+{
+    return m_indirectCache.indirectOffset != indirectOffset || m_indirectCache.minVertexCount != minVertexCount || m_indirectCache.minInstanceCount != minInstanceCount || m_indirectCache.drawType != IndirectArgsCache::IndirectDraw;
+}
+
+bool Buffer::indirectIndexedBufferRequiresRecomputation(MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const
+{
+    return Buffer::indirectBufferRequiresRecomputation(indirectOffset, minVertexCount, minInstanceCount) || m_indirectCache.indexType != indexType || m_indirectCache.indexBufferOffsetInBytes != indexBufferOffsetInBytes || m_indirectCache.drawType != IndirectArgsCache::IndirectIndexedDraw;
+}
+
+void Buffer::indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool committed)
+{
+    m_indirectCache.indirectOffset = indirectOffset;
+    m_indirectCache.minVertexCount = minVertexCount;
+    m_indirectCache.minInstanceCount = minInstanceCount;
+    m_indirectCache.drawType = IndirectArgsCache::IndirectDraw;
+    m_indirectCache.committed = committed;
+}
+
+void Buffer::indirectIndexedBufferRecomputed(MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool committed)
+{
+    m_indirectCache.indexType = indexType;
+    m_indirectCache.indexBufferOffsetInBytes = indexBufferOffsetInBytes;
+    m_indirectCache.indirectOffset = indirectOffset;
+    m_indirectCache.minVertexCount = minVertexCount;
+    m_indirectCache.minInstanceCount = minInstanceCount;
+    m_indirectCache.drawType = IndirectArgsCache::IndirectIndexedDraw;
+    m_indirectCache.committed = committed;
+}
+
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 void Buffer::indirectBufferInvalidated(CommandEncoder& commandEncoder)
 {
     m_maxUnsignedIndex = m_maxUshortIndex = 0;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -950,10 +950,20 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
     splitEncoder = true;
+<<<<<<< HEAD
     encoder.parentEncoder().addBuffer(finalScratch);
     encoder.parentEncoder().addBuffer(intermediateScratch);
     // Device-loss flag lives in intermediateScratch; also retain finalScratch until GPU completion.
     encoder.trackIndirectDeviceLostCheck(intermediateScratch, intermediateScratchOffset, finalScratch);
+=======
+    indexedIndirectBuffer.indirectIndexedBufferRecomputed(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount);
+    encoder.parentEncoder().addOnCommitHandler([weakBuffer = ThreadSafeWeakPtr { indexedIndirectBuffer }, indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount](CommandBuffer&, CommandEncoder&) {
+        if (RefPtr buffer = weakBuffer.get())
+            buffer->indirectIndexedBufferRecomputed(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount, true);
+        return true;
+    });
+    checkForIndirectDrawDeviceLost(device, encoder, indirectBuffer);
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 
     return std::make_pair(finalScratch, finalScratchOffset);
 }
@@ -989,8 +999,18 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValid
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
     splitEncoder = true;
+<<<<<<< HEAD
     encoder.parentEncoder().addBuffer(scratch);
     encoder.trackIndirectDeviceLostCheck(scratch, scratchOffset, nil);
+=======
+    indirectBuffer.indirectBufferRecomputed(indirectOffset, minVertexCount, minInstanceCount);
+    encoder.parentEncoder().addOnCommitHandler([weakBuffer = ThreadSafeWeakPtr { indirectBuffer }, indirectOffset, minVertexCount, minInstanceCount](CommandBuffer&, CommandEncoder&) {
+        if (RefPtr buffer = weakBuffer.get())
+            buffer->indirectBufferRecomputed(indirectOffset, minVertexCount, minInstanceCount, true);
+        return true;
+    });
+    checkForIndirectDrawDeviceLost(device, encoder, indirectBuffer.indirectBuffer());
+>>>>>>> a9ffefa3b5d0 ([WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch)
 
     return std::make_pair(scratch, scratchOffset);
 }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://185367233 to main. [a9ffefa3b5d0] caused a merge conflict. 

```
[WebGPU] Unsubmitted command encoder can poison drawIndirect clamp cache leading to GPU OOB vertex fetch
https://bugs.webkit.org/show_bug.cgi?id=315627
rdar://176482416

Reviewed by Mike Wyrzykowski.

Buffer::m_indirectCache records the {offset, minVertexCount, minInstanceCount}
of the last clamp shader queued into m_indirectBuffer so repeated drawIndirect
calls with identical args can skip re-clamping. indirectBufferRecomputed()
updates this cache at encode time, but m_indirectBuffer is only written when
the containing command buffer executes on the GPU. A GPUCommandEncoder that
records a clamp but is finished and never submitted leaves m_indirectCache
claiming m_indirectBuffer holds {minVertexCount=SMALL} while the GPU buffer
still holds {vertexCount=LARGE} from a prior submission. A subsequent encoder
with matching args takes the cache-hit path, encodes
drawPrimitives:indirectBuffer:m_indirectBuffer without re-clamping, and
fetches LARGE vertices against a SMALL vertex buffer.

The fix adds a `committed` flag to IndirectArgsCache. The miss path registers
an addOnCommitHandler that rewrites the cache as {captured args, committed=true}
when its command buffer is committed (last-committer-wins). The hit path's
preCommit handler is broadened to take the slow path when
m_mustTakeSlowIndexValidationPath || !m_indirectCache.committed (the clamp that
populated the cache was never committed) || indirectBufferRequiresRecomputation
(captured) (the cache was overwritten by a different clamp after this hit). The
encode-time cache key is unchanged, so steady-state in-order rendering encodes
zero extra barriers.

On the slow path, takeSlowIndirectValidationPath re-runs the clamp shader into a
standalone command buffer committed ahead of the consumer on the serial
MTLCommandQueue, so the cache-hit draw reads freshly clamped (in-bounds) args
instead of stale ones. If a clamp pipeline or command buffer cannot be created
(device lost, allocation failure, destroyed buffer), it falls back to
clearBuffer(m_indirectBuffer, 0, ...) and resets m_indirectCache so the draw
becomes a safe no-op and the next frame re-validates. A completion handler
loses the device when the clamp reports lostOrOOBRead, matching the encode-time
clamp path. The previous CPU read/verify/restore of m_buffer and the
verifyIndirectBufferData helper are removed.

The drawIndexedIndirect skip handler gains the same committed and recomputation
checks for symmetry, but its arg-cache never hits today
(indirectIndexedBufferRequiresRecomputation is currently always true), so the
indexed path always re-validates at encode time and is unaffected. Enabling
indexed arg-cache reuse and reworking its slow path are tracked separately in
rdar://180757145

* LayoutTests/fast/webgpu/nocrash/draw-indirect-unsubmitted-encoder-cache-desync-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/draw-indirect-unsubmitted-encoder-cache-desync.html: Added.
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::takeSlowIndirectValidationPath):
(WebGPU::Buffer::skippedDrawIndirectIndexedValidation):
(WebGPU::Buffer::skippedDrawIndirectValidation):
(WebGPU::Buffer::indirectBufferRecomputed):
(WebGPU::Buffer::indirectIndexedBufferRecomputed):
(WebGPU::verifyIndirectBufferData): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):

Originally-landed-as: 305413.1063@safari-7624.5-branch (a9ffefa3b5d0). rdar://185367233


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33d0fd3e39e0412b87b4be6ce67ea67327cc8cf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183971 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57895 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194194 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148264 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59240 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57630 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/194194 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148264 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186926 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/59240 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/194194 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/59240 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/57630 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/194194 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/59240 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5376 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50551 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/57630 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196132 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57565 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/196132 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58269 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/196132 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/58269 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130560 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127021 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56777 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/51712 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56148 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56387 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56215 "") | | | 
<!--EWS-Status-Bubble-End-->