### PR TITLE
WPT: add coverage for synchronizing a list interface object when the reflected attribute changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value-expected.txt
@@ -1,0 +1,22 @@
+
+FAIL SVGNumberList (rotate on text): animVal read before an attribute change reports the new item count assert_equals: animVal after the change expected 2 but got 3
+FAIL SVGNumberList (rotate on text): animVal read before an attribute change reports the new value assert_equals: expected 40 but got 10
+PASS SVGNumberList (rotate on text): the animVal list object survives an attribute change
+PASS SVGNumberList (rotate on text): animVal reports the new item count after a baseVal DOM change
+PASS SVGNumberList (rotate on text): animVal items are read only
+FAIL SVGLengthList (x on text): animVal read before an attribute change reports the new item count assert_equals: animVal after the change expected 2 but got 3
+FAIL SVGLengthList (x on text): animVal read before an attribute change reports the new value assert_equals: expected 7 but got 1
+PASS SVGLengthList (x on text): the animVal list object survives an attribute change
+PASS SVGLengthList (x on text): animVal reports the new item count after a baseVal DOM change
+PASS SVGLengthList (x on text): animVal items are read only
+FAIL SVGPointList (points on polyline, animatedPoints): animVal read before an attribute change reports the new item count assert_equals: animVal after the change expected 2 but got 3
+FAIL SVGPointList (points on polyline, animatedPoints): animVal read before an attribute change reports the new value assert_equals: expected 11 but got 1
+PASS SVGPointList (points on polyline, animatedPoints): the animVal list object survives an attribute change
+PASS SVGPointList (points on polyline, animatedPoints): animVal reports the new item count after a baseVal DOM change
+PASS SVGPointList (points on polyline, animatedPoints): animVal items are read only
+FAIL SVGTransformList (gradientTransform on linearGradient): animVal read before an attribute change reports the new item count assert_equals: animVal after the change expected 2 but got 3
+FAIL SVGTransformList (gradientTransform on linearGradient): animVal read before an attribute change reports the new value assert_equals: expected 11 but got 1
+PASS SVGTransformList (gradientTransform on linearGradient): the animVal list object survives an attribute change
+PASS SVGTransformList (gradientTransform on linearGradient): animVal reports the new item count after a baseVal DOM change
+PASS SVGTransformList (gradientTransform on linearGradient): animVal items are read only
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value.html
@@ -1,0 +1,132 @@
+<!DOCTYPE HTML>
+<title>animVal of a list attribute reflects the base value when nothing is animating</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#DOMInterfacesForReflectingSVGAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedNumberList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#ReadOnlyList">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="stage" width="200" height="100" viewBox="0 0 200 100"></svg>
+<script>
+// "The baseVal and animVal IDL attributes represent the current non-animated
+// value of the reflected attribute. On getting baseVal or animVal, an
+// SVGNumberList object is returned that reflects the base value of the
+// reflected attribute."
+//
+// There is no animation anywhere in this file, so SVG 1.1 and SVG 2 ask for the
+// same thing here and the SVG 2 "animVal is an alias of baseVal" wording does not
+// have to be settled for these subtests to be meaningful.
+//
+// The order of the two reads is the whole point. Reading animVal BEFORE the
+// attribute changes is what catches an implementation that builds animVal once
+// and never refreshes it; the same assertions after the change would pass there.
+
+const SVGNS = "http://www.w3.org/2000/svg";
+const stage = document.getElementById("stage");
+
+const SUBJECTS = [
+  {
+    name: "SVGNumberList (rotate on text)",
+    attr: "rotate", v3: "10 20 30", v2: "40 50", shrunkAt0: 40,
+    build() {
+      const e = document.createElementNS(SVGNS, "text");
+      e.setAttribute("rotate", this.v3);
+      e.setAttribute("x", "5");
+      e.setAttribute("y", "20");
+      stage.appendChild(e);
+      return e;
+    },
+    base: e => e.rotate.baseVal,
+    anim: e => e.rotate.animVal,
+    read: it => it.value,
+    write: (it, v) => { it.value = v; },
+  },
+  {
+    name: "SVGLengthList (x on text)",
+    attr: "x", v3: "1 2 3", v2: "7 8", shrunkAt0: 7,
+    build() {
+      const e = document.createElementNS(SVGNS, "text");
+      e.setAttribute("x", this.v3);
+      e.setAttribute("y", "45");
+      stage.appendChild(e);
+      return e;
+    },
+    base: e => e.x.baseVal,
+    anim: e => e.x.animVal,
+    read: it => it.value,
+    write: (it, v) => { it.value = v; },
+  },
+  {
+    name: "SVGPointList (points on polyline, animatedPoints)",
+    attr: "points", v3: "1,2 3,4 5,6", v2: "11,12 13,14", shrunkAt0: 11,
+    build() {
+      const e = document.createElementNS(SVGNS, "polyline");
+      e.setAttribute("points", this.v3);
+      e.setAttribute("fill", "none");
+      e.setAttribute("stroke", "black");
+      stage.appendChild(e);
+      return e;
+    },
+    base: e => e.points,
+    anim: e => e.animatedPoints,
+    read: it => it.x,
+    write: (it, v) => { it.x = v; },
+  },
+  {
+    name: "SVGTransformList (gradientTransform on linearGradient)",
+    attr: "gradientTransform",
+    v3: "translate(1,2) translate(3,4) translate(5,6)",
+    v2: "translate(11,12) translate(13,14)", shrunkAt0: 11,
+    build() {
+      const e = document.createElementNS(SVGNS, "linearGradient");
+      e.setAttribute("gradientTransform", this.v3);
+      stage.appendChild(e);
+      return e;
+    },
+    base: e => e.gradientTransform.baseVal,
+    anim: e => e.gradientTransform.animVal,
+    read: it => it.matrix.e,
+    write: (it, v) => { it.setTranslate(v, 0); },
+  },
+];
+
+for (const s of SUBJECTS) {
+  test(() => {
+    const el = s.build();
+    const anim = s.anim(el);
+    assert_equals(anim.numberOfItems, 3, "before the change");
+    el.setAttribute(s.attr, s.v2);
+    assert_equals(s.base(el).numberOfItems, 2, "baseVal after the change");
+    assert_equals(anim.numberOfItems, 2, "animVal after the change");
+  }, s.name + ": animVal read before an attribute change reports the new item count");
+
+  test(() => {
+    const el = s.build();
+    const anim = s.anim(el);
+    anim.getItem(0);
+    el.setAttribute(s.attr, s.v2);
+    assert_equals(s.read(anim.getItem(0)), s.shrunkAt0);
+  }, s.name + ": animVal read before an attribute change reports the new value");
+
+  test(() => {
+    const el = s.build();
+    const anim = s.anim(el);
+    el.setAttribute(s.attr, s.v2);
+    assert_equals(s.anim(el), anim, "animVal is [SameObject]");
+  }, s.name + ": the animVal list object survives an attribute change");
+
+  test(() => {
+    const el = s.build();
+    const anim = s.anim(el);
+    const n = anim.numberOfItems;
+    s.base(el).removeItem(2);
+    assert_equals(n, 3, "before the change");
+    assert_equals(anim.numberOfItems, 2, "animVal after the change");
+  }, s.name + ": animVal reports the new item count after a baseVal DOM change");
+
+  test(() => {
+    const el = s.build();
+    const item = s.anim(el).getItem(0);
+    assert_throws_dom("NoModificationAllowedError", () => { s.write(item, 42); });
+  }, s.name + ": animVal items are read only");
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize-expected.txt
@@ -1,0 +1,56 @@
+
+PASS SVGNumberList (rotate on text): getItem returns the same object for one index, with no attribute change
+FAIL SVGNumberList (rotate on text): a same-count change updates the values of the held items assert_equals: held item 0 expected 40 but got 10
+FAIL SVGNumberList (rotate on text): a same-count change keeps the held item in the list assert_equals: the object at index 0 is unchanged expected object "[object SVGNumber]" but got object "[object SVGNumber]"
+FAIL SVGNumberList (rotate on text): the held item is still attached after a same-count change assert_equals: the list reports the value written through the held item expected 42 but got 40
+FAIL SVGNumberList (rotate on text): a grow updates the held item and appends new ones assert_equals: held item 0 expected 40 but got 10
+FAIL SVGNumberList (rotate on text): a shrink updates the held items that are still in range assert_equals: the item still in range expected 40 but got 10
+PASS SVGNumberList (rotate on text): a shrink detaches the truncated item, which keeps its value
+PASS SVGNumberList (rotate on text): the truncated item stops reaching the element and stops being read only
+PASS SVGNumberList (rotate on text): the list interface object survives the change
+PASS SVGLengthList (x on text): getItem returns the same object for one index, with no attribute change
+FAIL SVGLengthList (x on text): a same-count change updates the values of the held items assert_equals: held item 0 expected 7 but got 1
+FAIL SVGLengthList (x on text): a same-count change keeps the held item in the list assert_equals: the object at index 0 is unchanged expected object "[object SVGLength]" but got object "[object SVGLength]"
+FAIL SVGLengthList (x on text): the held item is still attached after a same-count change assert_equals: the list reports the value written through the held item expected 42 but got 7
+FAIL SVGLengthList (x on text): a grow updates the held item and appends new ones assert_equals: held item 0 expected 7 but got 1
+FAIL SVGLengthList (x on text): a shrink updates the held items that are still in range assert_equals: the item still in range expected 7 but got 1
+PASS SVGLengthList (x on text): a shrink detaches the truncated item, which keeps its value
+PASS SVGLengthList (x on text): the truncated item stops reaching the element and stops being read only
+PASS SVGLengthList (x on text): the list interface object survives the change
+PASS SVGPointList (points on polyline): getItem returns the same object for one index, with no attribute change
+FAIL SVGPointList (points on polyline): a same-count change updates the values of the held items assert_equals: held item 0 expected 11 but got 1
+FAIL SVGPointList (points on polyline): a same-count change keeps the held item in the list assert_equals: the object at index 0 is unchanged expected object "[object SVGPoint]" but got object "[object SVGPoint]"
+FAIL SVGPointList (points on polyline): the held item is still attached after a same-count change assert_equals: the list reports the value written through the held item expected 42 but got 11
+FAIL SVGPointList (points on polyline): a grow updates the held item and appends new ones assert_equals: held item 0 expected 11 but got 1
+FAIL SVGPointList (points on polyline): a shrink updates the held items that are still in range assert_equals: the item still in range expected 11 but got 1
+PASS SVGPointList (points on polyline): a shrink detaches the truncated item, which keeps its value
+PASS SVGPointList (points on polyline): the truncated item stops reaching the element and stops being read only
+PASS SVGPointList (points on polyline): the list interface object survives the change
+PASS SVGTransformList (transform on g): getItem returns the same object for one index, with no attribute change
+PASS SVGTransformList (transform on g): a same-count change updates the values of the held items
+PASS SVGTransformList (transform on g): a same-count change keeps the held item in the list
+PASS SVGTransformList (transform on g): the held item is still attached after a same-count change
+PASS SVGTransformList (transform on g): a grow updates the held item and appends new ones
+PASS SVGTransformList (transform on g): a shrink updates the held items that are still in range
+PASS SVGTransformList (transform on g): a shrink detaches the truncated item, which keeps its value
+PASS SVGTransformList (transform on g): the truncated item stops reaching the element and stops being read only
+PASS SVGTransformList (transform on g): the list interface object survives the change
+PASS SVGTransformList (gradientTransform on linearGradient): getItem returns the same object for one index, with no attribute change
+PASS SVGTransformList (gradientTransform on linearGradient): a same-count change updates the values of the held items
+PASS SVGTransformList (gradientTransform on linearGradient): a same-count change keeps the held item in the list
+PASS SVGTransformList (gradientTransform on linearGradient): the held item is still attached after a same-count change
+PASS SVGTransformList (gradientTransform on linearGradient): a grow updates the held item and appends new ones
+PASS SVGTransformList (gradientTransform on linearGradient): a shrink updates the held items that are still in range
+PASS SVGTransformList (gradientTransform on linearGradient): a shrink detaches the truncated item, which keeps its value
+PASS SVGTransformList (gradientTransform on linearGradient): the truncated item stops reaching the element and stops being read only
+PASS SVGTransformList (gradientTransform on linearGradient): the list interface object survives the change
+FAIL SVGTransformList (transform): a changed transform function keeps the held item in the list assert_equals: the object at index 0 is unchanged expected object "[object SVGTransform]" but got object "[object SVGTransform]"
+FAIL SVGTransformList (transform): a changed transform function updates the held item's type and matrix assert_equals: type expected 3 but got 2
+FAIL SVGTransformList (transform): swapping two transform functions keeps both held items assert_equals: index 0 expected object "[object SVGTransform]" but got object "[object SVGTransform]"
+PASS SVGTransformList (transform): an empty list detaches every item
+FAIL SVGTransformList (gradientTransform): a changed transform function keeps the held item in the list assert_equals: the object at index 0 is unchanged expected object "[object SVGTransform]" but got object "[object SVGTransform]"
+FAIL SVGTransformList (gradientTransform): a changed transform function updates the held item's type and matrix assert_equals: type expected 3 but got 2
+FAIL SVGTransformList (gradientTransform): swapping two transform functions keeps both held items assert_equals: index 0 expected object "[object SVGTransform]" but got object "[object SVGTransform]"
+PASS SVGTransformList (gradientTransform): an empty list detaches every item
+PASS SVGStringList: a change replaces the list rather than updating items
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize.html
@@ -1,0 +1,281 @@
+<!DOCTYPE HTML>
+<title>Synchronizing a list interface object when the reflected attribute changes</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#SynchronizingReflectedValues">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermSynchronizeList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermDetach">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#TransformMatrixObject">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="stage" width="200" height="100" viewBox="0 0 200 100"></svg>
+<script>
+// A base value change runs the steps for synchronizing a list interface object.
+// Step 4.1 is the only detach and is guarded by "If length > new length", so a
+// held item object survives a same-count change, a grow, and the part of a
+// shrink that is still in range. Step 4.4 then sets its value. This file has one
+// subtest per branch per list interface, and it keeps identity assertions in
+// separate subtests from value assertions: an engine that returns a fresh
+// wrapper object from every getItem call fails the identity ones for an
+// unrelated reason, and the value ones say what an author actually loses.
+
+const SVGNS = "http://www.w3.org/2000/svg";
+const stage = document.getElementById("stage");
+
+const SUBJECTS = [
+  {
+    name: "SVGNumberList (rotate on text)",
+    attr: "rotate",
+    v3: "10 20 30", v3b: "40 50 60", v4: "40 50 60 70", v2: "40 50",
+    newAt: [40, 50, 60], shrunkAt: [40, 50], oldAt: [10, 20, 30],
+    build() {
+      const e = document.createElementNS(SVGNS, "text");
+      e.setAttribute("rotate", this.v3);
+      e.setAttribute("x", "5");
+      e.setAttribute("y", "20");
+      stage.appendChild(e);
+      return e;
+    },
+    list: e => e.rotate.baseVal,
+    read: it => it.value,
+    write: (it, v) => { it.value = v; },
+  },
+  {
+    name: "SVGLengthList (x on text)",
+    attr: "x",
+    v3: "1 2 3", v3b: "7 8 9", v4: "7 8 9 10", v2: "7 8",
+    newAt: [7, 8, 9], shrunkAt: [7, 8], oldAt: [1, 2, 3],
+    build() {
+      const e = document.createElementNS(SVGNS, "text");
+      e.setAttribute("x", this.v3);
+      e.setAttribute("y", "45");
+      stage.appendChild(e);
+      return e;
+    },
+    list: e => e.x.baseVal,
+    read: it => it.value,
+    write: (it, v) => { it.value = v; },
+  },
+  {
+    name: "SVGPointList (points on polyline)",
+    attr: "points",
+    v3: "1,2 3,4 5,6", v3b: "11,12 13,14 15,16",
+    v4: "11,12 13,14 15,16 17,18", v2: "11,12 13,14",
+    newAt: [11, 13, 15], shrunkAt: [11, 13], oldAt: [1, 3, 5],
+    build() {
+      const e = document.createElementNS(SVGNS, "polyline");
+      e.setAttribute("points", this.v3);
+      e.setAttribute("fill", "none");
+      e.setAttribute("stroke", "black");
+      stage.appendChild(e);
+      return e;
+    },
+    list: e => e.points,
+    read: it => it.x,
+    write: (it, v) => { it.x = v; },
+  },
+  {
+    name: "SVGTransformList (transform on g)",
+    attr: "transform",
+    v3: "translate(1,2) translate(3,4) translate(5,6)",
+    v3b: "translate(11,12) translate(13,14) translate(15,16)",
+    v4: "translate(11,12) translate(13,14) translate(15,16) translate(17,18)",
+    v2: "translate(11,12) translate(13,14)",
+    newAt: [11, 13, 15], shrunkAt: [11, 13], oldAt: [1, 3, 5],
+    build() {
+      const e = document.createElementNS(SVGNS, "g");
+      e.setAttribute("transform", this.v3);
+      stage.appendChild(e);
+      return e;
+    },
+    list: e => e.transform.baseVal,
+    read: it => it.matrix.e,
+    write: (it, v) => { it.setTranslate(v, 0); },
+  },
+  {
+    name: "SVGTransformList (gradientTransform on linearGradient)",
+    attr: "gradientTransform",
+    v3: "translate(1,2) translate(3,4) translate(5,6)",
+    v3b: "translate(11,12) translate(13,14) translate(15,16)",
+    v4: "translate(11,12) translate(13,14) translate(15,16) translate(17,18)",
+    v2: "translate(11,12) translate(13,14)",
+    newAt: [11, 13, 15], shrunkAt: [11, 13], oldAt: [1, 3, 5],
+    build() {
+      const e = document.createElementNS(SVGNS, "linearGradient");
+      e.setAttribute("gradientTransform", this.v3);
+      stage.appendChild(e);
+      return e;
+    },
+    list: e => e.gradientTransform.baseVal,
+    read: it => it.matrix.e,
+    write: (it, v) => { it.setTranslate(v, 0); },
+  },
+];
+
+for (const s of SUBJECTS) {
+  // Precondition. If this fails, the identity subtests below cannot be read as
+  // statements about the synchronize algorithm.
+  test(() => {
+    const list = s.list(s.build());
+    assert_equals(list.getItem(0), list.getItem(0),
+                  "getItem must return the same object for the same index");
+  }, s.name + ": getItem returns the same object for one index, with no attribute change");
+
+  // Same item count. Steps 4.1 and 4.2 are both skipped.
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const held = [list.getItem(0), list.getItem(1), list.getItem(2)];
+    el.setAttribute(s.attr, s.v3b);
+    for (let i = 0; i < 3; i++)
+      assert_equals(s.read(held[i]), s.newAt[i], "held item " + i);
+  }, s.name + ": a same-count change updates the values of the held items");
+
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const held = list.getItem(0);
+    el.setAttribute(s.attr, s.v3b);
+    assert_equals(list.getItem(0), held, "the object at index 0 is unchanged");
+  }, s.name + ": a same-count change keeps the held item in the list");
+
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const held = list.getItem(0);
+    el.setAttribute(s.attr, s.v3b);
+    s.write(held, 42);
+    assert_equals(s.read(s.list(el).getItem(0)), 42,
+                  "the list reports the value written through the held item");
+  }, s.name + ": the held item is still attached after a same-count change");
+
+  // The list grows. Step 4.2 appends, step 4.4 updates everything.
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const held = list.getItem(0);
+    el.setAttribute(s.attr, s.v4);
+    assert_equals(list.numberOfItems, 4, "numberOfItems");
+    assert_equals(s.read(held), s.newAt[0], "held item 0");
+  }, s.name + ": a grow updates the held item and appends new ones");
+
+  // The list shrinks. Step 4.1 detaches only the items at or above new length.
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const survivor = list.getItem(0);
+    el.setAttribute(s.attr, s.v2);
+    assert_equals(list.numberOfItems, 2, "numberOfItems");
+    assert_equals(s.read(survivor), s.shrunkAt[0], "the item still in range");
+  }, s.name + ": a shrink updates the held items that are still in range");
+
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const truncated = list.getItem(2);
+    el.setAttribute(s.attr, s.v2);
+    assert_equals(s.read(truncated), s.oldAt[2],
+                  "a detached object keeps the value it had");
+  }, s.name + ": a shrink detaches the truncated item, which keeps its value");
+
+  // Asserts against the LIST, never against the serialized attribute string. An
+  // implementation may reserialize the attribute in a canonical form that differs
+  // from the author's string (for instance dropping the U+002C between an
+  // SVGPoint's x and y), and comparing strings would read that as a value change.
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    const truncated = list.getItem(2);
+    el.setAttribute(s.attr, s.v2);
+    s.write(truncated, 42);
+    const values = [];
+    for (let i = 0; i < list.numberOfItems; i++)
+      values.push(s.read(list.getItem(i)));
+    assert_equals(values.indexOf(42), -1,
+                  "a detached object is no longer associated with the element, so the "
+                  + "write landed nowhere in the list: got [" + values.join(",") + "]");
+    assert_equals(s.read(truncated), 42,
+                  "a detached object is no longer read only");
+  }, s.name + ": the truncated item stops reaching the element and stops being read only");
+
+  // The list object itself is [SameObject] and is not replaced.
+  test(() => {
+    const el = s.build();
+    const list = s.list(el);
+    el.setAttribute(s.attr, s.v3b);
+    assert_equals(s.list(el), list, "the list object is not replaced");
+  }, s.name + ": the list interface object survives the change");
+}
+
+// Step 4.4 carries no condition on the transform function, and 4.4.4 requires
+// the item's matrix object to be updated rather than replaced.
+for (const attr of ["transform", "gradientTransform"]) {
+  const build = (value) => {
+    const e = document.createElementNS(SVGNS,
+      attr === "transform" ? "g" : "linearGradient");
+    e.setAttribute(attr, value);
+    stage.appendChild(e);
+    return e;
+  };
+  const listOf = (e) => attr === "transform" ? e.transform.baseVal
+                                             : e.gradientTransform.baseVal;
+
+  test(() => {
+    const el = build("translate(1,2)");
+    const list = listOf(el);
+    const held = list.getItem(0);
+    el.setAttribute(attr, "scale(3)");
+    assert_equals(list.getItem(0), held, "the object at index 0 is unchanged");
+  }, "SVGTransformList (" + attr + "): a changed transform function keeps the held item in the list");
+
+  // Separate from the identity subtest above on purpose: this one is readable in
+  // an engine that returns a fresh wrapper from every getItem call.
+  test(() => {
+    const el = build("translate(1,2)");
+    const list = listOf(el);
+    const held = list.getItem(0);
+    const matrix = held.matrix;
+    el.setAttribute(attr, "scale(3)");
+    assert_equals(held.type, SVGTransform.SVG_TRANSFORM_SCALE, "type");
+    assert_equals(held.matrix, matrix, "the matrix object is not replaced");
+    assert_equals(matrix.a, 3, "the matrix components were updated");
+  }, "SVGTransformList (" + attr + "): a changed transform function updates the held item's type and matrix");
+
+  test(() => {
+    const el = build("translate(1,2) scale(3)");
+    const list = listOf(el);
+    const held0 = list.getItem(0);
+    const held1 = list.getItem(1);
+    el.setAttribute(attr, "scale(4) translate(5,6)");
+    assert_equals(list.getItem(0), held0, "index 0");
+    assert_equals(list.getItem(1), held1, "index 1");
+  }, "SVGTransformList (" + attr + "): swapping two transform functions keeps both held items");
+
+  test(() => {
+    const el = build("translate(1,2)");
+    const list = listOf(el);
+    const held = list.getItem(0);
+    if (attr === "transform")
+      el.setAttribute("transform", "none");
+    else
+      el.removeAttribute(attr);
+    assert_equals(list.numberOfItems, 0, "numberOfItems");
+    assert_equals(held.matrix.e, 1, "the detached item keeps its value");
+  }, "SVGTransformList (" + attr + "): an empty list detaches every item");
+}
+
+// The DOMString branch, step 5, is deliberately the other way round: the list is
+// replaced rather than updated in place. Without this the object branch could be
+// satisfied by an engine that never replaces anything.
+test(() => {
+  const el = document.createElementNS(SVGNS, "g");
+  el.setAttribute("systemLanguage", "en,fr,de");
+  stage.appendChild(el);
+  const list = el.systemLanguage;
+  const before = list.getItem(0);
+  el.setAttribute("systemLanguage", "it,es,pt");
+  assert_equals(list.numberOfItems, 3, "numberOfItems");
+  assert_equals(list.getItem(0), "it", "index 0");
+  assert_equals(list.getItem(1), "es", "index 1");
+  assert_equals(list.getItem(2), "pt", "index 2");
+  assert_not_equals(before, list.getItem(0), "the list was replaced");
+}, "SVGStringList: a change replaces the list rather than updating items");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
@@ -90,7 +90,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLengthList-appendItemFromClearedList.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLengthList-basics.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLengthList-getItem.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGMatrix.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPoint.html


### PR DESCRIPTION
#### 3af009681039cc036433568f4840b580c2e03219
<pre>
WPT: add coverage for synchronizing a list interface object when the reflected attribute changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322976">https://bugs.webkit.org/show_bug.cgi?id=322976</a>
<a href="https://rdar.apple.com/186248273">rdar://186248273</a>

Reviewed by Nikolas Zimmermann.

Nothing in WPT holds an item out of an SVG list and then changes the content
attribute, so no branch of &quot;synchronizing a list interface object&quot; is covered:
<a href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermSynchronizeList">https://w3c.github.io/svgwg/svg2-draft/types.html#TermSynchronizeList</a>

The two tests cover the four branches of that algorithm across SVGNumberList,
SVGLengthList, SVGPointList and SVGTransformList, the SVGStringList branch that
replaces the list instead, and animVal reporting the base value when nothing is
animating.

33 of 54 and 12 of 20 subtests pass. The failures belong to bugs 322973, 322974
and 322975, so the baselines record them and a fix shows up as a rebaseline.
Firefox 156 passes both files in full.

This will be exported to WPT.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-animVal-reflects-base-value.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-reflected-attribute-synchronize.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/320322@main">https://commits.webkit.org/320322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e6091f1e63e47868c7bd20779ce51b97f1c26f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148267 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9fae87b-7ea0-41be-b3e7-b936913cbb7b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143613 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99775 "Exiting early after 60 failures. 60 tests run. 61 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6f07155-242c-400c-a4a6-827e5a5b9f6f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124032 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec9c0467-32d4-42dd-afb2-df66026368a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44315 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156489 "Found 2 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WebKit.DefaultQuota (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43891 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5380 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196136 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41121 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58273 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152839 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47377 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127033 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56781 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18902 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56152 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56391 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->