### PR TITLE
EWS should terminate an ongoing job as soon as a hash becomes obsolete

### DIFF
--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -76,3 +76,14 @@ loadConfig.loadBuilderConfig(
     setup_main_schedulers=True,
     setup_force_schedulers=is_test_mode_enabled,
 )
+
+# https://docs.buildbot.net/latest/manual/configuration/services/old_build_canceller.html
+c['services'] = [
+    util.OldBuildCanceller(
+        'old_build_canceller',
+        [(
+            [builder['name'] for builder in c['builders']],
+            util.SourceStampFilter(branch_re=r'^refs/pull/\d+/'),
+        )],
+    ),
+]


### PR DESCRIPTION
#### d605b748cde6fdbc4ce5e39f690df9a6439166d6
<pre>
EWS should terminate an ongoing job as soon as a hash becomes obsolete
<a href="https://bugs.webkit.org/show_bug.cgi?id=201924">https://bugs.webkit.org/show_bug.cgi?id=201924</a>
<a href="https://rdar.apple.com/problem/27768813">rdar://problem/27768813</a>

Reviewed by Ryan Haddad.

Configure Buildbot 4&apos;s OldBuildCanceller service on the EWS back-end master,
scoped to pull-request source stamps. Pushing a new commit to a pull request now
cancels the builds still running or queued for the commit it replaces, instead of
letting them finish and report results for a commit nobody is looking at anymore.

Queues started directly by a pull-request event are cancelled immediately. A
triggered tester queue is cancelled once the build queue feeding it requests its
replacement.

* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/320241@main">https://commits.webkit.org/320241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b53890a45b71299da46e5b11b089fff078bcc90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58155 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148524 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59500 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57890 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/194455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148524 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57890 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/5637 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57890 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196394 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183635 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57826 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153388 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58530 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27971 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/47594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57038 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51973 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->