### PR TITLE
A policy check that does not navigate a frame is cancelled by one that does

### DIFF
--- a/LayoutTests/http/wpt/html/browsers/windows/resources/post-search-to-broadcast-channel.html
+++ b/LayoutTests/http/wpt/html/browsers/windows/resources/post-search-to-broadcast-channel.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+new BroadcastChannel("target-blank-multiple-windows").postMessage(location.search.substring(1));
+window.close();
+</script>

--- a/LayoutTests/http/wpt/html/browsers/windows/target-blank-not-cancelled-by-fragment-navigation-expected.txt
+++ b/LayoutTests/http/wpt/html/browsers/windows/target-blank-not-cancelled-by-fragment-navigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A same-task fragment navigation does not cancel a target=_blank window
+

--- a/LayoutTests/http/wpt/html/browsers/windows/target-blank-not-cancelled-by-fragment-navigation.html
+++ b/LayoutTests/http/wpt/html/browsers/windows/target-blank-not-cancelled-by-fragment-navigation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Navigating the source frame does not cancel a target=_blank window</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/document-sequences.html#the-rules-for-choosing-a-navigable">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// PolicyChecker::stopCheck() used to answer every outstanding check with Ignore, losing the window.
+promise_test(async t => {
+    const channel = new BroadcastChannel("target-blank-multiple-windows");
+    t.add_cleanup(() => channel.close());
+    const opened = new Promise(resolve => {
+        channel.addEventListener("message", e => resolve(e.data), { once: true });
+    });
+
+    const a = document.createElement("a");
+    a.target = "_blank";
+    a.href = "resources/post-search-to-broadcast-channel.html?popup";
+    document.body.appendChild(a);
+    t.add_cleanup(() => a.remove());
+    a.click();
+    location.hash = "frag";
+
+    assert_equals(await opened, "popup");
+}, "A same-task fragment navigation does not cancel a target=_blank window");
+</script>
+</body>

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -254,10 +254,10 @@ void WebFrameProxy::webProcessWillShutDown()
         m_activeListener = nullptr;
     }
 
-    // Download checks survive navigation, but not the frame itself.
-    auto activeDownloadListeners = std::exchange(m_activeDownloadListeners, { });
-    for (Ref downloadListener : activeDownloadListeners.values())
-        downloadListener->ignore();
+    // A check that does not navigate this frame survives navigation, but not the frame itself.
+    auto activeNonNavigationListeners = std::exchange(m_activeNonNavigationListeners, { });
+    for (Ref listener : activeNonNavigationListeners.values())
+        listener->ignore();
 
     if (m_navigateCallback)
         m_navigateCallback({ }, { });
@@ -430,12 +430,12 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTF::move(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, IsDownloadPolicyCheck isDownloadPolicyCheck)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, NavigatesThisFrame navigatesThisFrame)
 {
-    bool isDownload = isDownloadPolicyCheck == IsDownloadPolicyCheck::Yes;
-    auto downloadListenerID = isDownload ? ++m_nextDownloadListenerID : 0;
+    bool isNavigation = navigatesThisFrame == NavigatesThisFrame::Yes;
+    auto listenerID = isNavigation ? 0 : ++m_nextNonNavigationListenerID;
 
-    if (!isDownload) {
+    if (isNavigation) {
         if (RefPtr previousListener = m_activeListener)
             previousListener->ignore();
     }
@@ -444,23 +444,23 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
         this,
         protectedThis = Ref { *this },
         completionHandler = WTF::move(completionHandler),
-        isDownload,
-        downloadListenerID
+        isNavigation,
+        listenerID
     ] (PolicyAction action, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
         if (action != PolicyAction::Use && m_navigateCallback)
             m_navigateCallback(pageIdentifier(), frameID());
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
 
-        if (isDownload)
-            m_activeDownloadListeners.remove(downloadListenerID);
-        else
+        if (isNavigation)
             m_activeListener = nullptr;
+        else
+            m_activeNonNavigationListeners.remove(listenerID);
     };
 
-    if (isDownload) {
-        m_activeDownloadListeners.add(downloadListenerID, WebFramePolicyListenerProxy::create(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
-        return *m_activeDownloadListeners.get(downloadListenerID);
+    if (!isNavigation) {
+        m_activeNonNavigationListeners.add(listenerID, WebFramePolicyListenerProxy::create(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
+        return *m_activeNonNavigationListeners.get(listenerID);
     }
 
     m_activeListener = WebFramePolicyListenerProxy::create(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -212,12 +212,10 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    // Only one navigation policy check can be outstanding per frame, so a new one displaces the
-    // previous. A download is not a navigation, so it neither displaces nor is displaced. The check
-    // for a server redirect in a load the client let continue is a navigation check even though its
-    // action still carries the download attribute: it belongs to that load, and dies with it.
-    enum class IsDownloadPolicyCheck : bool { No, Yes };
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, IsDownloadPolicyCheck);
+    // A frame has at most one navigation check outstanding, so a new one displaces the previous. A check that
+    // does not navigate it, for a new window or a download attribute activation, is independent instead.
+    enum class NavigatesThisFrame : bool { No, Yes };
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, NavigatesThisFrame);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTF::move(contentFilterUnblockHandler); }
@@ -373,8 +371,8 @@ private:
     WebCore::CertificateInfo m_certificateInfo;
     HashMap<String, WebCore::CertificateInfo> m_hostAndPortToCertificateInfo;
     RefPtr<WebFramePolicyListenerProxy> m_activeListener;
-    HashMap<uint64_t, Ref<WebFramePolicyListenerProxy>> m_activeDownloadListeners;
-    uint64_t m_nextDownloadListenerID { 0 };
+    HashMap<uint64_t, Ref<WebFramePolicyListenerProxy>> m_activeNonNavigationListeners;
+    uint64_t m_nextNonNavigationListenerID { 0 };
     WebCore::FrameIdentifier m_frameID;
     ListHashSet<Ref<WebFrameProxy>> m_childFrames;
     WeakPtr<WebFrameProxy> m_parentFrame;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10227,7 +10227,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, navigationAction->shouldPerformDownload() && !navigationAction->isRedirect() ? WebFrameProxy::IsDownloadPolicyCheck::Yes : WebFrameProxy::IsDownloadPolicyCheck::No);
+    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, navigationAction->shouldPerformDownload() && !navigationAction->isRedirect() ? WebFrameProxy::NavigatesThisFrame::No : WebFrameProxy::NavigatesThisFrame::Yes);
     if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)
@@ -10406,7 +10406,7 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         RELEASE_ASSERT(processSwapRequestedByClient == ProcessSwapRequestedByClient::No);
 
         receivedPolicyDecision(policyAction, nullptr, std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
-    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::IsDownloadPolicyCheck::No);
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::NavigatesThisFrame::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForNewWindowAction(*this, *frame, navigationAction.get(), request, frameName, WTF::move(listener));
@@ -10587,7 +10587,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::IsDownloadPolicyCheck::No);
+    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::NavigatesThisFrame::Yes);
     if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
         navigation->whenSafeBrowsingCheckCompletes([listener] mutable {
             listener->didReceiveSafeBrowsingResults();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -219,7 +219,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
             downloadAttributePolicyDocumentLoader = localFrame->loader().policyDocumentLoader();
         }
     }
-    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes, downloadAttributeInitiatingDocument, WTF::move(downloadAttributePolicyDocumentLoader));
+    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes, downloadAttributeInitiatingDocument ? WebFrame::PolicyCheckKind::DownloadAttribute : WebFrame::PolicyCheckKind::Navigation, downloadAttributeInitiatingDocument, WTF::move(downloadAttributePolicyDocumentLoader));
 
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -995,7 +995,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
     auto navigationID = policyDocumentLoader ? policyDocumentLoader->navigationID() : std::nullopt;
 
     Ref frame = m_frame;
-    uint64_t listenerID = frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No);
+    uint64_t listenerID = frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No, WebFrame::PolicyCheckKind::Navigation);
 
     bool isShowingInitialAboutBlank = m_localFrame->loader().stateMachine().isDisplayingInitialEmptyDocument();
     auto activeDocumentCOOPValue = m_localFrame->document() ? protect(m_localFrame->document())->crossOriginOpenerPolicy().value : CrossOriginOpenerPolicyValue::SameOrigin;
@@ -1013,9 +1013,14 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         return;
     }
 
-    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No);
-
     Ref localFrame = m_localFrame.get();
+
+    // The check is only this frame's to answer while the document that asked for the window is still in it.
+    Markable<WebCore::ScriptExecutionContextIdentifier> initiatingDocument;
+    if (auto* document = localFrame->document())
+        initiatingDocument = document->identifier();
+    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No, WebFrame::PolicyCheckKind::NewWindow, initiatingDocument);
+
     auto& mouseEventData = navigationAction.mouseEventData();
     NavigationActionData navigationActionData {
         navigationAction.type(),

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -393,12 +393,13 @@ ScopeExit<Function<void()>> WebFrame::makeInvalidator()
     });
 }
 
-uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader)
+uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction, PolicyCheckKind kind, Markable<WebCore::ScriptExecutionContextIdentifier> initiatingDocument, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader)
 {
     auto policyListenerID = generateListenerID();
     m_pendingPolicyChecks.add(policyListenerID, PolicyCheck {
         forNavigationAction,
-        downloadAttributeInitiatingDocument,
+        kind,
+        initiatingDocument,
         WTF::move(downloadAttributePolicyDocumentLoader),
         WTF::move(policyFunction)
     });
@@ -406,18 +407,18 @@ uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunc
     return policyListenerID;
 }
 
-// Unlike a navigation check, a download check is not cancelled by what this frame does next, so it can be
-// answered once the frame is no longer in a page - which startDownload() requires - or once another
-// document has committed. The document matters because PolicyChecker::checkNavigationPolicy() decides
-// against live frame state, including the sandbox allow-downloads flag that
-// LocalFrame::effectiveSandboxFlags() takes from the current document.
-bool WebFrame::shouldHonorDownloadAttributePolicyCheck(const PolicyCheck& policyCheck) const
+// Unlike a navigation check, a check that does not navigate this frame is not cancelled by what the frame does
+// next, so it can be answered once the frame is no longer in a page - which startDownload() requires - or once
+// another document has committed. The document matters because PolicyChecker decides against live frame state:
+// for a download, the sandbox allow-downloads flag that LocalFrame::effectiveSandboxFlags() takes from the
+// current document; for a new window, whether that document is allowed to open one at all.
+bool WebFrame::initiatingDocumentIsStillCurrent(const PolicyCheck& policyCheck) const
 {
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame || !localFrame->page())
         return false;
     RefPtr document = localFrame->document();
-    return document && document->identifier() == policyCheck.downloadAttributeInitiatingDocument;
+    return document && document->identifier() == policyCheck.initiatingDocument;
 }
 
 // A download check outliving the navigation that started it also means its decision can arrive once a newer
@@ -665,7 +666,7 @@ void WebFrame::invalidatePolicyListeners()
 
     HashMap<uint64_t, PolicyCheck> policyChecksToCancel;
     for (auto& [listenerID, policyCheck] : std::exchange(m_pendingPolicyChecks, { })) {
-        if (policyCheck.downloadAttributeInitiatingDocument && shouldHonorDownloadAttributePolicyCheck(policyCheck))
+        if (policyCheck.kind != PolicyCheckKind::Navigation && initiatingDocumentIsStillCurrent(policyCheck))
             m_pendingPolicyChecks.add(listenerID, WTF::move(policyCheck));
         else
             policyChecksToCancel.add(listenerID, WTF::move(policyCheck));
@@ -701,7 +702,7 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     FramePolicyFunction function = WTF::move(policyCheck.policyFunction);
     bool forNavigationAction = policyCheck.forNavigationAction == ForNavigationAction::Yes;
 
-    if (policyCheck.downloadAttributeInitiatingDocument && !shouldHonorDownloadAttributePolicyCheck(policyCheck))
+    if (policyCheck.kind != PolicyCheckKind::Navigation && !initiatingDocumentIsStillCurrent(policyCheck))
         return function(PolicyAction::Ignore);
 
     // Nothing below is the download's to apply once a newer navigation owns the load this check was made for.
@@ -709,7 +710,7 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     // client allowed it for. Only a download is still meaningful, so answer anything else Ignore, which
     // FrameLoader::loadWithDocumentLoader() drops rather than continue with, since it no longer owns the
     // policy document loader.
-    bool newerNavigationOwnsTheLoad = policyCheck.downloadAttributeInitiatingDocument && newerNavigationOwnsDownloadAttributePolicyCheckLoad(policyCheck);
+    bool newerNavigationOwnsTheLoad = policyCheck.kind == PolicyCheckKind::DownloadAttribute && newerNavigationOwnsDownloadAttributePolicyCheckLoad(policyCheck);
     if (newerNavigationOwnsTheLoad && policyDecision.policyAction != PolicyAction::Download)
         return function(PolicyAction::Ignore);
 
@@ -721,9 +722,10 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     }
 
     m_policyDownloadID = policyDecision.downloadID;
-    // Only a download skips this: a download attribute link the client answered Use for is a
-    // navigation like any other, and m_policyDocumentLoader is its own.
-    if (policyDecision.policyAction != PolicyAction::Download) {
+    // Only a download skips this: a download attribute link the client answered Use for is a navigation like
+    // any other, and m_policyDocumentLoader is its own. A new window skips it too, since its navigation state
+    // belongs to the window being opened rather than to this frame.
+    if (policyDecision.policyAction != PolicyAction::Download && policyCheck.kind != PolicyCheckKind::NewWindow) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
             auto& loader = localFrame->loader();
             if (RefPtr policyDocumentLoader = loader.policyDocumentLoader()) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -156,10 +156,11 @@ public:
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
 
     enum class ForNavigationAction : bool { No, Yes };
-    // A non-null initiating document marks this as a download attribute check. Such a check outlives the
-    // navigation that started it, so it also carries the load it was made for: the frame's policy document
-    // loader at the time, which a newer navigation can replace before the decision arrives.
-    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument = { }, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader = { });
+    // A check that does not navigate this frame outlives whatever the frame does next, so it carries the
+    // document that made it: once the frame has a different document, the check can no longer be honored. A
+    // download attribute check also carries the load it was made for, which a newer navigation can replace.
+    enum class PolicyCheckKind : uint8_t { Navigation, DownloadAttribute, NewWindow };
+    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction, PolicyCheckKind, Markable<WebCore::ScriptExecutionContextIdentifier> initiatingDocument = { }, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader = { });
     void invalidatePolicyListeners();
     void didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&&);
 
@@ -340,13 +341,14 @@ private:
 
     struct PolicyCheck {
         ForNavigationAction forNavigationAction { ForNavigationAction::No };
-        Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument;
+        PolicyCheckKind kind { PolicyCheckKind::Navigation };
+        Markable<WebCore::ScriptExecutionContextIdentifier> initiatingDocument;
         SingleThreadWeakPtr<WebCore::DocumentLoader> downloadAttributePolicyDocumentLoader;
         WebCore::FramePolicyFunction policyFunction;
     };
     HashMap<uint64_t, PolicyCheck> m_pendingPolicyChecks;
 
-    bool shouldHonorDownloadAttributePolicyCheck(const PolicyCheck&) const;
+    bool initiatingDocumentIsStillCurrent(const PolicyCheck&) const;
     bool newerNavigationOwnsDownloadAttributePolicyCheckLoad(const PolicyCheck&) const;
 
     std::optional<DownloadID> m_policyDownloadID;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/OpenAndCloseWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/OpenAndCloseWindow.mm
@@ -41,6 +41,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWindowFeaturesPrivate.h>
 #import <WebKit/_WKFrameTreeNode.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/darwin/DispatchExtras.h>
 
@@ -592,4 +593,61 @@ TEST(WEBKIT, NavigationActionHasOpener14)
 TEST(WEBKIT, NavigationActionHasOpener15)
 {
     runHasOpenerTest(@"<form action='https://www.apple.com' target='_blank' rel='opener'><input id='testButton' type='submit'></form><script>function runTest() { document.getElementById('testButton').click(); }</script>", true);
+}
+
+// Each click chooses its own navigable, so holding every decision must leave every check outstanding rather
+// than letting a newer one cancel the last.
+TEST(WebKit, TargetBlankPolicyChecksDoNotCancelEachOther)
+{
+    static constexpr NSUInteger linkCount = 5;
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    __block RetainPtr heldDecisions = adoptNS([NSMutableArray new]);
+    __block bool everyCheckIsOutstanding = false;
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        // A null target frame is a new window.
+        if (action.targetFrame) {
+            decisionHandler(WKNavigationActionPolicyAllow);
+            return;
+        }
+        [heldDecisions addObject:makeBlockPtr(decisionHandler).get()];
+        if ([heldDecisions count] == linkCount)
+            everyCheckIsOutstanding = true;
+    };
+
+    __block RetainPtr openedWebViews = adoptNS([NSMutableArray new]);
+    __block bool everyWindowWasCreated = false;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *openedConfiguration, WKNavigationAction *, WKWindowFeatures *) {
+        [openedWebViews addObject:adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:openedConfiguration]).get()];
+        if ([openedWebViews count] == linkCount)
+            everyWindowWasCreated = true;
+        return [openedWebViews lastObject];
+    };
+
+    [webView synchronouslyLoadHTMLString:@"<script>function runTest() {"
+        "for (let i = 0; i < 5; i++) {"
+        "    let a = document.createElement('a');"
+        "    a.target = '_blank';"
+        "    a.href = 'https://webkit.org/' + i;"
+        "    document.body.appendChild(a);"
+        "    a.click();"
+        "}"
+        "}</script>"];
+    [webView evaluateJavaScript:@"runTest()" completionHandler:nil];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&everyCheckIsOutstanding, 5_s));
+    EXPECT_EQ(linkCount, [heldDecisions count]);
+
+    for (void (^decisionHandler)(WKNavigationActionPolicy) in heldDecisions.get())
+        decisionHandler(WKNavigationActionPolicyAllow);
+
+    TestWebKitAPI::Util::runFor(&everyWindowWasCreated, 5_s);
+    EXPECT_EQ(linkCount, [openedWebViews count]);
 }


### PR DESCRIPTION
#### 799571146940807a81c8ad8a8d5159a1f6b22009
<pre>
A policy check that does not navigate a frame is cancelled by one that does
<a href="https://bugs.webkit.org/show_bug.cgi?id=37756">https://bugs.webkit.org/show_bug.cgi?id=37756</a>
<a href="https://rdar.apple.com/186253237">rdar://186253237</a>

Reviewed by Alex Christensen.

A target=_blank activation navigates the new frame it creates, not the
frame the link was activated in. The policy check for it is made in that
source frame all the same, and WebKit routed it through machinery that
assumes any check a frame makes is for a load of its own, in both
processes, so anything the source frame did next destroyed it.

In the UI process WebFrameProxy keeps one policy listener per frame and
setUpPolicyListenerProxy() resolves the previous one with ignore(), so
each activation cancelled the one before it: N target=_blank clicks in a
single task opened one window, the last. In the web process
PolicyChecker::stopCheck() answers every outstanding check with
PolicyAction::Ignore, so a navigation of the source frame in the same
task lost the window outright.

319105@main took download attribute checks out of these same two
cancellations, though that case is not quite this one: activating a
download attribute link is still a navigation of a kind, and one the
client can answer Use for, which makes it an ordinary one. What it shares
with creating a new frame is that when the check is made no load in this
frame is waiting on the answer, so nothing the frame does next
invalidates it - unlike the check for a redirect in the load an allowed
activation starts, whose DocumentLoader is. Both now turn on that rather
than on what kind of check it is.

The single listener in the UI process dates to 193833@main. 240828@main
made the web process able to hold several checks at once for this exact
symptom, citing WPT tests that timed out because &quot;only the last one would
proceed&quot;, but left the UI process alone, so the symptom survived wherever
the embedder does not answer policy synchronously. It still shows in
Safari: imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html
passes under WebKitTestRunner and reports 1 of 13 subtests in Safari,
always the last.

The API test holds every new window decision instead of answering it, so
all five checks are outstanding at once. As 319105@main notes, a delegate
that answers immediately never reaches that state, so no layout test can
cover the UI process half; one that answers after a single run loop hop
reaches it only as a race, which made the layout test written first pass
4 times in 10. The web process half needs no held decision - the check is
outstanding across the reply from the UI process however fast it comes -
so a layout test covers that one.

Canonical link: <a href="https://commits.webkit.org/320325@main">https://commits.webkit.org/320325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7732421b33cfdc4f3d30c490b9a3b23493ef6da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148749 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3460bfd5-bb5e-4a4f-8df8-8baf321edfd9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144013 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100069 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e177267c-44c7-45e2-99bd-a73eebab0a91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47803 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124429 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de43fd53-922f-4d23-b487-faf3a016806d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46514 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44301 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5866 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41124 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58765 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40920 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153254 "Found 1 new API test failure: TestAutomationSession:/webkit/WebKitAutomationSession/request-session (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47780 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131058 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127498 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57268 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19315 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56701 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->