### PR TITLE
Review the padding of the new WPE Platform API classes

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
@@ -48,7 +48,7 @@ struct _WPEBufferClass
     GBytes  *(* import_to_pixels)    (WPEBuffer *buffer,
                                       GError   **error);
 
-    gpointer padding[32];
+    gpointer padding[16];
 };
 
 #define WPE_BUFFER_ERROR (wpe_buffer_error_quark())

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
@@ -53,7 +53,7 @@ struct _WPEClipboardClass
                         gboolean             is_local,
                         WPEClipboardContent *content);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API WPEClipboard        *wpe_clipboard_new              (WPEDisplay          *display);

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
@@ -50,7 +50,7 @@ struct _WPEGamepadClass
                                   gdouble     weak_magnitude,
                                   guint       duration_ms);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h
@@ -43,7 +43,7 @@ struct _WPEGamepadManagerClass
 {
     GObjectClass parent_class;
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API void         wpe_gamepad_manager_add_device    (WPEGamepadManager *manager,

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -159,7 +159,7 @@ struct _WPEInputMethodContextClass
                                      guint                  selection_index);
     void     (* reset)              (WPEInputMethodContext *context);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API WPEInputMethodContext   *wpe_input_method_context_new                (WPEView                 *view);

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
@@ -82,7 +82,7 @@ struct _WPEKeymapClass
                                                WPEModifiers    *consumed_modifiers);
     WPEModifiers (* get_modifiers)            (WPEKeymap       *keymap);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API gboolean     wpe_keymap_get_entries_for_keyval   (WPEKeymap       *keymap,

--- a/Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h
@@ -114,7 +114,7 @@ struct _WPEProcessManagerClass {
     void    (* terminate) (WPEProcessManager* manager, guint64 process_id);
 
     /*< private >*/
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API GQuark   wpe_process_manager_error_quark (void);

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
@@ -46,7 +46,7 @@ struct _WPEScreenClass
     void                   (* invalidate)        (WPEScreen *screen);
     WPEScreenSyncObserver *(* get_sync_observer) (WPEScreen *screen);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API guint32                wpe_screen_get_id               (WPEScreen *screen);

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
@@ -57,7 +57,7 @@ struct _WPEScreenSyncObserverClass
     void (* stop)  (WPEScreenSyncObserver *observer);
     void (* sync)  (WPEScreenSyncObserver *observer);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API guint    wpe_screen_sync_observer_add_callback    (WPEScreenSyncObserver        *observer,


### PR DESCRIPTION
#### cd1fc3fb980708ddc60723028a2e9ecccf96b89b
<pre>
Review the padding of the new WPE Platform API classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322985">https://bugs.webkit.org/show_bug.cgi?id=322985</a>

Reviewed by Carlos Garcia Campos.

Reduce padding of some classes now that their APIs have consolidated.
The goal is to leave enough room for all classes to grow without having
excessive padding unused.

* Source/WebKit/WPEPlatform/wpe/WPEBuffer.h:
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepad.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.h:
* Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h:
* Source/WebKit/WPEPlatform/wpe/WPEScreen.h:
* Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h:

Canonical link: <a href="https://commits.webkit.org/320157@main">https://commits.webkit.org/320157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fceda902c878c660e239ff7fe5a8d8446d4909b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99790 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47406 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46113 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5397 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196153 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57586 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58290 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/152854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27918 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47391 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130580 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56798 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18921 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->