### PR TITLE
Make FormListedElement::setCustomValidity simplify newlines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines-expected.txt
@@ -1,0 +1,4 @@
+
+PASS setValidity() should normalize newlines with the customError flag set
+PASS setValidity() should normalize newlines with another validity flag set
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>ElementInternals: setValidity() normalizes newlines in the given message</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+class MyControl extends HTMLElement {
+  static get formAssociated() { return true; }
+
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+  }
+  get i() { return this.internals_; }
+}
+customElements.define('my-control', MyControl);
+
+const message = 'First line\rSecond line\r\nThird line\nFourth line';
+const normalized = 'First line\nSecond line\nThird line\nFourth line';
+
+test(() => {
+  const control = new MyControl();
+  control.i.setValidity({customError: true}, message);
+  assert_equals(control.i.validationMessage, normalized);
+}, 'setValidity() should normalize newlines with the customError flag set');
+
+test(() => {
+  const control = new MyControl();
+  control.i.setValidity({valueMissing: true}, message);
+  assert_equals(control.i.validationMessage, normalized);
+}, 'setValidity() should normalize newlines with another validity flag set');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/w3c-import.log
@@ -24,6 +24,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-reportValidity-delegatesFocus.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-submit-behavior-dialog.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-submit-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/setCustomValidity-normalize-newlines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/setCustomValidity-normalize-newlines-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL setCustomValidity should normalize newlines from the given error message assert_equals: expected "First line\nSecond line\nThird line\nFourth line" but got "First line\rSecond line\r\nThird line\nFourth line"
+PASS setCustomValidity should normalize newlines from the given error message
 

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -280,7 +280,7 @@ String FormListedElement::validationMessage() const
 
 void FormListedElement::setCustomValidity(const String& error)
 {
-    m_customValidationMessage = error;
+    m_customValidationMessage = makeStringBySimplifyingNewLines(error);
 }
 
 void FormListedElement::resetFormAttributeTargetObserver()


### PR DESCRIPTION
#### 7094241f824bee3109640a3907d7a6f2b67eab67
<pre>
Make FormListedElement::setCustomValidity simplify newlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=322988">https://bugs.webkit.org/show_bug.cgi?id=322988</a>

Reviewed by Tim Nguyen.

This was standardized except for it also needing to impact
ElementInternals. That&apos;s now covered here:

    <a href="https://github.com/whatwg/html/pull/12870">https://github.com/whatwg/html/pull/12870</a>

Test: imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setValidity-normalize-newlines.html

web-platform-tests changes: <a href="https://github.com/web-platform-tests/wpt/pull/62327">https://github.com/web-platform-tests/wpt/pull/62327</a>

Canonical link: <a href="https://commits.webkit.org/320235@main">https://commits.webkit.org/320235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8330bb92a12de3426cb4db0d8d886d6c6acfa1c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148285 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e74c11d7-1986-40c6-8898-12b8eaa10c13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143628 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99792 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c26d51a-0b55-48fc-a1c4-1e1163673b1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25bd5388-cde8-4bdd-8044-bc5733d2377a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44332 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156504 "Found 6 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PanelHidCancel, TestWebKitAPI.PrivateClickMeasurement.BasicWithEphemeralIOSSPI, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.PrivateClickMeasurement.DestinationClickFraudPrevention, TestWebKitAPI.PrivateClickMeasurement.BasicWithIOSSPI, TestWebKitAPI.PrivateClickMeasurement.EphemeralWithAttributedBundleIdentifier (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43907 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5398 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153179 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152855 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47394 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130581 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127074 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18918 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->