### PR TITLE
[scroll-animations] match style-originated timelines globally

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Timelines are visible by default promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+PASS Timelines are visible by default
 PASS Descendant can attach to a timeline under the same timeline-scope
 PASS Timeline outside of the target's scope subtree is inaccessible
-FAIL Timeline lookups isn't stopped by timeline-scope if the name doesn't match assert_equals: expected "100px" but got "0px"
-FAIL Timeline under a different timeline-scope subtree is not visible to the target. assert_equals: expected "100px" but got "0px"
-FAIL Timeline with a different timeline-scope is not visible to the target. assert_equals: expected "100px" but got "0px"
+PASS Timeline lookups isn't stopped by timeline-scope if the name doesn't match
+PASS Timeline under a different timeline-scope subtree is not visible to the target.
+PASS Timeline with a different timeline-scope is not visible to the target.
 PASS Dynamically re-attaching
 PASS Dynamically detaching
 PASS Removing/inserting element with attaching timeline

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -44,6 +44,7 @@
 #include "ViewTimeline.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
+#include "WebAnimationUtilities.h"
 #include <JavaScriptCore/VM.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/TextStream.h>
@@ -122,8 +123,26 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
         element = element->parentElementInComposedTree();
     }
 
-    ASSERT_NOT_REACHED();
-    return nullptr;
+    // If we get to this point, this means we haven't found a matching timeline that has
+    // its originating element in the provided `timeline-scope` element's hierarchy. Since
+    // timelines match globally, we must use global tree order..
+    ASSERT(!timelineScopeElement);
+    auto sortedTimelines = ancestorTimelines;
+    std::ranges::stable_sort(sortedTimelines, [](auto& lhs, auto& rhs) {
+        auto lhsStyleable = originatingElement(lhs).styleable();
+        auto rhsStyleable = originatingElement(rhs).styleable();
+        ASSERT(lhsStyleable);
+        ASSERT(rhsStyleable);
+
+        if (lhsStyleable == rhsStyleable) {
+            ASSERT(is<ViewTimeline>(lhs) != is<ViewTimeline>(rhs));
+            if (!is<ViewTimeline>(lhs))
+                return false;
+        }
+
+        return compareStyleablePositionsInDocumentTreeOrder(*lhsStyleable, *rhsStyleable);
+    });
+    return sortedTimelines.first().unsafePtr();
 }
 
 static bool timelineIsInScopeForTarget(const Ref<ScrollTimeline>& timeline, Element& targetElement, Style::ScopeOrdinal animationTimelineNameScopeOrdinal)
@@ -156,9 +175,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
         Ref targetElement { styleable.element };
         if (!timelineIsInScopeForTarget(timeline, targetElement.get(), targetTimelineScopeOrdinal))
             continue;
-        Ref protectedElementForTimeline { styleableForTimeline->element };
-        if (&styleableForTimeline->element == &styleable.element || styleable.element.isComposedTreeDescendantOf(protectedElementForTimeline.get()))
-            matchedTimelines.append(timeline);
+        matchedTimelines.append(timeline);
     }
     if (matchedTimelines.isEmpty())
         return nullptr;

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -50,7 +50,7 @@
 
 namespace WebCore {
 
-static bool compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder(const Styleable& a, const Styleable& b)
+bool compareStyleablePositionsInDocumentTreeOrder(const Styleable& a, const Styleable& b)
 {
     // We should not ever be calling this function with two Elements that are the same. If that were the case,
     // then comparing objects of this kind would yield inconsistent results when comparing A == B and B == A.
@@ -153,7 +153,7 @@ static bool compareCSSTransitions(const CSSTransition& a, const CSSTransition& b
 
     // If the owning element of A and B differs, sort A and B by tree order of their corresponding owning elements.
     if (*aOwningElement != *bOwningElement)
-        return compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder(*aOwningElement, *bOwningElement);
+        return compareStyleablePositionsInDocumentTreeOrder(*aOwningElement, *bOwningElement);
 
     // Otherwise, if A and B have different transition generation values, sort by their corresponding transition generation in ascending order.
     if (a.generationTime() != b.generationTime())
@@ -174,7 +174,7 @@ static bool compareCSSAnimations(const CSSAnimation& a, const CSSAnimation& b)
 
     // If the owning element of A and B differs, sort A and B by tree order of their corresponding owning elements.
     if (*aOwningElement != *bOwningElement)
-        return compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder(*aOwningElement, *bOwningElement);
+        return compareStyleablePositionsInDocumentTreeOrder(*aOwningElement, *bOwningElement);
 
     // Sort A and B based on their position in the computed value of the animation-name property of the (common) owning element.
     auto& cssAnimationList = aOwningElement->ensureKeyframeEffectStack().cssAnimationList();
@@ -253,7 +253,7 @@ static std::optional<bool> compareStyleOriginatedAnimationEvents(const Animation
 
     auto aStyleable = Styleable(*downcast<Element>(aTarget), aAsDStyleOriginatedAnimationEventAnimationEvent->pseudoElementIdentifier());
     auto bStyleable = Styleable(*downcast<Element>(bTarget), bAsDStyleOriginatedAnimationEventAnimationEvent->pseudoElementIdentifier());
-    return compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder(aStyleable, bStyleable);
+    return compareStyleablePositionsInDocumentTreeOrder(aStyleable, bStyleable);
 }
 
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase& a, const AnimationEventBase& b)

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -40,6 +40,8 @@ class Document;
 class Element;
 class WebAnimation;
 
+struct Styleable;
+
 namespace Style {
 class ComputedStyle;
 struct PseudoElementIdentifier;
@@ -61,6 +63,7 @@ inline double secondsToWebAnimationsAPITime(const Seconds time)
 
 const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 
+bool compareStyleablePositionsInDocumentTreeOrder(const Styleable&, const Styleable&);
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementIdentifier>&);


### PR DESCRIPTION
#### 0da994ab75f665dc639506bf7d920ba64fd5c26c
<pre>
[scroll-animations] match style-originated timelines globally
<a href="https://bugs.webkit.org/show_bug.cgi?id=322989">https://bugs.webkit.org/show_bug.cgi?id=322989</a>
<a href="https://rdar.apple.com/186261285">rdar://186261285</a>

Reviewed by Tim Nguyen.

The CSS WG updated style-originated timelines to match globally by default [0], allowing timelines
to be defined outside of the target&apos;s hierarchy or that of an element with a `timeline-scope`
property.

We update our matching code to no longer assume timelines must be contained within the target&apos;s
hierarchy and ensure that when a `timeline-scope` property is not set for a given timeline&apos;s name
we use global document ordering to determine which timeline to match.

To that end we rename `compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder()`
to `compareStyleablePositionsInDocumentTreeOrder()` and make it public.

This fixes many of the failures in the WPT test `scroll-animations/css/timeline-scope.html` that
were introduced due to the relevant WPT changes [1] but some more specific issues will be fixed
with followup patches.

[0] <a href="https://github.com/w3c/csswg-drafts/pull/13624">https://github.com/w3c/csswg-drafts/pull/13624</a>
[1] <a href="https://github.com/web-platform-tests/wpt/pull/61776">https://github.com/web-platform-tests/wpt/pull/61776</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleablePositionsInDocumentTreeOrder):
(WebCore::compareCSSTransitions):
(WebCore::compareCSSAnimations):
(WebCore::compareStyleOriginatedAnimationEvents):
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder): Deleted.
* Source/WebCore/animation/WebAnimationUtilities.h:

Canonical link: <a href="https://commits.webkit.org/320183@main">https://commits.webkit.org/320183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeaf43b80a053fba7b122b368490d3fb862dc501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184027 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148320 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143661 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99827 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124080 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46140 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43935 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5433 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196189 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57622 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153214 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58326 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152887 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47421 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130616 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18946 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56205 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->