### PR TITLE
[Site Isolation] imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html fails

### DIFF
--- a/LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler-expected.txt
@@ -1,0 +1,5 @@
+PASS dispatchedEvents.join(',') is "load,message"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler.html
+++ b/LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler.html
@@ -1,0 +1,17 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+window.jsTestIsAsync = true;
+
+// A message posted by a frame in another process from its own load event handler has to be dispatched
+// after the load event of the frame's owner element, which is how it is ordered when both frames are
+// in the same process.
+var dispatchedEvents = [];
+
+addEventListener("message", () => {
+    dispatchedEvents.push("message");
+    shouldBeEqualToString("dispatchedEvents.join(',')", "load,message");
+    finishJSTest();
+});
+</script>
+<iframe onload="dispatchedEvents.push('load')" src="http://localhost:8000/site-isolation/resources/post-message-to-parent-on-load.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent-on-load.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent-on-load.html
@@ -1,0 +1,5 @@
+<script>
+addEventListener("load", () => {
+    window.parent.postMessage("message posted from load event handler", "*");
+});
+</script>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2449,19 +2449,27 @@ void LocalDOMWindow::dispatchLoadEvent()
         WTFEmitSignpost(document.get(), NavigationAndPaintTiming, "loadEventBegin");
     }
 
-    dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No), document.get());
+    {
+        // The load event of the frame owner element is dispatched synchronously below, even when the owner
+        // lives in another process, whereas a message posted to another process from a load event handler is
+        // dispatched from a task. Defer sending such messages until the load event has been sent so that the
+        // owner observes the same ordering it would if both frames were in the same process.
+        Page::DeferRemotePostMessageScope deferRemotePostMessageScope(frame ? frame->page() : nullptr);
 
-    if (shouldMarkLoadEventTimes) {
-        auto now = MonotonicTime::now();
-        protectedLoader->timing().setLoadEventEnd(now);
-        protect(performance())->navigationFinished(now);
-        WTFEmitSignpost(document.get(), NavigationAndPaintTiming, "loadEventEnd");
-        WTFEndSignpost(document.get(), NavigationAndPaintTiming);
+        dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No), document.get());
+
+        if (shouldMarkLoadEventTimes) {
+            auto now = MonotonicTime::now();
+            protectedLoader->timing().setLoadEventEnd(now);
+            protect(performance())->navigationFinished(now);
+            WTFEmitSignpost(document.get(), NavigationAndPaintTiming, "loadEventEnd");
+            WTFEndSignpost(document.get(), NavigationAndPaintTiming);
+        }
+
+        // Send a separate load event to the element that owns this frame.
+        if (RefPtr frame = this->frame())
+            frame->dispatchLoadEventToParent();
     }
-
-    // Send a separate load event to the element that owns this frame.
-    if (RefPtr frame = this->frame())
-        frame->dispatchLoadEventToParent();
 
     InspectorInstrumentation::loadEventFired(protect(this->frame()).get());
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4786,6 +4786,29 @@ void Page::forEachWindowEventLoop(NOESCAPE const Function<void(WindowEventLoop&)
         functor(eventLoop);
 }
 
+Page::DeferRemotePostMessageScope::DeferRemotePostMessageScope(Page* page)
+    : m_page(page)
+{
+    if (m_page)
+        ++m_page->m_remotePostMessageDeferralCount;
+}
+
+Page::DeferRemotePostMessageScope::~DeferRemotePostMessageScope()
+{
+    if (!m_page || --m_page->m_remotePostMessageDeferralCount)
+        return;
+
+    auto deferredRemotePostMessages = std::exchange(m_page->m_deferredRemotePostMessages, { });
+    for (auto& deferredRemotePostMessage : deferredRemotePostMessages)
+        deferredRemotePostMessage();
+}
+
+void Page::deferRemotePostMessage(Function<void()>&& sendMessage)
+{
+    ASSERT(shouldDeferRemotePostMessage());
+    m_deferredRemotePostMessages.append(WTF::move(sendMessage));
+}
+
 bool Page::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMainResource) const
 {
     if (mainFrameMainResource == MainFrameMainResource::No && !m_loadsSubresources)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1438,6 +1438,24 @@ public:
     void syncLocalFrameInfoToRemote();
     RenderingUpdateScheduler& renderingUpdateScheduler() LIFETIME_BOUND;
 
+    // Cross-process postMessage is sent to the other process as soon as postMessage() is called, whereas
+    // same-process postMessage merely queues a task on the target's event loop. Notifications which are
+    // dispatched synchronously in the target process, such as the load event of a frame owner element,
+    // would therefore be observed out of order with respect to the same-process behavior. This scope
+    // buffers those sends so that they can be flushed after such a notification has been sent.
+    class DeferRemotePostMessageScope {
+        WTF_MAKE_NONCOPYABLE(DeferRemotePostMessageScope);
+    public:
+        explicit DeferRemotePostMessageScope(Page*);
+        ~DeferRemotePostMessageScope();
+
+    private:
+        const RefPtr<Page> m_page;
+    };
+
+    bool shouldDeferRemotePostMessage() const { return m_remotePostMessageDeferralCount; }
+    void deferRemotePostMessage(Function<void()>&&);
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1932,6 +1950,9 @@ private:
 #if ENABLE(THREADED_ANIMATIONS)
     const std::unique_ptr<AcceleratedTimelinesUpdater> m_acceleratedTimelinesUpdater;
 #endif
+
+    unsigned m_remotePostMessageDeferralCount { 0 };
+    Vector<Function<void()>> m_deferredRemotePostMessages;
 
 }; // class Page
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -27,6 +27,7 @@
 #include "RemoteDOMWindow.h"
 
 #include "Document.h"
+#include "DocumentPage.h"
 #include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
@@ -130,8 +131,23 @@ ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGloba
     RefPtr userGestureToForward = UserGestureIndicator::currentUserGesture();
 
     MessageWithMessagePorts messageWithPorts { messageData.releaseReturnValue(), disentangledPorts.releaseReturnValue() };
-    if (RefPtr remoteFrame = frame())
-        remoteFrame->client().postMessageToRemote(sourceFrame->frameID(), sourceOrigin, remoteFrame->frameID(), target, messageWithPorts, userGestureToForward ? std::optional(userGestureToForward->data()) : std::nullopt);
+    RefPtr remoteFrame = frame();
+    if (!remoteFrame)
+        return { };
+
+    auto sendMessage = [remoteFrame = WeakPtr { *remoteFrame }, sourceFrameID = sourceFrame->frameID(), sourceOrigin, target, messageWithPorts = WTF::move(messageWithPorts), userGestureToForward = userGestureToForward ? std::optional(userGestureToForward->data()) : std::nullopt] mutable {
+        if (RefPtr frame = remoteFrame.get())
+            frame->client().postMessageToRemote(sourceFrameID, sourceOrigin, frame->frameID(), target, messageWithPorts, userGestureToForward);
+    };
+
+    // Sending the message right away would let it be observed by the target process before notifications
+    // which are sent later in this task but dispatched synchronously, such as the load event of a frame
+    // owner element. Buffer the message in that case so that the ordering matches the same-process behavior.
+    RefPtr page = remoteFrame->page();
+    if (page && page->shouldDeferRemotePostMessage())
+        page->deferRemotePostMessage(WTF::move(sendMessage));
+    else
+        sendMessage();
     return { };
 }
 


### PR DESCRIPTION
#### fa2571b1c143711a9bcd6f2b3d2bee9da257c6da
<pre>
[Site Isolation] imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=322990">https://bugs.webkit.org/show_bug.cgi?id=322990</a>

Reviewed by NOBODY (OOPS!).

When a frame calls postMessage() on its parent from its own load event handler
and the two frames are in different processes, the message races with the load
event of the frame&apos;s owner element. imported/w3c/web-platform-tests/fetch/api/
redirect/redirect-keepalive.https.any.html times out in roughly 30% of runs
with --site-isolation-enabled-by-default because of this: keepalive-helper.js
only starts listening for the message after awaiting the iframe&apos;s load event,
so whenever the message is dispatched first it is dropped and the test hangs
waiting for it.

LocalDOMWindow::dispatchLoadEvent() runs the load event handlers and only then
calls LocalFrame::dispatchLoadEventToParent(), so the child process sends
WebPageProxy::PostMessageToRemote before
WebPageProxy::DispatchLoadEventToFrameOwnerElement. The parent process handles
the two asymmetrically: WebPage::remotePostMessage ends up in
LocalDOMWindow::processPostMessage, which queues a task on the
PostedMessageQueue task source, while
WebPage::dispatchLoadEventToFrameOwnerElement dispatches the event
synchronously from the IPC handler. Whether the load event wins therefore
depends on whether the parent&apos;s event loop happens to turn between the two IPC
dispatches. In a single process there is no race: dispatchLoadEventToParent()
dispatches on the owner element synchronously, so it always runs before the
message task queued by the handler.

Because the parent process receives the two messages in the order they were
sent, the ordering has to be corrected in the sending process. Add
Page::DeferRemotePostMessageScope, which buffers cross-process postMessage
sends made while a window&apos;s load event is being dispatched and flushes them
once the owner element has been notified. That reproduces the single-process
ordering, and since the flush happens synchronously in the same task, no
message is lost if the frame or the process goes away afterwards.

HTML leaves the relative order of tasks from different task sources
implementation-defined, so neither ordering is a conformance violation, but
load-then-message is what WebKit dispatches without site isolation and site
isolation should not change it.

Measured over ten fresh page loads with an ordering probe: without site
isolation the load event came first 10/10 times, with site isolation it came
first 6/10 times before this change and 10/10 after it. The web platform test
above now passes 40/40 iterations.

Tests: http/tests/site-isolation/load-event-before-message-posted-in-load-handler.html
       imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html

* LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/load-event-before-message-posted-in-load-handler.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-to-parent-on-load.html: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchLoadEvent):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::DeferRemotePostMessageScope::DeferRemotePostMessageScope):
(WebCore::Page::DeferRemotePostMessageScope::~DeferRemotePostMessageScope):
(WebCore::Page::deferRemotePostMessage):
* Source/WebCore/page/Page.h:
(WebCore::Page::shouldDeferRemotePostMessage const):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::postMessage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa2571b1c143711a9bcd6f2b3d2bee9da257c6da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148531 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45d34d4d-16ad-412e-a110-a92e42ba7778) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143838 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99973 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5daed229-07b3-4277-9a8f-3921281b0cc7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124253 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ddcb75ad-2a08-42c1-8a86-f06d4bc8030e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44538 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44113 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5643 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196401 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153401 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58538 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153070 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47601 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130837 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127294 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57045 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19122 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56656 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->