### PR TITLE
Bundle SVGImage's container parameters into a struct

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -295,7 +295,7 @@ static RefPtr<NativeImage> createNativeImageFromSVGImage(SVGImage& image, const 
     if (!buffer)
         return nullptr;
 
-    Ref svgImageContainer = SVGImageForContainer::create(&image, size, 1, { });
+    Ref svgImageContainer = SVGImageForContainer::create(&image, { .containerSize = size });
     buffer->context().drawImage(svgImageContainer.get(), FloatPoint::zero());
 
     return ImageBuffer::sinkIntoNativeImage(WTF::move(buffer));

--- a/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
@@ -178,11 +178,11 @@ RefPtr<WebCore::Image> CrossfadeImage::image(const RenderElement* renderer, cons
 
     if (RefPtr fromSVGImage = dynamicDowncast<SVGImage>(protectedFromImage)) {
         auto fromURL = m_cachedFromImage ? protect(m_cachedFromImage)->url() : WTF::URL();
-        protectedFromImage = SVGImageForContainer::create(fromSVGImage.get(), size, 1, fromURL);
+        protectedFromImage = SVGImageForContainer::create(fromSVGImage.get(), { .containerSize = size, .initialFragmentURL = fromURL });
     }
     if (RefPtr toSVGImage = dynamicDowncast<SVGImage>(protectedToImage)) {
         auto toURL = m_cachedToImage ? protect(m_cachedToImage)->url() : WTF::URL();
-        protectedToImage = SVGImageForContainer::create(toSVGImage.get(), size, 1, toURL);
+        protectedToImage = SVGImageForContainer::create(toSVGImage.get(), { .containerSize = size, .initialFragmentURL = toURL });
     }
 
     return CrossfadeGeneratedImage::create(*protectedFromImage, *protectedToImage, m_progress.value.value, fixedSize(*renderer), size);

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -224,7 +224,7 @@ IntSize SVGImage::containerSize() const
     return IntSize(currentSize);
 }
 
-ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const Style::LinkParameters& linkParameters, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
+ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const ContainerContext& containerContext, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     if (!m_page)
         return ImageDrawResult::DidNothing;
@@ -232,19 +232,20 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
     ImageObserverDisableScope imageObserverDisabler(*this);
 
+    auto containerSize = containerContext.containerSize;
     IntSize roundedContainerSize = roundedIntSize(containerSize);
     setContainerSize(roundedContainerSize);
 
     FloatRect scaledSrc = srcRect;
-    scaledSrc.scale(1 / containerZoom);
+    scaledSrc.scale(1 / containerContext.containerZoom);
 
     // Compensate for the container size rounding by adjusting the source rect.
     FloatSize adjustedSrcSize = scaledSrc.size();
     adjustedSrcSize.scale(roundedContainerSize.width() / containerSize.width(), roundedContainerSize.height() / containerSize.height());
     scaledSrc.setSize(adjustedSrcSize);
 
-    applyLinkParameters(linkParameters);
-    protect(frameView())->scrollToFragment(initialFragmentURL);
+    applyLinkParameters(containerContext.linkParameters);
+    protect(frameView())->scrollToFragment(containerContext.initialFragmentURL);
 
     return draw(context, dstRect, scaledSrc, options);
 }
@@ -304,11 +305,11 @@ RefPtr<NativeImage> SVGImage::nativeImage(const FloatSize& size, const Destinati
     return ImageBuffer::sinkIntoNativeImage(WTF::move(imageBuffer));
 }
 
-void SVGImage::drawPatternForContainer(GraphicsContext& context, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, const Style::LinkParameters& linkParameters, const FloatRect& srcRect,
+void SVGImage::drawPatternForContainer(GraphicsContext& context, const ContainerContext& containerContext, const FloatRect& srcRect,
     const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const FloatRect& dstRect, ImagePaintingOptions options)
 {
-    FloatRect zoomedContainerRect = FloatRect(FloatPoint(), containerSize);
-    zoomedContainerRect.scale(containerZoom);
+    FloatRect zoomedContainerRect = FloatRect(FloatPoint(), containerContext.containerSize);
+    zoomedContainerRect.scale(containerContext.containerZoom);
 
     // The ImageBuffer size needs to be scaled to match the final resolution.
     AffineTransform transform = context.getCTM();
@@ -323,7 +324,7 @@ void SVGImage::drawPatternForContainer(GraphicsContext& context, const FloatSize
     if (!buffer)
         return;
 
-    drawForContainer(buffer->context(), containerSize, containerZoom, initialFragmentURL, linkParameters, imageBufferSize, zoomedContainerRect);
+    drawForContainer(buffer->context(), containerContext, imageBufferSize, zoomedContainerRect);
     if (context.drawLuminanceMask())
         buffer->convertToLuminanceMask();
 

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -45,6 +45,13 @@ class Settings;
 
 class SVGImage final : public Image {
 public:
+    struct ContainerContext {
+        FloatSize containerSize { };
+        float containerZoom { 1 };
+        URL initialFragmentURL { };
+        Style::LinkParameters linkParameters { CSS::Keyword::None { } };
+    };
+
     static Ref<SVGImage> create(ImageObserver* observer) { return adoptRef(*new SVGImage(observer)); }
     WEBCORE_EXPORT static void tryCreateFromData(std::span<const uint8_t>, CompletionHandler<void(RefPtr<SVGImage>&&)>&&);
     WEBCORE_EXPORT static bool isDataDecodable(const Settings&, std::span<const uint8_t>);
@@ -112,8 +119,8 @@ private:
 
     WEBCORE_EXPORT explicit SVGImage(ImageObserver*);
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
-    ImageDrawResult drawForContainer(GraphicsContext&, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const Style::LinkParameters&, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
-    void drawPatternForContainer(GraphicsContext&, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, const Style::LinkParameters&, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect&, ImagePaintingOptions = { });
+    ImageDrawResult drawForContainer(GraphicsContext&, const ContainerContext&, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
+    void drawPatternForContainer(GraphicsContext&, const ContainerContext&, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect& dstRect, ImagePaintingOptions = { });
 
     void applyLinkParameters(const Style::LinkParameters&);
 

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -64,7 +64,12 @@ void SVGImageCache::setContainerContextForClient(const CachedImageClient& client
     FloatSize containerSizeWithoutZoom(containerSize);
     containerSizeWithoutZoom.scale(1 / containerZoom);
 
-    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protect(m_svgImage).get(), containerSizeWithoutZoom, containerZoom, imageURL, linkParameters));
+    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protect(m_svgImage).get(), {
+        .containerSize = containerSizeWithoutZoom,
+        .containerZoom = containerZoom,
+        .initialFragmentURL = imageURL,
+        .linkParameters = linkParameters
+    }));
 }
 
 Image* SVGImageCache::findImageForRenderer(const RenderObject* renderer) const

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -28,31 +28,28 @@
 
 namespace WebCore {
 
-SVGImageForContainer::SVGImageForContainer(SVGImage* image, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, Style::LinkParameters&& linkParameters)
+SVGImageForContainer::SVGImageForContainer(SVGImage* image, SVGImage::ContainerContext&& containerContext)
     : m_image(image)
-    , m_containerSize(containerSize)
-    , m_containerZoom(containerZoom)
-    , m_initialFragmentURL(initialFragmentURL)
-    , m_linkParameters(WTF::move(linkParameters))
+    , m_containerContext(WTF::move(containerContext))
 {
 }
 
 FloatSize SVGImageForContainer::size(ImageOrientation) const
 {
-    FloatSize scaledContainerSize(m_containerSize);
-    scaledContainerSize.scale(m_containerZoom);
+    FloatSize scaledContainerSize(m_containerContext.containerSize);
+    scaledContainerSize.scale(m_containerContext.containerZoom);
     return FloatSize(roundedIntSize(scaledContainerSize));
 }
 
 ImageDrawResult SVGImageForContainer::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    return protect(m_image)->drawForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, m_linkParameters, dstRect, srcRect, options);
+    return protect(m_image)->drawForContainer(context, m_containerContext, dstRect, srcRect, options);
 }
 
 void SVGImageForContainer::drawPattern(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, const AffineTransform& patternTransform,
     const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    protect(m_image)->drawPatternForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, m_linkParameters, srcRect, patternTransform, phase, spacing, dstRect, options);
+    protect(m_image)->drawPatternForContainer(context, m_containerContext, srcRect, patternTransform, phase, spacing, dstRect, options);
 }
 
 RefPtr<NativeImage> SVGImageForContainer::currentNativeImage()

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.h
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.h
@@ -37,9 +37,9 @@ namespace WebCore {
 
 class SVGImageForContainer final : public Image {
 public:
-    static Ref<SVGImageForContainer> create(SVGImage* image, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, Style::LinkParameters linkParameters = CSS::Keyword::None { })
+    static Ref<SVGImageForContainer> create(SVGImage* image, SVGImage::ContainerContext&& containerContext)
     {
-        return adoptRef(*new SVGImageForContainer(image, containerSize, containerZoom, initialFragmentURL, WTF::move(linkParameters)));
+        return adoptRef(*new SVGImageForContainer(image, WTF::move(containerContext)));
     }
 
     bool NODELETE isSVGImageForContainer() const final { return true; }
@@ -65,13 +65,10 @@ public:
     RefPtr<NativeImage> currentNativeImage() final;
 
 private:
-    WEBCORE_EXPORT SVGImageForContainer(SVGImage*, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, Style::LinkParameters&&);
+    WEBCORE_EXPORT SVGImageForContainer(SVGImage*, SVGImage::ContainerContext&&);
 
     WeakPtr<SVGImage> m_image;
-    const FloatSize m_containerSize;
-    const float m_containerZoom;
-    const URL m_initialFragmentURL;
-    const Style::LinkParameters m_linkParameters;
+    const SVGImage::ContainerContext m_containerContext;
 };
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp
@@ -91,7 +91,7 @@ TEST(SVGImageCasts, SVGImageForContainerIsNotSVGImage)
     Image& svgImageBase = svgImage.get();
     EXPECT_TRUE(is<SVGImage>(svgImageBase));
     EXPECT_FALSE(is<SVGImageForContainer>(svgImageBase));
-    auto svgImageForContainer = SVGImageForContainer::create(svgImage.ptr(), { }, 0, URL());
+    auto svgImageForContainer = SVGImageForContainer::create(svgImage.ptr(), { });
     Image& svgImageForContainerBase = svgImageForContainer.get();
     EXPECT_FALSE(is<SVGImage>(svgImageForContainerBase));
     EXPECT_TRUE(is<SVGImageForContainer>(svgImageForContainerBase));


### PR DESCRIPTION
#### 097a3b9edb13b2e2d9667b85dbbfc65cd338a21a
<pre>
Bundle SVGImage&apos;s container parameters into a struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=322995">https://bugs.webkit.org/show_bug.cgi?id=322995</a>
<a href="https://rdar.apple.com/186264558">rdar://186264558</a>

Reviewed by Simon Fraser.

Introduce SVGImage::ContainerContext which holds container size, zoom,
fragment URL and link parameters.

There should be no behavior change.

* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::createNativeImageFromSVGImage):
* Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp:
(WebCore::Style::CrossfadeImage::image const):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::drawForContainer):
(WebCore::SVGImage::drawPatternForContainer):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::setContainerContextForClient):
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
(WebCore::SVGImageForContainer::SVGImageForContainer):
(WebCore::SVGImageForContainer::size const):
(WebCore::SVGImageForContainer::draw):
(WebCore::SVGImageForContainer::drawPattern):
* Source/WebCore/svg/graphics/SVGImageForContainer.h:
* Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp:
(TestWebKitAPI::TEST(SVGImageCasts, SVGImageForContainerIsNotSVGImage)):

Canonical link: <a href="https://commits.webkit.org/320176@main">https://commits.webkit.org/320176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d2e85f289018fdc11db2d683543192a705a256

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148304 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143652 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99811 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124071 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46128 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43924 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5417 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57606 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41018 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58310 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152875 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47410 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130600 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56818 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18935 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56189 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56428 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->