### PR TITLE
Make parseRange() follow the Fetch Standard

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any-expected.txt
@@ -37,4 +37,15 @@ PASS Preflight for {"range":"bytes 100-200"}
 PASS Preflight for {"range":"bytes = 100-200"}
 PASS Preflight for {"range":",bytes=100-200"}
 PASS Preflight for {"range":"bytes=,100-200"}
+PASS Preflight for {"range":"BYTES=100-200"}
+PASS Preflight for {"range":"Bytes=100-200"}
+PASS Preflight for {"range":"bytes=+0-100"}
+PASS Preflight for {"range":"bytes=0-+100"}
+PASS Preflight for {"range":"bytes=+5-"}
+PASS Preflight for {"range":"bytes=0--1"}
+PASS Preflight for {"range":"bytes\f=100-200"}
+PASS Preflight for {"range":"bytes=\f100-200"}
+PASS Preflight for {"range":"bytes=100\f-200"}
+PASS Preflight for {"range":"bytes=100-\f200"}
+PASS Preflight for {"range":"bytes=100-200\f"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.js
@@ -66,6 +66,17 @@ function safelist(headers, expectPreflight = false) {
   ["bytes = 100-200", true],
   [",bytes=100-200", true],
   ["bytes=,100-200", true],
+  ["BYTES=100-200", true],
+  ["Bytes=100-200", true],
+  ["bytes=+0-100", true],
+  ["bytes=0-+100", true],
+  ["bytes=+5-", true],
+  ["bytes=0--1", true],
+  ["bytes\u000C=100-200", true],
+  ["bytes=\u000C100-200", true],
+  ["bytes=100\u000C-200", true],
+  ["bytes=100-\u000C200", true],
+  ["bytes=100-200\u000C", true]
 ].forEach(([value, preflight = false]) => {
   safelist({"range": value}, preflight);
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.worker-expected.txt
@@ -37,4 +37,15 @@ PASS Preflight for {"range":"bytes 100-200"}
 PASS Preflight for {"range":"bytes = 100-200"}
 PASS Preflight for {"range":",bytes=100-200"}
 PASS Preflight for {"range":"bytes=,100-200"}
+PASS Preflight for {"range":"BYTES=100-200"}
+PASS Preflight for {"range":"Bytes=100-200"}
+PASS Preflight for {"range":"bytes=+0-100"}
+PASS Preflight for {"range":"bytes=0-+100"}
+PASS Preflight for {"range":"bytes=+5-"}
+PASS Preflight for {"range":"bytes=0--1"}
+PASS Preflight for {"range":"bytes\f=100-200"}
+PASS Preflight for {"range":"bytes=\f100-200"}
+PASS Preflight for {"range":"bytes=100\f-200"}
+PASS Preflight for {"range":"bytes=100-\f200"}
+PASS Preflight for {"range":"bytes=100-200\f"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
@@ -11,8 +11,13 @@ PASS Blob range with whitespace after hyphen
 PASS Blob range with whitespace around equals sign
 PASS Blob range with no value
 PASS Blob range with incorrect range header
+PASS Blob range unit is case-sensitive
+PASS Blob range unit is case-sensitive #2
 PASS Blob range with incorrect range header #2
 PASS Blob range with incorrect range header #3
+PASS Blob range with U+000C where HTTP tab or space is allowed
+PASS Blob range with U+000C before the dash
+PASS Blob range with U+000B where HTTP tab or space is allowed
 PASS Blob range request with multiple range values
 PASS Blob range request with multiple range values and whitespace
 PASS Blob range request with trailing comma
@@ -21,6 +26,9 @@ PASS Blob range request with short range end
 PASS Blob range start should be an ASCII digit
 PASS Blob range should have a dash
 PASS Blob range end should be an ASCII digit
+PASS Blob range start must not be signed
+PASS Blob range start must not be signed #2
+PASS Blob range end must not be signed
 PASS Blob range should include '-'
 PASS Blob range should include '='
 PASS Blob range should include 'bytes='

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
@@ -107,6 +107,18 @@ const unsupportedBlobRange = [
     range: "byte=0-"
   },
   {
+    name: "Blob range unit is case-sensitive",
+    data: ["The range unit must be lowercase"],
+    type: "text/plain",
+    range: "BYTES=0-5"
+  },
+  {
+    name: "Blob range unit is case-sensitive #2",
+    data: ["The range unit must be lowercase"],
+    type: "text/plain",
+    range: "ByTes=0-5"
+  },
+  {
     name: "Blob range with incorrect range header #2",
     data: ["A"],
     type: "text/plain",
@@ -117,6 +129,24 @@ const unsupportedBlobRange = [
     data: ["A"],
     type: "text/plain",
     range: "bytes\t \t"
+  },
+  {
+    name: "Blob range with U+000C where HTTP tab or space is allowed",
+    data: ["U+000C is not HTTP tab or space"],
+    type: "text/plain",
+    range: "bytes=\u000C0-5"
+  },
+  {
+    name: "Blob range with U+000C before the dash",
+    data: ["U+000C is not HTTP tab or space"],
+    type: "text/plain",
+    range: "bytes=0\u000C-5"
+  },
+  {
+    name: "Blob range with U+000B where HTTP tab or space is allowed",
+    data: ["U+000B is not HTTP tab or space"],
+    type: "text/plain",
+    range: "bytes=\u000B0-5"
   },
   {
     name: "Blob range request with multiple range values",
@@ -165,6 +195,24 @@ const unsupportedBlobRange = [
     data: ["Range end must be an ASCII digit"],
     type: "text/plain",
     range: "bytes=5-x",
+  },
+  {
+    name: "Blob range start must not be signed",
+    data: ["Range start must be an ASCII digit"],
+    type: "text/plain",
+    range: "bytes=+0-5",
+  },
+  {
+    name: "Blob range start must not be signed #2",
+    data: ["Range start must be an ASCII digit"],
+    type: "text/plain",
+    range: "bytes=+5-",
+  },
+  {
+    name: "Blob range end must not be signed",
+    data: ["Range end must be an ASCII digit"],
+    type: "text/plain",
+    range: "bytes=0-+5",
   },
   {
     name: "Blob range should include '-'",

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.worker-expected.txt
@@ -11,8 +11,13 @@ PASS Blob range with whitespace after hyphen
 PASS Blob range with whitespace around equals sign
 PASS Blob range with no value
 PASS Blob range with incorrect range header
+PASS Blob range unit is case-sensitive
+PASS Blob range unit is case-sensitive #2
 PASS Blob range with incorrect range header #2
 PASS Blob range with incorrect range header #3
+PASS Blob range with U+000C where HTTP tab or space is allowed
+PASS Blob range with U+000C before the dash
+PASS Blob range with U+000B where HTTP tab or space is allowed
 PASS Blob range request with multiple range values
 PASS Blob range request with multiple range values and whitespace
 PASS Blob range request with trailing comma
@@ -21,6 +26,9 @@ PASS Blob range request with short range end
 PASS Blob range start should be an ASCII digit
 PASS Blob range should have a dash
 PASS Blob range end should be an ASCII digit
+PASS Blob range start must not be signed
+PASS Blob range start must not be signed #2
+PASS Blob range end must not be signed
 PASS Blob range should include '-'
 PASS Blob range should include '='
 PASS Blob range should include 'bytes='

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -614,61 +614,56 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
 }
 
 // Implements <https://fetch.spec.whatwg.org/#simple-range-header-value>.
-// FIXME: this whole function could be more efficient by walking through the range value once.
 std::optional<HTTPRange> parseRange(StringView range, RangeAllowWhitespace allowWhitespace)
 {
-    // Only 0x20 and 0x09 matter as newlines are already gone by the time we parse a header value.
-    if (allowWhitespace == RangeAllowWhitespace::No && range.contains(isTabOrSpace<char16_t>))
+    static constexpr auto bytesPrefix = "bytes"_s;
+    if (!range.startsWith(bytesPrefix))
         return std::nullopt;
 
-    // The "bytes" unit identifier should be present.
-    static const unsigned bytesLength = 5;
-    if (!startsWithLettersIgnoringASCIICase(range, "bytes"_s))
-        return std::nullopt;
+    return readCharactersForParsing(range.substring(bytesPrefix.length()), [allowWhitespace](auto buffer) -> std::optional<HTTPRange> {
+        // Only 0x20 and 0x09 matter as newlines are already gone by the time we parse a header value.
+        auto skipOptionalWhitespace = [&] {
+            if (allowWhitespace == RangeAllowWhitespace::Yes)
+                WTF::skipWhile<isTabOrSpace>(buffer);
+        };
+        auto collectDigits = [&] {
+            auto digits = buffer.span();
+            WTF::skipWhile<isASCIIDigit>(buffer);
+            return digits.first(digits.size() - buffer.lengthRemaining());
+        };
 
-    auto byteRange = range.substring(bytesLength).trim(isASCIIWhitespaceWithoutFF<char16_t>);
-
-    if (!byteRange.startsWith('='))
-        return std::nullopt;
-
-    byteRange = byteRange.substring(1);
-
-    // The '-' character needs to be present.
-    size_t index = byteRange.find('-');
-    if (index == notFound)
-        return std::nullopt;
-
-    // If the '-' character is at the beginning, the suffix length, which specifies the last N bytes, is provided.
-    // Example:
-    //     -500
-    if (!index) {
-        auto value = parseInteger<uint64_t>(byteRange.substring(index + 1));
-        if (!value)
+        skipOptionalWhitespace();
+        if (!skipExactly(buffer, '='))
             return std::nullopt;
-        return HTTPRange { std::nullopt, *value };
-    }
-
-    // Otherwise, the first-byte-position and the last-byte-position are provied.
-    // Examples:
-    //     0-499
-    //     500-
-    auto firstBytePos = parseInteger<uint64_t>(byteRange.left(index));
-    if (!firstBytePos)
-        return std::nullopt;
-
-    auto lastBytePosStr = byteRange.substring(index + 1);
-    std::optional<uint64_t> lastBytePos;
-    if (!lastBytePosStr.isEmpty()) {
-        auto value = parseInteger<uint64_t>(lastBytePosStr);
-        if (!value)
+        skipOptionalWhitespace();
+        auto startDigits = collectDigits();
+        skipOptionalWhitespace();
+        if (!skipExactly(buffer, '-'))
             return std::nullopt;
-        lastBytePos = *value;
-    }
+        skipOptionalWhitespace();
+        auto endDigits = collectDigits();
+        if (!buffer.atEnd())
+            return std::nullopt;
+        if (startDigits.empty() && endDigits.empty())
+            return std::nullopt;
 
-    if (lastBytePos && *firstBytePos > *lastBytePos)
-        return std::nullopt;
+        std::optional<uint64_t> start;
+        if (!startDigits.empty()) {
+            start = parseInteger<uint64_t>(startDigits);
+            if (!start)
+                return std::nullopt;
+        }
+        std::optional<uint64_t> end;
+        if (!endDigits.empty()) {
+            end = parseInteger<uint64_t>(endDigits);
+            if (!end)
+                return std::nullopt;
+        }
+        if (start && end && *start > *end)
+            return std::nullopt;
 
-    return HTTPRange { *firstBytePos, lastBytePos };
+        return HTTPRange { start, end };
+    });
 }
 
 template<typename CharacterType>


### PR DESCRIPTION
#### d4107fcb3662e705b8f3cf03b7a28a6b9d2682b8
<pre>
Make parseRange() follow the Fetch Standard
<a href="https://bugs.webkit.org/show_bug.cgi?id=322999">https://bugs.webkit.org/show_bug.cgi?id=322999</a>

Reviewed by Youenn Fablet.

261968@main made parseRange() shared between blob: URLs and the CORS-safelisted
request-header check, but it had a few minor issues:

* &quot;bytes&quot; was matched case-insensitively.
* Byte positions were parsed with parseInteger(), which allows a leading &quot;+&quot;,
  whereas the algorithm collects ASCII digits.
* parseInteger() skips U+000B and U+000C as whitespace.

Apart from addressing those we also make the algorithm perform a single pass as
per the FIXME.

Tests are upstreamed via <a href="https://github.com/web-platform-tests/wpt/pull/62329.">https://github.com/web-platform-tests/wpt/pull/62329.</a>
Firefox passes all. Chrome passes all CORS tests, but does not reuse the parser
for blob: URLs. Hopefully the new tests will help them address that.

Canonical link: <a href="https://commits.webkit.org/320912@main">https://commits.webkit.org/320912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e0fd14c66552bdf22e94a998005604e76151bbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148306 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/103ce4c0-a195-4b6c-bf90-772c12958ba0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143648 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99813 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8efaca2-baeb-4e11-ae80-0209e01199da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124067 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06814307-bd0e-47f4-a377-2fde3a382e5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44349 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156525 "Found 6 new API test failures: TestWebKitAPI.WKWebExtensionAPIWebNavigation.BeforeNavigateEvent, TestWebKitAPI.ResourceLoadStatistics.UserGestureLogsUserInteraction, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRuleWithoutHostAccessPermission, TestWebKitAPI.WKWebExtensionAPIScripting.CSSAuthorOrigin, TestWebKitAPI.WKWebExtensionAPIMenus.ActionMenus (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43925 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57608 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41553 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58312 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152874 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47411 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130602 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127100 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56820 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18936 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56191 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->