### PR TITLE
AX: VoiceOver ignores list content inside elements referenced by aria-describedby

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-describedby-with-list-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-describedby-with-list-expected.txt
@@ -1,0 +1,16 @@
+This test ensures a node referenced by aria-labelledby or aria-describedby contributes the text of nested lists and tables, not just its non-container children.
+
+PASS: nameFor('labelledby-list') === 'This is a note First item Second item'
+PASS: labelTextFor('labelledby-list') === 'This is a note First item Second item'
+PASS: descriptionFor('describedby-list') === 'This is a note First item Second item'
+PASS: descriptionFor('describedby-list-only') === 'First item Second item'
+PASS: nameFor('labelledby-unordered-list') === 'This is a note Bullet item'
+PASS: labelTextFor('labelledby-unordered-list') === 'This is a note Bullet item'
+PASS: descriptionFor('describedby-data-table') === 'This is a note Heading Cell one'
+PASS: descriptionFor('describedby-nested-divs') === 'This is a note Nested sentence'
+PASS: descriptionFor('describedby-list-directly') === 'First item Second item'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/aria-labelledby-describedby-with-list.html
+++ b/LayoutTests/accessibility/aria-labelledby-describedby-with-list.html
@@ -1,0 +1,92 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+
+<!-- When a node is referenced by aria-labelledby or aria-describedby, accname step 2F requires the
+     text of its whole subtree, whether or not the descendant roles support name-from-content. So
+     nested lists and tables should contribute their contents, even though the heuristic in
+     shouldUseAccessibilityObjectInnerText() skips such containers when computing a name from
+     content in the ordinary way. -->
+
+<div id="label1"><p>This is a note</p><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="labelledby-list" type="text" aria-labelledby="label1">
+
+<div id="label2"><p>This is a note</p><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="describedby-list" type="text" aria-describedby="label2">
+
+<div id="label3"><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="describedby-list-only" type="text" aria-describedby="label3">
+
+<div id="label4"><p>This is a note</p><ul><li>Bullet item</li></ul></div>
+<input id="labelledby-unordered-list" type="text" aria-labelledby="label4">
+
+<div id="label5"><p>This is a note</p><table><tr><th>Heading</th></tr><tr><td>Cell one</td></tr></table></div>
+<input id="describedby-data-table" type="text" aria-describedby="label5">
+
+<!-- Controls. These already behaved correctly, and narrow the failure to container descendants of
+     the referenced node. -->
+
+<div id="label6"><p>This is a note</p><div>Nested sentence</div></div>
+<input id="describedby-nested-divs" type="text" aria-describedby="label6">
+
+<ol id="label7"><li>First item</li><li>Second item</li></ol>
+<input id="describedby-list-directly" type="text" aria-describedby="label7">
+
+</div>
+
+<script>
+var output = "This test ensures a node referenced by aria-labelledby or aria-describedby contributes the text of nested lists and tables, not just its non-container children.\n\n";
+
+// The point of this test is which text is present, not how it is separated, so collapse whitespace.
+function collapseWhitespace(text)
+{
+    return text.replace(/\s+/g, " ").trim();
+}
+
+function nameFor(id)
+{
+    return collapseWhitespace(platformValueForW3CName(accessibilityController.accessibleElementById(id)));
+}
+
+// The label text an aria-labelledby target contributes reaches the platform through two separate
+// WebCore strings: the one nameFor() reads, and the LabelByElement text that titleAttributeValue()
+// exposes. macOS reads the latter as AXTitle, and it is what ATSPI reports as the accessible name,
+// so assert it too rather than leaving one of the two paths uncovered.
+function labelTextFor(id)
+{
+    return collapseWhitespace(stripAXPrefix(accessibilityController.accessibleElementById(id).title));
+}
+
+function descriptionFor(id)
+{
+    // Cocoa platforms expose aria-describedby as custom content rather than as help text.
+    var axElement = accessibilityController.accessibleElementById(id);
+    var isCocoa = accessibilityController.platformName == "mac" || accessibilityController.platformName == "ios";
+    var raw = isCocoa ? axElement.customContent : axElement.helpText;
+    return collapseWhitespace(raw.split(": ").slice(1).join(": "));
+}
+
+if (window.accessibilityController) {
+    output += expect("nameFor('labelledby-list')", "'This is a note First item Second item'");
+    output += expect("labelTextFor('labelledby-list')", "'This is a note First item Second item'");
+    output += expect("descriptionFor('describedby-list')", "'This is a note First item Second item'");
+    output += expect("descriptionFor('describedby-list-only')", "'First item Second item'");
+    output += expect("nameFor('labelledby-unordered-list')", "'This is a note Bullet item'");
+    output += expect("labelTextFor('labelledby-unordered-list')", "'This is a note Bullet item'");
+    output += expect("descriptionFor('describedby-data-table')", "'This is a note Heading Cell one'");
+    output += expect("descriptionFor('describedby-nested-divs')", "'This is a note Nested sentence'");
+    output += expect("descriptionFor('describedby-list-directly')", "'First item Second item'");
+
+    document.getElementById("content").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list-expected.txt
@@ -1,0 +1,16 @@
+This test ensures a node referenced by aria-labelledby or aria-describedby contributes the text of nested lists and tables, not just its non-container children.
+
+PASS: nameFor('labelledby-list') === 'This is a note First item Second item'
+PASS: labelTextFor('labelledby-list') === 'This is a note First item Second item'
+PASS: descriptionFor('describedby-list') === 'This is a note First item Second item'
+PASS: descriptionFor('describedby-list-only') === 'First item Second item'
+PASS: nameFor('labelledby-unordered-list') === 'This is a note Bullet item'
+PASS: labelTextFor('labelledby-unordered-list') === 'This is a note Bullet item'
+PASS: descriptionFor('describedby-data-table') === 'This is a note Heading Cell one'
+PASS: descriptionFor('describedby-nested-divs') === 'This is a note Nested sentence'
+PASS: descriptionFor('describedby-list-directly') === 'First item Second item'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list.html
+++ b/LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list.html
@@ -1,0 +1,92 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+
+<!-- When a node is referenced by aria-labelledby or aria-describedby, accname step 2F requires the
+     text of its whole subtree, whether or not the descendant roles support name-from-content. So
+     nested lists and tables should contribute their contents, even though the heuristic in
+     shouldUseAccessibilityObjectInnerText() skips such containers when computing a name from
+     content in the ordinary way. -->
+
+<div id="label1"><p>This is a note</p><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="labelledby-list" type="text" aria-labelledby="label1">
+
+<div id="label2"><p>This is a note</p><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="describedby-list" type="text" aria-describedby="label2">
+
+<div id="label3"><ol><li>First item</li><li>Second item</li></ol></div>
+<input id="describedby-list-only" type="text" aria-describedby="label3">
+
+<div id="label4"><p>This is a note</p><ul><li>Bullet item</li></ul></div>
+<input id="labelledby-unordered-list" type="text" aria-labelledby="label4">
+
+<div id="label5"><p>This is a note</p><table><tr><th>Heading</th></tr><tr><td>Cell one</td></tr></table></div>
+<input id="describedby-data-table" type="text" aria-describedby="label5">
+
+<!-- Controls. These already behaved correctly, and narrow the failure to container descendants of
+     the referenced node. -->
+
+<div id="label6"><p>This is a note</p><div>Nested sentence</div></div>
+<input id="describedby-nested-divs" type="text" aria-describedby="label6">
+
+<ol id="label7"><li>First item</li><li>Second item</li></ol>
+<input id="describedby-list-directly" type="text" aria-describedby="label7">
+
+</div>
+
+<script>
+var output = "This test ensures a node referenced by aria-labelledby or aria-describedby contributes the text of nested lists and tables, not just its non-container children.\n\n";
+
+// The point of this test is which text is present, not how it is separated, so collapse whitespace.
+function collapseWhitespace(text)
+{
+    return text.replace(/\s+/g, " ").trim();
+}
+
+function nameFor(id)
+{
+    return collapseWhitespace(platformValueForW3CName(accessibilityController.accessibleElementById(id)));
+}
+
+// The label text an aria-labelledby target contributes reaches the platform through two separate
+// WebCore strings: the one nameFor() reads, and the LabelByElement text that titleAttributeValue()
+// exposes. macOS reads the latter as AXTitle, and it is what ATSPI reports as the accessible name,
+// so assert it too rather than leaving one of the two paths uncovered.
+function labelTextFor(id)
+{
+    return collapseWhitespace(stripAXPrefix(accessibilityController.accessibleElementById(id).title));
+}
+
+function descriptionFor(id)
+{
+    // Cocoa platforms expose aria-describedby as custom content rather than as help text.
+    var axElement = accessibilityController.accessibleElementById(id);
+    var isCocoa = accessibilityController.platformName == "mac" || accessibilityController.platformName == "ios";
+    var raw = isCocoa ? axElement.customContent : axElement.helpText;
+    return collapseWhitespace(raw.split(": ").slice(1).join(": "));
+}
+
+if (window.accessibilityController) {
+    output += expect("nameFor('labelledby-list')", "'This is a note First item Second item'");
+    output += expect("labelTextFor('labelledby-list')", "'This is a note First item Second item'");
+    output += expect("descriptionFor('describedby-list')", "'This is a note First item Second item'");
+    output += expect("descriptionFor('describedby-list-only')", "'First item Second item'");
+    output += expect("nameFor('labelledby-unordered-list')", "'This is a note Bullet item'");
+    output += expect("labelTextFor('labelledby-unordered-list')", "'This is a note Bullet item'");
+    output += expect("descriptionFor('describedby-data-table')", "'This is a note Heading Cell one'");
+    output += expect("descriptionFor('describedby-nested-divs')", "'This is a note Nested sentence'");
+    output += expect("descriptionFor('describedby-list-directly')", "'First item Second item'");
+
+    document.getElementById("content").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -142,7 +142,7 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static String accessibleNameForNode(Node&, Node* labelledbyNode = nullptr);
+static String accessibleNameForNode(Node&, Node* labelledbyNode = nullptr, DescendIntoContainers = DescendIntoContainers::No);
 static void appendNameToStringBuilder(StringBuilder&, String&&, bool prependSpace = true, bool prependNewline = false);
 
 AccessibilityNodeObject::AccessibilityNodeObject(AXID axID, Node* node, AXObjectCache& cache)
@@ -3325,7 +3325,7 @@ String AccessibilityNodeObject::textAsLabelFor(const AccessibilityObject& labele
     return textUnderElement();
 }
 
-String AccessibilityNodeObject::textForLabelElements(Vector<Ref<HTMLElement>>&& labelElements) const
+String AccessibilityNodeObject::textForLabelElements(Vector<Ref<HTMLElement>>&& labelElements, DescendIntoContainers descendIntoContainers) const
 {
     // https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
     // "...if more than one label is associated; concatenate by DOM order, delimited by spaces."
@@ -3351,7 +3351,7 @@ String AccessibilityNodeObject::textForLabelElements(Vector<Ref<HTMLElement>>&& 
             appendNameToStringBuilder(result, axLabel->textAsLabelFor(*this));
 #endif
         else
-            appendNameToStringBuilder(result, accessibleNameForNode(labelElement.get(), /* labelledByNode */ protect(node())));
+            appendNameToStringBuilder(result, accessibleNameForNode(labelElement.get(), /* labelledByNode */ protect(node()), descendIntoContainers));
     }
 
     return result.toString();
@@ -3387,10 +3387,14 @@ void AccessibilityNodeObject::labelText(Vector<AccessibilityText>& textOrder) co
             return RefPtr { dynamicDowncast<HTMLElement>(axLabel->element()) };
         }));
     }
+    // Labels sourced from aria-labelledby are an accname relation traversal, so the text of the
+    // whole referenced subtree counts, containers included. Native <label> elements keep the
+    // ordinary name-from-content behavior.
+    auto descendIntoContainers = elementLabels.size() ? DescendIntoContainers::Yes : DescendIntoContainers::No;
     if (!elementLabels.size())
         elementLabels = Accessibility::labelsForElement(element.get());
 
-    String label = textForLabelElements(WTF::move(elementLabels));
+    String label = textForLabelElements(WTF::move(elementLabels), descendIntoContainers);
     if (!label.isEmpty()) {
         textOrder.append({ WTF::move(label), isMeter() ? AccessibilityTextSource::Alternative : AccessibilityTextSource::LabelByElement });
         return;
@@ -4378,7 +4382,7 @@ SRGBA<uint8_t> AccessibilityNodeObject::colorValue() const
 
 // This function implements the ARIA accessible name as described by the Mozilla
 // ARIA Implementer's Guide.
-static String accessibleNameForNode(Node& node, Node* labelledbyNode)
+static String accessibleNameForNode(Node& node, Node* labelledbyNode, DescendIntoContainers descendIntoContainers)
 {
     auto* element = dynamicDowncast<Element>(node);
 
@@ -4421,7 +4425,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
 
         StringBuilder builder;
         for (const auto& child : selectedChildren)
-            appendNameToStringBuilder(builder, accessibleNameForNode(protect(*child->node())));
+            appendNameToStringBuilder(builder, accessibleNameForNode(protect(*child->node()), nullptr, descendIntoContainers));
 
         String childText = builder.toString();
         if (!childText.isEmpty())
@@ -4435,7 +4439,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
             if (!labels.isEmpty()) {
                 StringBuilder builder;
                 for (auto& label : labels)
-                    appendNameToStringBuilder(builder, accessibleNameForNode(label.get()));
+                    appendNameToStringBuilder(builder, accessibleNameForNode(label.get(), nullptr, descendIntoContainers));
                 String labelText = builder.toString();
                 if (!labelText.isEmpty())
                     return labelText;
@@ -4467,7 +4471,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
                 RefPtr assignedElement = dynamicDowncast<Element>(assignedNode.get());
                 if (assignedElement && isRenderHidden(safeStyleFrom(*assignedElement)))
                     continue;
-                appendNameToStringBuilder(builder, accessibleNameForNode(*assignedNode));
+                appendNameToStringBuilder(builder, accessibleNameForNode(*assignedNode, nullptr, descendIntoContainers));
             }
 
             auto assignedNodesText = builder.toString();
@@ -4479,7 +4483,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
     String text;
     if (axObject) {
         if (axObject->accessibleNameDerivesFromContent())
-            text = axObject->textUnderElement({ TextUnderElementMode::Children::IncludeNameFromContentsChildren, true, true, false, IncludeListMarkerText::No, DescendIntoContainers::No, TrimWhitespace::Yes, labelledbyNode });
+            text = axObject->textUnderElement({ TextUnderElementMode::Children::IncludeNameFromContentsChildren, true, true, false, IncludeListMarkerText::No, descendIntoContainers, TrimWhitespace::Yes, labelledbyNode });
     } else
         text = (element ? element->innerText() : node.textContent()).simplifyWhiteSpace(isASCIIWhitespace);
 
@@ -4498,7 +4502,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
         if (RefPtr shadowRoot = shadowRootIgnoringUserAgentShadow(node)) {
             StringBuilder builder;
             for (RefPtr child = shadowRoot->firstChild(); child; child = child->nextSibling())
-                appendNameToStringBuilder(builder, accessibleNameForNode(*child));
+                appendNameToStringBuilder(builder, accessibleNameForNode(*child, nullptr, descendIntoContainers));
 
             String shadowText = builder.toString();
             if (!shadowText.isEmpty())
@@ -4538,8 +4542,11 @@ String AccessibilityNodeObject::accessibilityDescriptionForChildren() const
 String AccessibilityNodeObject::descriptionForElements(const Vector<Ref<Element>>& elements) const
 {
     StringBuilder builder;
-    for (auto& element : elements)
-        appendNameToStringBuilder(builder, accessibleNameForNode(element.get(), protect(node())));
+    for (auto& element : elements) {
+        // This is the aria-labelledby / aria-describedby traversal, so descend into containers
+        // such as lists and tables to match the spec.
+        appendNameToStringBuilder(builder, accessibleNameForNode(element.get(), protect(node()), DescendIntoContainers::Yes));
+    }
     return builder.toString();
 }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -304,7 +304,7 @@ protected:
     bool isLabelable() const;
     AccessibilityObject* controlForLabelElement() const final;
     String textAsLabelFor(const AccessibilityObject&) const;
-    String textForLabelElements(Vector<Ref<HTMLElement>>&&) const;
+    String textForLabelElements(Vector<Ref<HTMLElement>>&&, DescendIntoContainers = DescendIntoContainers::No) const;
     HTMLLabelElement* labelElementContainer() const;
 
     Vector<Ref<Element>> ariaLabeledByElements() const;


### PR DESCRIPTION
#### bb09e1b5e8a67c3900c94694b1cb1bca887dbd91
<pre>
AX: VoiceOver ignores list content inside elements referenced by aria-describedby
<a href="https://bugs.webkit.org/show_bug.cgi?id=322998">https://bugs.webkit.org/show_bug.cgi?id=322998</a>
<a href="https://rdar.apple.com/186015032">rdar://186015032</a>

Reviewed by Tyler Wilcock.

accessibleNameForNode() always passed DescendIntoContainers::No to
textUnderElement(), so list, table, tree and canvas children were skipped.
That heuristic exists so that a focusable container does not take its entire inner
text as its own name, which is the right behavior when deriving a name
from content in the ordinary way. It is not right when the traversal
is an aria-labelledby or aria-describedby recursion: the ACCNAME spec
requires the text of the whole referenced subtree is included.

Tests: accessibility/aria-labelledby-describedby-with-list.html
       accessibility/isolated-tree/aria-labelledby-describedby-with-list.html

* LayoutTests/accessibility/aria-labelledby-describedby-with-list-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-describedby-with-list.html: Added.
* LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/aria-labelledby-describedby-with-list.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):
(WebCore::AccessibilityNodeObject::textForLabelElements const):
(WebCore::AccessibilityNodeObject::labelText const):
(WebCore::AccessibilityNodeObject::descriptionForElements const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:

Canonical link: <a href="https://commits.webkit.org/320290@main">https://commits.webkit.org/320290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc53896b1e6898a247666e7f7589157afa4312d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148436 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/674e90d3-a15d-461b-b357-04d41f19b097) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143746 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99889 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8083cdbf-35d0-43f9-8197-4b7e0a7ceebc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124165 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d6215a7-03b0-4783-a5f5-116c1c019771) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44443 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156624 "Found 5 new API test failures: TestWebKitAPI.WKWebExtensionAPIWebNavigation.BeforeNavigateEvent, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.ModifyHeadersRule, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIWindows.GetCurrentWindowAfterTabMove, TestWebKitAPI.WKWebExtensionAPIMenus.ActionMenus (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44020 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5549 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196305 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58442 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152977 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47516 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130733 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127211 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56950 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19032 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->