### PR TITLE
[JSC][Wasm] Don't CCall elem.drop and data.drop

### DIFF
--- a/JSTests/wasm/stress/elem-data-drop.js
+++ b/JSTests/wasm/stress/elem-data-drop.js
@@ -1,0 +1,41 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const elemWat = `
+(module
+  (table $t 1 funcref)
+  (elem $e funcref (ref.func $f))
+  (func $f)
+  (func (export "drop")
+    (elem.drop $e))
+  (func (export "init")
+    (table.init $t $e (i32.const 0) (i32.const 0) (i32.const 1)))
+)
+`
+
+const dataWat = `
+(module
+  (memory 1)
+  (data $d "x")
+  (func (export "drop")
+    (data.drop $d))
+  (func (export "init")
+    (memory.init $d (i32.const 0) (i32.const 0) (i32.const 1)))
+)
+`
+
+async function test() {
+    const elem = await instantiate(elemWat, {})
+    elem.exports.init()
+    elem.exports.drop()
+    elem.exports.drop()
+    assert.throws(() => { elem.exports.init() }, WebAssembly.RuntimeError, "Out of bounds table access")
+
+    const data = await instantiate(dataWat, {})
+    data.exports.init()
+    data.exports.drop()
+    data.exports.drop()
+    assert.throws(() => { data.exports.init() }, WebAssembly.RuntimeError, "Out of bounds memory access")
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -882,13 +882,31 @@ void BBQJIT::emitZeroExtendAddressOperand(bool is64Bit, Value operand)
     return { };
 }
 
+template<typename Func>
+void BBQJIT::emitPassiveBitClear(ptrdiff_t bitVectorOffset, unsigned bitIndex, Func operation)
+{
+    if (bitIndex >= BitVector::maxInlineBitCount()) {
+        Vector<Value, 8> arguments = { instanceValue(), Value::fromI32(bitIndex) };
+        emitCCall(operation, arguments);
+        return;
+    }
+
+    m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, bitVectorOffset), wasmScratchGPR);
+    JumpList slowPath;
+    slowPath.append(m_jit.branchTest64(ResultCondition::Zero, wasmScratchGPR, TrustedImm64(static_cast<int64_t>(BitVector::inlineBitMask()))));
+    m_jit.andPtr(TrustedImmPtr(static_cast<size_t>(~(static_cast<uintptr_t>(1) << bitIndex))), wasmScratchGPR);
+    m_jit.storePtr(wasmScratchGPR, Address(GPRInfo::wasmContextInstancePointer, bitVectorOffset));
+    MacroAssembler::Label done(m_jit);
+    m_slowPaths.append({ origin(), WTF::move(slowPath), WTF::move(done), copyBindings(), [bitIndex, operation](BBQJIT&, CCallHelpers& jit) {
+        jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
+        jit.setupArguments<Func>(GPRInfo::wasmContextInstancePointer, TrustedImm32(bitIndex));
+        jit.callOperation<OperationPtrTag>(operation);
+    } });
+}
+
 [[nodiscard]] PartialResult BBQJIT::addElemDrop(unsigned elementIndex)
 {
-    Vector<Value, 8> arguments = {
-        instanceValue(),
-        Value::fromI32(elementIndex)
-    };
-    emitCCall(&operationWasmElemDrop, arguments);
+    emitPassiveBitClear(JSWebAssemblyInstance::offsetOfPassiveElements(), elementIndex, &operationWasmElemDrop);
 
     LOG_INSTRUCTION("ElemDrop", elementIndex);
     return { };
@@ -1224,8 +1242,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset, W
 
 [[nodiscard]] PartialResult BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 {
-    Vector<Value, 8> arguments = { instanceValue(), Value::fromI32(dataSegmentIndex) };
-    emitCCall(&operationWasmDataDrop, arguments);
+    emitPassiveBitClear(JSWebAssemblyInstance::offsetOfPassiveDataSegments(), dataSegmentIndex, &operationWasmDataDrop);
 
     LOG_INSTRUCTION("DataDrop", dataSegmentIndex);
     return { };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1105,6 +1105,8 @@ public:
 
     void emitWriteBarrier(GPRReg cellGPR);
     void emitMutatorFence();
+    template<typename Func>
+    void emitPassiveBitClear(ptrdiff_t bitVectorOffset, unsigned bitIndex, Func operation);
 
     [[nodiscard]] PartialResult setGlobal(uint32_t index, Value value);
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -767,6 +767,8 @@ public:
     [[nodiscard]] PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex);
     void emitMemoryFill(Value* dstAddress, Value* targetValue, Value* count, uint8_t memoryIndex);
     void emitMemoryCopy(Value* dstAddress, Value* srcAddress, Value* count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex);
+    template<typename Func>
+    void emitPassiveBitClear(ptrdiff_t bitVectorOffset, unsigned bitIndex, Func operation);
     [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addDataDrop(unsigned);
 
@@ -1849,12 +1851,47 @@ auto OMGIRGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, Ex
     return { };
 }
 
+template<typename Func>
+void OMGIRGenerator::emitPassiveBitClear(ptrdiff_t bitVectorOffset, unsigned bitIndex, Func operation)
+{
+    if (bitIndex >= BitVector::maxInlineBitCount()) {
+        callWasmOperation(m_currentBlock, B3::Void, operation,
+            instanceValue(),
+            constant(Int32, bitIndex));
+        return;
+    }
+
+    auto* bits = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(bitVectorOffset));
+    auto* isInline = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), BitVector::inlineBitMask()));
+
+    auto* inlinePath = m_proc.addBlock();
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), isInline,
+        FrequentedBlock(inlinePath), FrequentedBlock(slowPath, FrequencyClass::Rare));
+    inlinePath->addPredecessor(m_currentBlock);
+    slowPath->addPredecessor(m_currentBlock);
+
+    m_currentBlock = inlinePath;
+    auto* cleared = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), ~(static_cast<uint64_t>(1) << bitIndex)));
+    m_currentBlock->appendNew<MemoryValue>(m_proc, Store, origin(), cleared, instanceValue(), safeCast<int32_t>(bitVectorOffset));
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    callWasmOperation(m_currentBlock, B3::Void, operation,
+        instanceValue(),
+        constant(Int32, bitIndex));
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+}
+
 auto OMGIRGenerator::addElemDrop(unsigned elementIndex) -> PartialResult
 {
-    callWasmOperation(m_currentBlock, B3::Void, operationWasmElemDrop,
-        instanceValue(),
-        constant(Int32, elementIndex));
-
+    emitPassiveBitClear(JSWebAssemblyInstance::offsetOfPassiveElements(), elementIndex, operationWasmElemDrop);
     return { };
 }
 
@@ -2306,10 +2343,7 @@ void OMGIRGenerator::emitMemoryCopy(Value* dstAddressValue, Value* srcAddressVal
 
 auto OMGIRGenerator::addDataDrop(unsigned dataSegmentIndex) -> PartialResult
 {
-    callWasmOperation(m_currentBlock, B3::Void, operationWasmDataDrop,
-        instanceValue(),
-        constant(Int32, dataSegmentIndex));
-
+    emitPassiveBitClear(JSWebAssemblyInstance::offsetOfPassiveDataSegments(), dataSegmentIndex, operationWasmDataDrop);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -319,6 +319,9 @@ public:
         return &Wasm::Global::fromBinding(*pointer);
     }
 
+    static constexpr ptrdiff_t offsetOfPassiveElements() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_passiveElements); }
+    static constexpr ptrdiff_t offsetOfPassiveDataSegments() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_passiveDataSegments); }
+
     static constexpr ptrdiff_t offsetOfCachedTable0Buffer() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Buffer); }
     static constexpr ptrdiff_t offsetOfCachedTable0Length() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Length); }
     static constexpr ptrdiff_t offsetOfBuiltinCalleeBits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_builtinCalleeBits); }

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -396,7 +396,11 @@ public:
         return byteCount(bitCount);
     }
     unsigned outOfLineMemoryUse() const { return outOfLineMemoryUse(size()); }
-        
+
+    static constexpr unsigned maxInlineBitCount() { return maxInlineBits(); }
+    static constexpr uintptr_t inlineBitMask() { return static_cast<uintptr_t>(1) << maxInlineBitCount(); }
+    bool isInline() const { return m_bitsOrPointer >> maxInlineBits(); }
+
     WTF_EXPORT_PRIVATE void shiftRightByMultipleOf64(size_t);
 
 private:
@@ -495,8 +499,6 @@ private:
         size_t m_numBits;
         uintptr_t m_words[0];
     };
-    
-    bool isInline() const { return m_bitsOrPointer >> maxInlineBits(); }
     
     const OutOfLineBits* outOfLineBits() const { return std::bit_cast<const OutOfLineBits*>(m_bitsOrPointer << 1); }
     OutOfLineBits* outOfLineBits() { return std::bit_cast<OutOfLineBits*>(m_bitsOrPointer << 1); }


### PR DESCRIPTION
#### 3e9c07ee3a82c00e5955ee5e52eee6fe3d9ccb35
<pre>
[JSC][Wasm] Don&apos;t CCall elem.drop and data.drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=322805">https://bugs.webkit.org/show_bug.cgi?id=322805</a>

Reviewed by NOBODY (OOPS!).

BBQ and OMG clear the instance passive-segment BitVector
inline when that BitVector is still stored inline. Out-of-line
storage still CCalls.

* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/WTF/wtf/BitVector.h:
* JSTests/wasm/stress/elem-data-drop.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9c07ee3a82c00e5955ee5e52eee6fe3d9ccb35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149019 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58410 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144377 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100259 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124659 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44885 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6612 "Found 1 new JSC stress test failure: Too many failures: 2104 jsc tests failed (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13469 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44536 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6149 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46030 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197043 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58351 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153850 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59053 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153508 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48025 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131342 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127896 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57553 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->