### PR TITLE
Cherry-pick 320157@main (cd1fc3fb9807). https://bugs.webkit.org/show_bug.cgi?id=322985

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
@@ -48,7 +48,7 @@ struct _WPEBufferClass
     GBytes  *(* import_to_pixels)    (WPEBuffer *buffer,
                                       GError   **error);
 
-    gpointer padding[32];
+    gpointer padding[16];
 };
 
 #define WPE_BUFFER_ERROR (wpe_buffer_error_quark())

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
@@ -53,7 +53,7 @@ struct _WPEClipboardClass
                         gboolean             is_local,
                         WPEClipboardContent *content);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API WPEClipboard        *wpe_clipboard_new              (WPEDisplay          *display);

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
@@ -50,7 +50,7 @@ struct _WPEGamepadClass
                                   gdouble     weak_magnitude,
                                   guint       duration_ms);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h
@@ -43,7 +43,7 @@ struct _WPEGamepadManagerClass
 {
     GObjectClass parent_class;
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API void         wpe_gamepad_manager_add_device    (WPEGamepadManager *manager,

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -159,7 +159,7 @@ struct _WPEInputMethodContextClass
                                      guint                  selection_index);
     void     (* reset)              (WPEInputMethodContext *context);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API WPEInputMethodContext   *wpe_input_method_context_new                (WPEView                 *view);

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
@@ -82,7 +82,7 @@ struct _WPEKeymapClass
                                                WPEModifiers    *consumed_modifiers);
     WPEModifiers (* get_modifiers)            (WPEKeymap       *keymap);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API gboolean     wpe_keymap_get_entries_for_keyval   (WPEKeymap       *keymap,

--- a/Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h
@@ -114,7 +114,7 @@ struct _WPEProcessManagerClass {
     void    (* terminate) (WPEProcessManager* manager, guint64 process_id);
 
     /*< private >*/
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API GQuark   wpe_process_manager_error_quark (void);

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
@@ -46,7 +46,7 @@ struct _WPEScreenClass
     void                   (* invalidate)        (WPEScreen *screen);
     WPEScreenSyncObserver *(* get_sync_observer) (WPEScreen *screen);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API guint32                wpe_screen_get_id               (WPEScreen *screen);

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
@@ -57,7 +57,7 @@ struct _WPEScreenSyncObserverClass
     void (* stop)  (WPEScreenSyncObserver *observer);
     void (* sync)  (WPEScreenSyncObserver *observer);
 
-    gpointer padding[32];
+    gpointer padding[8];
 };
 
 WPE_API guint    wpe_screen_sync_observer_add_callback    (WPEScreenSyncObserver        *observer,


### PR DESCRIPTION
#### 23b4c9a60608180ff787bf941151d7d01c0341e2
<pre>
Cherry-pick 320157@main (cd1fc3fb9807). <a href="https://bugs.webkit.org/show_bug.cgi?id=322985">https://bugs.webkit.org/show_bug.cgi?id=322985</a>

    Review the padding of the new WPE Platform API classes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322985">https://bugs.webkit.org/show_bug.cgi?id=322985</a>

    Reviewed by Carlos Garcia Campos.

    Reduce padding of some classes now that their APIs have consolidated.
    The goal is to leave enough room for all classes to grow without having
    excessive padding unused.

    * Source/WebKit/WPEPlatform/wpe/WPEBuffer.h:
    * Source/WebKit/WPEPlatform/wpe/WPEClipboard.h:
    * Source/WebKit/WPEPlatform/wpe/WPEGamepad.h:
    * Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.h:
    * Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
    * Source/WebKit/WPEPlatform/wpe/WPEKeymap.h:
    * Source/WebKit/WPEPlatform/wpe/WPEProcessManager.h:
    * Source/WebKit/WPEPlatform/wpe/WPEScreen.h:
    * Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h:

    Canonical link: <a href="https://commits.webkit.org/320157@main">https://commits.webkit.org/320157@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.165@webkitglib/2.54">https://commits.webkit.org/317695.165@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0efe6a399db7a06726c71c699cd951583e9d4c64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184031 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57955 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194255 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148324 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59300 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57690 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143663 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148324 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186986 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59300 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124082 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59300 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57690 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59300 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5437 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50612 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57690 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196193 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57626 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153217 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58330 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152890 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27936 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58330 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130620 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127116 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/56838 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51773 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56209 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56448 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56276 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->