### PR TITLE
[Swift in WebKit] Make `IPC::TransferString` available to Swift

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -315,6 +315,12 @@ module WebKit_Internal [system] {
         requires objc
     }
 
+    module TransferString {
+        requires cplusplus23
+        header "../../Platform/IPC/TransferString.h"
+        export *
+    }
+
     module WKDeferringGestureRecognizer {
         header "../../UIProcess/Cocoa/WKDeferringGestureRecognizer.h"
         export *

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -156,6 +156,8 @@ TransferString::IPCData TransferString::toIPCData() const LIFETIME_BOUND
     );
 }
 
+TransferString::TransferString(TransferString&&) = default;
+
 TransferString::TransferString(const TransferString& other)
 {
     WTF::switchOn(other.m_storage,

--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -66,7 +66,8 @@ public:
     TransferString(IPCData&&);
     TransferString(const TransferString&);
     TransferString& operator=(const TransferString&);
-    TransferString(TransferString&&) = default;
+    // Defined out-of-line to work around rdar://186108994.
+    TransferString(TransferString&&);
     TransferString& operator=(TransferString&&) = default;
 
     static constexpr size_t transferAsMappingSize = 16384;


### PR DESCRIPTION
#### 6d79bc7223fa37eea4784b42b1eb16e1b4c6cc0c
<pre>
[Swift in WebKit] Make `IPC::TransferString` available to Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=323014">https://bugs.webkit.org/show_bug.cgi?id=323014</a>
<a href="https://rdar.apple.com/186280362">rdar://186280362</a>

Reviewed by Abrar Rahman Protyasha.

Add it to the module, and workaround a compiler bug by defining `TransferString(TransferString&amp;&amp;)` out-of-line.

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/Platform/IPC/TransferString.cpp:
* Source/WebKit/Platform/IPC/TransferString.h:

Canonical link: <a href="https://commits.webkit.org/320180@main">https://commits.webkit.org/320180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9db6267430ad857d6e6b126936e4c8e70d381dc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148330 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186992 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124086 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43939 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5443 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196199 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57632 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58336 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152894 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47426 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130626 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56844 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18950 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->