### PR TITLE
[WPT] Import JSPI TestSandwich await and ESM worker message-shape fixes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7899,7 +7899,6 @@ imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-link.tentativ
 imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style-subresource.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style.tentative.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html [ Pass Failure ]
 
 http/tests/iframe-memory-monitor/video-iframe.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.js
@@ -321,11 +321,11 @@ async function TestSandwich(suspend) {
 }
 
 promise_test(async () => {
-  TestSandwich(true);
+  await TestSandwich(true);
 }, "Test sandwich with suspension");
 
 promise_test(async () => {
-  TestSandwich(false);
+  await TestSandwich(false);
 }, "Test sandwich with no suspension");
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing import of WebAssembly from JavaScript worker Error: assert_equals: expected (number) 42 but got (object) object "[object Object]"
+PASS Testing import of WebAssembly from JavaScript worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.js", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg.data, 42);
+  assert_equals(msg.data.value, 42);
   done();
 }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.wasm", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg, 42);
+  assert_equals(msg.data.value, 42);
   done();
 }
 worker.onerror = () => {


### PR DESCRIPTION
#### 62e2c330811c5874a195504cd1455b1612385295
<pre>
[WPT] Import JSPI TestSandwich await and ESM worker message-shape fixes

Reviewed by Yusuke Suzuki.

Import two already-merged WPT test fixes.

Await TestSandwich so testharness does not finish while JSPI is still
suspended, and drop the [ Pass Failure ] flake line.

Match ESM worker tests to the worker-helper {value, checks} message
shape. worker-import now expects PASS. worker.tentative still FAILs
because the worker errors before the message assert.

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62092">https://github.com/web-platform-tests/wpt/pull/62092</a>
Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62118">https://github.com/web-platform-tests/wpt/pull/62118</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html:

Canonical link: <a href="https://commits.webkit.org/320437@main">https://commits.webkit.org/320437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f71794ec947b0773e1a66d0d049a465154019ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143680 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99842 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44379 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156556 "Found 6 new API test failures: TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.ModifyHeadersRule, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIWebRequest.BeforeRequestEventWithRequestBodyAndJSON, TestWebKitAPI.WKWebExtensionAPIMenus.ActionMenus, TestWebKitAPI.WKWebExtensionAPITabs.ActiveTab, TestWebKitAPI.WKWebExtensionAPIScripting.CSSUserOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43954 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5458 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45329 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196214 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152909 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47443 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127132 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56859 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18964 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->