### PR TITLE
[Quirks] Reduce compile flags in Quirks table

### DIFF
--- a/Source/WebCore/page/QuirkNames.h
+++ b/Source/WebCore/page/QuirkNames.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <wtf/BitSet.h>
-#include <wtf/Platform.h>
 
 namespace WebCore {
 
@@ -62,112 +61,70 @@ enum class QuirkSite : uint8_t {
 };
 
 enum class SiteSpecificQuirk {
-#if PLATFORM(IOS) || PLATFORM(VISION)
     AllowLayeredFullscreenVideos,
-#endif
-#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
     BlocksEnteringStandardFullscreenFromPictureInPictureQuirk,
     BlocksReturnToFullscreenFromPictureInPictureQuirk,
-#endif
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture,
     HasBrokenEncryptedMediaAPISupportQuirk,
     ImplicitMuteWhenVolumeSetToZero,
     InputMethodUsesCorrectKeyEventOrder,
     InputMethodMustUseCompositionEvents,
-#if PLATFORM(MAC)
     IsNeverRichlyEditableForTouchBarQuirk,
     IsTouchBarUpdateSuppressedForHiddenContentEditableQuirk,
-#endif
     MaybeBypassBackForwardCache,
-#if ENABLE(TWO_PHASE_CLICKS)
     MayNeedToIgnoreContentObservation,
-#endif
     NeedsAirIndiaExpressLayeringQuirk,
     NeedsBodyScrollbarWidthNoneDisabledQuirk,
     NeedsCanPlayAfterSeekedQuirk,
     NeedsChromeMediaControlsPseudoElementQuirk,
-#if PLATFORM(COCOA)
     NeedsCNNCaptionQuirk,
-#endif
-#if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
     NeedsLimitedMatroskaSupportQuirk,
-#endif
     NeedsLogoutCookieCleanupQuirk,
-#if PLATFORM(IOS_FAMILY)
     NeedsAmazonDesignMenuViewportUnitQuirk,
     NeedsClaudeSidebarViewportUnitQuirk,
     NeedsHideSelectionDuringOverflowScrollQuirk,
-#endif
     NeedsCustomUserAgentData,
-#if PLATFORM(IOS_FAMILY)
     NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk,
-#endif
     NeedsDisableDOMPasteAccessQuirk,
     NeedsFacebookRemoveNotSupportedQuirk,
-#if PLATFORM(COCOA)
     NeedsAnchorToBeMouseFocusableQuirk,
     NeedsFormControlToBeMouseFocusableQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
     NeedsFullscreenDisplayNoneQuirk,
     NeedsFullscreenObjectFitQuirk,
     NeedsGMailOverflowScrollQuirk,
     NeedsGoogleMapsScrollingQuirk,
     NeedsGoogleTranslateScrollingQuirk,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
     NeedsNetflixVolumeSliderQuirk,
-#endif
     NeedsGeforcenowWarningDisplayNoneQuirk,
     NeedsExpediaGroupAnimationQuirk,
     NeedsMediaRewriteRangeRequestQuirk,
     NeedsMozillaFileTypeForDataTransferQuirk,
     NeedsNavigatorUserAgentDataQuirk,
     NeedsNowPlayingFullscreenSwapQuirk,
-#if PLATFORM(IOS_FAMILY)
     NeedsSuppressedPauseEventOnFullscreenExitQuirk,
     NeedsPreloadAutoQuirk,
-#endif
     NeedsResettingTransitionCancelsRunningTransitionQuirk,
     NeedsReuseLiveRangeForSelectionUpdateQuirk,
     NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
     NeedsScrollbarWidthThinDisabledQuirk,
     NeedsSeekingSupportDisabledQuirk,
-#if ENABLE(MEDIA_SOURCE)
     NeedsSupportsProgressMonitoringQuirk,
-#endif
     NeedsSuppressPostLayoutBoundaryEventsQuirk,
     NeedsTikTokOverflowingContentQuirk,
     NeedsVideoShouldMaintainAspectRatioQuirk,
     NeedsWebKitMediaTextTrackDisplayQuirk,
-#if PLATFORM(COCOA)
     NeedsYouTubeCaptionQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
     NeedsYouTubeEmbedAutoplayQuirk,
-#endif
-#if ENABLE(TWO_PHASE_CLICKS)
     NeedsYouTubeMouseOutQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
     NeedsYouTubeOverflowScrollQuirk,
-#endif
     NeedsZeroMaxTouchPointsQuirk,
-#if PLATFORM(MAC)
     NeedsZomatoEmailLoginLabelQuirk,
-#endif
-#if ENABLE(VIDEO_PRESENTATION_MODE)
     RequiresUserGestureToLoadInPictureInPictureQuirk,
     RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk,
     RequiresUserGestureToPauseInPictureInPictureQuirk,
-#endif
-#if ENABLE(FULLSCREEN_API)
     RequiresUserGestureToPlayInFullscreenQuirk,
-#endif
     ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk,
-#if PLATFORM(IOS_FAMILY)
     ShouldAllowPopupFromMicrosoftOfficeToOneDrive,
-#endif
     ShouldAutoplayWebAudioForArbitraryUserGestureQuirk,
     ShouldAvoidProgrammaticScrollClampingQuirk,
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
@@ -176,132 +133,77 @@ enum class SiteSpecificQuirk {
     ShouldBypassAsyncScriptDeferring,
     ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions,
     ShouldDelayReloadWhenRegisteringServiceWorker,
-#if HAVE(PIP_SKIP_PREROLL)
     ShouldDisableAdSkippingInPip,
-#endif
     ShouldDisableDataURLPaddingValidation,
     ShouldDisableDOMAudioSession,
-#if PLATFORM(IOS_FAMILY)
     ShouldDisableElementFullscreenQuirk,
-#endif
-#if ENABLE(VIDEO_PRESENTATION_MODE)
     ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk,
-#endif
     ShouldDisableFetchMetadata,
-#if PLATFORM(VISION)
     ShouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk,
-#endif
-#if ENABLE(MEDIA_STREAM)
     ShouldDisableImageCaptureQuirk,
     ShouldAllowMediaStreamTrackSerializationQuirk,
-#endif
     ShouldDisableLazyIframeLoadingQuirk,
     ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk,
-#if PLATFORM(IOS_FAMILY)
     ShouldDisablePointerEventsQuirk,
-#endif
     ShouldDisablePushStateFilePathRestrictions,
     ShouldDisableScrollAnchoringQuirk,
-#if ENABLE(THREADED_ANIMATIONS)
     ShouldDisableThreadedAnimationsQuirk,
-#endif
     ShouldDisableWritingSuggestionsByDefaultQuirk,
     ShouldDispatchPlayPauseEventsOnResume,
-#if ENABLE(TOUCH_EVENTS)
     ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick,
-#endif
     ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk,
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
-#if ENABLE(MEDIA_STREAM)
     ShouldEnableCameraAndMicrophonePermissionStateQuirk,
     ShouldEnableCameraBackgroundPlayback,
     ShouldEnableEnumerateDeviceQuirk,
     ShouldEnableFacebookFlagQuirk,
-#endif
     ShouldEnableFontLoadingAPIQuirk,
-#if ENABLE(MEDIA_STREAM)
     ShouldEnableLegacyGetUserMediaQuirk,
     ShouldEnableRemoteTrackLabelQuirk,
-#endif
-#if ENABLE(WEB_RTC)
     ShouldEnableRTCEncodedStreamsQuirk,
-#endif
-#if ENABLE(MEDIA_STREAM)
     ShouldEnableSpeakerSelectionPermissionsPolicyQuirk,
-#endif
     ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen,
     ShouldExposeShowModalDialog,
-#if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
     ShouldFlipScreenDimensionsQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
     ShouldHideCoarsePointerCharacteristicsQuirk,
     ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk,
     ShouldIgnoreAriaForFastPathContentObservationCheckQuirk,
     ShouldIgnoreInputModeNone,
-#endif
     ShouldIgnorePlaysInlineRequirementQuirk,
-#if ENABLE(TEXT_AUTOSIZING)
     ShouldIgnoreTextAutoSizingQuirk,
-#endif
-#if ENABLE(META_VIEWPORT)
     ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk,
     ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk,
     ShouldUseDynamicViewportUnitsAsDefaultQuirk,
-#endif
     ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk,
-#if PLATFORM(IOS_FAMILY)
     ShouldNavigatorPluginsBeEmpty,
-#endif
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     ShouldPreventDispatchOfTouchEventQuirk,
-#endif
     ShouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk,
-#if ENABLE(PICTURE_IN_PICTURE_API)
     ShouldReportDocumentAsVisibleIfActivePIPQuirk,
-#endif
     ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk,
-#if PLATFORM(IOS_FAMILY)
     ShouldUseLayoutViewportForClientRectsQuirk,
     ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
     ShouldSilenceMediaQueryListChangeEvents,
     ShouldSilenceResizeObservers,
-#endif
-#if PLATFORM(IOS_FAMILY)
     ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk,
-#endif
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
     NeedsWebExScrollabilityQuirk,
     ShouldSupportHoverMediaQueriesQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
     ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk,
-#endif
-#if ENABLE(CONTENT_CHANGE_OBSERVER)
     ShouldTreatAddingMouseOutEventListenerAsContentChange,
-#endif
     ShouldUnloadHeavyFrames,
     ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
     ShouldAllowNotificationPermissionWithoutUserGesture,
     NeedsInstagramResizingReelsQuirk,
     NeedsYahooVolumeSliderQuirk,
-#if PLATFORM(IOS_FAMILY)
     NeedsChromeOSNavigatorUserAgentQuirk,
     ShouldSendFakeTouchForceChangeEvent,
-#endif
     ShouldLimitHLSPlaybackRate,
     ShouldDeferIntersectionObserversDuringResize,
     ShouldSuppressHLSSubtitles,
     ShouldSuppressMediaSessionPauseActionOnInterruption,
     ShouldBlockAudiblePlaybackWhileAudioIsPlaying,
-#if PLATFORM(COCOA)
     NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk,
-#endif
+
     NumberOfQuirks
 };
 

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -26,9 +26,134 @@
 #include "config.h"
 #include "QuirkTable.h"
 
+#include <algorithm>
 #include <array>
+#include <span>
+#include <utility>
 
 namespace WebCore {
+
+namespace BuildCondition {
+
+constexpr bool always = true;
+
+#if PLATFORM(COCOA)
+constexpr bool cocoa = true;
+#else
+constexpr bool cocoa = false;
+#endif
+#if PLATFORM(MAC)
+constexpr bool mac = true;
+#else
+constexpr bool mac = false;
+#endif
+#if PLATFORM(IOS)
+constexpr bool iOS = true;
+#else
+constexpr bool iOS = false;
+#endif
+#if PLATFORM(IOS_FAMILY)
+constexpr bool iOSFamily = true;
+#else
+constexpr bool iOSFamily = false;
+#endif
+#if PLATFORM(VISION)
+constexpr bool vision = true;
+#else
+constexpr bool vision = false;
+#endif
+#if ENABLE(CONTENT_CHANGE_OBSERVER)
+constexpr bool contentChangeObserver = true;
+#else
+constexpr bool contentChangeObserver = false;
+#endif
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+constexpr bool desktopContentModeQuirks = true;
+#else
+constexpr bool desktopContentModeQuirks = false;
+#endif
+#if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
+constexpr bool flipScreenDimensionsQuirks = true;
+#else
+constexpr bool flipScreenDimensionsQuirks = false;
+#endif
+#if ENABLE(FULLSCREEN_API)
+constexpr bool fullscreenAPI = true;
+#else
+constexpr bool fullscreenAPI = false;
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+constexpr bool videoPresentationMode = true;
+#else
+constexpr bool videoPresentationMode = false;
+#endif
+#if ENABLE(MEDIA_RECORDER)
+constexpr bool mediaRecorder = true;
+#else
+constexpr bool mediaRecorder = false;
+#endif
+#if ENABLE(COCOA_WEBM_PLAYER)
+constexpr bool cocoaWebMPlayer = true;
+#else
+constexpr bool cocoaWebMPlayer = false;
+#endif
+#if ENABLE(MEDIA_SOURCE)
+constexpr bool mediaSource = true;
+#else
+constexpr bool mediaSource = false;
+#endif
+#if ENABLE(MEDIA_STREAM)
+constexpr bool mediaStream = true;
+#else
+constexpr bool mediaStream = false;
+#endif
+#if ENABLE(META_VIEWPORT)
+constexpr bool metaViewport = true;
+#else
+constexpr bool metaViewport = false;
+#endif
+#if HAVE(PIP_SKIP_PREROLL)
+constexpr bool pipSkipPreroll = true;
+#else
+constexpr bool pipSkipPreroll = false;
+#endif
+#if ENABLE(PICTURE_IN_PICTURE_API)
+constexpr bool pictureInPictureAPI = true;
+#else
+constexpr bool pictureInPictureAPI = false;
+#endif
+#if ENABLE(TEXT_AUTOSIZING)
+constexpr bool textAutosizing = true;
+#else
+constexpr bool textAutosizing = false;
+#endif
+#if ENABLE(THREADED_ANIMATIONS)
+constexpr bool threadedAnimations = true;
+#else
+constexpr bool threadedAnimations = false;
+#endif
+#if ENABLE(TOUCH_EVENTS)
+constexpr bool touchEvents = true;
+#else
+constexpr bool touchEvents = false;
+#endif
+#if ENABLE(TOUCH_EVENT_REGIONS)
+constexpr bool touchEventRegions = true;
+#else
+constexpr bool touchEventRegions = false;
+#endif
+#if ENABLE(TWO_PHASE_CLICKS)
+constexpr bool twoPhaseClicks = true;
+#else
+constexpr bool twoPhaseClicks = false;
+#endif
+#if ENABLE(WEB_RTC)
+constexpr bool webRTC = true;
+#else
+constexpr bool webRTC = false;
+#endif
+
+} // namespace BuildCondition
 
 static constexpr std::array bbcDomains { "bbc.co.uk"_s, "bbc.com"_s };
 static constexpr std::array expediaGroupDomains {
@@ -36,59 +161,207 @@ static constexpr std::array expediaGroupDomains {
     "hotels.com"_s, "mrjet.se"_s, "orbitz.com"_s, "travelocity.ca"_s,
     "travelocity.com"_s, "wotif.co.nz"_s, "wotif.com"_s
 };
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
 static constexpr std::array naverHostsWithoutSimulatedMouseEvents { "tv.naver.com"_s, "mail.naver.com"_s, "m.naver.com"_s };
-#endif
-#if PLATFORM(COCOA)
 static constexpr std::array youTubeEmbedDomains { "youtube.com"_s, "youtube-nocookie.com"_s };
-#endif
-#if PLATFORM(IOS_FAMILY)
 static constexpr std::array claudeDomains { "claude.ai"_s, "claude.com"_s };
-#endif
 
 namespace SiteSpecificQuirks {
 using enum SiteSpecificQuirk;
 using namespace URLRefinement;
+using namespace BuildCondition;
 
-static constexpr Quirk table[] = {
-#if PLATFORM(IOS) || PLATFORM(VISION)
+consteval bool isAvailable(SiteSpecificQuirk quirk)
+{
+    switch (quirk) {
+    case AllowLayeredFullscreenVideos: return iOS || vision;
+    case BlocksEnteringStandardFullscreenFromPictureInPictureQuirk: return fullscreenAPI && videoPresentationMode;
+    case BlocksReturnToFullscreenFromPictureInPictureQuirk: return fullscreenAPI && videoPresentationMode;
+    case EnsureCaptionVisibilityInFullscreenAndPictureInPicture: return always;
+    case HasBrokenEncryptedMediaAPISupportQuirk: return always;
+    case ImplicitMuteWhenVolumeSetToZero: return always;
+    case InputMethodMustUseCompositionEvents: return mac;
+    case InputMethodUsesCorrectKeyEventOrder: return always;
+    case IsNeverRichlyEditableForTouchBarQuirk: return mac;
+    case IsTouchBarUpdateSuppressedForHiddenContentEditableQuirk: return mac;
+    case MayNeedToIgnoreContentObservation: return twoPhaseClicks;
+    case MaybeBypassBackForwardCache: return always;
+    case NeedsAirIndiaExpressLayeringQuirk: return always;
+    case NeedsAmazonDesignMenuViewportUnitQuirk: return iOSFamily;
+    case NeedsAnchorToBeMouseFocusableQuirk: return cocoa;
+    case NeedsBodyScrollbarWidthNoneDisabledQuirk: return always;
+    case NeedsCNNCaptionQuirk: return cocoa;
+    case NeedsCanPlayAfterSeekedQuirk: return always;
+    case NeedsChromeMediaControlsPseudoElementQuirk: return always;
+    case NeedsChromeOSNavigatorUserAgentQuirk: return iOSFamily;
+    case NeedsClaudeSidebarViewportUnitQuirk: return iOSFamily;
+    case NeedsCustomUserAgentData: return always;
+    case NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk: return iOSFamily;
+    case NeedsDisableDOMPasteAccessQuirk: return always;
+    case NeedsExpediaGroupAnimationQuirk: return always;
+    case NeedsFacebookRemoveNotSupportedQuirk: return always;
+    case NeedsFormControlToBeMouseFocusableQuirk: return mac;
+    case NeedsFullscreenDisplayNoneQuirk: return iOSFamily;
+    case NeedsFullscreenObjectFitQuirk: return iOSFamily;
+    case NeedsGMailOverflowScrollQuirk: return iOSFamily;
+    case NeedsGeforcenowWarningDisplayNoneQuirk: return always;
+    case NeedsGoogleMapsScrollingQuirk: return iOSFamily;
+    case NeedsGoogleTranslateScrollingQuirk: return iOSFamily;
+    case NeedsHideSelectionDuringOverflowScrollQuirk: return iOSFamily;
+    case NeedsInstagramResizingReelsQuirk: return always;
+    case NeedsLimitedMatroskaSupportQuirk: return mediaRecorder && cocoaWebMPlayer;
+    case NeedsLogoutCookieCleanupQuirk: return always;
+    case NeedsMediaRewriteRangeRequestQuirk: return always;
+    case NeedsMozillaFileTypeForDataTransferQuirk: return always;
+    case NeedsNavigatorUserAgentDataQuirk: return always;
+    case NeedsNetflixVolumeSliderQuirk: return iOS || vision;
+    case NeedsNowPlayingFullscreenSwapQuirk: return always;
+    case NeedsPreloadAutoQuirk: return iOSFamily;
+    case NeedsResettingTransitionCancelsRunningTransitionQuirk: return always;
+    case NeedsReuseLiveRangeForSelectionUpdateQuirk: return always;
+    case NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk: return always;
+    case NeedsScrollbarWidthThinDisabledQuirk: return always;
+    case NeedsSeekingSupportDisabledQuirk: return always;
+    case NeedsSupportsProgressMonitoringQuirk: return mediaSource;
+    case NeedsSuppressPostLayoutBoundaryEventsQuirk: return always;
+    case NeedsSuppressedPauseEventOnFullscreenExitQuirk: return iOS;
+    case NeedsTikTokOverflowingContentQuirk: return always;
+    case NeedsVideoShouldMaintainAspectRatioQuirk: return always;
+    case NeedsWebExScrollabilityQuirk: return desktopContentModeQuirks;
+    case NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk: return cocoa;
+    case NeedsWebKitMediaTextTrackDisplayQuirk: return always;
+    case NeedsYahooVolumeSliderQuirk: return always;
+    case NeedsYouTubeCaptionQuirk: return cocoa;
+    case NeedsYouTubeEmbedAutoplayQuirk: return iOSFamily;
+    case NeedsYouTubeMouseOutQuirk: return twoPhaseClicks;
+    case NeedsYouTubeOverflowScrollQuirk: return iOSFamily;
+    case NeedsZeroMaxTouchPointsQuirk: return always;
+    case NeedsZomatoEmailLoginLabelQuirk: return mac;
+    case RequiresUserGestureToLoadInPictureInPictureQuirk: return videoPresentationMode;
+    case RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk: return videoPresentationMode && iOS;
+    case RequiresUserGestureToPauseInPictureInPictureQuirk: return videoPresentationMode;
+    case RequiresUserGestureToPlayInFullscreenQuirk: return fullscreenAPI;
+    case ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk: return always;
+    case ShouldAllowMediaStreamTrackSerializationQuirk: return mediaStream;
+    case ShouldAllowNotificationPermissionWithoutUserGesture: return always;
+    case ShouldAllowPopupFromMicrosoftOfficeToOneDrive: return iOSFamily;
+    case ShouldAutoplayWebAudioForArbitraryUserGestureQuirk: return always;
+    case ShouldAvoidProgrammaticScrollClampingQuirk: return always;
+    case ShouldAvoidResizingWhenInputViewBoundsChangeQuirk: return always;
+    case ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk: return always;
+    case ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor: return always;
+    case ShouldBlockAudiblePlaybackWhileAudioIsPlaying: return always;
+    case ShouldBlockFetchWithNewlineAndLessThan: return always;
+    case ShouldBypassAsyncScriptDeferring: return always;
+    case ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions: return always;
+    case ShouldDeferIntersectionObserversDuringResize: return always;
+    case ShouldDelayReloadWhenRegisteringServiceWorker: return always;
+    case ShouldDisableAdSkippingInPip: return pipSkipPreroll;
+    case ShouldDisableDOMAudioSession: return always;
+    case ShouldDisableDataURLPaddingValidation: return always;
+    case ShouldDisableElementFullscreenQuirk: return iOSFamily;
+    case ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk: return videoPresentationMode;
+    case ShouldDisableFetchMetadata: return always;
+    case ShouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk: return vision;
+    case ShouldDisableImageCaptureQuirk: return mediaStream;
+    case ShouldDisableLazyIframeLoadingQuirk: return always;
+    case ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk: return always;
+    case ShouldDisablePointerEventsQuirk: return iOSFamily;
+    case ShouldDisablePushStateFilePathRestrictions: return always;
+    case ShouldDisableScrollAnchoringQuirk: return always;
+    case ShouldDisableThreadedAnimationsQuirk: return threadedAnimations;
+    case ShouldDisableWritingSuggestionsByDefaultQuirk: return always;
+    case ShouldDispatchPlayPauseEventsOnResume: return always;
+    case ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick: return touchEvents;
+    case ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk: return always;
+    case ShouldDispatchSimulatedMouseEventsQuirk: return touchEvents || touchEventRegions;
+    case ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk: return always;
+    case ShouldEnableCameraAndMicrophonePermissionStateQuirk: return mediaStream;
+    case ShouldEnableCameraBackgroundPlayback: return mediaStream;
+    case ShouldEnableEnumerateDeviceQuirk: return mediaStream;
+    case ShouldEnableFacebookFlagQuirk: return mediaStream;
+    case ShouldEnableFontLoadingAPIQuirk: return always;
+    case ShouldEnableLegacyGetUserMediaQuirk: return mediaStream;
+    case ShouldEnableRTCEncodedStreamsQuirk: return webRTC;
+    case ShouldEnableRemoteTrackLabelQuirk: return mediaStream;
+    case ShouldEnableSpeakerSelectionPermissionsPolicyQuirk: return mediaStream;
+    case ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen: return always;
+    case ShouldExposeShowModalDialog: return always;
+    case ShouldFlipScreenDimensionsQuirk: return flipScreenDimensionsQuirks;
+    case ShouldHideCoarsePointerCharacteristicsQuirk: return iOSFamily;
+    case ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk: return iOSFamily;
+    case ShouldIgnoreAriaForFastPathContentObservationCheckQuirk: return iOSFamily;
+    case ShouldIgnoreInputModeNone: return iOSFamily;
+    case ShouldIgnorePlaysInlineRequirementQuirk: return always;
+    case ShouldIgnoreTextAutoSizingQuirk: return textAutosizing;
+    case ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk: return metaViewport;
+    case ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk: return metaViewport;
+    case ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk: return always;
+    case ShouldLimitHLSPlaybackRate: return always;
+    case ShouldNavigatorPluginsBeEmpty: return iOSFamily;
+    case ShouldPreventDispatchOfTouchEventQuirk: return touchEvents || touchEventRegions;
+    case ShouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk: return always;
+    case ShouldReportDocumentAsVisibleIfActivePIPQuirk: return pictureInPictureAPI;
+    case ShouldSendFakeTouchForceChangeEvent: return iOSFamily;
+    case ShouldSilenceMediaQueryListChangeEvents: return iOS || vision;
+    case ShouldSilenceResizeObservers: return iOS || vision;
+    case ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting: return iOSFamily;
+    case ShouldSupportHoverMediaQueriesQuirk: return desktopContentModeQuirks;
+    case ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk: return iOSFamily;
+    case ShouldSuppressHLSSubtitles: return always;
+    case ShouldSuppressMediaSessionPauseActionOnInterruption: return always;
+    case ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk: return iOSFamily;
+    case ShouldTreatAddingMouseOutEventListenerAsContentChange: return contentChangeObserver;
+    case ShouldUnloadHeavyFrames: return always;
+    case ShouldUseDynamicViewportUnitsAsDefaultQuirk: return metaViewport;
+    case ShouldUseLayoutViewportForClientRectsQuirk: return iOSFamily;
+    case ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk: return always;
+    case NumberOfQuirks: break;
+    }
+    return false;
+}
+
+consteval QuirkBitSet computeUnavailableQuirks()
+{
+    QuirkBitSet bits;
+    for (size_t i = 0; i < static_cast<size_t>(NumberOfQuirks); ++i) {
+        if (!isAvailable(static_cast<SiteSpecificQuirk>(i)))
+            bits.set(i);
+    }
+    return bits;
+}
+
+static constexpr QuirkBitSet unavailableQuirks = computeUnavailableQuirks();
+
+static constexpr Quirk fullTable[] = {
     // 365scores.com rdar://116491386
     { .match = URLMatch::domain("365scores.com"_s),
-        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
-#endif
+        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting },
+        .availableWhen = iOS || vision },
 
-#if ENABLE(MEDIA_STREAM)
     // actesting.org rdar://124017544
     { .match = URLMatch::domain("actesting.org"_s),
         .behaviors = { ShouldEnableLegacyGetUserMediaQuirk } },
-#endif
 
     // airindiaexpress.com https://webkit.org/b/317375
     { .match = URLMatch::domain("airindiaexpress.com"_s),
         .behaviors = { NeedsAirIndiaExpressLayeringQuirk } },
 
     // Note: There is a userAgent override for rdar://117771731, see needsCustomUserAgentOverride()
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // airtable.com rdar://49124313
     { .match = URLMatch::domain("airtable.com"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
-#endif
 
     { .match = URLMatch::anyTopLevelDomain("amazon"_s),
         .behaviors = {
             // amazon.com rdar://49124529
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // amazon.com rdar://49124313
             ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
         },
         .site = QuirkSite::Amazon },
 
-#if PLATFORM(IOS_FAMILY)
     { .match = URLMatch::domain("amazon.design"_s),
         .behaviors = { NeedsAmazonDesignMenuViewportUnitQuirk } },
-#endif
 
     // apple.com rdar://154434137
     // FIXME: Maybe EnsureCaptionVisibilityInFullscreenAndPictureInPicture should apply to apple.com.cn too?
@@ -99,15 +372,14 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::anyTopLevelDomain("apple"_s).when(pathContains("/retail"_s)),
         .behaviors = { ShouldDisableScrollAnchoringQuirk } },
 
-#if PLATFORM(IOS_FAMILY)
     // as.com: rdar://121014613
     { .match = URLMatch::domain("as.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
 
     // att.com rdar://55185021
     { .match = URLMatch::domain("att.com"_s),
-        .behaviors = { ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk } },
-#endif
+        .behaviors = { ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk },
+        .availableWhen = iOSFamily },
 
     // Login issue on bankofamerica.com (rdar://104938789).
     { .match = URLMatch::domain("bankofamerica.com"_s),
@@ -144,64 +416,51 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::domain("capitalgroup.com"_s),
         .behaviors = { ShouldDelayReloadWhenRegisteringServiceWorker } },
 
-#if PLATFORM(IOS_FAMILY)
     // Remove this once rdar://139478801 is resolved.
     { .match = URLMatch::domain("cbssports.com"_s),
         .behaviors = {
             ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk,
         },
-        .site = QuirkSite::CBSSports },
-#endif
+        .site = QuirkSite::CBSSports,
+        .availableWhen = iOSFamily },
 
     { .match = URLMatch::hostOrSubdomainOf("ceac.state.gov"_s),
         .behaviors = {
-#if PLATFORM(MAC)
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
             NeedsFormControlToBeMouseFocusableQuirk,
-#endif
             // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=311383
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
         },
         .site = QuirkSite::CEAC },
-#if PLATFORM(IOS)
+
     { .match = URLMatch::domain("chess.com"_s).when(smallScreen()),
-        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
-#endif
+        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen },
+        .availableWhen = iOS },
+
     { .match = URLMatch::domain("claude.ai"_s),
         .behaviors = {
-#if PLATFORM(IOS_FAMILY)
             NeedsClaudeSidebarViewportUnitQuirk,
-#endif
             // rdar://174779259 - logout flow leaves identification cookies
             // causing redirect loop on next /chat boot.
             // See Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded().
             NeedsLogoutCookieCleanupQuirk,
         } },
 
-#if PLATFORM(IOS_FAMILY)
     { .match = URLMatch::domain(claudeDomains),
         .behaviors = { NeedsHideSelectionDuringOverflowScrollQuirk } },
-#endif
 
-#if PLATFORM(IOS_FAMILY)
     { .match = URLMatch::domain("cnn.com"_s),
         .behaviors = {
             // cnn.com rdar://119640248
             NeedsFullscreenObjectFitQuirk,
-#if PLATFORM(COCOA)
             NeedsCNNCaptionQuirk,
-#endif
-#if ENABLE(THREADED_ANIMATIONS)
             // cnn.com rdar://176539646
             ShouldDisableThreadedAnimationsQuirk,
-#endif
-        } },
-#endif
+        },
+        .availableWhen = iOSFamily },
 
-#if ENABLE(MEDIA_STREAM)
     { .match = URLMatch::host("codepen.io"_s),
         .behaviors = { ShouldEnableSpeakerSelectionPermissionsPolicyQuirk } },
-#endif
 
     { .match = URLMatch::domain("crunchyroll.com"_s),
         .behaviors = { NeedsSuppressPostLayoutBoundaryEventsQuirk } },
@@ -217,17 +476,13 @@ static constexpr Quirk table[] = {
         .behaviors = { ShouldDisableDOMAudioSession } },
 
     { .match = URLMatch::domain("dictionary.com"_s),
-        .behaviors = {
-#if PLATFORM(IOS_FAMILY)
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-#endif
-#if PLATFORM(COCOA)
-            NeedsAnchorToBeMouseFocusableQuirk,
-#endif
-        },
+        .behaviors = { NeedsAnchorToBeMouseFocusableQuirk },
         .site = QuirkSite::Dictionary },
 
-#if PLATFORM(IOS_FAMILY)
+    { .match = URLMatch::domain("dictionary.com"_s),
+        .behaviors = { NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .availableWhen = iOSFamily },
+
     // digitaltrends.com rdar://121014613
     { .match = URLMatch::domain("digitaltrends.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
@@ -236,34 +491,26 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::domain("discord.com"_s),
         .behaviors = { ShouldUseLayoutViewportForClientRectsQuirk } },
 
+    // disneyplus rdar://137613110
     { .match = URLMatch::domain("disneyplus.com"_s),
-        .behaviors = {
-            // disneyplus rdar://137613110
-            ShouldHideCoarsePointerCharacteristicsQuirk,
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-            // disneyplus rdar://151715964
-            NeedsZeroMaxTouchPointsQuirk,
-#endif
-        } },
-#endif
+        .behaviors = { ShouldHideCoarsePointerCharacteristicsQuirk } },
+
+    // disneyplus rdar://151715964
+    { .match = URLMatch::domain("disneyplus.com"_s),
+        .behaviors = { NeedsZeroMaxTouchPointsQuirk },
+        .availableWhen = iOSFamily && desktopContentModeQuirks },
 
     { .match = URLMatch::domain("ea.com"_s),
         .site = QuirkSite::EA },
 
     { .match = URLMatch::domain("espn.com"_s),
         .behaviors = {
-#if PLATFORM(IOS)
             // espn.com rdar://184169028
             NeedsSuppressedPauseEventOnFullscreenExitQuirk,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
             // espn.com rdar://problem/95651814
             AllowLayeredFullscreenVideos,
-#endif
-#if ENABLE(VIDEO_PRESENTATION_MODE)
             // espn.com rdar://problem/73227900
             ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk,
-#endif
         } },
 
     // Expedia Group rdar://126631968
@@ -280,11 +527,8 @@ static constexpr Quirk table[] = {
             NeedsFacebookRemoveNotSupportedQuirk,
             // facebook.com rdar://174179871
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
-#if ENABLE(VIDEO_PRESENTATION_MODE)
             // facebook.com rdar://67273166
             RequiresUserGestureToPauseInPictureInPictureQuirk,
-#endif
-#if ENABLE(MEDIA_STREAM)
             // facebook.com rdar://158736355
             ShouldEnableCameraAndMicrophonePermissionStateQuirk,
             ShouldEnableRemoteTrackLabelQuirk,
@@ -292,38 +536,27 @@ static constexpr Quirk table[] = {
             ShouldEnableFacebookFlagQuirk,
             // facebook.com rdar://161269819
             ShouldEnableEnumerateDeviceQuirk,
-#endif
-#if ENABLE(WEB_RTC)
             // facebook.com rdar://158736355
             ShouldEnableRTCEncodedStreamsQuirk,
-#endif
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // facebook.com rdar://174179871
             ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
         },
         .site = QuirkSite::Facebook },
 
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // flipkart.com rdar://49648520
     { .match = URLMatch::domain("flipkart.com"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
-#endif
 
-#if ENABLE(VIDEO_PRESENTATION_MODE)
     // forbes.com rdar://67273166
     { .match = URLMatch::domain("forbes.com"_s),
         .behaviors = { RequiresUserGestureToPauseInPictureInPictureQuirk } },
-#endif
 
     { .match = URLMatch::host("play.geforcenow.com"_s),
         .behaviors = { NeedsGeforcenowWarningDisplayNoneQuirk } },
 
-#if PLATFORM(IOS_FAMILY)
     // gizmodo.com rdar://102227302
     { .match = URLMatch::domain("gizmodo.com"_s),
         .behaviors = { NeedsFullscreenDisplayNoneQuirk } },
-#endif
 
     { .match = URLMatch::anyTopLevelDomain("google"_s),
         .behaviors = {
@@ -334,39 +567,28 @@ static constexpr Quirk table[] = {
 
     { .match = URLMatch::anyTopLevelDomain("google"_s).when(pathStartsWith("/maps/"_s)),
         .behaviors = {
-#if ENABLE(TWO_PHASE_CLICKS)
             // maps.google.com rdar://152194074
             MayNeedToIgnoreContentObservation,
-#endif
-#if PLATFORM(IOS_FAMILY)
             // maps.google.com rdar://67358928
             NeedsGoogleMapsScrollingQuirk,
-#endif
             // maps.google.com https://bugs.webkit.org/show_bug.cgi?id=214945
             ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // maps.google.com rdar://49124313
             ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
         },
         .site = QuirkSite::GoogleMaps },
 
     { .match = URLMatch::host("docs.google.com"_s),
         .behaviors = {
             InputMethodUsesCorrectKeyEventOrder,
-#if PLATFORM(MAC)
             InputMethodMustUseCompositionEvents,
             // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=161984
             IsTouchBarUpdateSuppressedForHiddenContentEditableQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
             // docs.google.com rdar://49864669
             ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk,
-#endif
         },
         .site = QuirkSite::GoogleDocs },
 
-#if PLATFORM(IOS_FAMILY)
     // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
     { .match = URLMatch::host("docs.google.com"_s).when(pathStartsWith("/spreadsheets/"_s)),
         .behaviors = { NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk } },
@@ -378,24 +600,20 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::host("mail.google.com"_s),
         .behaviors = { NeedsGMailOverflowScrollQuirk } },
 
+    // translate.google.com rdar://106539018
     { .match = URLMatch::host("translate.google.com"_s),
-        .behaviors = {
-            // translate.google.com rdar://106539018
-            NeedsGoogleTranslateScrollingQuirk,
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-        } },
-#endif
+        .behaviors = { NeedsGoogleTranslateScrollingQuirk } },
 
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    { .match = URLMatch::host("translate.google.com"_s),
+        .behaviors = { NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .availableWhen = iOSFamily },
+
     // sites.google.com rdar://58653069
     { .match = URLMatch::host("sites.google.com"_s),
         .behaviors = { ShouldPreventDispatchOfTouchEventQuirk } },
-#endif
 
-#if ENABLE(MEDIA_STREAM)
     { .match = URLMatch::host("meet.google.com"_s),
         .behaviors = { ShouldEnableCameraBackgroundPlayback } },
-#endif
 
     // hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
     { .match = URLMatch::domain("hbomax.com"_s),
@@ -403,17 +621,16 @@ static constexpr Quirk table[] = {
 
     { .match = URLMatch::host("play.hbomax.com"_s),
         .behaviors = {
-#if HAVE(PIP_SKIP_PREROLL)
             // play.hbomax.com rdar://158430821
             ShouldDisableAdSkippingInPip,
-#endif
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-            // hbomax.com: rdar://138424489
-            NeedsZeroMaxTouchPointsQuirk,
             // hbomax.com: rdar://138806698
             ShouldSupportHoverMediaQueriesQuirk,
-#endif
         } },
+
+    // hbomax.com: rdar://138424489
+    { .match = URLMatch::host("play.hbomax.com"_s),
+        .behaviors = { NeedsZeroMaxTouchPointsQuirk },
+        .availableWhen = desktopContentModeQuirks },
 
     { .match = URLMatch::domain("hulu.com"_s),
         .behaviors = {
@@ -425,16 +642,12 @@ static constexpr Quirk table[] = {
             ImplicitMuteWhenVolumeSetToZero,
         } },
 
-#if PLATFORM(IOS_FAMILY)
     // icloud.com rdar://131836301
     { .match = URLMatch::domain("icloud.com"_s).when(pathOrFragmentContains("mail"_s)),
         .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
-#endif
-#if PLATFORM(MAC)
     // icloud.com rdar://26013388
     { .match = URLMatch::domain("icloud.com"_s).when(pathOrFragmentContains("notes"_s)),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
-#endif
 
     { .match = URLMatch::domain("iheart.com"_s),
         .behaviors = {
@@ -454,17 +667,13 @@ static constexpr Quirk table[] = {
         .behaviors = {
             // rdar://166400170
             NeedsInstagramResizingReelsQuirk,
-#if PLATFORM(IOS_FAMILY)
             // instagram.com: rdar://174936655
             ShouldSendFakeTouchForceChangeEvent,
-#endif
         } },
 
-#if PLATFORM(IOS_FAMILY)
     // instagram.com rdar://121014613
     { .match = URLMatch::domain("instagram.com"_s),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
-#endif
 
     // invideo.io rdar://171741842 https://webkit.org/b/311602
     { .match = URLMatch::domain("invideo.io"_s),
@@ -478,10 +687,8 @@ static constexpr Quirk table[] = {
 
     { .match = URLMatch::domain("live.com"_s),
         .behaviors = {
-#if PLATFORM(IOS_FAMILY)
             // live.com: rdar://167489768
             NeedsChromeOSNavigatorUserAgentQuirk,
-#endif
             // live.com rdar://52116170
             ShouldAvoidResizingWhenInputViewBoundsChangeQuirk,
         } },
@@ -490,16 +697,15 @@ static constexpr Quirk table[] = {
         .behaviors = {
             // outlook.live.com: rdar://136624720
             NeedsMozillaFileTypeForDataTransferQuirk,
-#if ENABLE(TWO_PHASE_CLICKS)
             // outlook.live.com: rdar://152277211
             MayNeedToIgnoreContentObservation,
-#endif
-#if ENABLE(TOUCH_EVENTS)
-            // outlook.live.com rdar://48008837
-            ShouldPreventDispatchOfTouchEventQuirk,
-#endif
         },
         .site = QuirkSite::Outlook },
+
+    // outlook.live.com rdar://48008837
+    { .match = URLMatch::host("outlook.live.com"_s),
+        .behaviors = { ShouldPreventDispatchOfTouchEventQuirk },
+        .availableWhen = touchEvents },
 
     // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
     { .match = URLMatch::hostOrSubdomainOf("officeapps.live.com"_s),
@@ -507,7 +713,6 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::hostOrSubdomainOf("onedrive.live.com"_s),
         .behaviors = { ShouldDisableDataURLPaddingValidation } },
 
-#if PLATFORM(MAC)
     // onedrive.live.com rdar://26013388
     { .match = URLMatch::host("onedrive.live.com"_s),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
@@ -515,33 +720,26 @@ static constexpr Quirk table[] = {
     // madisoncity.k12.al.us https://bugs.webkit.org/show_bug.cgi?id=296989
     { .match = URLMatch::domain("madisoncity.k12.al.us"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
-#endif
 
-#if PLATFORM(IOS_FAMILY)
     // mailchimp.com rdar://47868965
     { .match = URLMatch::domain("mailchimp.com"_s),
         .behaviors = { ShouldDisablePointerEventsQuirk } },
-#endif
 
     { .match = URLMatch::domain("marcus.com"_s),
         .behaviors = {
             // Marcus: <rdar://101086391>.
             ShouldExposeShowModalDialog,
-#if PLATFORM(IOS_FAMILY)
             // marcus.com rdar://102959860
             ShouldNavigatorPluginsBeEmpty,
-#endif
         } },
 
     // medium.com rdar://50457837
     { .match = URLMatch::domain("medium.com"_s),
         .behaviors = { ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk } },
 
-#if PLATFORM(IOS_FAMILY)
     // m365.cloud.microsoft rdar://157794706
     { .match = URLMatch::hostOrSubdomainOf("m365.cloud.microsoft"_s),
         .behaviors = { ShouldAllowPopupFromMicrosoftOfficeToOneDrive } },
-#endif
 
     // safe.menlosecurity.com rdar://135114489
     { .match = URLMatch::host("safe.menlosecurity.com"_s),
@@ -549,60 +747,51 @@ static constexpr Quirk table[] = {
 
     { .match = URLMatch::domain("messenger.com"_s),
         .behaviors = {
-#if ENABLE(MEDIA_STREAM)
             // facebook.com rdar://158736355
             ShouldEnableCameraAndMicrophonePermissionStateQuirk,
             ShouldEnableRemoteTrackLabelQuirk,
             // facebook.com rdar://161269819
             ShouldEnableEnumerateDeviceQuirk,
-#endif
-#if ENABLE(WEB_RTC)
             // facebook.com rdar://158736355
             ShouldEnableRTCEncodedStreamsQuirk,
-#endif
         } },
 
-#if PLATFORM(IOS_FAMILY)
     // rdar://147429596
     { .match = URLMatch::domain("nba.com"_s),
         .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
         },
-        .site = QuirkSite::NBA },
-#if PLATFORM(IOS)
-    { .match = URLMatch::domain("nba.com"_s).when(smallScreen()),
-        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen } },
-#endif
-#endif
+        .site = QuirkSite::NBA,
+        .availableWhen = iOSFamily },
 
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
+    { .match = URLMatch::domain("nba.com"_s).when(smallScreen()),
+        .behaviors = { ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen },
+        .availableWhen = iOS },
+
     // mybinder.org rdar://51770057
     { .match = URLMatch::domain("mybinder.org"_s),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk },
-        .site = QuirkSite::MyBinder },
+        .site = QuirkSite::MyBinder,
+        .availableWhen = touchEvents || touchEventRegions },
 
     // naver.com rdar://48068610
     { .match = URLMatch::hostOrSubdomainOf("naver.com"_s).exceptWhen(hostIs(naverHostsWithoutSimulatedMouseEvents)),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
-#endif
 
     { .match = URLMatch::domain("netflix.com"_s),
         .behaviors = {
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
             NeedsSeekingSupportDisabledQuirk,
-#if PLATFORM(VISION)
-            NeedsNowPlayingFullscreenSwapQuirk,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
             // netflix.com rdar://178545839
             NeedsNetflixVolumeSliderQuirk,
-#endif
-#if ENABLE(TOUCH_EVENTS)
             // netflix.com https://bugs.webkit.org/show_bug.cgi?id=304608
             ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick,
-#endif
         },
         .site = QuirkSite::Netflix },
+
+    { .match = URLMatch::domain("netflix.com"_s),
+        .behaviors = { NeedsNowPlayingFullscreenSwapQuirk },
+        .availableWhen = vision },
 
     { .match = URLMatch::domain("nfl.com"_s),
         .behaviors = { ShouldSuppressHLSSubtitles } },
@@ -610,11 +799,10 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::domain("nhl.com"_s),
         .behaviors = { NeedsWebKitMediaTextTrackDisplayQuirk } },
 
-#if PLATFORM(IOS) || PLATFORM(VISION)
     // nytimes.com: rdar://problem/5976384
     { .match = URLMatch::domain("nytimes.com"_s),
-        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting } },
-#endif
+        .behaviors = { ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting },
+        .availableWhen = iOS || vision },
 
     // Pandora: <rdar://100243111>.
     { .match = URLMatch::domain("pandora.com"_s),
@@ -635,26 +823,20 @@ static constexpr Quirk table[] = {
             ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
         } },
 
-#if PLATFORM(IOS_FAMILY)
     // ralphlauren.com rdar://55629493
     { .match = URLMatch::domain("ralphlauren.com"_s),
         .behaviors = { ShouldIgnoreAriaForFastPathContentObservationCheckQuirk } },
-#endif
 
-#if ENABLE(VIDEO_PRESENTATION_MODE) || PLATFORM(IOS_FAMILY)
+    // reddit.com: rdar://80550715
     { .match = URLMatch::domain("reddit.com"_s),
-        .behaviors = {
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-            // reddit.com: rdar://80550715
-            RequiresUserGestureToPauseInPictureInPictureQuirk,
-#endif
-#if PLATFORM(IOS_FAMILY)
-            // reddit.com with Sink It extension: rdar://176377447.
-            ShouldDisableScrollAnchoringQuirk,
-#endif
-        },
-        .site = QuirkSite::Reddit },
-#endif
+        .behaviors = { RequiresUserGestureToPauseInPictureInPictureQuirk },
+        .site = QuirkSite::Reddit,
+        .availableWhen = videoPresentationMode || iOSFamily },
+
+    // reddit.com with Sink It extension: rdar://176377447.
+    { .match = URLMatch::domain("reddit.com"_s),
+        .behaviors = { ShouldDisableScrollAnchoringQuirk },
+        .availableWhen = iOSFamily },
 
     { .match = URLMatch::domain("scribd.com"_s),
         .behaviors = { NeedsReuseLiveRangeForSelectionUpdateQuirk } },
@@ -667,15 +849,14 @@ static constexpr Quirk table[] = {
     { .match = URLMatch::domain("sharepoint.com"_s),
         .behaviors = { ShouldAvoidResizingWhenInputViewBoundsChangeQuirk } },
 
-#if PLATFORM(IOS_FAMILY) && ENABLE(META_VIEWPORT)
     { .match = URLMatch::domain("slack.com"_s),
         .behaviors = {
             // slack.com: rdar://138614711
             ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk,
             // slack.com: rdar://171190689
             ShouldUseDynamicViewportUnitsAsDefaultQuirk,
-        } },
-#endif
+        },
+        .availableWhen = iOSFamily },
 
     { .match = URLMatch::domain("soundcloud.com"_s),
         .behaviors = {
@@ -683,18 +864,14 @@ static constexpr Quirk table[] = {
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
             // Soundcloud: rdar://102913500
             ShouldExposeShowModalDialog,
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // soundcloud.com rdar://52915981
             ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
         },
         .site = QuirkSite::SoundCloud },
 
-#if ENABLE(TOUCH_EVENTS)
     // soylent.*: rdar://113314067
     { .match = URLMatch::anyTopLevelDomain("soylent"_s),
         .behaviors = { ShouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick } },
-#endif
 
     // spotify.com rdar://138918575
     { .match = URLMatch::host("open.spotify.com"_s),
@@ -705,70 +882,53 @@ static constexpr Quirk table[] = {
             NeedsWebKitMediaTextTrackDisplayQuirk,
             ShouldDeferIntersectionObserversDuringResize,
             ShouldBlockAudiblePlaybackWhileAudioIsPlaying,
-#if PLATFORM(COCOA)
             NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk,
-#endif
         } },
 
-#if ENABLE(CONTENT_CHANGE_OBSERVER)
     // Remove this once rdar://142573562 is resolved.
     { .match = URLMatch::domain("steampowered.com"_s),
         .behaviors = { ShouldTreatAddingMouseOutEventListenerAsContentChange } },
-#endif
 
-#if PLATFORM(IOS_FAMILY)
     { .match = URLMatch::anyTopLevelDomain("theguardian"_s),
         .behaviors = { ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk } },
 
     // theguardian.com rdar://166727225
     { .match = QuirkURLMatch::embeddedDocumentInTopMatch(URLMatch::anyTopLevelDomain("theguardian"_s), URLMatch::domain(youTubeEmbedDomains)),
         .behaviors = { NeedsYouTubeEmbedAutoplayQuirk } },
-#endif
 
     { .match = URLMatch::domain("thesaurus.com"_s),
-        .behaviors = {
-#if PLATFORM(IOS_FAMILY)
-            NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
-#endif
-#if PLATFORM(COCOA)
-            NeedsAnchorToBeMouseFocusableQuirk,
-#endif
-        },
+        .behaviors = { NeedsAnchorToBeMouseFocusableQuirk },
         .site = QuirkSite::Thesaurus },
+
+    { .match = URLMatch::domain("thesaurus.com"_s),
+        .behaviors = { NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+        .availableWhen = iOSFamily },
 
     { .match = URLMatch::domain("tiktok.com"_s),
         .behaviors = {
             NeedsTikTokOverflowingContentQuirk,
             // tiktok.com rdar://174179805
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // tiktok.com rdar://174179805
             ShouldDispatchSimulatedMouseEventsQuirk,
-#endif
         },
         .site = QuirkSite::TikTok },
 
-#if PLATFORM(MAC)
     // trix-editor.org rdar://28242210
     { .match = URLMatch::domain("trix-editor.org"_s),
         .behaviors = { IsNeverRichlyEditableForTouchBarQuirk } },
-#endif
 
-#if ENABLE(PICTURE_IN_PICTURE_API)
     // twitch.tv rdar://102420527
     { .match = URLMatch::domain("twitch.tv"_s),
         .behaviors = { ShouldReportDocumentAsVisibleIfActivePIPQuirk } },
-#endif
 
     // https://tympanus.net/Tutorials/WebGPUFluid/ does not load (rdar://143839620).
     { .match = URLMatch::domain("tympanus.net"_s),
         .behaviors = { ShouldBlockFetchWithNewlineAndLessThan } },
 
-#if ENABLE(MEDIA_SOURCE)
     // unifi.ui.com rdar://180411019
     { .match = URLMatch::domain("ui.com"_s),
         .behaviors = { NeedsSupportsProgressMonitoringQuirk } },
-#endif
 
     // Breaks express checkout on victoriassecret.com (rdar://104818312).
     { .match = URLMatch::domain("victoriassecret.com"_s),
@@ -778,53 +938,41 @@ static constexpr Quirk table[] = {
         .behaviors = {
             // vimeo.com rdar://56996057
             MaybeBypassBackForwardCache,
-#if PLATFORM(IOS_FAMILY)
             // vimeo.com rdar://55759025
             NeedsPreloadAutoQuirk,
-#endif
-#if ENABLE(VIDEO_PRESENTATION_MODE)
             // vimeo.com: rdar://problem/73227900
             ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk,
-#endif
-#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
             // vimeo.com: rdar://107592139
             BlocksEnteringStandardFullscreenFromPictureInPictureQuirk,
             // vimeo.com: rdar://problem/70788878
             BlocksReturnToFullscreenFromPictureInPictureQuirk,
-#endif
         },
         .site = QuirkSite::Vimeo },
 
-#if PLATFORM(IOS_FAMILY)
     // rdar://116531089
     { .match = URLMatch::domain("vimeo.com"_s).when(smallScreen()),
         .behaviors = { ShouldDisableElementFullscreenQuirk } },
-#endif
 
-#if ENABLE(TWO_PHASE_CLICKS)
     // walmart.com: rdar://123734840
     { .match = URLMatch::domain("walmart.com"_s),
         .behaviors = {
             MayNeedToIgnoreContentObservation,
         },
-        .site = QuirkSite::Walmart },
-#endif
+        .site = QuirkSite::Walmart,
+        .availableWhen = twoPhaseClicks },
 
-#if PLATFORM(MAC)
     // weather.com rdar://139689157
     { .match = URLMatch::domain("weather.com"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
-#endif
 
-#if PLATFORM(IOS_FAMILY) && ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
     { .match = URLMatch::domain("webex.com"_s),
         .behaviors = {
             NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,
             // webex.com rdar://143715630
             NeedsWebExScrollabilityQuirk,
         },
-        .site = QuirkSite::WebEx },
-#endif
+        .site = QuirkSite::WebEx,
+        .availableWhen = iOSFamily && desktopContentModeQuirks },
 
     // weebly.com rdar://48003980
     { .match = URLMatch::domain("weebly.com"_s),
@@ -834,49 +982,42 @@ static constexpr Quirk table[] = {
         .behaviors = {
             // wikipedia.org rdar://54856323
             ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk,
-#if ENABLE(META_VIEWPORT)
             // wikipedia.org https://webkit.org/b/247636
             ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk,
-#endif
         } },
 
     // rdar://170412045, https://bugs.webkit.org/show_bug.cgi?id=307933
-#if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
     // wix.com rdar://49124313, except while picking a template.
     { .match = URLMatch::domain("wix.com"_s).exceptWhen(pathStartsWith("/website/templates/"_s)),
         .behaviors = { ShouldDispatchSimulatedMouseEventsQuirk } },
-#endif
 
     { .match = URLMatch::domain("workspaces.xyz"_s),
         .behaviors = { ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions } },
 
-#if PLATFORM(MAC)
     // wpdevelopment.ca rdar://156109518
     { .match = URLMatch::domain("wpdevelopment.ca"_s),
         .behaviors = { NeedsFormControlToBeMouseFocusableQuirk } },
-#endif
 
     { .match = URLMatch::domain("x.com"_s),
         .behaviors = {
-#if PLATFORM(VISION)
             // x.com: rdar://132850672
             ShouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
             // rdar://121473410
             ShouldSilenceMediaQueryListChangeEvents,
-            // x.com: rdar://problem/58804852 and rdar://problem/61731801
-            ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting,
-            // x.com: rdar://175565114
-            ShouldAvoidProgrammaticScrollClampingQuirk,
-#endif
-#if ENABLE(VIDEO_PRESENTATION_MODE)
             // x.com: rdar://73369869
             RequiresUserGestureToLoadInPictureInPictureQuirk,
             // x.com: rdar://73369869
             RequiresUserGestureToPauseInPictureInPictureQuirk,
-#endif
         } },
+
+    { .match = URLMatch::domain("x.com"_s),
+        .behaviors = {
+            // x.com: rdar://problem/58804852 and rdar://problem/61731801
+            ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting,
+            // x.com: rdar://175565114
+            ShouldAvoidProgrammaticScrollClampingQuirk,
+        },
+        .availableWhen = iOS || vision },
 
     { .match = URLMatch::anyTopLevelDomain("yahoo"_s),
         .behaviors = {
@@ -884,23 +1025,20 @@ static constexpr Quirk table[] = {
             NeedsYahooVolumeSliderQuirk,
             // yahoo.com: rdar://136767005
             ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
-#if ENABLE(TOUCH_EVENTS)
-            // yahoo.com : rdar://142894603
-            ShouldPreventDispatchOfTouchEventQuirk,
-#endif
         } },
 
-#if ENABLE(VIDEO_PRESENTATION_MODE) && PLATFORM(IOS)
     // yahoo.com: rdar://148284059
     { .match = QuirkURLMatch::embeddedDocumentInTopMatch(URLMatch::anyTopLevelDomain("yahoo"_s), URLMatch::domain("yimg.com"_s)),
         .behaviors = { RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk } },
-#endif
 
-#if ENABLE(TEXT_AUTOSIZING)
+    // yahoo.com : rdar://142894603
+    { .match = URLMatch::anyTopLevelDomain("yahoo"_s),
+        .behaviors = { ShouldPreventDispatchOfTouchEventQuirk },
+        .availableWhen = touchEvents },
+
     // news.ycombinator.com: rdar://127246368
     { .match = URLMatch::host("news.ycombinator.com"_s),
         .behaviors = { ShouldIgnoreTextAutoSizingQuirk } },
-#endif
 
     { .match = URLMatch::domain("youtube.com"_s),
         .behaviors = {
@@ -908,22 +1046,15 @@ static constexpr Quirk table[] = {
             HasBrokenEncryptedMediaAPISupportQuirk,
             // youtube.com rdar://135886305
             NeedsScrollbarWidthThinDisabledQuirk,
-#if PLATFORM(COCOA)
             NeedsYouTubeCaptionQuirk,
-#endif
-#if PLATFORM(IOS) || PLATFORM(VISION)
             // youtube.com: rdar://110097836
             ShouldSilenceResizeObservers,
-#endif
         } },
 
-#if PLATFORM(COCOA)
     // Embedded youtube.com players need the caption quirk regardless of the embedding site.
     { .match = QuirkURLMatch::embeddedDocument(URLMatch::domain(youTubeEmbedDomains)),
         .behaviors = { NeedsYouTubeCaptionQuirk } },
-#endif
 
-#if PLATFORM(IOS_FAMILY)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
     { .match = URLMatch::domain("youtube.com"_s).when(smallScreen()),
@@ -941,53 +1072,89 @@ static constexpr Quirk table[] = {
         .behaviors = { NeedsYouTubeOverflowScrollQuirk } },
 
     { .match = URLMatch::domain("youtube.com"_s).when(tubularApp()),
-        .behaviors = { ShouldSuppressMediaSessionPauseActionOnInterruption } },
-#endif
+        .behaviors = { ShouldSuppressMediaSessionPauseActionOnInterruption },
+        .availableWhen = iOSFamily },
 
-#if ENABLE(TWO_PHASE_CLICKS)
     // www.youtube.com rdar://52361019
     { .match = URLMatch::host("www.youtube.com"_s),
         .behaviors = { NeedsYouTubeMouseOutQuirk } },
-#endif
 
-#if PLATFORM(VISION) && ENABLE(FULLSCREEN_API)
     // Lens.app rdar://178769976
     { .match = URLMatch::domain("youtube.com"_s).when(lensApp()),
-        .behaviors = { RequiresUserGestureToPlayInFullscreenQuirk } },
-#endif
+        .behaviors = { RequiresUserGestureToPlayInFullscreenQuirk },
+        .availableWhen = vision },
 
-#if ENABLE(MEDIA_RECORDER) && ENABLE(COCOA_WEBM_PLAYER)
     // zencastr.com rdar://143087016
     { .match = URLMatch::domain("zencastr.com"_s),
         .behaviors = { NeedsLimitedMatroskaSupportQuirk } },
-#endif
 
     // zillow.com rdar://53103732
     { .match = URLMatch::host("www.zillow.com"_s),
         .behaviors = { ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk } },
 
-#if PLATFORM(IOS) || PLATFORM(VISION)
     // zillow.com rdar://110097836
     { .match = URLMatch::domain("zillow.com"_s),
         .behaviors = { ShouldSilenceResizeObservers } },
-#endif
 
-#if PLATFORM(MAC)
     { .match = URLMatch::domain("zomato.com"_s),
         .behaviors = { NeedsZomatoEmailLoginLabelQuirk } },
-#endif
 
     { .match = URLMatch::domain("zoom.us"_s),
         .behaviors = {
             // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
             ShouldAutoplayWebAudioForArbitraryUserGestureQuirk,
-#if ENABLE(MEDIA_STREAM)
             // zoom.us rdar://118185086
             ShouldDisableImageCaptureQuirk,
             ShouldAllowMediaStreamTrackSerializationQuirk,
-#endif
         } },
 };
+
+consteval bool shouldEmit(const Quirk& quirk)
+{
+    if (!quirk.availableWhen)
+        return false;
+
+    if (quirk.site)
+        return true;
+
+    auto usable = quirk.behaviors.bits();
+    usable.exclude(unavailableQuirks);
+    return !usable.isEmpty();
+}
+
+consteval size_t emittedQuirkCount()
+{
+    return std::ranges::count_if(fullTable, shouldEmit);
+}
+
+consteval auto emittedQuirkIndices()
+{
+    std::array<size_t, emittedQuirkCount()> indices { };
+    size_t index = 0;
+    size_t next = 0;
+    for (auto& quirk : fullTable) {
+        if (shouldEmit(quirk))
+            indices[next++] = index;
+        ++index;
+    }
+    return indices;
+}
+
+consteval Quirk maskedQuirk(const Quirk& quirk)
+{
+    Quirk masked = quirk;
+    masked.behaviors.exclude(unavailableQuirks);
+    return masked;
+}
+
+template<size_t... indices> consteval auto prunedTable(std::index_sequence<indices...>)
+{
+    constexpr auto emitted = emittedQuirkIndices();
+    constexpr auto quirks = std::span { fullTable };
+    return std::array<Quirk, sizeof...(indices)> { maskedQuirk(quirks[emitted[indices]])... };
+}
+
+static constexpr auto table = prunedTable(std::make_index_sequence<emittedQuirkCount()> { });
 
 } // namespace SiteSpecificQuirks
 

--- a/Source/WebCore/page/QuirkTable.h
+++ b/Source/WebCore/page/QuirkTable.h
@@ -45,6 +45,8 @@ public:
 
     constexpr const QuirkBitSet& bits() const LIFETIME_BOUND { return m_bits; }
 
+    constexpr void exclude(const QuirkBitSet& quirks) { m_bits.exclude(quirks); }
+
 private:
     QuirkBitSet m_bits;
 };
@@ -90,6 +92,7 @@ struct Quirk {
     QuirkURLMatch match;
     QuirkBehaviors behaviors { };
     std::optional<QuirkSite> site { };
+    bool availableWhen { true };
 
     void apply(QuirksData&) const;
 };


### PR DESCRIPTION
#### 785247e3f1d650d27c2fc9653e0881307fdae98e
<pre>
[Quirks] Reduce compile flags in Quirks table
<a href="https://bugs.webkit.org/show_bug.cgi?id=323025">https://bugs.webkit.org/show_bug.cgi?id=323025</a>
<a href="https://rdar.apple.com/186290524">rdar://186290524</a>

Reviewed by Brent Fulgham.

There are many compile flags in the Quirks table, which makes it
difficult to read and reason about. Instead of having many compile
flags, we make the availability of the behavior or quirk data
returned from a function or on the Quirk. This significantly cleans
up the table and more closely models what we&apos;ll see when we switch
to defining quirks in a data file.

Quirks that are unavailable for the current platform are still compiled
out of the binary to reduce code bloat by pruning the table at compile
time.

* Source/WebCore/page/QuirkNames.h:
* Source/WebCore/page/QuirkTable.cpp:
(WebCore::SiteSpecificQuirks::listsEveryQuirkOnce):
(WebCore::SiteSpecificQuirks::computeUnavailableQuirks):
(WebCore::Quirk::apply const):
(WebCore::resolveSiteSpecificQuirks):
(WebCore::SiteSpecificQuirks::shouldEmit):
(WebCore::SiteSpecificQuirks::emittedQuirkCount):
(WebCore::SiteSpecificQuirks::emittedQuirkIndices):
(WebCore::SiteSpecificQuirks::maskedQuirk):
(WebCore::SiteSpecificQuirks::prunedTable):
(WebCore::SiteSpecificQuirks::everyEmittedQuirkIsUsable):
* Source/WebCore/page/QuirkTable.h:
(WebCore::QuirkBehaviors::exclude):

Canonical link: <a href="https://commits.webkit.org/320338@main">https://commits.webkit.org/320338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54044cf935d68ac4791edfd9b708d393d0995bca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0d76d9d-acb2-4d83-aa4d-7738fd3d44a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100094 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9fac6cd-8ed9-432f-963e-bae88f5bb042) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47850 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f01cab2-6fa8-4afc-b364-2b89e66885e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46562 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44347 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58113 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41131 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58818 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47830 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131109 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57321 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19361 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56685 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->