### PR TITLE
[JSC][Wasm] Inline memory.init

### DIFF
--- a/JSTests/wasm/stress/memory-init-inline.js
+++ b/JSTests/wasm/stress/memory-init-inline.js
@@ -1,0 +1,52 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+function bytes(memory, offset, length) {
+    return Array.from(new Uint8Array(memory.buffer, offset, length));
+}
+
+async function test() {
+    const instance = await instantiate(`
+      (module
+        (memory (export "memory") 1)
+        (data "abcdefgh")
+        (func (export "init") (param i32 i32 i32)
+          (memory.init 0 (local.get 0) (local.get 1) (local.get 2)))
+        (func (export "drop")
+          (data.drop 0)))
+    `);
+    const { memory, init, drop } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        init(4, 0, 8);
+        assert.eq(bytes(memory, 4, 8), [97, 98, 99, 100, 101, 102, 103, 104]);
+        init(20, 2, 3);
+        assert.eq(bytes(memory, 20, 3), [99, 100, 101]);
+        init(65536, 0, 0);
+        assert.throws(() => init(65537, 0, 0), WebAssembly.RuntimeError, "Out of bounds memory access");
+        assert.throws(() => init(65535, 0, 2), WebAssembly.RuntimeError, "Out of bounds memory access");
+        assert.throws(() => init(0, 8, 1), WebAssembly.RuntimeError, "Out of bounds memory access");
+        assert.throws(() => init(0, 0, 9), WebAssembly.RuntimeError, "Out of bounds memory access");
+        assert.throws(() => init(0, 0xffffffff, 1), WebAssembly.RuntimeError, "Out of bounds memory access");
+    }
+
+    drop();
+    init(0, 0, 0);
+    assert.throws(() => init(0, 0, 1), WebAssembly.RuntimeError, "Out of bounds memory access");
+    assert.throws(() => init(0, 1, 0), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    const active = await instantiate(`
+      (module
+        (memory (export "memory") 1)
+        (data (i32.const 0) "xy")
+        (func (export "init") (param i32 i32 i32)
+          (memory.init 0 (local.get 0) (local.get 1) (local.get 2))))
+    `);
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        active.exports.init(0, 0, 0);
+        assert.throws(() => active.exports.init(0, 0, 1), WebAssembly.RuntimeError, "Out of bounds memory access");
+    }
+}
+
+await assert.asyncTest(test());
+

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1203,6 +1203,14 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset, W
     ASSERT(length.type() == TypeKind::I32);
 
     emitZeroExtendAddressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
+    if (!srcAddress.isConst()) {
+        Location srcLocation = loadIfNecessary(srcAddress);
+        m_jit.zeroExtend32ToWord(srcLocation.asGPR(), srcLocation.asGPR());
+    }
+    if (!length.isConst()) {
+        Location lengthLocation = loadIfNecessary(length);
+        m_jit.zeroExtend32ToWord(lengthLocation.asGPR(), lengthLocation.asGPR());
+    }
 
     Vector<Value, 8> arguments = {
         instanceValue(),

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -656,7 +656,7 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_init, int32_t dataIndex, IPIntStackEntry* sp, 
     const auto& info = instance->module().moduleInformation();
     uint64_t d = info.memory(memoryIndex).isMemory64() ? sp[2].i64 : static_cast<uint32_t>(sp[2].i32);
 
-    if (!Wasm::memoryInit(instance, dataIndex, d, s, n, memoryIndex))
+    if (!Wasm::memoryInit(instance, dataIndex, d, static_cast<uint32_t>(s), static_cast<uint32_t>(n), memoryIndex))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     IPINT_END();
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2231,22 +2231,84 @@ void OMGIRGenerator::emitMemoryFill(Value* dstAddressValue, Value* targetValue, 
 
 auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex) -> PartialResult
 {
-    auto dstAddressValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
+    auto* dstAddressValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
+    auto* srcAddressValue = pointerOfInt32(get(srcAddress));
+    auto* lengthValue = pointerOfInt32(get(length));
 
-    Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryInit,
-        instanceValue(),
-        constant(Int32, dataSegmentIndex),
-        dstAddressValue, get(srcAddress), get(length), constant(Int32, memoryIndex));
-
-    {
+    auto emitCCall = [&] {
+        Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryInit,
+            instanceValue(),
+            constant(Int32, dataSegmentIndex),
+            dstAddressValue, srcAddressValue, lengthValue, constant(Int32, memoryIndex));
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, constant(Int32, 0)));
-
         check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
+        });
+    };
+
+    if (memoryIndex || dataSegmentIndex >= BitVector::maxInlineBitCount()) {
+        emitCCall();
+        return { };
+    }
+
+    auto* bits = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfPassiveDataSegments()));
+    auto* isInline = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), BitVector::inlineBitMask()));
+
+    auto* inlinePath = m_proc.addBlock();
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), isInline,
+        FrequentedBlock(inlinePath), FrequentedBlock(slowPath, FrequencyClass::Rare));
+    inlinePath->addPredecessor(m_currentBlock);
+    slowPath->addPredecessor(m_currentBlock);
+
+    m_currentBlock = inlinePath;
+    {
+        auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
+        m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
+        auto* dstSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, lengthValue);
+        auto* dstSumOverflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), dstSum, dstAddressValue);
+        Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), dstSumOverflowed, m_currentBlock->appendNew<Value>(m_proc, Above, origin(), dstSum, memorySize));
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
+        check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
+        });
+    }
+    {
+        auto* dropped = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), static_cast<uintptr_t>(1) << dataSegmentIndex)),
+            constant(pointerType(), 0));
+        auto* segmentSize = m_currentBlock->appendNew<Value>(m_proc, B3::Select, origin(), dropped,
+            constant(pointerType(), 0),
+            constant(pointerType(), m_info.data[dataSegmentIndex]->sizeInBytes()));
+        auto* srcSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), srcAddressValue, lengthValue);
+        auto* srcSumOverflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), srcSum, srcAddressValue);
+        Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), srcSumOverflowed, m_currentBlock->appendNew<Value>(m_proc, Above, origin(), srcSum, segmentSize));
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
+        check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
         });
     }
 
+    auto* srcPointer = m_currentBlock->appendNew<Value>(m_proc, Add, origin(),
+        constant(pointerType(), std::bit_cast<uintptr_t>(m_info.data[dataSegmentIndex]->span().data())),
+        srcAddressValue);
+    m_currentBlock->appendNew<BulkMemoryValue>(
+        m_proc, MemoryCopy, origin(),
+        m_currentBlock->appendNew<WasmAddressValue>(m_proc, origin(), dstAddressValue, GPRInfo::wasmBaseMemoryPointer),
+        srcPointer,
+        lengthValue);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    emitCCall();
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1584,7 +1584,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, 
     return toUCPUStrictInt32(memoryAtomicNotify(instance, base, offset, countValue, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint64_t srcAddress, uint64_t length, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryInit(instance, dataSegmentIndex, dstAddress, srcAddress, length, memoryIndex));
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -108,7 +108,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int64_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t, uint64_t, int32_t, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint64_t dstAddress, uint64_t srcAddress, uint64_t length, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmDataDrop, void, (JSWebAssemblyInstance*, unsigned dataSegmentIndex));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t));

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -673,7 +673,7 @@ inline int64_t memorySize(JSWebAssemblyInstance* instance, uint8_t memoryIndex)
     return instance->memory(memoryIndex)->memory().size();
 }
 
-inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex)
+inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint64_t srcAddress, uint64_t length, uint8_t memoryIndex)
 {
     ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
     return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex, memoryIndex);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -584,11 +584,11 @@ void JSWebAssemblyInstance::elemDrop(uint32_t elementIndex)
     m_passiveElements.quickClear(elementIndex);
 }
 
-bool JSWebAssemblyInstance::memoryInit(uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex, uint8_t memoryIndex)
+bool JSWebAssemblyInstance::memoryInit(uint64_t dstAddress, uint64_t srcAddress, uint64_t length, uint32_t dataSegmentIndex, uint8_t memoryIndex)
 {
     RELEASE_ASSERT(dataSegmentIndex < module().moduleInformation().dataSegmentsCount());
 
-    if (sumOverflows<uint32_t>(srcAddress, length))
+    if (sumOverflows<uint64_t>(srcAddress, length))
         return false;
 
     auto& segment = module().moduleInformation().data[dataSegmentIndex];
@@ -596,10 +596,10 @@ bool JSWebAssemblyInstance::memoryInit(uint64_t dstAddress, uint32_t srcAddress,
     if (srcAddress + length > segmentSizeInBytes)
         return false;
 
-    const uint8_t* segmentData = !length ? nullptr : &segment->byte(srcAddress);
+    const uint8_t* segmentData = !length ? nullptr : &segment->byte(static_cast<uint32_t>(srcAddress));
 
     ASSERT(memoryIndex < m_moduleInformation->memoryCount());
-    return memory(memoryIndex)->memory().init(dstAddress, segmentData, length);
+    return memory(memoryIndex)->memory().init(dstAddress, segmentData, static_cast<uint32_t>(length));
 }
 
 void JSWebAssemblyInstance::dataDrop(uint32_t dataSegmentIndex)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -208,7 +208,7 @@ public:
 
     void elemDrop(uint32_t elementIndex);
 
-    bool memoryInit(uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex, uint8_t memoryIndex);
+    bool memoryInit(uint64_t dstAddress, uint64_t srcAddress, uint64_t length, uint32_t dataSegmentIndex, uint8_t memoryIndex);
 
     void dataDrop(uint32_t dataSegmentIndex);
 
@@ -329,6 +329,7 @@ public:
 #endif
     static constexpr ptrdiff_t offsetOfMemoryIsMemory64Bits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_memoryIsMemory64Bits); }
     static constexpr ptrdiff_t offsetOfCachedMemory0Size() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory0Size); }
+    static constexpr ptrdiff_t offsetOfPassiveDataSegments() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_passiveDataSegments); }
 
     // Tail accessors.
     static_assert(sizeof(WasmMemoryBaseAndSize) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(WasmMemoryBaseAndSize)), "We rely on this for the alignment to be correct");

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -396,7 +396,10 @@ public:
         return byteCount(bitCount);
     }
     unsigned outOfLineMemoryUse() const { return outOfLineMemoryUse(size()); }
-        
+
+    static constexpr unsigned maxInlineBitCount() { return maxInlineBits(); }
+    static constexpr uintptr_t inlineBitMask() { return static_cast<uintptr_t>(1) << maxInlineBitCount(); }
+
     WTF_EXPORT_PRIVATE void shiftRightByMultipleOf64(size_t);
 
 private:


### PR DESCRIPTION
#### 8e5e122d7786f86ed534f36b94da68493670f205
<pre>
[JSC][Wasm] Inline memory.init
<a href="https://bugs.webkit.org/show_bug.cgi?id=322803">https://bugs.webkit.org/show_bug.cgi?id=322803</a>

Reviewed by NOBODY (OOPS!).

OMG bounds-checks memory.init for memory 0 and copies with the
existing memcpy helper when the passive-data BitVector is still
inline. Extra memories, out-of-line storage, and segment indices
past the inline word still use the runtime operation. Source and
length are zero-extended i32s and the operation takes them as
uint64_t.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
* Source/WTF/wtf/BitVector.h:
* JSTests/wasm/stress/memory-init-inline.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e5e122d7786f86ed534f36b94da68493670f205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150298 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145000 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100534 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45467 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7196 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; jscore-tests (cancelled)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14083 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45151 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6923 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46804 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59123 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154182 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48649 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132186 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58306 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->