### PR TITLE
[corner-shape] Incorrect rendering when inner corners intersect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html
@@ -2,7 +2,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape' rendering with overflow</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-bevel-overflow-ref.html">
-<meta name="fuzzy" content="maxDifference=0-36;totalPixels=0-256">
+<meta name="fuzzy" content="maxDifference=0-53; totalPixels=0-198">
 <style>
     .bevel {
         background: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: two adjacent scoop corners whose inner edges intersect &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 138.07 434.31 250 600 250 L 600 500 L 0 500 L 0 250 C 165.69 250 300 138.07 300 0 Z M 300 231.51 C 352.11 283.17 421.38 321.27 500 338.97 L 500 400 L 100 400 L 100 338.97 C 178.62 321.27 247.89 283.17 300 231.51 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: two adjacent scoop corners whose inner edges intersect &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 138.07 434.31 250 600 250 L 600 500 L 0 500 L 0 250 C 165.69 250 300 138.07 300 0 Z M 300 231.51 C 352.11 283.17 421.38 321.27 500 338.97 L 500 400 L 100 400 L 100 338.97 C 178.62 321.27 247.89 283.17 300 231.51 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-intersection001-ref.html">
+<meta name="fuzzy" content="maxDifference=0-92; totalPixels=0-1535">
+<meta name="assert" content="Test for rendering corretcness when the inner edge of two adjacent scoop corners intersect.">
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        border: 100px solid green;
+        border-top-left-radius: 50%;
+        corner-top-left-shape: scoop;
+        border-top-right-radius: 50%;
+        corner-top-right-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: two adjacent scoop corners of differing radii whose inner edges intersect &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 220.91 434.31 400 600 400 L 600 500 L 0 500 L 0 250 C 165.69 250 300 138.07 300 0 Z M 260.89 265.31 C 287.06 317.46 320.71 363.14 359.96 400 L 500 400 L 100 400 L 100 338.97 C 160.31 325.39 215.12 299.81 260.9 265.31 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: two adjacent scoop corners of differing radii whose inner edges intersect &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 220.91 434.31 400 600 400 L 600 500 L 0 500 L 0 250 C 165.69 250 300 138.07 300 0 Z M 260.89 265.31 C 287.06 317.46 320.71 363.14 359.96 400 L 500 400 L 100 400 L 100 338.97 C 160.31 325.39 215.12 299.81 260.9 265.31 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-intersection002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-1550">
+<meta name="assert" content="Test for rendering corretcness when the inner edge of two adjacent scoop corners intersect.">
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        border: 100px solid green;
+        border-top-left-radius: 50%;
+        corner-top-left-shape: scoop;
+        border-top-right-radius: 50% 80%;
+        corner-top-right-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners whose inner edges intersect across the corner between them &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 248.53 434.31 450 600 450 L 600 500 L 540 500 C 540 472.39 298.23 450 0 450 L 0 250 C 165.69 250 300 138.07 300 0 Z M 252.14 271.72 C 266.44 306.25 283.38 338.45 302.58 367.79 C 240.49 359.97 172.25 354.48 100 351.82 L 100 338.97 C 156.51 326.25 208.19 302.98 252.14 271.72 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners whose inner edges intersect across the corner between them &mdash; reference</title>
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        background: green;
+        clip-path: path(evenodd, "M 300 0 C 300 248.53 434.31 450 600 450 L 600 500 L 540 500 C 540 472.39 298.23 450 0 450 L 0 250 C 165.69 250 300 138.07 300 0 Z M 252.14 271.72 C 266.44 306.25 283.38 338.45 302.58 367.79 C 240.49 359.97 172.25 354.48 100 351.82 L 100 338.97 C 156.51 326.25 208.19 302.98 252.14 271.72 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-intersection003-ref.html">
+<meta name="fuzzy" content="maxDifference=0-85; totalPixels=0-2285">
+<meta name="assert" content="Test for rendering correctness when the inner edges of two scoop corners intersect across the corner between them.">
+<style>
+    .target {
+        margin: 50px;
+        width: 600px;
+        height: 500px;
+        box-sizing: border-box;
+        border: 100px solid green;
+
+        border-top-left-radius: 50%;
+        corner-top-left-shape: scoop;
+
+        border-top-right-radius: 50% 90%;
+        corner-top-right-shape: scoop;
+
+        border-bottom-left-radius: 90% 10%;
+        corner-bottom-left-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numbers>
+#include <optional>
 #include <utility>
 
 namespace WebCore {
@@ -205,6 +206,99 @@ static bool boxesTouchOrOverlap(const FloatRect& first, const FloatRect& second)
         && first.maxY() >= second.y() && first.y() <= second.maxY();
 }
 
+static FloatRect controlPointBounds(const BezierSegment& curve)
+{
+    FloatRect bounds { curve.start, FloatSize { } };
+    bounds.extend(curve.controlPoint1);
+    bounds.extend(curve.controlPoint2);
+    bounds.extend(curve.end);
+    return bounds;
+}
+
+// Boxes below this are treated as a point when locating a crossing, and the subdivision
+// depth is capped in case a pair of curves overlaps rather than crossing cleanly.
+constexpr float crossingTolerance = 1.0f / 256;
+constexpr unsigned maximumCrossingDepth = 40;
+
+static FloatRect monotonicBounds(const BezierSegment& curve)
+{
+    FloatRect bounds { curve.start, FloatSize { } };
+    bounds.extend(curve.end);
+    return bounds;
+}
+
+static FloatRect monotonicBounds(const Vector<BezierSegment>& curves)
+{
+    FloatRect bounds { curves.first().start, FloatSize { } };
+    bounds.extend(curves.last().end);
+    return bounds;
+}
+
+static bool boxesCanReach(FloatRect first, const FloatRect& second)
+{
+    first.inflate(crossingTolerance);
+    return boxesTouchOrOverlap(first, second);
+}
+
+struct CurveParameterPair {
+    float onFirst { 0 };
+    float onSecond { 0 };
+};
+
+static void appendCurveCrossings(const BezierSegment& first, float firstStart, float firstEnd, const BezierSegment& second, float secondStart, float secondEnd, unsigned depth, Vector<CurveParameterPair>& crossings)
+{
+    auto firstBounds = monotonicBounds(first);
+    auto secondBounds = monotonicBounds(second);
+    if (!boxesTouchOrOverlap(firstBounds, secondBounds))
+        return;
+
+    float firstExtent = std::max(firstBounds.width(), firstBounds.height());
+    float secondExtent = std::max(secondBounds.width(), secondBounds.height());
+
+    float firstMiddle = (firstStart + firstEnd) / 2;
+    float secondMiddle = (secondStart + secondEnd) / 2;
+
+    if (depth >= maximumCrossingDepth || (firstExtent <= crossingTolerance && secondExtent <= crossingTolerance)) {
+        crossings.append({ firstMiddle, secondMiddle });
+        return;
+    }
+
+    if (firstExtent >= secondExtent) {
+        auto [before, after] = splitBezier(first, 0.5f);
+        appendCurveCrossings(before, firstStart, firstMiddle, second, secondStart, secondEnd, depth + 1, crossings);
+        appendCurveCrossings(after, firstMiddle, firstEnd, second, secondStart, secondEnd, depth + 1, crossings);
+        return;
+    }
+
+    auto [before, after] = splitBezier(second, 0.5f);
+    appendCurveCrossings(first, firstStart, firstEnd, before, secondStart, secondMiddle, depth + 1, crossings);
+    appendCurveCrossings(first, firstStart, firstEnd, after, secondMiddle, secondEnd, depth + 1, crossings);
+}
+
+static Vector<BezierSegment> curvesUpToIntersection(const Vector<BezierSegment>& curves, size_t index, float parameter)
+{
+    Vector<BezierSegment> kept;
+    for (size_t position = 0; position < index; ++position)
+        kept.append(curves[position]);
+
+    if (parameter > parameterEpsilon)
+        kept.append(splitBezier(curves[index], parameter).first);
+
+    return kept;
+}
+
+static Vector<BezierSegment> curvesFromIntersection(const Vector<BezierSegment>& curves, size_t index, float parameter)
+{
+    Vector<BezierSegment> kept;
+    if (parameter < 1.0f - parameterEpsilon)
+        kept.append(splitBezier(curves[index], parameter).second);
+
+    for (size_t position = index + 1; position < curves.size(); ++position)
+        kept.append(curves[position]);
+
+    return kept;
+}
+
 } // namespace
 
 // `parameter` is the Bézier curve parameter t in [0, 1] (the variable of the Bernstein basis
@@ -224,11 +318,7 @@ FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter
 
 Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect& rect)
 {
-    // The curve stays within its control points' convex hull
-    FloatRect controlBounds { curve.start, FloatSize { } };
-    controlBounds.extend(curve.controlPoint1);
-    controlBounds.extend(curve.controlPoint2);
-    controlBounds.extend(curve.end);
+    auto controlBounds = controlPointBounds(curve);
 
     // Inside -> no trim; disjoint -> empty. Inclusive test keeps zero-area (axis-aligned line) bounds.
     if (rect.contains(controlBounds))
@@ -252,6 +342,50 @@ Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRe
         curves = clipped;
     }
     return curves;
+}
+
+std::optional<BezierCurvesIntersection> findMonotonicBezierCurvesIntersection(const Vector<BezierSegment>& first, const Vector<BezierSegment>& second)
+{
+    if (first.isEmpty() || second.isEmpty())
+        return { };
+
+    if (!boxesCanReach(monotonicBounds(first), monotonicBounds(second)))
+        return { };
+
+    std::optional<BezierCurvesIntersection> found;
+    for (size_t firstIndex = 0; firstIndex < first.size(); ++firstIndex) {
+        for (size_t secondIndex = 0; secondIndex < second.size(); ++secondIndex) {
+            const auto& firstCurve = first[firstIndex];
+            const auto& secondCurve = second[secondIndex];
+
+            if (!boxesCanReach(monotonicBounds(firstCurve), monotonicBounds(secondCurve)))
+                continue;
+
+            Vector<CurveParameterPair> candidates;
+            appendCurveCrossings(firstCurve, 0, 1, secondCurve, 0, 1, 0, candidates);
+
+            for (auto candidate : candidates) {
+                bool isLater = !found || firstIndex > found->indexOnFirst || (firstIndex == found->indexOnFirst && candidate.onFirst > found->parameterOnFirst);
+                if (!isLater)
+                    continue;
+
+                found = BezierCurvesIntersection {
+                    firstIndex, candidate.onFirst,
+                    secondIndex, candidate.onSecond,
+                    (firstIndex + candidate.onFirst) / static_cast<float>(first.size()),
+                    (secondIndex + candidate.onSecond) / static_cast<float>(second.size()),
+                };
+            }
+        }
+    }
+
+    return found;
+}
+
+void trimMonotonicBezierCurvesAtIntersection(Vector<BezierSegment>& first, Vector<BezierSegment>& second, const BezierCurvesIntersection& intersection)
+{
+    first = curvesUpToIntersection(first, intersection.indexOnFirst, intersection.parameterOnFirst);
+    second = curvesFromIntersection(second, intersection.indexOnSecond, intersection.parameterOnSecond);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatRect.h>
+#include <optional>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -38,6 +39,21 @@ struct BezierSegment {
 };
 
 WEBCORE_EXPORT Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect&);
+
+struct BezierCurvesIntersection {
+    size_t indexOnFirst { 0 };
+    float parameterOnFirst { 0 };
+    size_t indexOnSecond { 0 };
+    float parameterOnSecond { 0 };
+    float fractionAlongFirst { 0 };
+    float fractionAlongSecond { 0 };
+    bool isTailToHead() const { return fractionAlongFirst > fractionAlongSecond; }
+};
+
+WEBCORE_EXPORT std::optional<BezierCurvesIntersection> findMonotonicBezierCurvesIntersection(const Vector<BezierSegment>& first, const Vector<BezierSegment>& second);
+
+WEBCORE_EXPORT void trimMonotonicBezierCurvesAtIntersection(Vector<BezierSegment>& first, Vector<BezierSegment>& second, const BezierCurvesIntersection&);
+
 // `parameter` is the Bézier curve parameter t in [0, 1]: 0 is the start point, 1 is the end point (not arc length).
 FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter);
 

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -345,6 +345,7 @@ static std::array<BezierSegment, 2> superellipseCornerBeziers(const Corner& corn
     BezierSegment secondHalf { midpoint, mapPointToCorner(corner, transpose(secondControl)), mapPointToCorner(corner, transpose(firstControl)), corner.end };
     return { firstHalf, secondHalf };
 }
+
 static BezierSegment shallowConcaveCornerBezier(const Corner& corner, const FloatPoint& tangentVertex)
 {
     constexpr float circleHandle = 0.5522847498307933f; // 4 / 3 * (sqrt(2) - 1): cubic approximation of a quarter circle
@@ -411,6 +412,7 @@ static void addCurvedCorner(Path& path, const ResolvedCorner& corner)
     // General superellipse: squircle (s=2) and superellipse(n)
     if (extendPathForSharpCorner(path, adjusted))
         return;
+
     for (const auto& curve : cornerCurveBeziers(corner))
         path.addBezierCurveTo(curve.controlPoint1, curve.controlPoint2, curve.end);
 }
@@ -426,8 +428,17 @@ static FloatPoint sharpInnerCornerPoint(const FloatRect& innerRect, BoxCorner or
     return { };
 }
 
-// rect ∩ corner-carve
-static void addTrimmedSuperellipseCorner(Path& path, const ResolvedCorner& corner, const FloatRect& innerRect, bool& started)
+static Vector<BezierSegment> trimmedSuperellipseCornerCurves(const ResolvedCorner& corner, const FloatRect& innerRect)
+{
+    Vector<BezierSegment> clippedCurves;
+    for (const auto& bezier : cornerCurveBeziers(corner)) {
+        for (const auto& curve : trimBezierToRect(bezier, innerRect))
+            clippedCurves.append(curve);
+    }
+    return clippedCurves;
+}
+
+static void addSuperellipseCornerCurves(Path& path, const Vector<BezierSegment>& curves, const FloatPoint& sharpCornerPoint, bool& started)
 {
     auto lineOrMoveTo = [&](FloatPoint point) {
         if (!started) {
@@ -437,17 +448,12 @@ static void addTrimmedSuperellipseCorner(Path& path, const ResolvedCorner& corne
             path.addLineTo(point);
     };
 
-    Vector<BezierSegment, 4> clippedCurves;
-    for (const auto& bezier : cornerCurveBeziers(corner)) {
-        for (const auto& curve : trimBezierToRect(bezier, innerRect))
-            clippedCurves.append(curve);
-    }
-
-    if (clippedCurves.isEmpty()) {
-        lineOrMoveTo(sharpInnerCornerPoint(innerRect, corner.adjusted.orientation));
+    if (curves.isEmpty()) {
+        lineOrMoveTo(sharpCornerPoint);
         return;
     }
-    for (const auto& curve : clippedCurves) {
+
+    for (const auto& curve : curves) {
         lineOrMoveTo(curve.start);
         path.addBezierCurveTo(curve.controlPoint1, curve.controlPoint2, curve.end);
     }
@@ -495,16 +501,69 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
             path.addLineTo(point);
     };
 
-    for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
+    static constexpr std::array<BoxCorner, 4> contourOrder { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft };
+
+    struct PreparedCorner {
+        ResolvedCorner resolved;
+        bool insetToTargetRect { false };
+        bool usesCurves { false };
+        bool isSwallowed { false };
+        Vector<BezierSegment> curves;
+    };
+
+    Vector<PreparedCorner, 4> corners;
+    for (auto key : contourOrder) {
         const auto& input = cornerRects[key];
-        auto corner = resolveCorner(makeCorner(input), input.startInset, input.endInset);
+
+        auto resolved = resolveCorner(makeCorner(input), input.startInset, input.endInset);
+        bool insetToTargetRect = targetRect && input.startInset >= 0.0 && input.endInset >= 0.0
+            && !isEmpty(resolved.adjusted);
+        bool usesCurves = insetToTargetRect && std::isfinite(resolved.adjusted.curvature);
+
+        Vector<BezierSegment> curves;
+        if (usesCurves)
+            curves = trimmedSuperellipseCornerCurves(resolved, *targetRect);
+
+        corners.append(PreparedCorner { WTF::move(resolved), insetToTargetRect, usesCurves, false, WTF::move(curves) });
+    }
+
+    // Concave corners can intersect; trim them at the cusp. A corner's inset curve can also intersect with non-adjacent edges.
+    // Trim non-adjacent pairs come first
+    for (size_t gap = corners.size() / 2; gap; --gap) {
+        for (size_t index = 0; index < corners.size(); ++index) {
+            auto& first = corners[index];
+            auto& second = corners[(index + gap) % corners.size()];
+
+            if (!first.usesCurves || !second.usesCurves || first.isSwallowed || second.isSwallowed)
+                continue;
+
+            auto intersection = findMonotonicBezierCurvesIntersection(first.curves, second.curves);
+            if (!intersection)
+                continue;
+
+            // Corners sharing an edge are visited once, in contour order, so their ordering
+            // is already the right way round. A non-adjacent pair gets visited both ways, and only
+            // one of those describes the tail of the first running into the head of the second.
+            if (gap > 1 && !intersection->isTailToHead())
+                continue;
+
+            trimMonotonicBezierCurvesAtIntersection(first.curves, second.curves, *intersection);
+
+            for (size_t between = 1; between < gap; ++between)
+                corners[(index + between) % corners.size()].isSwallowed = true;
+        }
+    }
+
+    for (auto& prepared : corners) {
+        if (prepared.isSwallowed)
+            continue;
+
+        const auto& corner = prepared.resolved;
         const auto& adjusted = corner.adjusted;
 
-        bool insetToTargetRect = targetRect && input.startInset >= 0.0 && input.endInset >= 0.0
-            && !isEmpty(adjusted);
-        if (insetToTargetRect) {
-            if (std::isfinite(adjusted.curvature))
-                addTrimmedSuperellipseCorner(path, corner, *targetRect, started);
+        if (prepared.insetToTargetRect) {
+            if (prepared.usesCurves)
+                addSuperellipseCornerCurves(path, prepared.curves, sharpInnerCornerPoint(*targetRect, adjusted.orientation), started);
             else
                 addClampedSharpCorner(path, corner, *targetRect, started);
             continue;
@@ -519,6 +578,7 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
 
         if ((adjusted.start - corner.miterStart).diagonalLength() >= limit)
             path.addLineTo(adjusted.start);
+
         addCurvedCorner(path, corner);
         path.addLineTo(corner.miterEnd);
     }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -719,6 +719,7 @@
 				WebCore/ApplicationManifestParser.cpp,
 				WebCore/ASN1Utilities.cpp,
 				WebCore/AudioSampleFormat.cpp,
+				WebCore/BezierUtilitiesTests.cpp,
 				WebCore/CachedMatchFinder.cpp,
 				WebCore/CARingBufferTest.cpp,
 				WebCore/CBORReaderTest.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
@@ -46,6 +46,18 @@ static void expectPointNear(const FloatPoint& actual, float expectedX, float exp
     EXPECT_NEAR(actual.y(), expectedY, tolerance);
 }
 
+// Finds and applies the intersection in one step, as the corner contour builder does for
+// corners that share an edge, where the ordering is known to be the right way round.
+static bool trimAtIntersection(Vector<BezierSegment>& first, Vector<BezierSegment>& second)
+{
+    auto intersection = findMonotonicBezierCurvesIntersection(first, second);
+    if (!intersection)
+        return false;
+
+    trimMonotonicBezierCurvesAtIntersection(first, second, *intersection);
+    return true;
+}
+
 // A curve entirely inside the rect is returned unchanged (single piece, all four control points intact).
 TEST(BezierUtilities, TrimReturnsStraightCurveInsideUnchanged)
 {
@@ -186,6 +198,186 @@ TEST(BezierUtilities, TrimKeepsLineLyingAlongTopEdge)
     auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
 
     EXPECT_FALSE(result.isEmpty());
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesLeavesSeparatedRunsAlone)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 10 }, { 4, 0 }) }; // reaches the edge at x = 4
+    Vector<BezierSegment> second { lineCurve({ 8, 0 }, { 12, 10 }) }; // leaves it at x = 8
+
+    EXPECT_FALSE(trimAtIntersection(first, second));
+
+    ASSERT_EQ(1u, first.size());
+    ASSERT_EQ(1u, second.size());
+    expectPointNear(first[0].end, 4, 0);
+    expectPointNear(second[0].start, 8, 0);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesMeetsStraightRunsAtTheirIntersection)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 10, 10 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 10 }, { 10, 0 }) };
+
+    EXPECT_TRUE(trimAtIntersection(first, second));
+
+    ASSERT_EQ(1u, first.size());
+    ASSERT_EQ(1u, second.size());
+    expectPointNear(first[0].start, 0, 0); // the far end of each run is untouched
+    expectPointNear(first[0].end, 5, 5);
+    expectPointNear(second[0].start, 5, 5);
+    expectPointNear(second[0].end, 10, 0);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesFindsIntersectionAwayFromMidParameter)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 12, 12 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 4 }, { 8, 4 }) };
+
+    EXPECT_TRUE(trimAtIntersection(first, second));
+
+    ASSERT_FALSE(first.isEmpty());
+    ASSERT_FALSE(second.isEmpty());
+    expectPointNear(first.last().end, 4, 4);
+    expectPointNear(second.first().start, 4, 4);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesLeavesParallelRunsAlone)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 10, 10 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 3 }, { 10, 13 }) }; // parallel, three above
+
+    EXPECT_FALSE(trimAtIntersection(first, second));
+
+    ASSERT_EQ(1u, first.size());
+    ASSERT_EQ(1u, second.size());
+    expectPointNear(first[0].start, 0, 0);
+    expectPointNear(first[0].end, 10, 10);
+    expectPointNear(second[0].start, 0, 3);
+    expectPointNear(second[0].end, 10, 13);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesKeepsEarlierSegmentsWhole)
+{
+    // y = x, split at (5, 5), and y = 8, split at x = 5. They meet at (8, 8).
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 5, 5 }), lineCurve({ 5, 5 }, { 10, 10 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 8 }, { 5, 8 }), lineCurve({ 5, 8 }, { 10, 8 }) };
+
+    EXPECT_TRUE(trimAtIntersection(first, second));
+
+    ASSERT_EQ(2u, first.size());
+    expectPointNear(first[0].start, 0, 0);
+    expectPointNear(first[0].end, 5, 5); // untouched
+    expectPointNear(first[1].end, 8, 8); // cut at the intersection
+
+    ASSERT_EQ(1u, second.size()); // everything before the intersection is gone
+    expectPointNear(second[0].start, 8, 8);
+    expectPointNear(second[0].end, 10, 8);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesLeavesRunsMeetingAtAPointAlone)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 10 }, { 5, 0 }) };
+    Vector<BezierSegment> second { lineCurve({ 5, 0 }, { 10, 10 }) };
+
+    trimAtIntersection(first, second);
+
+    ASSERT_EQ(1u, first.size());
+    ASSERT_EQ(1u, second.size());
+    expectPointNear(first[0].start, 0, 10);
+    expectPointNear(first[0].end, 5, 0);
+    expectPointNear(second[0].start, 5, 0);
+    expectPointNear(second[0].end, 10, 10);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesMeetsCurvedRunsAtOnePoint)
+{
+    Vector<BezierSegment> first { { { 0, 0 }, { 6, 0 }, { 10, 4 }, { 10, 10 } } };
+    Vector<BezierSegment> second { { { 0, 10 }, { 6, 10 }, { 10, 6 }, { 10, 0 } } };
+
+    EXPECT_TRUE(trimAtIntersection(first, second));
+
+    ASSERT_FALSE(first.isEmpty());
+    ASSERT_FALSE(second.isEmpty());
+
+    auto meeting = first.last().end;
+    expectPointNear(second.first().start, meeting.x(), meeting.y());
+
+    // Inside the box the two arcs span, and away from either run's far end.
+    EXPECT_GT(meeting.x(), 0);
+    EXPECT_LT(meeting.x(), 10);
+    EXPECT_GT(meeting.y(), 0);
+    EXPECT_LT(meeting.y(), 10);
+}
+
+TEST(BezierUtilities, TrimMonotonicCurvesHandlesEmptyRuns)
+{
+    Vector<BezierSegment> empty;
+    Vector<BezierSegment> curves { lineCurve({ 0, 0 }, { 10, 10 }) };
+
+    EXPECT_FALSE(trimAtIntersection(empty, curves));
+    EXPECT_TRUE(empty.isEmpty());
+    ASSERT_EQ(1u, curves.size());
+    expectPointNear(curves[0].end, 10, 10);
+
+    EXPECT_FALSE(trimAtIntersection(curves, empty));
+    EXPECT_TRUE(empty.isEmpty());
+    ASSERT_EQ(1u, curves.size());
+    expectPointNear(curves[0].end, 10, 10);
+}
+
+
+// The intersection is reported with where it sits on each run, which is what lets a caller
+// that tries both orderings of a pair keep only the meaningful one.
+TEST(BezierUtilities, FindMonotonicCurvesReportsWhereTheIntersectionSits)
+{
+    // y = x split at (5, 5), and y = 8 split at x = 5. They meet at (8, 8), in the second
+    // curve of each run, three fifths of the way along it.
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 5, 5 }), lineCurve({ 5, 5 }, { 10, 10 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 8 }, { 5, 8 }), lineCurve({ 5, 8 }, { 10, 8 }) };
+
+    auto intersection = findMonotonicBezierCurvesIntersection(first, second);
+    ASSERT_TRUE(intersection.has_value());
+
+    EXPECT_EQ(1u, intersection->indexOnFirst);
+    EXPECT_NEAR(intersection->parameterOnFirst, 0.6f, 0.01f);
+    EXPECT_EQ(1u, intersection->indexOnSecond);
+    EXPECT_NEAR(intersection->parameterOnSecond, 0.6f, 0.01f);
+
+    // Both runs hold two curves, so the fractions are (1 + 0.6) / 2.
+    EXPECT_NEAR(intersection->fractionAlongFirst, 0.8f, 0.01f);
+    EXPECT_NEAR(intersection->fractionAlongSecond, 0.8f, 0.01f);
+}
+
+// Swapping the two runs describes the same point, but the sides to keep swap with it. Only
+// one of the two orderings has the first run's tail meeting the second run's head.
+TEST(BezierUtilities, FindMonotonicCurvesRejectsTheReversedOrdering)
+{
+    // The first run reaches the meeting point late, the second reaches it early.
+    Vector<BezierSegment> tailFirst { lineCurve({ 0, 0 }, { 10, 10 }) };
+    Vector<BezierSegment> headSecond { lineCurve({ 6, 6 }, { 16, 0 }) };
+
+    auto forward = findMonotonicBezierCurvesIntersection(tailFirst, headSecond);
+    ASSERT_TRUE(forward.has_value());
+    EXPECT_GT(forward->fractionAlongFirst, forward->fractionAlongSecond);
+    EXPECT_TRUE(forward->isTailToHead());
+
+    auto reversed = findMonotonicBezierCurvesIntersection(headSecond, tailFirst);
+    ASSERT_TRUE(reversed.has_value());
+    EXPECT_FALSE(reversed->isTailToHead());
+}
+
+// Finding leaves the runs untouched, so a caller can look before deciding to cut.
+TEST(BezierUtilities, FindMonotonicCurvesDoesNotModifyTheRuns)
+{
+    Vector<BezierSegment> first { lineCurve({ 0, 0 }, { 10, 10 }) };
+    Vector<BezierSegment> second { lineCurve({ 0, 10 }, { 10, 0 }) };
+
+    ASSERT_TRUE(findMonotonicBezierCurvesIntersection(first, second).has_value());
+
+    ASSERT_EQ(1u, first.size());
+    ASSERT_EQ(1u, second.size());
+    expectPointNear(first[0].end, 10, 10);
+    expectPointNear(second[0].start, 0, 10);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 49ccbd38ad53774502fcb0ff8d42828e2d569d45
<pre>
[corner-shape] Incorrect rendering when inner corners intersect
<a href="https://bugs.webkit.org/show_bug.cgi?id=322658">https://bugs.webkit.org/show_bug.cgi?id=322658</a>
<a href="https://rdar.apple.com/185931169">rdar://185931169</a>

Reviewed by Tim Nguyen.

With larger border thickness and border-radius, adjacent corners of the inner border edge can intesect,
causing bad rendering with overlapping and holes.

Fix by implementing logic to intersect bezier paths, but we only need to support the simple, monotonic curves
that are used by corner-shape. `addSuperellipseCornerCurves` calls functions in CornerShapeUtilities to do this.
The intersection logic uses a recursive function (`appendCurveCrossings()`) with a depth limit.

Even non-adjacent corners can intersect (see inner-corner-intersection003.html), which `addSuperellipseCornerCurves()`
handles.

Add API tests for the Bezier functions. BezierUtilitiesTests.cpp wasn&apos;t being compiled at all, so add it
to the target.

Based on work by Lilly Le (@cupidsity).

Tests: Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection003.html: Added.
* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::trimBezierToRect):
(WebCore::findMonotonicBezierCurvesIntersection):
(WebCore::trimMonotonicBezierCurvesAtIntersection):
* Source/WebCore/platform/graphics/BezierUtilities.h:
(WebCore::BezierCurvesIntersection::isTailToHead const):
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Add BezierUtilitiesTests.cpp to the target; it wasn&apos;t compiled before.
* Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp:
(TestWebKitAPI::trimAtIntersection):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesLeavesSeparatedRunsAlone)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesMeetsStraightRunsAtTheirIntersection)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesFindsIntersectionAwayFromMidParameter)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesLeavesParallelRunsAlone)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesKeepsEarlierSegmentsWhole)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesLeavesRunsMeetingAtAPointAlone)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesMeetsCurvedRunsAtOnePoint)):
(TestWebKitAPI::TEST(BezierUtilities, TrimMonotonicCurvesHandlesEmptyRuns)):
(TestWebKitAPI::TEST(BezierUtilities, FindMonotonicCurvesReportsWhereTheIntersectionSits)):
(TestWebKitAPI::TEST(BezierUtilities, FindMonotonicCurvesRejectsTheReversedOrdering)):
(TestWebKitAPI::TEST(BezierUtilities, FindMonotonicCurvesDoesNotModifyTheRuns)):
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html:

Canonical link: <a href="https://commits.webkit.org/320287@main">https://commits.webkit.org/320287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd9959f1bf612cea59b00920eadd795a90d0f6ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c4302ce-dc52-4e6e-bc77-4076db44ab4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143837 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99975 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5196021-7863-45f5-aa60-f926c253324a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124252 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08588afc-5f2e-4c25-ad0c-28989436bee0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44540 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156734 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44111 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5646 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41094 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58541 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153071 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47600 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130840 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57048 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56420 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->