### PR TITLE
git-webkit pr should warn when the commit looks like a merge-back con…

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -468,6 +468,23 @@ class PullRequest(Command):
             print('Posted pull request link to {}'.format(issue.link))
 
     @classmethod
+    def is_merge_back_radar(cls, issue):
+        return bool(issue and issue.title and issue.title.startswith('[merge-back]'))
+
+    @classmethod
+    def confirm_merge_back_pr_creation(cls, args, radar_issue):
+        # A fresh PR here loses the title format the merge-back automation relies on to
+        # recognize the source as landed, which can get it re-dispatched as a duplicate.
+        if not cls.is_merge_back_radar(radar_issue) or args.defaults:
+            return True
+        return Terminal.choose(
+            "'{}' looks like a WebKit security merge-back conflict.\n"
+            "Are you sure you want to use this tool instead of following the resolution instructions?".format(radar_issue.link),
+            options=('Yes', 'No'),
+            default='No',
+        ) == 'Yes'
+
+    @classmethod
     def create_pull_request(cls, repository, args, branch_point, callback=None, unblock=True, update_issue=None):
         if update_issue is None:
             update_issue = getattr(args, 'update_issue', True)
@@ -659,6 +676,10 @@ class PullRequest(Command):
                     ).returncode not in [0, 3]:
                         sys.stderr.write("Failed to add '{}' remote\n".format(target))
                         return 1
+
+        if not existing_pr and not cls.confirm_merge_back_pr_creation(args, radar_issue):
+            sys.stderr.write("User declined to create a new pull-request for a merge-back conflict\n")
+            return 1
 
         # Remove any active labels
         if existing_pr and existing_pr._metadata and existing_pr._metadata.get('issue'):


### PR DESCRIPTION
…flict resolution

https://bugs.webkit.org/show_bug.cgi?id=323031
rdar://186299423

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py: (PullRequest):
(PullRequest.is_merge_back_radar):
(PullRequest.confirm_merge_back_pr_creation):
(PullRequest.create_pull_request):

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa1de76bf3a3aa46008082ee48836b7eb9264221

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148385 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92d0a215-1f97-465d-997c-42a222525d18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143703 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99862 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d45dbf5-4941-4715-98bb-a2df97cd0151) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124122 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97f45277-10c8-4555-9522-e669204c06fa) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183420 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44407 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156585 "Found 2 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKScrollViewTests.WheelEventDispatchedToSubframe (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43978 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5498 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196254 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183496 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57687 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58391 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152935 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47479 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127169 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56899 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18989 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56270 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56509 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->