### PR TITLE
[Site Isolation] Web Inspector: Sources are not available after reloading a page

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache-expected.txt
@@ -1,0 +1,14 @@
+Tests that Network.getResponseBody returns the body of a stylesheet served from a cross-origin frame process's memory cache under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBodyMemoryCache
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBodyMemoryCache
+Frame A stylesheet (cold): statusCode=200, responseSource=Symbol(network), cached=false, hasRequestIdentifier=true
+PASS: Frame A's load should come from the network.
+Frame B stylesheet (cached): statusCode=200, responseSource=Symbol(memory-cache), cached=true, hasRequestIdentifier=true
+PASS: Frame B's load should come from the memory cache.
+PASS: requestContent() should succeed for the memory-cached stylesheet.
+PASS: requestContent() should return non-empty content.
+PASS: Content should be the stylesheet that was served.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache.html
@@ -1,0 +1,100 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    // Checks that Network.getResponseBody returns a body for a stylesheet the memory cache served to
+    // a cross-origin frame, which under Site Isolation means it was stored by that frame's own
+    // WebContent process.
+    //
+    // Frames A and B are the same origin, so under Site Isolation they share one WebContent process
+    // and its memory cache. The stylesheet is cold-loaded in A, whose <link> stays alive so the
+    // resource stays cached, and then the same URL is loaded in B. B's load is the cache hit. It has
+    // to be a second *document* rather than a second <link> in one document, because
+    // loadedResourceFromMemoryCache early-returns on haveToldClientAboutLoad, which is per
+    // DocumentLoader, so an intra-document duplicate is never reported to the inspector at all.
+    //
+    // No reload is involved. The main frame equivalent, which needs one so that its subresources
+    // acquire a requestIdentifier, is get-response-body-after-reload.html.
+
+    // A per-run query string keeps A's load off the disk cache. That cache outlives a single test --
+    // nothing clears it between tests, and testRunner.clearMemoryCache() only reaches the memory
+    // cache -- so on a repeated run a fixed URL is served to A from disk, and A is no longer the
+    // cold load this test needs it to be.
+    const frameCSSHref = `memory-cache-frame-stylesheet.css?${Math.random()}`;
+
+    async function settle(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    async function frameTargetContaining(substring) {
+        let target = await frameTargetForURLContaining(substring);
+        InspectorTest.assert(target instanceof WI.FrameTarget, `Frame target for "${substring}" should exist.`);
+        await waitForExpressionInTarget(target, "typeof loadStylesheet === 'function'");
+        return target;
+    }
+
+    // Both frames load the same URL, so already-seen resources are skipped to be sure the second
+    // call resolves with the second frame's resource and not the first frame's.
+    let seenStylesheets = new Set;
+
+    async function loadStylesheetAndAwaitResource(frameTarget, href) {
+        let added = new Promise((resolve) => {
+            function handler(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(href) || seenStylesheets.has(resource))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, handler);
+                seenStylesheets.add(resource);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, handler);
+        });
+
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression: `loadStylesheet(${JSON.stringify(href)})`, objectGroup: "test"});
+        let resource = await added;
+        await settle(resource);
+        return resource;
+    }
+
+    function describe(label, resource) {
+        // responseSource is a Symbol (WI.Resource.ResponseSource), so it needs String().
+        InspectorTest.log(`${label}: statusCode=${resource.statusCode}, responseSource=${String(resource.responseSource)}, cached=${resource.cached}, hasRequestIdentifier=${!!resource.requestIdentifier}`);
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBodyMemoryCache");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBodyMemoryCache",
+        description: "A stylesheet served from a cross-origin frame process's memory cache should have a retrievable body.",
+        async test() {
+            let frameA = await frameTargetContaining("iframe-with-stylesheet.html?a");
+            let coldResource = await loadStylesheetAndAwaitResource(frameA, frameCSSHref);
+            describe("Frame A stylesheet (cold)", coldResource);
+            InspectorTest.expectEqual(coldResource.responseSource, WI.Resource.ResponseSource.Network, "Frame A's load should come from the network.");
+
+            let frameB = await frameTargetContaining("iframe-with-stylesheet.html?b");
+            let cachedResource = await loadStylesheetAndAwaitResource(frameB, frameCSSHref);
+            describe("Frame B stylesheet (cached)", cachedResource);
+            InspectorTest.expectEqual(cachedResource.responseSource, WI.Resource.ResponseSource.MemoryCache, "Frame B's load should come from the memory cache.");
+
+            let {content, error} = await cachedResource.requestContent();
+            if (error)
+                InspectorTest.log(`Frame B stylesheet: requestContent() failed with: ${error}`);
+            InspectorTest.expectThat(!error, "requestContent() should succeed for the memory-cached stylesheet.");
+            InspectorTest.expectThat(!!content, "requestContent() should return non-empty content.");
+            if (content)
+                InspectorTest.expectThat(content.includes("rgb(20, 60, 120)"), "Content should be the stylesheet that was served.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody returns the body of a stylesheet served from a cross-origin frame process's memory cache under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?a"></iframe>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?b"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt
@@ -1,4 +1,4 @@
-Test that Network.requestServedFromMemoryCache forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.
+Test that the Network domain forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.
 
 
 
@@ -7,5 +7,10 @@ Test that Network.requestServedFromMemoryCache forwards the sourceMapURL for a c
 Cold load in frame A finished; loading the same URL in frame B.
 PASS: Resource should be a stylesheet.
 PASS: Resource should be served from the memory cache.
-PASS: requestServedFromMemoryCache should carry the SourceMap header value.
+PASS: Network.loadingFinished should carry the SourceMap header value.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.MemoryCacheSourceMapURLFromInlineComment
+Cold load in frame A finished; loading the same URL in frame B.
+PASS: Resource should be served from the memory cache.
+PASS: Network.loadingFinished should carry the inline sourceMappingURL comment value.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html
@@ -5,12 +5,17 @@
 function test() {
     let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrameMemoryCacheSourceMapURL");
 
-    // Spy on downloadSourceMap to capture the sourceMapURL that
-    // Network.requestServedFromMemoryCache forwards (via the CachedResource object),
-    // without performing the (flaky, network-dependent) source map download.
-    let capturedSourceMapURL;
-    WI.networkManager.downloadSourceMap = function(sourceMapURL) {
-        capturedSourceMapURL = sourceMapURL;
+    // Spy on downloadSourceMap to capture the sourceMapURL the backend forwarded, without
+    // performing the (flaky, network-dependent) source map download. Keyed by the resource it was
+    // forwarded for, because each case loads one URL twice and a single shared variable could not
+    // tell the cold load's value from the cached load's.
+    //
+    // The event that carries it is Network.loadingFinished, not
+    // Network.requestServedFromMemoryCache: that one only fires for a cache hit taken while style is
+    // being resolved, which is not how a <link> is loaded.
+    let sourceMapURLByResource = new Map;
+    WI.networkManager.downloadSourceMap = function(sourceMapURL, baseURL, originalSourceCode) {
+        sourceMapURLByResource.set(originalSourceCode, sourceMapURL);
     };
 
     // Add a <link> for `href` in the given frame and resolve with the resulting resource once it
@@ -44,7 +49,7 @@ function test() {
 
     suite.addTestCase({
         name: "SiteIsolation.Network.CrossOriginIFrame.MemoryCacheSourceMapURLFromHeader",
-        description: "requestServedFromMemoryCache for a cross-origin iframe stylesheet should carry the SourceMap header value.",
+        description: "A cross-origin iframe stylesheet served from the memory cache should carry the SourceMap header value.",
         async test() {
             let href = "stylesheet-with-source-map-header-cacheable.py";
 
@@ -57,12 +62,32 @@ function test() {
 
             // Loading the same URL in frame B is served from the shared memory cache.
             let frameB = await frameTargetContaining("iframe-with-stylesheet.html?b");
-            capturedSourceMapURL = undefined;
             let cached = await loadStylesheetAndAwaitResource(frameB, href);
 
             InspectorTest.expectEqual(cached.type, WI.Resource.Type.StyleSheet, "Resource should be a stylesheet.");
             InspectorTest.expectEqual(cached.responseSource, WI.Resource.ResponseSource.MemoryCache, "Resource should be served from the memory cache.");
-            InspectorTest.expectEqual(capturedSourceMapURL, "stylesheet-header.css.map", "requestServedFromMemoryCache should carry the SourceMap header value.");
+            InspectorTest.expectEqual(sourceMapURLByResource.get(cached), "stylesheet-header.css.map", "Network.loadingFinished should carry the SourceMap header value.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.MemoryCacheSourceMapURLFromInlineComment",
+        description: "A cross-origin iframe stylesheet served from the memory cache should carry the inline sourceMappingURL comment value.",
+        async test() {
+            // A SourceMap header is captured from the response, so it survives a load that delivers
+            // no body. This value is not: it is read out of the stylesheet text, so it only reaches
+            // the frontend if the body of a memory-cache hit was recovered from the cache.
+            let href = "stylesheet-with-inline-source-map.css";
+
+            let frameA = await frameTargetContaining("iframe-with-stylesheet.html?a");
+            await loadStylesheetAndAwaitResource(frameA, href);
+            InspectorTest.log("Cold load in frame A finished; loading the same URL in frame B.");
+
+            let frameB = await frameTargetContaining("iframe-with-stylesheet.html?b");
+            let cached = await loadStylesheetAndAwaitResource(frameB, href);
+
+            InspectorTest.expectEqual(cached.responseSource, WI.Resource.ResponseSource.MemoryCache, "Resource should be served from the memory cache.");
+            InspectorTest.expectEqual(sourceMapURLByResource.get(cached), "stylesheet-inline.css.map", "Network.loadingFinished should carry the inline sourceMappingURL comment value.");
         }
     });
 
@@ -71,7 +96,7 @@ function test() {
 </script>
 
 <body onload="runTest()">
-<p>Test that Network.requestServedFromMemoryCache forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.</p>
+<p>Test that the Network domain forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.</p>
 <iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?a"></iframe>
 <iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?b"></iframe>
 </body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload-expected.txt
@@ -1,0 +1,30 @@
+Tests that Network.getResponseBody returns the body of the main frame's same-origin subresources after reloading with the inspector open under Site Isolation, including subresources served from the memory cache.
+
+
+== Running test suite: SiteIsolation.Network.GetResponseBodyAfterReload
+-- Running test case: SiteIsolation.Network.GetResponseBodyAfterReload.Reload
+Reloading...
+PASS: Stylesheet should be present in the main frame after the reload.
+PASS: Script should be present in the main frame after the reload.
+PASS: Main resource should be present after the reload.
+Main resource: responseSource=Symbol(network), cached=false, hasRequestIdentifier=true
+Stylesheet: responseSource=Symbol(memory-cache), cached=true, hasRequestIdentifier=true
+Script: responseSource=Symbol(memory-cache), cached=true, hasRequestIdentifier=true
+PASS: Stylesheet should be served from the memory cache.
+PASS: Script should be served from the memory cache.
+
+-- Running test case: SiteIsolation.Network.GetResponseBodyAfterReload.MainResource
+PASS: Main resource: requestContent() should succeed.
+PASS: Main resource: requestContent() should return non-empty content.
+PASS: Main resource: content should contain "reload-memory-cached.css".
+
+-- Running test case: SiteIsolation.Network.GetResponseBodyAfterReload.StyleSheet
+PASS: Stylesheet: requestContent() should succeed.
+PASS: Stylesheet: requestContent() should return non-empty content.
+PASS: Stylesheet: content should contain "background-color".
+
+-- Running test case: SiteIsolation.Network.GetResponseBodyAfterReload.Script
+PASS: Script: requestContent() should succeed.
+PASS: Script: requestContent() should return non-empty content.
+PASS: Script: content should contain "reloadMemoryCachedScriptRan".
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload.html
@@ -1,0 +1,140 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<link rel="stylesheet" href="resources/reload-memory-cached.css">
+<script src="resources/reload-memory-cached.js"></script>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function test() {
+    // Reloads the main frame with the inspector already open, then fetches the content of each
+    // same-origin subresource through WI.Resource.requestContent().
+    //
+    // Only a reload shows the defect: requestContentFromBackend switches from
+    // Page.getResourceContent to Network.getResponseBody once a resource has a requestIdentifier,
+    // and on the initial load the inspector attaches too late for the subresources to have one.
+    //
+    // The subresources come from the memory cache, which is the case under test, so responseSource
+    // is asserted and not only logged. The main resource is a control: a reload refetches it over
+    // the network, so it passes either way.
+    //
+    // For the same defect without a reload, see
+    // cross-origin-iframe-get-response-body-memory-cache.html.
+
+    const cssURLPart = "reload-memory-cached.css";
+    const jsURLPart = "reload-memory-cached.js";
+
+    function findResource(urlSubstring) {
+        for (let resource of WI.networkManager.mainFrame.resourceCollection) {
+            if (resource.url && resource.url.includes(urlSubstring))
+                return resource;
+        }
+        return null;
+    }
+
+    // Network events arrive on the backend target's connection while Page load events arrive on the
+    // page target's, so "test page did load" does not mean the subresources are in the frame model.
+    function waitForResource(urlSubstring) {
+        let existing = findResource(urlSubstring);
+        if (existing)
+            return Promise.resolve(existing);
+
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function settle(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    function describe(label, resource) {
+        // statusCode is deliberately not logged. Whether these loads revalidate against the disk
+        // cache depends on what earlier runs left there, so the status is 200 on a cold machine and
+        // 304 on a warm one, which is not what this test is about.
+        //
+        // responseSource is a Symbol (WI.Resource.ResponseSource), so it needs String().
+        InspectorTest.log(`${label}: responseSource=${String(resource.responseSource)}, cached=${resource.cached}, hasRequestIdentifier=${!!resource.requestIdentifier}`);
+    }
+
+    async function expectContent(label, resource, expectedSubstring) {
+        let {content, error} = await resource.requestContent();
+        if (error)
+            InspectorTest.log(`${label}: requestContent() failed with: ${error}`);
+        InspectorTest.expectThat(!error, `${label}: requestContent() should succeed.`);
+        InspectorTest.expectThat(!!content, `${label}: requestContent() should return non-empty content.`);
+        if (content)
+            InspectorTest.expectThat(content.includes(expectedSubstring), `${label}: content should contain "${expectedSubstring}".`);
+    }
+
+    let cssResource;
+    let jsResource;
+    let mainResource;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.GetResponseBodyAfterReload");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.GetResponseBodyAfterReload.Reload",
+        description: "Reload the main frame with the inspector open and locate its subresources.",
+        async test() {
+            InspectorTest.log("Reloading...");
+            await InspectorTest.reloadPage();
+            await InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            cssResource = await waitForResource(cssURLPart);
+            jsResource = await waitForResource(jsURLPart);
+            mainResource = WI.networkManager.mainFrame.mainResource;
+
+            InspectorTest.expectThat(!!cssResource, "Stylesheet should be present in the main frame after the reload.");
+            InspectorTest.expectThat(!!jsResource, "Script should be present in the main frame after the reload.");
+            InspectorTest.expectThat(!!mainResource, "Main resource should be present after the reload.");
+
+            await settle(cssResource);
+            await settle(jsResource);
+            await settle(mainResource);
+
+            describe("Main resource", mainResource);
+            describe("Stylesheet", cssResource);
+            describe("Script", jsResource);
+
+            InspectorTest.expectEqual(cssResource.responseSource, WI.Resource.ResponseSource.MemoryCache, "Stylesheet should be served from the memory cache.");
+            InspectorTest.expectEqual(jsResource.responseSource, WI.Resource.ResponseSource.MemoryCache, "Script should be served from the memory cache.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.GetResponseBodyAfterReload.MainResource",
+        description: "The main resource is refetched by a reload, so its body should be available (control case).",
+        async test() {
+            await expectContent("Main resource", mainResource, "reload-memory-cached.css");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.GetResponseBodyAfterReload.StyleSheet",
+        description: "A memory-cached stylesheet's body should be available after a reload.",
+        async test() {
+            await expectContent("Stylesheet", cssResource, "background-color");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.GetResponseBodyAfterReload.Script",
+        description: "A memory-cached script's body should be available after a reload.",
+        async test() {
+            await expectContent("Script", jsResource, "reloadMemoryCachedScriptRan");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody returns the body of the main frame's same-origin subresources after reloading with the inspector open under Site Isolation, including subresources served from the memory cache.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/memory-cache-frame-stylesheet.css
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/memory-cache-frame-stylesheet.css
@@ -1,0 +1,5 @@
+/* Loaded on demand by two same-origin cross-origin frames, so the second load is served from the
+   memory cache they share via their common WebContent process. */
+p {
+    color: rgb(20, 60, 120);
+}

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.css
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.css
@@ -1,0 +1,5 @@
+/* A static, cacheable stylesheet. A reload serves this from the memory cache, which reaches the
+   inspector as synthesized loader callbacks carrying no response body. */
+body {
+    background-color: rgb(240, 240, 240);
+}

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.js
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.js
@@ -1,0 +1,3 @@
+// A static, cacheable script. A reload serves this from the memory cache, which reaches the
+// inspector as synthesized loader callbacks carrying no response body.
+window.reloadMemoryCachedScriptRan = true;

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py
@@ -3,7 +3,7 @@
 import sys
 
 # Cacheable (no "no-store") so the second load in the test is served from the
-# in-memory cache, exercising the RequestServedFromMemoryCache path.
+# in-memory cache.
 sys.stdout.write('Content-Type: text/css\r\n')
 sys.stdout.write('Cache-Control: max-age=3600\r\n')
 sys.stdout.write('SourceMap: stylesheet-header.css.map\r\n')

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -53,6 +53,7 @@
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
 #include <wtf/WallTime.h>
 
 namespace WebKit {
@@ -281,6 +282,12 @@ void FrameNetworkAgentProxy::didReceiveData(ResourceLoaderIdentifier resourceID,
         page->identifier());
 }
 
+static bool finishedWithoutContent(const BackendResourceDataStore::ResourceData* resourceData)
+{
+    return resourceData && !resourceData->hasContent() && !resourceData->hasBufferedData()
+        && !resourceData->isContentEvicted() && !resourceData->buffer();
+}
+
 void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const NetworkLoadMetrics&, ResourceLoader*)
 {
     if (!loader || !loader->frame() || !loader->frame()->document())
@@ -298,6 +305,20 @@ void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceI
     }
 
     m_resourcesData->maybeDecodeDataToContent(resourceID);
+
+    // A memory cache hit synthesizes the loader callbacks with a null buffer
+    // (FrameLoader::loadedResourceFromMemoryCache), so no body ever reached didReceiveData. The
+    // store keeps no CachedResource references, so copy the body out here, while the cache entry
+    // that served this load is still alive. The resource is found by URL because this path has no
+    // ResourceLoader to ask for it.
+    if (auto* resourceData = m_resourcesData->data(resourceID); finishedWithoutContent(resourceData)) {
+        if (RefPtr cachedResource = ResourceUtilities::cachedResource(frame.get(), URL { resourceData->url() })) {
+            String content;
+            bool base64Encoded;
+            if (ResourceUtilities::cachedResourceContent(*cachedResource, &content, &base64Encoded))
+                m_resourcesData->setResourceContent(resourceID, content, base64Encoded);
+        }
+    }
 
     RefPtr page = m_page.get();
     if (!page)
@@ -357,8 +378,8 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
     m_resourcesData->resourceCreated(resourceID, *frameID, resourceType);
 
     // Copy content from the CachedResource now, since the store does not hold
-    // CachedResource references. This is the only chance to capture the content
-    // for memory-cached resources (they don't go through didReceiveData).
+    // CachedResource references and memory-cached resources don't go through
+    // didReceiveData.
     String content;
     bool base64Encoded;
     if (ResourceUtilities::cachedResourceContent(cachedResource, &content, &base64Encoded))


### PR DESCRIPTION
#### c350248cf40ed8be05338c444c15fc945e814770
<pre>
[Site Isolation] Web Inspector: Sources are not available after reloading a page
<a href="https://rdar.apple.com/184277031">rdar://184277031</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323032">https://bugs.webkit.org/show_bug.cgi?id=323032</a>

Reviewed by NOBODY (OOPS!).

After a reload with the inspector already open, every same-origin
subresource in the Sources tab fails to load its content, and
Network.getResponseBody reports &quot;Missing content of resource for given
requestId&quot;. Only a reload shows this: requestContentFromBackend switches
from Page.getResourceContent to Network.getResponseBody once a resource
has a requestIdentifier, and on the initial load the inspector usually
attaches too late for the subresources to have one.

Those subresources come from the memory cache, and a memory cache hit
delivers no body to the inspector:
FrameLoader::loadedResourceFromMemoryCache synthesizes the loader
callbacks with a null buffer, so didReceiveData carries nothing.
InspectorNetworkAgent survives this because NetworkResourcesData keeps a
CachedResource pointer per entry and reads the body out of the cache as
a last resort in getResponseBody. BackendResourceDataStore holds no
WebCore references by design, so it has to copy the body itself.

FrameNetworkAgentProxy::didLoadResourceFromMemoryCache already makes
that copy, but these loads never reach it.
FrameLoader::loadedResourceFromMemoryCache notifies the inspector
directly only while memory cache client calls are disabled, which
Style::PostResolutionCallbackDisabler does for the span of a style
resolution, or when the frame loader client reports memory cache loads,
which WebLocalFrameLoaderClient does not implement. A stylesheet or
script fetched for a &lt;link&gt; or &lt;script&gt; element misses both, so the hit
arrives as synthesized loader callbacks instead.

Make the same copy in didFinishLoading, gated on the entry having ended
up with neither content nor buffered data. Observing that no body
arrived, rather than predicting it from the response source, also covers
the other loads that finish without data, including a 304 revalidation
-- only its content, not the mime type and status patch-up that
InspectorNetworkAgent does for XHR and Fetch in didReceiveResponse,
which still has no Site Isolation equivalent. The resource is found by
URL because this path has no ResourceLoader to ask for its
CachedResource.

Tests: http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache.html
       http/tests/site-isolation/inspector/network/get-response-body-after-reload.html

The two new tests cover the two ways a memory cache hit can reach the
inspector under Site Isolation: the reported case, a main frame&apos;s own
subresources across a reload, and a cross-origin frame served out of its
own process&apos;s cache without a reload.

The same finding corrects an adjacent test.
cross-origin-iframe-network-memory-cache-source-map-url.html said it
covered Network.requestServedFromMemoryCache, but its stylesheet comes
from a &lt;link&gt;, so the event it exercises is Network.loadingFinished. Its
spy also kept a single shared variable while loading one URL twice, so
the cold load&apos;s value could satisfy an assertion about the cached load;
it is now keyed by the resource the value was forwarded for. With that
fixed, a second case covers the inline sourceMappingURL comment. Unlike
a SourceMap header, which is captured from the response, that value is
read out of the stylesheet text, so it reaches the frontend for a memory
cache hit only because of the recovery above -- it is the one place the
recovered body is observable without asking for the body itself.

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-memory-cache.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html:
* LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/get-response-body-after-reload.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/memory-cache-frame-stylesheet.css: Added.
(p):
* LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.css: Added.
(body):
* LayoutTests/http/tests/site-isolation/inspector/network/resources/reload-memory-cached.js: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::finishedWithoutContent):
(WebKit::FrameNetworkAgentProxy::didFinishLoading):
(WebKit::FrameNetworkAgentProxy::didLoadResourceFromMemoryCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c350248cf40ed8be05338c444c15fc945e814770

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148649 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd6d333b-7898-4318-ba16-338b4a838763) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143911 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100030 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65255740-4844-4275-b2b5-323bc2c0494d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124326 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23dbec14-b198-4a40-8406-738b4df3848d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44604 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44197 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196609 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153496 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153154 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47681 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130937 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127363 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57148 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19212 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56516 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->