### PR TITLE
[JSC] Scan toLowerCase / toUpperCase strings in DFG / FTL inline

### DIFF
--- a/JSTests/stress/to-lower-case-16-bit-ascii-fast-path.js
+++ b/JSTests/stress/to-lower-case-16-bit-ascii-fast-path.js
@@ -1,0 +1,87 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${JSON.stringify(expected)} got ${JSON.stringify(actual)}`);
+}
+
+// The JIT scans a string for characters that need converting and returns the string itself when
+// there are none. Cover that scan for 16-bit strings, whose content may still be pure ASCII.
+const nonLatin1 = "\u2014"; // EM DASH
+
+function toLowerCase(string) { return string.toLowerCase(); }
+noInline(toLowerCase);
+function lowercasesToItself(string) { return string.toLowerCase() === string; }
+noInline(lowercasesToItself);
+
+// A 16-bit string with the given content. This throws rather than quietly hand back an 8-bit
+// string: a Latin-1 string of one character or none can only be stored as 8 bit.
+function wide(string) {
+    const result = $vm.make16BitStringIfPossible(string);
+    if (is8BitString(result))
+        throw new Error(`not a 16-bit string: ${JSON.stringify(string)}`);
+    return result;
+}
+
+// Tested both as an 8-bit and as a 16-bit string, so none of these is shorter than two
+// characters. The leading '0' is that padding, and both of the JIT's range checks ('A' to 'Z',
+// and 0x00 to 0x7F) leave it alone, so the character after it is what the entry really covers.
+const cases = [
+    ["0@", "0@"],
+    ["0A", "0a"],
+    ["0Z", "0z"],
+    ["0[", "0["],
+    ["0\x7F", "0\x7F"],
+    ["0\x80", "0\x80"],
+    ["0\u00E9", "0\u00E9"],
+    ["0\u00C9", "0\u00E9"],
+    ["0\u0130", "0i\u0307"],
+    ["ab", "ab"],
+    ["AB", "ab"],
+    ["already lower 123", "already lower 123"],
+    ["Mixed Case Here", "mixed case here"],
+    ["trailingA", "trailinga"],
+    ["Atrailing", "atrailing"],
+];
+
+// Too short to be stored as 16 bit, so these only reach the JIT's 8-bit scan.
+const narrowOnlyCases = [
+    ["", ""],
+    ["a", "a"],
+    ["A", "a"],
+    ["z", "z"],
+    ["Z", "z"],
+];
+
+const all = [];
+for (const [input, expected] of cases) {
+    all.push([input, expected]);
+    all.push([wide(input), expected]);
+}
+for (const [input, expected] of narrowOnlyCases)
+    all.push([input, expected]);
+// A single character outside Latin-1 is stored as 16 bit without any help.
+all.push([nonLatin1, nonLatin1]);
+all.push(["\u0130", "i\u0307"]);
+all.push(["A" + nonLatin1, "a" + nonLatin1]);
+all.push([nonLatin1 + "ABC", nonLatin1 + "abc"]);
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const [input, expected] of all)
+        shouldBe(toLowerCase(input), expected);
+}
+
+const identity = ["already lower", wide("already lower"), nonLatin1, wide("0\x7F")];
+const notIdentity = ["Already Lower", wide("Already Lower"), "\u00C9", wide("0\u00C9")];
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const string of identity)
+        shouldBe(lowercasesToItself(string), true);
+    for (const string of notIdentity)
+        shouldBe(lowercasesToItself(string), false);
+}
+
+function toLowerCaseRope(a, b) { return (a + b).toLowerCase(); }
+noInline(toLowerCaseRope);
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    shouldBe(toLowerCaseRope("ABC", "def"), "abcdef");
+    shouldBe(toLowerCaseRope("abc", nonLatin1), "abc" + nonLatin1);
+    shouldBe(toLowerCaseRope("ABC", nonLatin1), "abc" + nonLatin1);
+}

--- a/JSTests/stress/to-upper-case-16-bit-ascii-fast-path.js
+++ b/JSTests/stress/to-upper-case-16-bit-ascii-fast-path.js
@@ -1,0 +1,89 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${JSON.stringify(expected)} got ${JSON.stringify(actual)}`);
+}
+
+// The JIT scans a string for characters that need converting and returns the string itself when
+// there are none. Cover that scan for 16-bit strings, whose content may still be pure ASCII.
+const nonLatin1 = "\u2014"; // EM DASH
+
+function toUpperCase(string) { return string.toUpperCase(); }
+noInline(toUpperCase);
+function uppercasesToItself(string) { return string.toUpperCase() === string; }
+noInline(uppercasesToItself);
+
+// A 16-bit string with the given content. This throws rather than quietly hand back an 8-bit
+// string: a Latin-1 string of one character or none can only be stored as 8 bit.
+function wide(string) {
+    const result = $vm.make16BitStringIfPossible(string);
+    if (is8BitString(result))
+        throw new Error(`not a 16-bit string: ${JSON.stringify(string)}`);
+    return result;
+}
+
+// Tested both as an 8-bit and as a 16-bit string, so none of these is shorter than two
+// characters. The leading '0' is that padding, and both of the JIT's range checks ('a' to 'z',
+// and 0x00 to 0x7F) leave it alone, so the character after it is what the entry really covers.
+const cases = [
+    ["0`", "0`"],
+    ["0a", "0A"],
+    ["0z", "0Z"],
+    ["0{", "0{"],
+    ["0\x7F", "0\x7F"],
+    ["0\x80", "0\x80"],
+    ["0\u00C9", "0\u00C9"],
+    ["0\u00E9", "0\u00C9"],
+    ["0\u00DF", "0SS"],
+    ["0\uFB01", "0FI"],
+    ["AB", "AB"],
+    ["ab", "AB"],
+    ["ALREADY UPPER 123", "ALREADY UPPER 123"],
+    ["Mixed Case Here", "MIXED CASE HERE"],
+    ["TRAILINGa", "TRAILINGA"],
+    ["aTRAILING", "ATRAILING"],
+];
+
+// Too short to be stored as 16 bit, so these only reach the JIT's 8-bit scan.
+const narrowOnlyCases = [
+    ["", ""],
+    ["A", "A"],
+    ["a", "A"],
+    ["Z", "Z"],
+    ["z", "Z"],
+    ["\u00DF", "SS"],
+];
+
+const all = [];
+for (const [input, expected] of cases) {
+    all.push([input, expected]);
+    all.push([wide(input), expected]);
+}
+for (const [input, expected] of narrowOnlyCases)
+    all.push([input, expected]);
+// A single character outside Latin-1 is stored as 16 bit without any help.
+all.push([nonLatin1, nonLatin1]);
+all.push(["\uFB01", "FI"]);
+all.push(["a" + nonLatin1, "A" + nonLatin1]);
+all.push([nonLatin1 + "abc", nonLatin1 + "ABC"]);
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const [input, expected] of all)
+        shouldBe(toUpperCase(input), expected);
+}
+
+const identity = ["ALREADY UPPER", wide("ALREADY UPPER"), nonLatin1, wide("0\x7F")];
+const notIdentity = ["Already Upper", wide("Already Upper"), "\u00E9", wide("0\u00E9")];
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (const string of identity)
+        shouldBe(uppercasesToItself(string), true);
+    for (const string of notIdentity)
+        shouldBe(uppercasesToItself(string), false);
+}
+
+function toUpperCaseRope(a, b) { return (a + b).toUpperCase(); }
+noInline(toUpperCaseRope);
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    shouldBe(toUpperCaseRope("abc", "DEF"), "ABCDEF");
+    shouldBe(toUpperCaseRope("ABC", nonLatin1), "ABC" + nonLatin1);
+    shouldBe(toUpperCaseRope("abc", nonLatin1), "ABC" + nonLatin1);
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3873,7 +3873,7 @@ JSC_DEFINE_JIT_OPERATION(operationToUpperCase, JSString*, (JSGlobalObject* globa
     if (!inputString->length())
         OPERATION_RETURN(scope, vm.smallStrings.emptyString());
 
-    String uppercasedString = inputString->is8Bit() ? inputString->convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : inputString->convertToUppercaseWithoutLocale();
+    String uppercasedString = inputString->is8Bit() ? inputString->convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : inputString->convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(failingIndex);
     if (uppercasedString.impl() == inputString->impl())
         OPERATION_RETURN(scope, string);
     OPERATION_RETURN(scope, jsString(vm, WTF::move(uppercasedString)));
@@ -3892,7 +3892,7 @@ JSC_DEFINE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject* globa
     if (!inputString->length())
         OPERATION_RETURN(scope, vm.smallStrings.emptyString());
 
-    String lowercasedString = inputString->is8Bit() ? inputString->convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : inputString->convertToLowercaseWithoutLocale();
+    String lowercasedString = inputString->is8Bit() ? inputString->convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : inputString->convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(failingIndex);
     if (lowercasedString.impl() == inputString->impl())
         OPERATION_RETURN(scope, string);
     OPERATION_RETURN(scope, jsString(vm, WTF::move(lowercasedString)));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1713,40 +1713,56 @@ void SpeculativeJIT::compileToUpperCase(Node* node)
     ASSERT(node->op() == ToUpperCase);
     SpeculateCellOperand string(this, node->child1());
     GPRTemporary temp(this);
+    GPRTemporary data(this);
     GPRTemporary index(this);
     GPRTemporary charReg(this);
     GPRTemporary length(this);
 
     GPRReg stringGPR = string.gpr();
     GPRReg tempGPR = temp.gpr();
+    GPRReg dataGPR = data.gpr();
     GPRReg indexGPR = index.gpr();
     GPRReg charGPR = charReg.gpr();
     GPRReg lengthGPR = length.gpr();
 
-    speculateString(node->child1(), stringGPR);
-
     JumpList slowPath;
+    JumpList loopDone;
+
+    speculateString(node->child1(), stringGPR);
 
     move(TrustedImmPtr(nullptr), indexGPR);
 
     loadPtr(Address(stringGPR, JSString::offsetOfValue()), tempGPR);
     if (canBeRope(node->child1()))
         slowPath.append(branchIfRopeStringImpl(tempGPR));
-    slowPath.append(branchTest32(
-        Zero, Address(tempGPR, StringImpl::flagsOffset()),
-        TrustedImm32(StringImpl::flagIs8Bit())));
     load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
-    loadPtr(Address(tempGPR, StringImpl::dataOffset()), tempGPR);
+    loadPtr(Address(tempGPR, StringImpl::dataOffset()), dataGPR);
+    auto is16Bit = branchTest32(
+        Zero, Address(tempGPR, StringImpl::flagsOffset()),
+        TrustedImm32(StringImpl::flagIs8Bit()));
 
-    auto loopStart = label();
-    auto loopDone = branch32(AboveOrEqual, indexGPR, lengthGPR);
-    load8(BaseIndex(tempGPR, indexGPR, TimesOne), charGPR);
-    slowPath.append(branchTest32(NonZero, charGPR, TrustedImm32(~0x7F)));
-    sub32(TrustedImm32('a'), charGPR);
-    slowPath.append(branch32(BelowOrEqual, charGPR, TrustedImm32('z' - 'a')));
+    // 16-bit strings need this scan as much as 8-bit ones: one non-Latin1 character anywhere in a
+    // document makes every string derived from it 16 bit, ASCII content and all.
+    auto emitScanForCharacterNeedingConversion = [&](auto emitLoadCharacter) {
+        auto loopStart = label();
+        loopDone.append(branch32(AboveOrEqual, indexGPR, lengthGPR));
+        emitLoadCharacter();
+        slowPath.append(branchTest32(NonZero, charGPR, TrustedImm32(~0x7F)));
+        sub32(TrustedImm32('a'), charGPR);
+        slowPath.append(branch32(BelowOrEqual, charGPR, TrustedImm32('z' - 'a')));
 
-    add32(TrustedImm32(1), indexGPR);
-    jump().linkTo(loopStart, this);
+        add32(TrustedImm32(1), indexGPR);
+        jump().linkTo(loopStart, this);
+    };
+
+    emitScanForCharacterNeedingConversion([&] {
+        load8(BaseIndex(dataGPR, indexGPR, TimesOne), charGPR);
+    });
+
+    is16Bit.link(this);
+    emitScanForCharacterNeedingConversion([&] {
+        load16(BaseIndex(dataGPR, indexGPR, TimesTwo), charGPR);
+    });
 
     slowPath.link(this);
     callOperationWithSilentSpill(operationToUpperCase, lengthGPR, LinkableConstant::globalObject(*this, node), stringGPR, indexGPR);
@@ -1764,41 +1780,57 @@ void SpeculativeJIT::compileToLowerCase(Node* node)
     ASSERT(node->op() == ToLowerCase);
     SpeculateCellOperand string(this, node->child1());
     GPRTemporary temp(this);
+    GPRTemporary data(this);
     GPRTemporary index(this);
     GPRTemporary charReg(this);
     GPRTemporary length(this);
 
     GPRReg stringGPR = string.gpr();
     GPRReg tempGPR = temp.gpr();
+    GPRReg dataGPR = data.gpr();
     GPRReg indexGPR = index.gpr();
     GPRReg charGPR = charReg.gpr();
     GPRReg lengthGPR = length.gpr();
 
-    speculateString(node->child1(), stringGPR);
-
     JumpList slowPath;
+    JumpList loopDone;
+
+    speculateString(node->child1(), stringGPR);
 
     move(TrustedImmPtr(nullptr), indexGPR);
 
     loadPtr(Address(stringGPR, JSString::offsetOfValue()), tempGPR);
     if (canBeRope(node->child1()))
         slowPath.append(branchIfRopeStringImpl(tempGPR));
-    slowPath.append(branchTest32(
-        Zero, Address(tempGPR, StringImpl::flagsOffset()),
-        TrustedImm32(StringImpl::flagIs8Bit())));
     load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
-    loadPtr(Address(tempGPR, StringImpl::dataOffset()), tempGPR);
+    loadPtr(Address(tempGPR, StringImpl::dataOffset()), dataGPR);
+    auto is16Bit = branchTest32(
+        Zero, Address(tempGPR, StringImpl::flagsOffset()),
+        TrustedImm32(StringImpl::flagIs8Bit()));
 
-    auto loopStart = label();
-    auto loopDone = branch32(AboveOrEqual, indexGPR, lengthGPR);
-    load8(BaseIndex(tempGPR, indexGPR, TimesOne), charGPR);
-    slowPath.append(branchTest32(NonZero, charGPR, TrustedImm32(~0x7F)));
-    sub32(TrustedImm32('A'), charGPR);
-    slowPath.append(branch32(BelowOrEqual, charGPR, TrustedImm32('Z' - 'A')));
+    // 16-bit strings need this scan as much as 8-bit ones: one non-Latin1 character anywhere in a
+    // document makes every string derived from it 16 bit, ASCII content and all.
+    auto emitScanForCharacterNeedingConversion = [&](auto emitLoadCharacter) {
+        auto loopStart = label();
+        loopDone.append(branch32(AboveOrEqual, indexGPR, lengthGPR));
+        emitLoadCharacter();
+        slowPath.append(branchTest32(NonZero, charGPR, TrustedImm32(~0x7F)));
+        sub32(TrustedImm32('A'), charGPR);
+        slowPath.append(branch32(BelowOrEqual, charGPR, TrustedImm32('Z' - 'A')));
 
-    add32(TrustedImm32(1), indexGPR);
-    jump().linkTo(loopStart, this);
-    
+        add32(TrustedImm32(1), indexGPR);
+        jump().linkTo(loopStart, this);
+    };
+
+    emitScanForCharacterNeedingConversion([&] {
+        load8(BaseIndex(dataGPR, indexGPR, TimesOne), charGPR);
+    });
+
+    is16Bit.link(this);
+    emitScanForCharacterNeedingConversion([&] {
+        load16(BaseIndex(dataGPR, indexGPR, TimesTwo), charGPR);
+    });
+
     slowPath.link(this);
     callOperationWithSilentSpill(operationToLowerCase, lengthGPR, LinkableConstant::globalObject(*this, node), stringGPR, indexGPR);
     auto done = jump();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21131,26 +21131,21 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LBasicBlock notRope = m_out.newBlock();
         LBasicBlock is8Bit = m_out.newBlock();
-        LBasicBlock loopTop = m_out.newBlock();
-        LBasicBlock loopBody = m_out.newBlock();
+        LBasicBlock loop8Top = m_out.newBlock();
+        LBasicBlock loop8Body = m_out.newBlock();
+        LBasicBlock is16Bit = m_out.newBlock();
+        LBasicBlock loop16Top = m_out.newBlock();
+        LBasicBlock loop16Body = m_out.newBlock();
         LBasicBlock slowPath = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
         LValue string = lowString(m_node->child1());
-        ValueFromBlock startIndex = m_out.anchor(m_out.constInt32(0));
         ValueFromBlock startIndexForCall = m_out.anchor(m_out.constInt32(0));
         m_out.branch(isRopeString(string, m_node->child1()),
             rarely(slowPath), usually(notRope));
 
         LBasicBlock lastNext = m_out.appendTo(notRope, is8Bit);
         LValue impl = m_out.loadPtr(string, m_heaps.JSString_value);
-        m_out.branch(
-            m_out.testIsZero32(
-                m_out.load32(impl, m_heaps.StringImpl_hashAndFlags),
-                m_out.constInt32(StringImpl::flagIs8Bit())),
-            unsure(slowPath), unsure(is8Bit));
-
-        m_out.appendTo(is8Bit, loopTop);
         LValue length;
         if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
             length = m_out.constInt32(*stringLength);
@@ -21158,27 +21153,45 @@ IGNORE_CLANG_WARNINGS_END
             length = m_out.load32(impl, m_heaps.StringImpl_length);
         LValue buffer = m_out.loadPtr(impl, m_heaps.StringImpl_data);
         ValueFromBlock fastResult = m_out.anchor(string);
-        m_out.jump(loopTop);
+        m_out.branch(
+            m_out.testIsZero32(
+                m_out.load32(impl, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit())),
+            unsure(is16Bit), unsure(is8Bit));
 
-        m_out.appendTo(loopTop, loopBody);
-        LValue index = m_out.phi(Int32, startIndex);
-        ValueFromBlock indexFromBlock = m_out.anchor(index);
-        m_out.branch(m_out.below(index, length),
-            unsure(loopBody), unsure(continuation));
+        Vector<ValueFromBlock, 3> slowPathIndices;
+        slowPathIndices.append(startIndexForCall);
 
-        m_out.appendTo(loopBody, slowPath);
+        // 16-bit strings need this scan as much as 8-bit ones: one non-Latin1 character anywhere in
+        // a document makes every string derived from it 16 bit, ASCII content and all.
+        auto emitScanForCharacterNeedingConversion = [&](LBasicBlock entry, LBasicBlock top, LBasicBlock body, LBasicBlock nextBlock, bool is8BitString) {
+            m_out.appendTo(entry, top);
+            ValueFromBlock startIndex = m_out.anchor(m_out.constInt32(0));
+            m_out.jump(top);
 
-        // FIXME: Strings needs to be caged.
-        // https://bugs.webkit.org/show_bug.cgi?id=174924
-        LValue byte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, buffer, m_out.zeroExtPtr(index)));
-        LValue isInvalidAsciiRange = m_out.bitAnd(byte, m_out.constInt32(~0x7F));
-        LValue isLowerCase = m_out.belowOrEqual(m_out.sub(byte, m_out.constInt32('a')), m_out.constInt32('z' - 'a'));
-        LValue isBadCharacter = m_out.bitOr(isInvalidAsciiRange, isLowerCase);
-        m_out.addIncomingToPhi(index, m_out.anchor(m_out.add(index, m_out.int32One)));
-        m_out.branch(isBadCharacter, unsure(slowPath), unsure(loopTop));
+            m_out.appendTo(top, body);
+            LValue index = m_out.phi(Int32, startIndex);
+            slowPathIndices.append(m_out.anchor(index));
+            m_out.branch(m_out.below(index, length),
+                unsure(body), unsure(continuation));
+
+            m_out.appendTo(body, nextBlock);
+            LValue offset = m_out.zeroExtPtr(index);
+            LValue character = is8BitString
+                ? m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, buffer, offset))
+                : m_out.load16ZeroExt32(m_out.baseIndex(m_heaps.characters16, buffer, offset));
+            LValue isInvalidAsciiRange = m_out.bitAnd(character, m_out.constInt32(~0x7F));
+            LValue isLowerCase = m_out.belowOrEqual(m_out.sub(character, m_out.constInt32('a')), m_out.constInt32('z' - 'a'));
+            LValue isBadCharacter = m_out.bitOr(isInvalidAsciiRange, isLowerCase);
+            m_out.addIncomingToPhi(index, m_out.anchor(m_out.add(index, m_out.int32One)));
+            m_out.branch(isBadCharacter, unsure(slowPath), unsure(top));
+        };
+
+        emitScanForCharacterNeedingConversion(is8Bit, loop8Top, loop8Body, is16Bit, true);
+        emitScanForCharacterNeedingConversion(is16Bit, loop16Top, loop16Body, slowPath, false);
 
         m_out.appendTo(slowPath, continuation);
-        LValue slowPathIndex = m_out.phi(Int32, startIndexForCall, indexFromBlock);
+        LValue slowPathIndex = m_out.phi(Int32, slowPathIndices);
         ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationToUpperCase, weakPointer(globalObject), string, slowPathIndex));
         m_out.jump(continuation);
 
@@ -21191,26 +21204,21 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LBasicBlock notRope = m_out.newBlock();
         LBasicBlock is8Bit = m_out.newBlock();
-        LBasicBlock loopTop = m_out.newBlock();
-        LBasicBlock loopBody = m_out.newBlock();
+        LBasicBlock loop8Top = m_out.newBlock();
+        LBasicBlock loop8Body = m_out.newBlock();
+        LBasicBlock is16Bit = m_out.newBlock();
+        LBasicBlock loop16Top = m_out.newBlock();
+        LBasicBlock loop16Body = m_out.newBlock();
         LBasicBlock slowPath = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
         LValue string = lowString(m_node->child1());
-        ValueFromBlock startIndex = m_out.anchor(m_out.constInt32(0));
         ValueFromBlock startIndexForCall = m_out.anchor(m_out.constInt32(0));
         m_out.branch(isRopeString(string, m_node->child1()),
             rarely(slowPath), usually(notRope));
 
         LBasicBlock lastNext = m_out.appendTo(notRope, is8Bit);
         LValue impl = m_out.loadPtr(string, m_heaps.JSString_value);
-        m_out.branch(
-            m_out.testIsZero32(
-                m_out.load32(impl, m_heaps.StringImpl_hashAndFlags),
-                m_out.constInt32(StringImpl::flagIs8Bit())),
-            unsure(slowPath), unsure(is8Bit));
-
-        m_out.appendTo(is8Bit, loopTop);
         LValue length;
         if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
             length = m_out.constInt32(*stringLength);
@@ -21218,27 +21226,45 @@ IGNORE_CLANG_WARNINGS_END
             length = m_out.load32(impl, m_heaps.StringImpl_length);
         LValue buffer = m_out.loadPtr(impl, m_heaps.StringImpl_data);
         ValueFromBlock fastResult = m_out.anchor(string);
-        m_out.jump(loopTop);
+        m_out.branch(
+            m_out.testIsZero32(
+                m_out.load32(impl, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit())),
+            unsure(is16Bit), unsure(is8Bit));
 
-        m_out.appendTo(loopTop, loopBody);
-        LValue index = m_out.phi(Int32, startIndex);
-        ValueFromBlock indexFromBlock = m_out.anchor(index);
-        m_out.branch(m_out.below(index, length),
-            unsure(loopBody), unsure(continuation));
+        Vector<ValueFromBlock, 3> slowPathIndices;
+        slowPathIndices.append(startIndexForCall);
 
-        m_out.appendTo(loopBody, slowPath);
+        // 16-bit strings need this scan as much as 8-bit ones: one non-Latin1 character anywhere in
+        // a document makes every string derived from it 16 bit, ASCII content and all.
+        auto emitScanForCharacterNeedingConversion = [&](LBasicBlock entry, LBasicBlock top, LBasicBlock body, LBasicBlock nextBlock, bool is8BitString) {
+            m_out.appendTo(entry, top);
+            ValueFromBlock startIndex = m_out.anchor(m_out.constInt32(0));
+            m_out.jump(top);
 
-        // FIXME: Strings needs to be caged.
-        // https://bugs.webkit.org/show_bug.cgi?id=174924
-        LValue byte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, buffer, m_out.zeroExtPtr(index)));
-        LValue isInvalidAsciiRange = m_out.bitAnd(byte, m_out.constInt32(~0x7F));
-        LValue isUpperCase = m_out.belowOrEqual(m_out.sub(byte, m_out.constInt32('A')), m_out.constInt32('Z' - 'A'));
-        LValue isBadCharacter = m_out.bitOr(isInvalidAsciiRange, isUpperCase);
-        m_out.addIncomingToPhi(index, m_out.anchor(m_out.add(index, m_out.int32One)));
-        m_out.branch(isBadCharacter, unsure(slowPath), unsure(loopTop));
+            m_out.appendTo(top, body);
+            LValue index = m_out.phi(Int32, startIndex);
+            slowPathIndices.append(m_out.anchor(index));
+            m_out.branch(m_out.below(index, length),
+                unsure(body), unsure(continuation));
+
+            m_out.appendTo(body, nextBlock);
+            LValue offset = m_out.zeroExtPtr(index);
+            LValue character = is8BitString
+                ? m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, buffer, offset))
+                : m_out.load16ZeroExt32(m_out.baseIndex(m_heaps.characters16, buffer, offset));
+            LValue isInvalidAsciiRange = m_out.bitAnd(character, m_out.constInt32(~0x7F));
+            LValue isUpperCase = m_out.belowOrEqual(m_out.sub(character, m_out.constInt32('A')), m_out.constInt32('Z' - 'A'));
+            LValue isBadCharacter = m_out.bitOr(isInvalidAsciiRange, isUpperCase);
+            m_out.addIncomingToPhi(index, m_out.anchor(m_out.add(index, m_out.int32One)));
+            m_out.branch(isBadCharacter, unsure(slowPath), unsure(top));
+        };
+
+        emitScanForCharacterNeedingConversion(is8Bit, loop8Top, loop8Body, is16Bit, true);
+        emitScanForCharacterNeedingConversion(is16Bit, loop16Top, loop16Body, slowPath, false);
 
         m_out.appendTo(slowPath, continuation);
-        LValue slowPathIndex = m_out.phi(Int32, startIndexForCall, indexFromBlock);
+        LValue slowPathIndex = m_out.phi(Int32, slowPathIndices);
         ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationToLowerCase, weakPointer(globalObject), string, slowPathIndex));
         m_out.jump(continuation);
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -382,11 +382,26 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
         return *this;
     }
 
+    return convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(0);
+}
+
+Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned failingIndex)
+{
+    ASSERT(!is8Bit());
+    auto span = span16();
+#if ASSERT_ENABLED
+    for (unsigned i = 0; i < failingIndex; ++i) {
+        ASSERT(isASCII(span[i]));
+        ASSERT(!isASCIIUpper(span[i]));
+    }
+#endif
+
+    // Characters before the failing index are already known to be ASCII with no uppercase among
+    // them, so only the rest can decide which of the paths below applies.
     bool noUpper = true;
     unsigned ored = 0;
 
-    auto span = span16();
-    for (unsigned i = 0; i < span.size(); ++i) {
+    for (unsigned i = failingIndex; i < span.size(); ++i) {
         char16_t character = span[i];
         if (isASCIIUpper(character)) [[unlikely]]
             noUpper = false;
@@ -399,7 +414,8 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
     if (!(ored & ~0x7F)) {
         std::span<char16_t> data16;
         auto newImpl = createUninitializedInternalNonEmpty(m_length, data16);
-        for (unsigned i = 0; i < span.size(); ++i)
+        copyCharacters(data16, span.first(failingIndex));
+        for (unsigned i = failingIndex; i < span.size(); ++i)
             data16[i] = toASCIILower(span[i]);
         return newImpl;
     }
@@ -544,14 +560,36 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingInde
 Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleUpconvert()
 {
     auto upconvertedCharacters = StringView(*this).upconvertedCharacters();
-    auto source16 = upconvertedCharacters.span();
+    return convertToUppercaseWithoutLocale16Bit(upconvertedCharacters.span(), 0);
+}
+
+Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned failingIndex)
+{
+    ASSERT(!is8Bit());
+    auto span = span16();
+#if ASSERT_ENABLED
+    for (unsigned i = 0; i < failingIndex; ++i) {
+        ASSERT(isASCII(span[i]));
+        ASSERT(!isASCIILower(span[i]));
+    }
+#endif
+    return convertToUppercaseWithoutLocale16Bit(span, failingIndex);
+}
+
+Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocale16Bit(std::span<const char16_t> source16, unsigned failingIndex)
+{
+    ASSERT(source16.size() == m_length);
 
     std::span<char16_t> data16;
     auto newImpl = createUninitialized(source16.size(), data16);
 
+    // Characters before the failing index are already known to be ASCII that upper-casing leaves
+    // alone, so they can be copied across without being tested or converted.
+    copyCharacters(data16, source16.first(failingIndex));
+
     // Do a faster loop for the case where all the characters are ASCII.
     unsigned ored = 0;
-    for (unsigned i = 0; i < m_length; ++i) {
+    for (unsigned i = failingIndex; i < source16.size(); ++i) {
         char16_t character = source16[i];
         ored |= character;
         data16[i] = toASCIIUpper(character);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -463,8 +463,10 @@ public:
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToASCIIUppercase();
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToLowercaseWithoutLocale();
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned);
+    WTF_EXPORT_PRIVATE Ref<StringImpl> convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned);
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToUppercaseWithoutLocale();
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned);
+    WTF_EXPORT_PRIVATE Ref<StringImpl> convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned);
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToLowercaseWithLocale(const AtomString& localeIdentifier);
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToUppercaseWithLocale(const AtomString& localeIdentifier);
 
@@ -575,6 +577,7 @@ private:
     template<typename CharacterType> static Ref<StringImpl> createInternal(std::span<const CharacterType>);
     WTF_EXPORT_PRIVATE NEVER_INLINE unsigned hashSlowCase() const;
     Ref<StringImpl> convertToUppercaseWithoutLocaleUpconvert();
+    Ref<StringImpl> convertToUppercaseWithoutLocale16Bit(std::span<const char16_t> source, unsigned failingIndex);
 
     // The bottom bit in the ref count indicates a static (immortal) string.
     static constexpr uint32_t s_refCountFlagIsStaticString = 0x1;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -137,6 +137,11 @@ String String::convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigne
     SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : String { };
 }
 
+String String::convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned failingIndex) const
+{
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(failingIndex) : String { };
+}
+
 String String::convertToUppercaseWithoutLocale() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
@@ -158,6 +163,11 @@ String String::convertToUppercaseWithLocale(const AtomString& localeIdentifier) 
 String String::convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned failingIndex) const
 {
     SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : String { };
+}
+
+String String::convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned failingIndex) const
+{
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(failingIndex) : String { };
 }
 
 String String::trim(CodeUnitMatchFunction predicate) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -202,8 +202,10 @@ public:
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToASCIIUppercase() const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocale() const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned) const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocale() const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned failingIndex) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit(unsigned failingIndex) const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
 


### PR DESCRIPTION
#### d2c0435c584344707ac602307f2136de2b1ed3a4
<pre>
[JSC] Scan toLowerCase / toUpperCase strings in DFG / FTL inline
<a href="https://bugs.webkit.org/show_bug.cgi?id=323033">https://bugs.webkit.org/show_bug.cgi?id=323033</a>
<a href="https://rdar.apple.com/186301688">rdar://186301688</a>

Reviewed by Yijia Huang.

Previously 8bit strings are scanned in DFG / FTL in toLowerCase /
toUpperCase to skip calling C function when we do not need to convert
the input. This patch extends it to 16-bit strings as it is frequently
happening that 16-bit strings sliced from substring is actually not
including 16-bit characters.

Tests: JSTests/stress/to-lower-case-16-bit-ascii-fast-path.js
       JSTests/stress/to-upper-case-16-bit-ascii-fast-path.js

* JSTests/stress/to-lower-case-16-bit-ascii-fast-path.js: Added.
(shouldBe):
(toLowerCase):
(lowercasesToItself):
(wide):
(toLowerCaseRope):
* JSTests/stress/to-upper-case-16-bit-ascii-fast-path.js: Added.
(shouldBe):
(toUpperCase):
(uppercasesToItself):
(wide):
(toUpperCaseRope):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileToUpperCase):
(JSC::DFG::SpeculativeJIT::compileToLowerCase):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertToLowercaseWithoutLocale):
(WTF::StringImpl::convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit):
(WTF::StringImpl::convertToUppercaseWithoutLocaleUpconvert):
(WTF::StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit):
(WTF::StringImpl::convertToUppercaseWithoutLocale16Bit):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::convertToLowercaseWithoutLocaleStartingAtFailingIndex16Bit const):
(WTF::String::convertToUppercaseWithoutLocaleStartingAtFailingIndex16Bit const):
* Source/WTF/wtf/text/WTFString.h:

Canonical link: <a href="https://commits.webkit.org/320293@main">https://commits.webkit.org/320293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e1dfc39f5e267d6b0109f530d15114d2d395ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58085 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51903 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148454 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143773 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99912 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124192 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46248 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44462 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6163 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12980 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156643 "Found 3 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.UnifiedPDF.BackgroundAdaptsToColorScheme (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44040 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5567 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45438 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57756 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153324 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58460 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152998 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27994 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47536 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130751 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127229 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56968 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19052 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56339 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->