### PR TITLE
[Site Isolation] Web Inspector: Cross-origin resources don't show up in Network unless the page is reloaded with inspector open

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load-expected.txt
@@ -1,0 +1,33 @@
+Test that a cross-origin frame which finished loading before the frontend attached is described by the aggregated cross-process resource tree.
+
+
+
+== Running test suite: SiteIsolation.NetworkManager.AggregatedResourceTree
+-- Running test case: SiteIsolation.NetworkManager.AggregatedResourceTree.MergedAtAttach
+PASS: There should be a main frame.
+PASS: Cross-origin child frame's url should point at the iframe document, not at its origin.
+PASS: Cross-origin child's parent should be the main frame.
+PASS: Cross-origin child's name attribute should be reported.
+PASS: Cross-origin child should have a non-empty loaderIdentifier.
+PASS: Cross-origin child's loaderIdentifier should differ from the main frame's.
+PASS: Cross-origin child's stylesheet subresource should be in the frame model.
+PASS: There should be exactly one frame for the iframe document.
+PASS: The stylesheet subresource should not be duplicated.
+
+-- Running test case: SiteIsolation.NetworkManager.AggregatedResourceTree.MergeIsIdempotent
+PASS: Cross-origin child frame should be in the frame model.
+PASS: Merging again should not add frames.
+PASS: Merging again should keep the same WI.Frame objects.
+PASS: Merging again should not add resources.
+
+-- Running test case: SiteIsolation.NetworkManager.AggregatedResourceTree.NestedNewFrame
+PASS: Nested parent frame should be in the frame model.
+PASS: Grandchild frame should be in the frame model.
+PASS: Nested parent's parent should be the main frame.
+PASS: Grandchild's parent should be the nested parent frame, not the main frame.
+PASS: Grandchild's name attribute should be reported.
+PASS: Grandchild should have a non-empty loaderIdentifier.
+PASS: Grandchild's loaderIdentifier should differ from its parent's.
+PASS: There should be exactly one nested parent frame.
+PASS: There should be exactly one grandchild frame.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load.html
@@ -1,0 +1,142 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+// Appended while the document is still parsing, so the iframe and its subresources finish loading before the
+// load event -- which is when runTest() attaches the inspector. Moving this into the test body would defeat
+// the test: the frame's loads would then be observed live, which already works.
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-subresource.html`;
+    document.body.appendChild(iframe);
+}
+
+// resource-tree-frame-with-grandchild.html embeds its own further iframe once it loads, so this produces a
+// frame the page target's bootstrap cannot even placeholder: InspectorPageAgent's RemoteFrame handling does
+// not recurse into a remote frame's own children, so nothing about the grandchild exists in the frontend's
+// frame model until the aggregated merge introduces it -- and by then its immediate parent (the frame below)
+// is itself brand-new in that same merge, not an existing placeholder being corrected.
+function addNestedCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "nested-parent-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.NetworkManager.AggregatedResourceTree");
+
+    const documentPath = "/resource-tree-frame-with-subresource.html";
+    const stylePath = "/resource-tree-subframe-style.css";
+    const nestedParentPath = "/resource-tree-frame-with-grandchild.html";
+    const grandchildPath = "/resource-tree-frame.html";
+
+    function subresourcesOf(frame) {
+        return Array.from(frame.resourceCollection);
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.AggregatedResourceTree.MergedAtAttach",
+        description: "A cross-origin frame that finished loading before the frontend attached should be described by the aggregated cross-process resource tree instead of the page target's origin-only placeholder.",
+        async test() {
+            // The merge is a protocol round trip issued while the first frame target is initialized, so it
+            // races test(). Poll until the child frame is described, or give up and let the assertions fail.
+            let child = null;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                child = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith(documentPath));
+                if (child && subresourcesOf(child).some((resource) => resource.url.endsWith(stylePath)))
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectThat(!!WI.networkManager.mainFrame, "There should be a main frame.");
+
+            // Without the merge this is the placeholder built from the RemoteFrame's security origin, whose
+            // url is the bare origin with no path at all.
+            InspectorTest.expectThat(!!child, "Cross-origin child frame's url should point at the iframe document, not at its origin.");
+            if (!child)
+                return;
+
+            InspectorTest.expectThat(child.parentFrame === WI.networkManager.mainFrame, "Cross-origin child's parent should be the main frame.");
+            InspectorTest.expectEqual(child.name, "child-frame", "Cross-origin child's name attribute should be reported.");
+            InspectorTest.expectThat(!!child.loaderIdentifier, "Cross-origin child should have a non-empty loaderIdentifier.");
+            InspectorTest.expectThat(child.loaderIdentifier !== WI.networkManager.mainFrame.loaderIdentifier, "Cross-origin child's loaderIdentifier should differ from the main frame's.");
+
+            let subresources = subresourcesOf(child);
+            InspectorTest.expectThat(subresources.some((resource) => resource.url.endsWith(stylePath)), "Cross-origin child's stylesheet subresource should be in the frame model.");
+
+            // The merge fills in the existing frame rather than adding a second one, and adds each missing
+            // resource once.
+            let framesForDocument = WI.networkManager.frames.filter((frame) => frame.url && frame.url.endsWith(documentPath));
+            InspectorTest.expectEqual(framesForDocument.length, 1, "There should be exactly one frame for the iframe document.");
+
+            let stylesheets = subresources.filter((resource) => resource.url.endsWith(stylePath));
+            InspectorTest.expectEqual(stylesheets.length, 1, "The stylesheet subresource should not be duplicated.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.AggregatedResourceTree.MergeIsIdempotent",
+        description: "Merging the aggregated resource tree again should fill nothing in twice, and must not rebuild the frames the model already has.",
+        async test() {
+            let framesBefore = WI.networkManager.frames;
+            let child = framesBefore.find((frame) => frame.url && frame.url.endsWith(documentPath));
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should be in the frame model.");
+            if (!child)
+                return;
+
+            let subresourceCountBefore = child.resourceCollection.size;
+
+            let {frameTree} = await WI.backendTarget.PageAgent.getResourceTree();
+            WI.networkManager._mergeAggregatedResourceTreePayload(null, frameTree);
+
+            let framesAfter = WI.networkManager.frames;
+            InspectorTest.expectEqual(framesAfter.length, framesBefore.length, "Merging again should not add frames.");
+            InspectorTest.expectThat(framesAfter.every((frame, i) => frame === framesBefore[i]), "Merging again should keep the same WI.Frame objects.");
+            InspectorTest.expectEqual(child.resourceCollection.size, subresourceCountBefore, "Merging again should not add resources.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.AggregatedResourceTree.NestedNewFrame",
+        description: "A grandchild frame that the page target's bootstrap never even placeholdered should be added under its immediate parent, which the same merge also discovers for the first time.",
+        async test() {
+            let nestedParent = null;
+            let grandchild = null;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                nestedParent = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith(nestedParentPath));
+                grandchild = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith(grandchildPath));
+                if (nestedParent && grandchild)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectThat(!!nestedParent, "Nested parent frame should be in the frame model.");
+            InspectorTest.expectThat(!!grandchild, "Grandchild frame should be in the frame model.");
+            if (!nestedParent || !grandchild)
+                return;
+
+            InspectorTest.expectThat(nestedParent.parentFrame === WI.networkManager.mainFrame, "Nested parent's parent should be the main frame.");
+            InspectorTest.expectThat(grandchild.parentFrame === nestedParent, "Grandchild's parent should be the nested parent frame, not the main frame.");
+            InspectorTest.expectEqual(grandchild.name, "grandchild-frame", "Grandchild's name attribute should be reported.");
+            InspectorTest.expectThat(!!grandchild.loaderIdentifier, "Grandchild should have a non-empty loaderIdentifier.");
+            InspectorTest.expectThat(grandchild.loaderIdentifier !== nestedParent.loaderIdentifier, "Grandchild's loaderIdentifier should differ from its parent's.");
+
+            let nestedParentFrames = WI.networkManager.frames.filter((frame) => frame.url && frame.url.endsWith(nestedParentPath));
+            InspectorTest.expectEqual(nestedParentFrames.length, 1, "There should be exactly one nested parent frame.");
+
+            let grandchildFrames = WI.networkManager.frames.filter((frame) => frame.url && frame.url.endsWith(grandchildPath));
+            InspectorTest.expectEqual(grandchildFrames.length, 1, "There should be exactly one grandchild frame.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that a cross-origin frame which finished loading before the frontend attached is described by the aggregated cross-process resource tree.</p>
+<script>addCrossOriginIFrame(); addNestedCrossOriginIFrame();</script>
+</body>

--- a/LayoutTests/inspector/unit-tests/cookie-storage-object-expected.txt
+++ b/LayoutTests/inspector/unit-tests/cookie-storage-object-expected.txt
@@ -1,0 +1,12 @@
+Testing WI.CookieStorageObject.
+
+
+== Running test suite: CookieStorageObject
+-- Running test case: CookieStorageObject.prototype.filterCookiesForHost.StorageDomain
+PASS: Should keep both cookies whose domain matches the host.
+PASS: Should not gather resources on the Storage domain path.
+
+-- Running test case: CookieStorageObject.prototype.filterCookiesForHost.LegacyPageDomain
+PASS: Should keep the cookies whose path scopes the loaded document.
+PASS: Should drop the path-scoped cookie when only the origin-only stub is loaded.
+

--- a/LayoutTests/inspector/unit-tests/cookie-storage-object.html
+++ b/LayoutTests/inspector/unit-tests/cookie-storage-object.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createSyncSuite("CookieStorageObject");
+
+    const host = "www.example.com";
+    const loadedDocumentURL = "https://" + host + "/path/to/dir/index.html";
+
+    // The only resource the frame model has for an out-of-process frame at attach time
+    // is a stub whose URL is the bare security origin, with no path.
+    const originOnlyStubURL = "https://" + host;
+
+    function makeCookie(name, {domain, path, secure} = {})
+    {
+        return WI.Cookie.fromPayload({name, value: "value", domain, path, secure: !!secure, session: true});
+    }
+
+    // A `Set-Cookie` header with no explicit `Path` defaults the cookie's path to the document's directory.
+    let pathScopedCookie = makeCookie("pathScoped", {domain: "." + host, path: "/path/to/dir", secure: true});
+    let hostOnlyDomainCookie = makeCookie("hostOnlyDomain", {domain: host, path: "/"});
+    let otherHostCookie = makeCookie("otherHost", {domain: ".other.com", path: "/"});
+
+    function withStorageDomain(useStorageDomain, callback)
+    {
+        // `shouldUseStorageDomain` is a prototype getter; an own property shadows it for the duration.
+        Object.defineProperty(WI.storageManager, "shouldUseStorageDomain", {value: useStorageDomain, configurable: true});
+        try {
+            callback();
+        } finally {
+            delete WI.storageManager.shouldUseStorageDomain;
+        }
+    }
+
+    // Stands in for the frame model while `callback` runs, and reports whether it was consulted at all.
+    function withFrameForURL(url, callback)
+    {
+        let frame = {mainResource: {url, urlComponents: parseURL(url)}, resourceCollection: []};
+
+        let framesAccessed = false;
+        Object.defineProperty(WI.networkManager, "frames", {
+            get() {
+                framesAccessed = true;
+                return [frame];
+            },
+            configurable: true,
+        });
+        try {
+            callback();
+        } finally {
+            delete WI.networkManager.frames;
+        }
+        return framesAccessed;
+    }
+
+    function names(cookies)
+    {
+        return cookies.map((cookie) => cookie.name);
+    }
+
+    suite.addTestCase({
+        name: "CookieStorageObject.prototype.filterCookiesForHost.StorageDomain",
+        description: "Cookies from the authoritative store should be bucketed by cookie domain, ignoring the frame model.",
+        test() {
+            let cookieStorageObject = new WI.CookieStorageObject(host);
+            let cookies = [pathScopedCookie, hostOnlyDomainCookie, otherHostCookie];
+
+            withStorageDomain(true, () => {
+                let framesAccessed = withFrameForURL(originOnlyStubURL, () => {
+                    let filtered = cookieStorageObject.filterCookiesForHost(cookies);
+                    InspectorTest.expectShallowEqual(names(filtered), ["pathScoped", "hostOnlyDomain"], "Should keep both cookies whose domain matches the host.");
+                });
+                InspectorTest.expectFalse(framesAccessed, "Should not gather resources on the Storage domain path.");
+            });
+
+            return true;
+        }
+    });
+
+    suite.addTestCase({
+        name: "CookieStorageObject.prototype.filterCookiesForHost.LegacyPageDomain",
+        description: "The legacy Page path should keep matching cookies against the URLs of loaded resources.",
+        test() {
+            let cookieStorageObject = new WI.CookieStorageObject(host);
+            let cookies = [pathScopedCookie, hostOnlyDomainCookie, otherHostCookie];
+
+            withStorageDomain(false, () => {
+                withFrameForURL(loadedDocumentURL, () => {
+                    let filtered = cookieStorageObject.filterCookiesForHost(cookies);
+                    InspectorTest.expectShallowEqual(names(filtered), ["pathScoped", "hostOnlyDomain"], "Should keep the cookies whose path scopes the loaded document.");
+                });
+
+                withFrameForURL(originOnlyStubURL, () => {
+                    let filtered = cookieStorageObject.filterCookiesForHost(cookies);
+                    InspectorTest.expectShallowEqual(names(filtered), ["hostOnlyDomain"], "Should drop the path-scoped cookie when only the origin-only stub is loaded.");
+                });
+            });
+
+            return true;
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing WI.CookieStorageObject.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
@@ -215,7 +215,7 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
         if (!this._enabled)
             return;
 
-        if (!InspectorBackend.hasCommand("Page.getCookies"))
+        if (!WI.CookieStorageObject.canGetCookies)
             return;
 
         // Add the host of the frame that changed the main resource to the list of hosts there could be cookies for.

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -39,6 +39,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         this._waitingForMainFrameResourceTreePayload = true;
         this._transitioningPageTarget = false;
+        this._needsAggregatedResourceTreeMerge = false;
 
         this._sourceMapURLMap = new Map;
         this._downloadingSourceMaps = new Set;
@@ -256,6 +257,11 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             this._enabledPageForSiteIsolation = true;
             if (WI.backendTarget && WI.backendTarget.hasDomain("Network"))
                 this.initializeTarget(WI.backendTarget);
+
+            // The bootstrap snapshot cannot describe a frame in another process, and nothing replays loads
+            // that finished before the frontend attached, so fold in the aggregated tree now that
+            // ProxyingPageAgent is live.
+            this._requestAggregatedResourceTree();
         }
     }
 
@@ -1225,13 +1231,13 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         let frame = this.frameForIdentifier(frameIdentifier);
 
-        // FIXME: <webkit.org/b/308896> Under Site Isolation, cross-origin iframe frames may
-        // not be in the frame map. They don't appear in getResourceTree (dynamically added) or
-        // Page.frameNavigated (RemoteFrame, not LocalFrame), and Page.frameDetached removes any
-        // stubs during the provisional frame commit lifecycle. Create a stub frame on-demand so
-        // the resource is added as a subresource (firing ResourceWasAdded) rather than being
-        // treated as the main resource of a brand-new frame (firing FrameWasAdded). This will be
-        // resolved when Page.getResourceTree supports Site Isolation cross-process frames.
+        // Under Site Isolation, cross-origin iframe frames may not be in the frame map. They don't appear
+        // in the page target's getResourceTree (a RemoteFrame is reported as a placeholder with no
+        // subresources) or in Page.frameNavigated (RemoteFrame, not LocalFrame), and Page.frameDetached
+        // removes any stubs during the provisional frame commit lifecycle. The aggregated cross-process
+        // tree fills those gaps, but live events can arrive before it has been merged, so still create a
+        // stub frame on demand: the resource is then added as a subresource (firing ResourceWasAdded)
+        // rather than being treated as the main resource of a brand-new frame (firing FrameWasAdded).
         if (!frame && frameIdentifier.startsWith("frame-")) {
             let mainResource = new WI.Resource("about:blank");
             frame = new WI.Frame(frameIdentifier, frameOptions.name, frameOptions.securityOrigin, null, mainResource);
@@ -1439,6 +1445,20 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             this._transitioningPageTarget = false;
             this._mainFrame._dispatchMainResourceDidChangeEvent(oldMainFrame.mainResource);
         }
+
+        if (this._needsAggregatedResourceTreeMerge) {
+            this._needsAggregatedResourceTreeMerge = false;
+            this._requestAggregatedResourceTree();
+        }
+    }
+
+    // Only served once ProxyingPageAgent is live, which the first Frame target signals; see initializeTarget.
+    _requestAggregatedResourceTree()
+    {
+        if (!WI.backendTarget || !WI.backendTarget.hasDomain("Page"))
+            return;
+
+        WI.backendTarget.PageAgent.getResourceTree(this._mergeAggregatedResourceTreePayload.bind(this));
     }
 
     _createFrame(payload)
@@ -1508,6 +1528,105 @@ WI.NetworkManager = class NetworkManager extends WI.Object
         this._dispatchFrameWasAddedEvent(frame);
 
         return frame;
+    }
+
+    // Fold the aggregated cross-process resource tree into the frame model. Unlike
+    // _processMainFrameResourceTreePayload, which rebuilds the model from scratch, this only fills in what
+    // the model is missing, so it is safe to call at any point and more than once.
+    //
+    // FIXME: <https://webkit.org/b/XXXXXX> Once Page and Network fully move to the WebPage target, this
+    // becomes the only bootstrap and the merge-vs-placeholder distinction goes away entirely.
+    _mergeAggregatedResourceTreePayload(error, mainFramePayload)
+    {
+        if (error) {
+            console.error(JSON.stringify(error));
+            return;
+        }
+
+        // A bootstrap in flight is about to rebuild the model, so merging now would accomplish nothing. The
+        // order of the two replies isn't guaranteed by the protocol -- the aggregated fetch is even issued
+        // later than the page target's own getResourceTree -- but in practice it usually still arrives first.
+        if (this._waitingForMainFrameResourceTreePayload) {
+            this._needsAggregatedResourceTreeMerge = true;
+            return;
+        }
+
+        console.assert(mainFramePayload);
+        console.assert(mainFramePayload.frame);
+        if (!mainFramePayload || !mainFramePayload.frame)
+            return;
+
+        this._mergeAggregatedFrameTreePayload(mainFramePayload, null);
+    }
+
+    _mergeAggregatedFrameTreePayload(payload, parentFrame)
+    {
+        let framePayload = payload.frame;
+
+        let frame = this.frameForIdentifier(framePayload.id);
+        let isNewFrame = !frame;
+        if (isNewFrame) {
+            // A root frame the model has never seen would mean the page target and ProxyingPageAgent
+            // disagree on frame ids; adding it would build a second, parentless copy of the whole tree.
+            console.assert(parentFrame, "The aggregated tree's root frame should already be in the frame model.");
+            if (!parentFrame)
+                return;
+
+            frame = this._createFrame(framePayload);
+            parentFrame.addChildFrame(frame);
+        } else if (this._shouldUpdatePlaceholderMainResource(frame, framePayload)) {
+            frame.updatePlaceholderMainResource(framePayload.url, framePayload.mimeType, framePayload.loaderId, framePayload.name, framePayload.securityOrigin);
+        }
+
+        for (let resourcePayload of payload.resources || []) {
+            // The main resource is included as a resource. Skip it, since the frame already has one.
+            if (resourcePayload.type === "Document" && resourcePayload.url === framePayload.url)
+                continue;
+
+            // Never replace: a resource the frontend watched load carries request, timing and size data this
+            // snapshot lacks. Resources carrying a targetId go to that target below, not to the frame.
+            if (frame.resourceCollection.resourcesForURL(resourcePayload.url).size)
+                continue;
+
+            let resource = this._createResource(resourcePayload, payload);
+            if (resource.target === WI.pageTarget)
+                frame.addResource(resource);
+            else if (resource.target)
+                resource.target.addResource(resource);
+            else
+                this._addOrphanedResource(resource, resourcePayload.targetId);
+
+            if (resourcePayload.failed || resourcePayload.canceled)
+                resource.markAsFailed(resourcePayload.canceled);
+            else
+                resource.markAsFinished();
+        }
+
+        // Announce the frame only once its resources are in place, as the bootstrap path does.
+        if (isNewFrame)
+            this._dispatchFrameWasAddedEvent(frame);
+
+        for (let childPayload of payload.childFrames || [])
+            this._mergeAggregatedFrameTreePayload(childPayload, frame);
+    }
+
+    _shouldUpdatePlaceholderMainResource(frame, framePayload)
+    {
+        // Nothing to learn: the model already describes this document.
+        if (frame.mainResource.url === framePayload.url)
+            return false;
+
+        // Mid-navigation. The provisional load owns what this frame becomes next; stay out of it.
+        if (frame.provisionalLoaderIdentifier)
+            return false;
+
+        // No loader identifier: no way to tell whether this is the load the model already holds.
+        if (!framePayload.loaderId)
+            return false;
+
+        // Live events are at least as current as the snapshot, so only correct a placeholder that was never
+        // attributed to a load, or one for this very load.
+        return !frame.loaderIdentifier || frame.loaderIdentifier === framePayload.loaderId;
     }
 
     _addOrphanedResource(resource, targetId)

--- a/Source/WebInspectorUI/UserInterface/Models/CookieStorageObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CookieStorageObject.js
@@ -50,6 +50,15 @@ WI.CookieStorageObject = class CookieStorageObject
         return !!resourceDomain.match(new RegExp("^(?:[^\\.]+\\.)*" + cookieDomain.substring(1).escapeForRegExp() + "$"), "i");
     }
 
+    // Static, because the sidebar decides whether there are cookie buckets at all before there is any
+    // WI.CookieStorageObject to ask.
+    static get canGetCookies()
+    {
+        if (WI.storageManager.shouldUseStorageDomain)
+            return WI.backendTarget.hasCommand("Storage.getCookies");
+        return InspectorBackend.hasCommand("Page.getCookies");
+    }
+
     // Public
 
     get host()
@@ -64,9 +73,7 @@ WI.CookieStorageObject = class CookieStorageObject
 
     get canGetCookies()
     {
-        if (this._useStorageDomain)
-            return WI.backendTarget.hasCommand("Storage.getCookies");
-        return InspectorBackend.hasCommand("Page.getCookies");
+        return WI.CookieStorageObject.canGetCookies;
     }
 
     get canSetCookie()
@@ -94,7 +101,7 @@ WI.CookieStorageObject = class CookieStorageObject
     getCookies()
     {
         if (this._useStorageDomain) {
-            // No filter: fetch the full authoritative store; the view buckets by host. Partition
+            // No filter: fetch the full authoritative store; filterCookiesForHost buckets by host. Partition
             // "context" targets the inspected page's data store.
             return WI.backendTarget.StorageAgent.getCookies.invoke({partition: {type: "context"}}).then((payload) => payload.cookies);
         }
@@ -129,6 +136,18 @@ WI.CookieStorageObject = class CookieStorageObject
         return WI.assumingMainTarget().PageAgent.deleteCookie(cookie.name, cookie.url);
     }
 
+    filterCookiesForHost(cookies)
+    {
+        if (this._useStorageDomain) {
+            // Match by domain, not by resource URL: an out-of-process frame's only resource can be a stub whose
+            // URL is the bare origin, so a path check would drop every cookie scoped to a subdirectory.
+            return cookies.filter((cookie) => cookie.domain && WI.CookieStorageObject.cookieDomainMatchesResourceDomain(cookie.domain, this._host));
+        }
+
+        let resources = this._resourcesForHost();
+        return cookies.filter((cookie) => resources.some((resource) => WI.CookieStorageObject.cookieMatchesResourceURL(cookie, resource.url)));
+    }
+
     saveIdentityToCookie(cookie)
     {
         // FIXME <https://webkit.org/b/151413>: This class should actually store cookie data for this host.
@@ -140,6 +159,20 @@ WI.CookieStorageObject = class CookieStorageObject
     get _useStorageDomain()
     {
         return WI.storageManager.shouldUseStorageDomain;
+    }
+
+    _resourcesForHost()
+    {
+        let allResources = [];
+
+        // The main resource isn't part of `resourceCollection`, so add it as a candidate too.
+        for (let frame of WI.networkManager.frames)
+            allResources.push(frame.mainResource, ...frame.resourceCollection);
+
+        return allResources.filter((resource) => {
+            let urlComponents = resource.urlComponents;
+            return urlComponents && urlComponents.host && urlComponents.host === this._host;
+        });
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -97,6 +97,35 @@ WI.Frame = class Frame extends WI.Object
             this.dispatchEventToListeners(WI.Frame.Event.NameDidChange, {oldName});
     }
 
+    // Correct a placeholder description of the frame's current document. Unlike `initialize`, nothing is torn
+    // down: the frame has not navigated, so its subresources, child frames and execution contexts all still
+    // describe this same load.
+    //
+    // FIXME: <https://webkit.org/b/XXXXXX> Once Page and Network fully move to the WebPage target, there is
+    // no longer a placeholder to correct, and this method can be deleted.
+    updatePlaceholderMainResource(url, mimeType, loaderIdentifier, name, securityOrigin)
+    {
+        console.assert(this._mainResource);
+        console.assert(!this._loaderIdentifier || this._loaderIdentifier === loaderIdentifier, this._loaderIdentifier, loaderIdentifier);
+
+        if (loaderIdentifier)
+            this._loaderIdentifier = loaderIdentifier;
+
+        this._mainResource.updatePlaceholderURL(url, mimeType, loaderIdentifier);
+
+        if (name && name !== this._name) {
+            let oldName = this._name;
+            this._name = name;
+            this.dispatchEventToListeners(WI.Frame.Event.NameDidChange, {oldName});
+        }
+
+        if (securityOrigin && securityOrigin !== this._securityOrigin) {
+            let oldSecurityOrigin = this._securityOrigin;
+            this._securityOrigin = securityOrigin;
+            this.dispatchEventToListeners(WI.Frame.Event.SecurityOriginDidChange, {oldSecurityOrigin});
+        }
+    }
+
     startProvisionalLoad(provisionalMainResource)
     {
         console.assert(provisionalMainResource);

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -740,6 +740,49 @@ WI.Resource = class Resource extends WI.SourceCode
         return requestDataContentType && requestDataContentType.match(/^application\/x-www-form-urlencoded\s*(;.*)?$/i);
     }
 
+    // Correct a placeholder URL, and the resource type inferred from it, once the real ones are known. Under
+    // Site Isolation the page target can only describe an out-of-process frame's main resource by the
+    // frame's security origin, so the URL starts out with no path. This is the same load, so replacing the
+    // resource would double-count it everywhere.
+    //
+    // FIXME: <https://webkit.org/b/XXXXXX> Once Page and Network fully move to the WebPage target, there is
+    // no longer a placeholder to correct, and this method can be deleted.
+    updatePlaceholderURL(url, mimeType, loaderIdentifier)
+    {
+        console.assert(url);
+
+        let oldURL = this._url;
+        let oldMIMEType = this._mimeType;
+        let oldType = this._type;
+
+        this._url = url;
+
+        if (mimeType)
+            this._mimeType = mimeType;
+
+        this._type = Resource.resolvedType(undefined, this._mimeType);
+
+        if (loaderIdentifier)
+            this._loaderIdentifier = loaderIdentifier;
+
+        if (oldURL !== this._url) {
+            // Delete the URL components so the URL is re-parsed the next time it is requested.
+            this._urlComponents = null;
+
+            this.dispatchEventToListeners(WI.Resource.Event.URLDidChange, {oldURL});
+        }
+
+        if (oldMIMEType !== this._mimeType) {
+            // Delete the MIME-type components so the MIME-type is re-parsed the next time it is requested.
+            this._mimeTypeComponents = null;
+
+            this.dispatchEventToListeners(WI.Resource.Event.MIMETypeDidChange, {oldMIMEType});
+        }
+
+        if (oldType !== this._type)
+            this.dispatchEventToListeners(WI.Resource.Event.TypeDidChange, {oldType});
+    }
+
     updateForResponse(url, mimeType, type, responseHeaders, statusCode, statusText, elapsedTime, timingData, source, security)
     {
         console.assert(!this._finished);

--- a/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
@@ -385,29 +385,6 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
             this._reloadCookies();
     }
 
-    _getCookiesForHost(cookies, host)
-    {
-        let resourceMatchesStorageDomain = (resource) => {
-            let urlComponents = resource.urlComponents;
-            return urlComponents && urlComponents.host && urlComponents.host === host;
-        };
-
-        let allResources = [];
-        for (let frame of WI.networkManager.frames) {
-            // The main resource isn't in the list of resources, so add it as a candidate.
-            allResources.push(frame.mainResource, ...frame.resourceCollection);
-        }
-
-        let resourcesForDomain = allResources.filter(resourceMatchesStorageDomain);
-
-        let cookiesForDomain = cookies.filter((cookie) => {
-            return resourcesForDomain.some((resource) => {
-                return WI.CookieStorageObject.cookieMatchesResourceURL(cookie, resource.url);
-            });
-        });
-        return cookiesForDomain;
-    }
-
     _generateSortComparator()
     {
         let sortColumnIdentifier = this._table.sortColumnIdentifier;
@@ -562,7 +539,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
             return Promise.resolve();
 
         return this._getCookies().then((cookies) => {
-            this._cookies = this._getCookiesForHost(cookies.map(WI.Cookie.fromPayload), this.representedObject.host);
+            this._cookies = this.representedObject.filterCookiesForHost(cookies.map(WI.Cookie.fromPayload));
             this._updateSort();
             this._updateFilteredCookies();
             this._updateEmptyFilterResultsMessage();

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -171,6 +171,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         WI.Frame.addEventListener(WI.Frame.Event.ChildFrameWasAdded, this._handleFrameWasAdded, this);
         WI.Resource.addEventListener(WI.Resource.Event.LoadingDidFinish, this._resourceLoadingDidFinish, this);
         WI.Resource.addEventListener(WI.Resource.Event.LoadingDidFail, this._resourceLoadingDidFail, this);
+        WI.Resource.addEventListener(WI.Resource.Event.URLDidChange, this._handleResourceURLDidChange, this);
         WI.Resource.addEventListener(WI.Resource.Event.RedirectsDidChange, this._resourceRedirectsDidChange, this);
         WI.Resource.addEventListener(WI.Resource.Event.SizeDidChange, this._handleResourceSizeDidChange, this);
         WI.Resource.addEventListener(WI.Resource.Event.TransferSizeDidChange, this._resourceTransferSizeDidChange, this);
@@ -321,6 +322,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         WI.Frame.removeEventListener(WI.Frame.Event.ChildFrameWasAdded, this._handleFrameWasAdded, this);
         WI.Resource.removeEventListener(WI.Resource.Event.LoadingDidFinish, this._resourceLoadingDidFinish, this);
         WI.Resource.removeEventListener(WI.Resource.Event.LoadingDidFail, this._resourceLoadingDidFail, this);
+        WI.Resource.removeEventListener(WI.Resource.Event.URLDidChange, this._handleResourceURLDidChange, this);
         WI.Resource.removeEventListener(WI.Resource.Event.RedirectsDidChange, this._resourceRedirectsDidChange, this);
         WI.Resource.removeEventListener(WI.Resource.Event.SizeDidChange, this._handleResourceSizeDidChange, this);
         WI.Resource.removeEventListener(WI.Resource.Event.TransferSizeDidChange, this._resourceTransferSizeDidChange, this);
@@ -1992,6 +1994,23 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
 
             this._updateWaterfallTimeRange(resource.firstTimestamp, resource.timingData.responseEnd);
 
+            if (this._hasURLFilter())
+                this._checkURLFilterAgainstResource(resource);
+
+            if (wasMain)
+                this.needsLayout();
+        });
+    }
+
+    _handleResourceURLDidChange(event)
+    {
+        // A resource's URL can be corrected after its row exists: an out-of-process frame's main resource
+        // starts out as an origin-only placeholder. Re-render so the Name and Domain columns catch up.
+        this._runForMainCollection((collection, wasMain) => {
+            let resource = event.target;
+            collection.pendingUpdates.push(resource);
+
+            // The filter was evaluated against the old URL, and its result is memoized per resource.
             if (this._hasURLFilter())
                 this._checkURLFilterAgainstResource(resource);
 


### PR DESCRIPTION
#### 6d2079790578744750b00da00badc872d41f354f
<pre>
[Site Isolation] Web Inspector: Cross-origin resources don&apos;t show up in Network unless the page is reloaded with inspector open
<a href="https://bugs.webkit.org/show_bug.cgi?id=322556">https://bugs.webkit.org/show_bug.cgi?id=322556</a>
<a href="https://rdar.apple.com/185847508">rdar://185847508</a>

Reviewed by NOBODY (OOPS!).

Opening the inspector on an already-loaded page shows nothing in the
Network tab for a cross-origin iframe except one placeholder row named
after its origin. Reloading with the inspector open shows everything.

The per-page target&apos;s Page.getResourceTree can&apos;t describe a RemoteFrame
beyond its security origin, and nothing replays loads that finished
before the frontend attached. ProxyingPageAgent already assembles an
aggregated cross-process tree on the UIProcess for exactly this purpose
(NetworkManager.initializeTarget&apos;s comment already said as much);
nothing called it. This fetches it once the first Frame target appears,
since that is what signals the proxying agents are live, and folds the
result into the frame model.

The merge is a separate entry point rather than a second call into
_processMainFrameResourceTreePayload, which rebuilds the frame and
request maps from scratch and would discard anything live events have
already recorded. The merge instead only fills in what the model is
missing -- frames it has never seen, and resources whose URL a frame
doesn&apos;t already have -- so it is safe to run at any time, more than
once, and interleaved with live events.

A placeholder main resource is corrected in place rather than replaced
and announced as a navigation, since it is the same load:
Frame.initialize() would tear down subresources, child frames and
execution contexts as if this were a real navigation, but under Site
Isolation those are reported by the frame target and will not be
reported again without an actual navigation. A frame is corrected only
when the snapshot&apos;s loaderId is known to match the load already on the
frame, or the frame has none yet -- live events are always at least as
current as the snapshot.

The order of the two replies is not guaranteed by the protocol: the
aggregated fetch is even issued later than the page target&apos;s own
getResourceTree, once the first Frame target appears, but in practice
it usually still arrives first. A reply that arrives before the page
target&apos;s own bootstrap finishes is remembered and re-requested once
the model is rebuilt, rather than merged into a model that is about to
be discarded.

Test: http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load.html

* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-aggregated-resource-tree-attach-after-load.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.initializeTarget):
(WI.NetworkManager.prototype._addNewResourceToFrameOrTarget):
(WI.NetworkManager.prototype._processMainFrameResourceTreePayload):
(WI.NetworkManager.prototype._requestAggregatedResourceTree):
(WI.NetworkManager.prototype._mergeAggregatedResourceTreePayload):
(WI.NetworkManager.prototype._mergeAggregatedFrameTreePayload):
(WI.NetworkManager.prototype._shouldUpdatePlaceholderMainResource):
* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.updatePlaceholderMainResource):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.updatePlaceholderURL):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView):
(WI.NetworkTableContentView.prototype.closed):
(WI.NetworkTableContentView.prototype._handleResourceURLDidChange):
</pre>
----------------------------------------------------------------------
#### 2e540bdb5454949622b8d99ad89b85fc269454bf
<pre>
See <a href="https://github.com/WebKit/WebKit/pull/72466">https://github.com/WebKit/WebKit/pull/72466</a>

[Site Isolation] Web Inspector: Cross-origin cookies are missing in Storage until reloading with inspector open
<a href="https://rdar.apple.com/185268264">rdar://185268264</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322549">https://bugs.webkit.org/show_bug.cgi?id=322549</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d2079790578744750b00da00badc872d41f354f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148408 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143724 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99875 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124143 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44424 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43998 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5521 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196277 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153281 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58414 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152955 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47490 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130705 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129868 "Failed to checkout and rebase branch from PR 72893") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56293 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->