### PR TITLE
[GTK][WPE] PromiseDMABufImageContext is reference counted across threads

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -38,6 +38,7 @@
 #include <epoxy/gl.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 #if USE(TEXTURE_MAPPER)
 #include "TextureMapper.h"
@@ -324,7 +325,7 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
 
 #else
 
-class PromiseDMABufImageContext final : public RefCounted<PromiseDMABufImageContext> {
+class PromiseDMABufImageContext final : public ThreadSafeRefCounted<PromiseDMABufImageContext> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseDMABufImageContext);
 public:
     static Ref<PromiseDMABufImageContext> create(Ref<DMABufBuffer>&& buffer, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)


### PR DESCRIPTION
#### 2a6af1e45406751495293f8ab2878dafc4506fcb
<pre>
[GTK][WPE] PromiseDMABufImageContext is reference counted across threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=323052">https://bugs.webkit.org/show_bug.cgi?id=323052</a>

Reviewed by Carlos Garcia Campos.

PromiseDMABufImageContext is created on the thread producing the buffer, WebGL&apos;s
in the case of GraphicsContextGLTextureMapperGBM::prepareForDisplay(), and handed
to Skia as the context of a promise image texture. Skia releases those contexts
while flushing on the compositing thread, so the reference count is touched from
two threads while being a plain RefCounted and hits an ASSERT.

Make it ThreadSafeRefCounted. DMABufBuffer, which it holds, already is.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:

Canonical link: <a href="https://commits.webkit.org/320246@main">https://commits.webkit.org/320246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ea435b131cc89fcc805d9b0dbb10f31cf889150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57791 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143735 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99881 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44435 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156618 "Found 7 new API test failures: TestWebKitAPI.UnifiedPDF.BackgroundAdaptsToColorScheme, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.PrivateClickMeasurement.SourceClickFraudPrevention, TestWebKitAPI.DragAndDropTests.WebViewRemovedFromViewHierarchyDuringDrag, TestWebKitAPI.PrivateClickMeasurement.MigrateFromResourceLoadStatistics2, TestWebKitAPI.PrivateClickMeasurement.EphemeralWithAttributedBundleIdentifier, TestWebKitAPI.PrivateClickMeasurement.DestinationClickFraudPrevention (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44009 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5538 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57727 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153294 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58431 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152968 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47503 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130722 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56939 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->