### PR TITLE
[GLib] PDF documents never finish loading

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -142,6 +142,7 @@ inspector/page/setScreenSizeOverride.html [ Skip ]
 interaction-region [ Skip ]
 overlay-region [ Skip ]
 pdf [ Skip ]
+pdfjs [ Skip ] # Requires ENABLE(PDFJS)
 ipc/cocoa [ Skip ]
 ipc/ios [ Skip ]
 ipc/mac [ Skip ]

--- a/LayoutTests/pdfjs/document-load-event-expected.txt
+++ b/LayoutTests/pdfjs/document-load-event-expected.txt
@@ -1,0 +1,10 @@
+A PDF document should finish loading, so that embedders stop showing it as still loading.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pdfDocument.readyState is "complete"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/pdfjs/document-load-event.html
+++ b/LayoutTests/pdfjs/document-load-event.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ PDFJSViewerEnabled=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="resources/pdfjs-test.js"></script>
+</head>
+<body>
+<script>
+description("A PDF document should finish loading, so that embedders stop showing it as still loading.");
+jsTestIsAsync = true;
+
+(async () => {
+    const frame = loadPDFInFrame("resources/multi-page.pdf");
+    await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
+    // Wait for the viewer too, so that the messages it logs are always in the same place.
+    await waitForPDFToLoad(frame);
+    pdfDocument = frame.contentDocument;
+    shouldBeEqualToString("pdfDocument.readyState", "complete");
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/pdfjs/resources/multi-page.pdf
+++ b/LayoutTests/pdfjs/resources/multi-page.pdf
@@ -1,0 +1,76 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R 9 0 R 11 0 R] /Count 5 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Contents 4 0 R /Resources << /Font << /F1 13 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 57 >>
+stream
+BT /F1 18 Tf 30 200 Td (Cranberry jam on page one) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Contents 6 0 R /Resources << /Font << /F1 13 0 R >> >> >>
+endobj
+6 0 obj
+<< /Length 57 >>
+stream
+BT /F1 18 Tf 30 200 Td (Blueberry jam on page two) Tj ET
+endstream
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Contents 8 0 R /Resources << /Font << /F1 13 0 R >> >> >>
+endobj
+8 0 obj
+<< /Length 59 >>
+stream
+BT /F1 18 Tf 30 200 Td (Raspberry jam on page three) Tj ET
+endstream
+endobj
+9 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Contents 10 0 R /Resources << /Font << /F1 13 0 R >> >> >>
+endobj
+10 0 obj
+<< /Length 59 >>
+stream
+BT /F1 18 Tf 30 200 Td (Strawberry jam on page four) Tj ET
+endstream
+endobj
+11 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 300] /Contents 12 0 R /Resources << /Font << /F1 13 0 R >> >> >>
+endobj
+12 0 obj
+<< /Length 58 >>
+stream
+BT /F1 18 Tf 30 200 Td (Zebra stripes on page five) Tj ET
+endstream
+endobj
+13 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000140 00000 n 
+0000000267 00000 n 
+0000000373 00000 n 
+0000000500 00000 n 
+0000000606 00000 n 
+0000000733 00000 n 
+0000000841 00000 n 
+0000000969 00000 n 
+0000001078 00000 n 
+0000001207 00000 n 
+0000001315 00000 n 
+trailer
+<< /Size 14 /Root 1 0 R >>
+startxref
+1386
+%%EOF

--- a/LayoutTests/pdfjs/resources/pdfjs-test.js
+++ b/LayoutTests/pdfjs/resources/pdfjs-test.js
@@ -1,0 +1,28 @@
+// Helpers to reach into the PDF.js viewer that WebKit builds for a PDF document.
+// The viewer lives in a webkit-pdfjs-viewer:// iframe inside the PDF document, which is
+// only reachable from a test because layout tests allow universal access from file URLs.
+
+function loadPDFInFrame(url, width = 700, height = 400)
+{
+    const frame = document.createElement("iframe");
+    frame.style.width = `${width}px`;
+    frame.style.height = `${height}px`;
+    frame.src = url;
+    document.body.appendChild(frame);
+    return frame;
+}
+
+function viewerForFrame(frame)
+{
+    return frame.contentDocument?.querySelector("iframe")?.contentWindow?.PDFViewerApplication;
+}
+
+// Waits for the metadata rather than just the document, because reading the metadata is what
+// makes PDF.js log the line about the document it opened: waiting for it keeps that log line
+// in the same place in every test's output.
+async function waitForPDFToLoad(frame)
+{
+    while (!viewerForFrame(frame)?.documentInfo)
+        await new Promise(resolve => setTimeout(resolve, 0));
+    return viewerForFrame(frame);
+}

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -90,6 +90,9 @@ scrollingcoordinator/ [ Pass ]
 scrollingcoordinator/mac/ [ Skip ]
 scrollingcoordinator/ios/ [ Skip ]
 
+# Only the GLib ports build ENABLE(PDFJS).
+pdfjs [ Pass ]
+
 imported/w3c/web-platform-tests/css/CSS2/linebox/vertical-align-baseline-003.xht [ Pass ]
 imported/w3c/web-platform-tests/css/CSS2/linebox/vertical-align-baseline-009.xht [ Pass ]
 imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-079.xht [ Pass ]

--- a/Source/WebCore/html/PDFJSDocument.cpp
+++ b/Source/WebCore/html/PDFJSDocument.cpp
@@ -94,7 +94,11 @@ void PDFJSDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 
 void PDFJSDocumentParser::finish()
 {
-    document().finishedParsing();
+    if (isStopped())
+        return;
+
+    document().didFinishParsingPDF();
+    RawDataDocumentParser::finish();
 }
 
 /* PDFJSDocumentEventListener: event listener for the PDFJSDocument iframe */
@@ -178,7 +182,7 @@ void PDFJSDocument::updateDuringParsing()
         createDocumentStructure();
 }
 
-void PDFJSDocument::finishedParsing()
+void PDFJSDocument::didFinishParsingPDF()
 {
     ASSERT(m_iframe);
     m_isFinishedParsing = true;

--- a/Source/WebCore/html/PDFJSDocument.h
+++ b/Source/WebCore/html/PDFJSDocument.h
@@ -48,7 +48,7 @@ public:
     ~PDFJSDocument();
 
     void updateDuringParsing();
-    void finishedParsing();
+    void didFinishParsingPDF();
     void injectStyleAndContentScript();
 
     void postMessageToIframe(const String& name, JSC::JSObject* data);


### PR DESCRIPTION
#### dc17d7899f8f5e9cddbaab85f4e21448d623c5ad
<pre>
[GLib] PDF documents never finish loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=323059">https://bugs.webkit.org/show_bug.cgi?id=323059</a>

Reviewed by NOBODY (OOPS!).

PDFJSDocumentParser::finish() called document().finishedParsing(), which resolves to
PDFJSDocument::finishedParsing(), a method that shadows Document::finishedParsing()
rather than overriding it. The base RawDataDocumentParser::finish() therefore never
ran, so a PDF document stayed in the &quot;loading&quot; ready state forever: its load event
never fired and webkit_web_view_is_loading() never returned FALSE, leaving an
embedder&apos;s stop button in place for as long as the PDF was shown.

Rename the shadowing method to didFinishParsingPDF() and chain to the base class,
which is what every other RawDataDocumentParser subclass does.

Test: pdfjs/document-load-event.html

* LayoutTests/TestExpectations:
* LayoutTests/pdfjs/document-load-event-expected.txt: Added.
* LayoutTests/pdfjs/document-load-event.html: Added.
* LayoutTests/pdfjs/resources/multi-page.pdf: Added.
* LayoutTests/pdfjs/resources/pdfjs-test.js: Added.
(loadPDFInFrame):
(viewerForFrame):
(async waitForPDFToLoad):
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/html/PDFJSDocument.cpp:
(WebCore::PDFJSDocumentParser::finish):
(WebCore::PDFJSDocument::didFinishParsingPDF):
(WebCore::PDFJSDocument::finishedParsing): Deleted.
* Source/WebCore/html/PDFJSDocument.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc17d7899f8f5e9cddbaab85f4e21448d623c5ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148437 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143742 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99891 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44444 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156625 "Found 3 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPITabs.GetSelected, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRuleWithEnhancedSecurity (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44021 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5550 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153304 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152978 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47512 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130734 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56951 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->