### PR TITLE
Regression(314177@main) SetRawCookie's MESSAGE_CHECKs reject legitimate cookie writes from third-party iframes

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
+++ b/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+try {
+    internals.setCookie({
+        name: 'thirdpartyiframecookie',
+        value: 'value',
+        domain: 'localhost',
+        path: '/',
+        isSession: true,
+    });
+    parent.postMessage('PASS: setCookie from third-party iframe did not terminate the WebProcess', '*');
+} catch (e) {
+    parent.postMessage('FAIL: threw ' + e, '*');
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
@@ -1,0 +1,4 @@
+Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.
+
+PASS: setCookie from third-party iframe did not terminate the WebProcess
+

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.</p>
+<pre id="out"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const log = s => document.getElementById('out').textContent += s + '\n';
+
+window.addEventListener('message', (event) => {
+    log(event.data);
+    testRunner?.notifyDone();
+});
+
+const iframe = document.createElement('iframe');
+iframe.src = 'http://localhost:8000/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html';
+document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the NetworkProcess does not crash.

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if the NetworkProcess does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const ownOrigin = location.origin + '/';
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie: {
+            name:         'x',
+            value:        'y',
+            domain:       '127.0.0.1',
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     false,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        },
+        shouldPartitionCookie: 0,
+    });
+
+    setTimeout(() => {
+        window.testRunner?.notifyDone();
+    }, 500);
+};
+</script>

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK
+PASS SetRawCookie rejects cross-origin url via MESSAGE_CHECK
+

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that SetRawCookie validates cookie.domain and url against firstParty via MESSAGE_CHECK</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    // Drain any pending invalid-message string.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // cookie.domain is cross-origin from firstParty -> MESSAGE_CHECK at
+    // NetworkConnectionToWebProcess::setRawCookie should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie:     makeCookie('victim-bank.test'),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin cookie.domain should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK');
+
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // url is cross-origin from firstParty -> MESSAGE_CHECK should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: victimURL },
+        cookie:     makeCookie(new URL(ownOrigin).host),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin url should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin url via MESSAGE_CHECK');
+
+done();
+</script>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -974,8 +974,7 @@ void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const UR
 {
     auto access = validateCookieAccess("setRawCookie"_s, firstParty, url, nullptr);
     MESSAGE_CHECK(access != CookieAccess::Terminate);
-    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
-    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
+    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(url));
     if (access != CookieAccess::Allow)
         return;
 


### PR DESCRIPTION
#### d4867a890432d2368c2cd6a4bc1516da4d0f4c7b
<pre>
Regression(314177@main) SetRawCookie&apos;s MESSAGE_CHECKs reject legitimate cookie writes from third-party iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323060">https://bugs.webkit.org/show_bug.cgi?id=323060</a>
<a href="https://rdar.apple.com/177769847">rdar://177769847</a>

Reviewed by Ben Nham.

NetworkConnectionToWebProcess::setRawCookie validated cookie.domain and
url against firstParty:
```
MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
```

This is too strict. WebCookieJar::setRawCookie passes
document.firstPartyForCookies() as firstParty (the top-level page&apos;s URL)
and document.cookieURL() as url (the document&apos;s own URL). For a
third-party iframe these legitimately differ, so the checks terminate
the WebProcess whenever Web Inspector or internals.setCookie is used in
a cross-site iframe.

Replace the two checks with an integrity check that cookie.domain&apos;s
registrable domain matches url, mirroring the existing posture of
setCookieFromDOMAsync which validates firstParty only and trusts the
url/cookie pair. The new check still rejects a mismatched
cookie.domain/url pair (the most useful invariant) without coupling
either to the unrelated top-level firstParty.

Tests: http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
       ipc/set-raw-cookie-empty-commenturl-crash.html
       ipc/set-raw-cookie-firstparty-message-check.html

* LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html: Added.
* LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt: Added.
* LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html: Added.
Add test coverage for the overly strict checks.

* LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt: Added.
* LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html: Added.
* LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt: Added.
* LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html: Added.
Add test coverage for what 314177@main was trying to fix, to make sure
that we don&apos;t regress it.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::setRawCookie):

Canonical link: <a href="https://commits.webkit.org/320304@main">https://commits.webkit.org/320304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/118e188e4e7b7ff52d8dd8ae3e5a152db2cca406

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a07f1fd-194f-45ce-981a-48c6de0c4b69) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143743 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99892 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b288e057-f221-464a-b98e-d2afac19a749) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124162 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0bc33f7-07a1-4bbf-8aa1-6474211d3098) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44445 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156627 "Found 5 new API test failures: TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIScripting.CSSUserOrigin, TestWebKitAPI.WKWebExtensionAPIScripting.InsertAndRemoveCSS (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44024 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5551 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196307 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41105 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152979 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47515 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130735 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56952 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19036 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56562 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->