### PR TITLE
[Site Isolation] Always coordinate back/forward navigation in the UI process

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8526,3 +8526,5 @@ fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html [ ImageOnlyF
 fast/shadow-dom/svg-pattern-href-in-shadow-tree.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/svg/as-image/sprite-sheet-fractional-size.html [ ImageOnlyFailure ]
+
+fast/loader/site-isolation/form-state-restore-with-frames.html [ Timeout ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -14,6 +14,7 @@ http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html 
 http/tests/security/referrer-policy-header-strict-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html [ Crash ]
+[ Debug ] http/tests/navigation/post-frames-goback1.html [ Crash ]
 
 #######################
 # Tests that time out #
@@ -37,6 +38,7 @@ fast/loader/stateobjects/pushstate-in-iframe.html [ Timeout ]
 http/tests/navigation/cross-site-iframe-nav-with-bfcache.html [ Timeout ]
 http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html [ Failure Timeout ]
 inspector/dom-debugger/url-breakpoints-dom-text-and-regex.html [ Skip ]
+http/tests/navigation/forward-and-cancel.html [ Timeout ]
 
 ########################
 # Tests that Text fail #

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1740,8 +1740,6 @@ webkit.org/b/289094 [ Sequoia Debug ] imported/w3c/web-platform-tests/webcodecs/
 
 webkit.org/b/289121 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html [ Pass Failure ]
 
-webkit.org/b/289176 [ Debug ] http/tests/site-isolation/history/add-iframes-and-go-back.html [ Timeout ]
-
 webkit.org/b/307830 [ Debug arm64 ] http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html [ Pass Timeout ]
 
 webkit.org/b/289183 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-disabled-tracks.https.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -428,7 +428,7 @@ Ref<FrameState> ProvisionalPageProxy::copyFrameStateForBackForwardNavigation(API
 {
     Ref frameItem = navigation.targetFrameItem() ? *navigation.targetFrameItem() : item.mainFrameItem();
     if (RefPtr page = m_page.get()) {
-        if (protect(page->preferences())->useUIProcessForBackForwardItemLoading())
+        if (protect(page->preferences())->shouldUseUIProcessForBackForwardItemLoading())
             return frameItem->copyFrameState();
     }
     return frameItem->copyFrameStateWithChildren();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2826,7 +2826,7 @@ RefPtr<API::Navigation> WebPageProxy::goForward()
     if (!forwardItem)
         return nullptr;
 
-    Ref frameItem = protect(preferences())->useUIProcessForBackForwardItemLoading()
+    Ref frameItem = protect(preferences())->shouldUseUIProcessForBackForwardItemLoading()
         ? forwardItem->mainFrameItem()
         : forwardItem->navigatedFrameItem();
     return goToBackForwardItem(WTF::move(frameItem), FrameLoadType::Forward);
@@ -2938,7 +2938,7 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
 
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item->url()));
 
-    if (preferences->useUIProcessForBackForwardItemLoading()) {
+    if (preferences->shouldUseUIProcessForBackForwardItemLoading()) {
         bool anySent = false;
         if (RefPtr currentItem = backForwardList().currentItem())
             anySent = dispatchPerFrameTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
@@ -3044,7 +3044,7 @@ bool WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& 
 Ref<WebBackForwardListFrameItem> WebPageProxy::frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag)
 {
     Ref frameItem = targetItem.mainFrameItem();
-    if (protect(preferences())->useUIProcessForBackForwardItemLoading())
+    if (protect(preferences())->shouldUseUIProcessForBackForwardItemLoading())
         return frameItem;
     RefPtr currentItem = backForwardList().currentItem();
     if (!currentItem)
@@ -3074,7 +3074,7 @@ Ref<FrameState> WebPageProxy::copyFrameStateForBackForwardNavigation(WebBackForw
     };
 
     Ref targetFrameItem = frameItemForNavigation();
-    return protect(preferences())->useUIProcessForBackForwardItemLoading() ? targetFrameItem->copyFrameState() : targetFrameItem->copyFrameStateWithChildren();
+    return protect(preferences())->shouldUseUIProcessForBackForwardItemLoading() ? targetFrameItem->copyFrameState() : targetFrameItem->copyFrameStateWithChildren();
 }
 
 WebProcessProxy* WebPageProxy::frameProcessForNonCachedBackForwardNavigation(WebBackForwardListFrameItem& frameItem) const
@@ -9848,7 +9848,7 @@ RefPtr<FrameState> WebPageProxy::frameStateForBackForwardChildFrame(WebFrameProx
 void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& originalCompletionHandler)
 {
     RefPtr<FrameState> frameStateForBackForwardNavigation;
-    if (protect(preferences())->useUIProcessForBackForwardItemLoading() && navigationActionData.navigationType == WebCore::NavigationType::BackForward && navigationActionData.targetBackForwardItemIdentifier) {
+    if (protect(preferences())->shouldUseUIProcessForBackForwardItemLoading() && navigationActionData.navigationType == WebCore::NavigationType::BackForward && navigationActionData.targetBackForwardItemIdentifier) {
         if (RefPtr frameState = frameStateForBackForwardChildFrame(frame, *navigationActionData.targetBackForwardItemIdentifier)) {
             WEBPAGEPROXY_RELEASE_LOG(Loading, "frameStateForBackForwardChildFrame: Back/Forward child frame, rewriting URL to %" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
             navigationActionData.request.setURL(URL { frameState->urlString });

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -97,6 +97,13 @@ void WebPreferences::forceSiteIsolationAlwaysOnForTesting()
     WebKit::forceSiteIsolationAlwaysOnForTesting = true;
 }
 
+bool WebPreferences::shouldUseUIProcessForBackForwardItemLoading() const
+{
+    // Site Isolation spreads a page's frames across Web processes, so no single Web process can
+    // coordinate a back/forward traversal by itself; the UI process must always drive it.
+    return useUIProcessForBackForwardItemLoading() || siteIsolationEnabled();
+}
+
 const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()
 {
     static auto experimentalFeatures = NeverDestroyed([]() {

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -71,6 +71,8 @@ public:
     FOR_EACH_WEBKIT_PREFERENCE(DECLARE_PREFERENCE_GETTER_AND_SETTERS)
     FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(DECLARE_INSPECTOR_OVERRIDE_SETTERS)
 
+    bool shouldUseUIProcessForBackForwardItemLoading() const;
+
     static const Vector<RefPtr<API::Object>>& features();
     static const Vector<RefPtr<API::Object>>& experimentalFeatures();
     static const Vector<RefPtr<API::Object>>& internalDebugFeatures();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1383,14 +1383,8 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
 
     RefPtr relatedPage = pageConfiguration->relatedPage();
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
-    if (siteIsolationEnabled) {
-        Ref<WebPreferences> preferences = pageConfiguration->preferences();
-        // FIXME: we should enable UseUIProcessForBackForwardItemLoading not only here but also in test infrastructure
-        // when site isolation is enabled, but doing that causes a lot of test failures that we need to investigate.
-        // https://bugs.webkit.org/show_bug.cgi?id=316588
-        preferences->setUseUIProcessForBackForwardItemLoading(true);
-        preferences->setMultiProcessBackForwardCacheEnabled(true);
-    }
+    if (siteIsolationEnabled)
+        protect(pageConfiguration->preferences())->setMultiProcessBackForwardCacheEnabled(true);
     RefPtr preferredBrowsingContextGroup = pageConfiguration->preferredBrowsingContextGroup();
     RefPtr preferredFrameProcess = preferredBrowsingContextGroup ? preferredBrowsingContextGroup->processForSite(pageConfiguration->openedSite()) : nullptr;
     if (auto& openerInfo = pageConfiguration->openerInfo(); openerInfo && siteIsolationEnabled) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5405,6 +5405,7 @@ bool WebPage::isParentProcessAWebBrowser() const
 void WebPage::adjustSettingsForLockdownMode(Settings& settings, const WebPreferencesStore* store)
 {
     bool originalSiteIsolationEnabled = settings.siteIsolationEnabled();
+    bool originalUseUIProcessForBackForwardItemLoading = settings.useUIProcessForBackForwardItemLoading();
     // Disable unstable Experimental settings, even if the user enabled them for local use.
     settings.disableUnstableFeaturesForModernWebKit();
     Settings::disableGlobalUnstableFeaturesForModernWebKit();
@@ -5414,6 +5415,8 @@ void WebPage::adjustSettingsForLockdownMode(Settings& settings, const WebPrefere
     // setting to avoid IPC state mismatch.
     if (originalSiteIsolationEnabled)
         settings.setSiteIsolationEnabled(true);
+    if (originalUseUIProcessForBackForwardItemLoading)
+        settings.setUseUIProcessForBackForwardItemLoading(true);
 
 #if PLATFORM(COCOA)
     if (settings.downloadableBinaryFontTrustedTypes() != DownloadableBinaryFontTrustedTypes::None) {
@@ -5458,6 +5461,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     bool requiresUserGestureForMedia = store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForMediaPlaybackKey());
     settings.setRequiresUserGestureForVideoPlayback(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForVideoPlaybackKey()));
     settings.setRequiresUserGestureForAudioPlayback(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForAudioPlaybackKey()));
+    // Always turn on UseUIProcessForBackForwardItemLoading if SiteIsolationEnabled is on.
+    settings.setUseUIProcessForBackForwardItemLoading(store.getBoolValueForKey(WebPreferencesKey::useUIProcessForBackForwardItemLoadingKey()) || store.getBoolValueForKey(WebPreferencesKey::siteIsolationEnabledKey()));
     settings.setUserInterfaceDirectionPolicy(static_cast<WebCore::UserInterfaceDirectionPolicy>(store.getUInt32ValueForKey(WebPreferencesKey::userInterfaceDirectionPolicyKey())));
     settings.setSystemLayoutDirection(static_cast<TextDirection>(store.getUInt32ValueForKey(WebPreferencesKey::systemLayoutDirectionKey())));
     settings.setJavaScriptRuntimeFlags(static_cast<JSC::RuntimeFlags>(store.getUInt32ValueForKey(WebPreferencesKey::javaScriptRuntimeFlagsKey())));


### PR DESCRIPTION
#### 27077033d047911ef49e3afa674adad1092bb14d
<pre>
[Site Isolation] Always coordinate back/forward navigation in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=323062">https://bugs.webkit.org/show_bug.cgi?id=323062</a>
<a href="https://rdar.apple.com/186326286">rdar://186326286</a>

Reviewed by NOBODY (OOPS!).

Site Isolation requires the UI process to coordinate back/forward navigation, since a page&apos;s frames are spread across
processes and none of them can walk the frame tree alone. Two preferences are involved: SiteIsolationEnabled turns on
the Site Isolation architecture, and UseUIProcessForBackForwardItemLoading makes the UI process coordinate back/forward
navigation. We currently tie them together in WebProcessPool::createWebPage, which sets
UseUIProcessForBackForwardItemLoading from the SiteIsolationEnabled value at page creation.

That only holds until the preferences change. Any later write wins, so a client turning
UseUIProcessForBackForwardItemLoading off after the page is created gets it off. UseUIProcessForBackForwardItemLoading
is unstable, so WKPreferencesResetAllInternalDebugFeatures() in TestController::resetPreferencesToConsistentValues()
resets it to false between tests, which means tests that explicitly enable Site Isolation are run in an unsupported
configuration: SiteIsolationEnabled=true with UseUIProcessForBackForwardItemLoading=false.

To ensure the UI process always coordinates back/forward navigation under Site Isolation, add
WebPreferences::shouldUseUIProcessForBackForwardItemLoading(), computed from both preferences and true when either is
true, and change the existing checkers of UseUIProcessForBackForwardItemLoading to use it. WebPage::updatePreferences()
applies the same OR when populating Settings, so WebCore is unchanged. adjustSettingsForLockdownMode() needs a matching
restore, since disableUnstableFeaturesForModernWebKit() clears the setting and the two processes would otherwise
disagree; SiteIsolationEnabled already had one there for that reason. MultiProcessBackForwardCacheEnabled keeps its
createWebPage mutation: its consumers AND the two preferences, so it needs its own decision.

This fixes add-iframes-and-go-back.html, and exposes three pre-existing bugs that shipping Site Isolation clients hit
today. Those tests were passing only because they ran the unsupported configuration. They get TestExpectations entries
here and the underlying bugs will fixed in follow-up patches.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::copyFrameStateForBackForwardNavigation const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::frameItemForLegacyTraversalRouting):
(WebKit::WebPageProxy::copyFrameStateForBackForwardNavigation const):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::shouldUseUIProcessForBackForwardItemLoading const):
* Source/WebKit/UIProcess/WebPreferences.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::adjustSettingsForLockdownMode):
(WebKit::WebPage::updatePreferences):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27077033d047911ef49e3afa674adad1092bb14d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bac05ae-f86c-4d1e-bd10-2c0c841e9df5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143764 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99908 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69009d57-58e4-487a-8762-17a44ba54641) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124183 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1119e97c-9bdd-496d-9e47-b495e3cbd7e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46247 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44460 "Passed tests") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156642 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 10 api tests failed or timed out; 8 api tests failed or timed out; Compiled WebKit (warnings); 2 api tests failed or timed out; Found 4 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.UnifiedPDF.BackgroundAdaptsToColorScheme, TestWebKitAPI.PrivateClickMeasurement.SourceClickFraudPrevention (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44045 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5569 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196325 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58462 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152995 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47529 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130753 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127231 "Failed to checkout and rebase branch from PR 72910") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56970 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19057 "Found 3 new test failures: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->