### PR TITLE
WPT: add coverage for per-index getItem identity on the SVG list interfaces

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative-expected.txt
@@ -1,0 +1,20 @@
+
+PASS SVGNumberList (text rotate): getItem returns the same object for the same index
+PASS SVGNumberList (text rotate): two getItem calls for one index report the same value
+PASS SVGNumberList (text rotate): the indexed getter returns the same object as getItem
+PASS SVGNumberList (text rotate): different indices return different objects
+PASS SVGLengthList (text x): getItem returns the same object for the same index
+PASS SVGLengthList (text x): two getItem calls for one index report the same value
+PASS SVGLengthList (text x): the indexed getter returns the same object as getItem
+PASS SVGLengthList (text x): different indices return different objects
+PASS SVGPointList (polyline points): getItem returns the same object for the same index
+PASS SVGPointList (polyline points): two getItem calls for one index report the same value
+PASS SVGPointList (polyline points): the indexed getter returns the same object as getItem
+PASS SVGPointList (polyline points): different indices return different objects
+PASS SVGTransformList (rect transform): getItem returns the same object for the same index
+PASS SVGTransformList (rect transform): two getItem calls for one index report the same value
+PASS SVGTransformList (rect transform): the indexed getter returns the same object as getItem
+PASS SVGTransformList (rect transform): different indices return different objects
+PASS SVGLengthList: item objects are not shared between elements
+PASS SVGStringList: getItem returns a string, so identity is not a meaningful question
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative.html
@@ -1,0 +1,108 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>SVG list interfaces: getItem returns the same object for the same index (tentative)</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#ListInterfaces">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1169">
+<!--
+  TENTATIVE. SVG 2 does not state this requirement in one sentence; it follows from the
+  getItem algorithm's step 2 ("Return the element in the list at position index") together
+  with the note immediately after it ("if the list's element type is an object type, such
+  as SVGLength, then a reference to that object and not a copy of it is returned"). One
+  element sits at a given position, and a reference to it is returned each time, so two
+  getItem calls for the same index on an unmodified list return the same object.
+
+  Raised as w3c/svgwg#1169, which asks for the requirement to be stated outright. This
+  file stays .tentative until it is.
+
+  SVGStringList is deliberately in scope with the OPPOSITE expectation. Its element type
+  is DOMString, so getItem returns a string and comparison is by value. Asserting that is
+  not a weaker version of the same test: it pins the carve-out the note itself makes, and
+  without it a reader cannot tell that the exclusion is deliberate.
+
+  The text elements below carry no content on purpose. WebKit's test harness dumps the
+  rendered text of the page before the harness output, so any content would land in the
+  baseline, and in a file that builds one element per subtest the number of those lines
+  would track the subtest count. Measured: an empty text element gives the same item
+  counts, values and identity behaviour, so nothing is lost.
+-->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="200" height="200">
+  <text id="text" x="10 20 30" y="20" rotate="1 2 3"/>
+  <polyline id="polyline" points="1,2 3,4 5,6"/>
+  <rect id="rect" width="10" height="10" transform="translate(1) translate(2) translate(3)"
+        requiredExtensions="alpha beta gamma"/>
+</svg>
+<script>
+const $ = id => document.getElementById(id);
+
+// Each subject is a list whose element type is an object type, so identity is meaningful.
+const objectLists = [
+  ["SVGNumberList (text rotate)", () => $("text").rotate.baseVal],
+  ["SVGLengthList (text x)", () => $("text").x.baseVal],
+  ["SVGPointList (polyline points)", () => $("polyline").points],
+  ["SVGTransformList (rect transform)", () => $("rect").transform.baseVal],
+];
+
+for (const [name, getList] of objectLists) {
+  test(function() {
+    const list = getList();
+    assert_equals(list.numberOfItems, 3, "the markup should give three items");
+    for (let i = 0; i < list.numberOfItems; ++i)
+      assert_equals(list.getItem(i), list.getItem(i),
+                    "getItem(" + i + ") twice should give the same object, not two objects holding the same value");
+  }, name + ": getItem returns the same object for the same index");
+
+  // Separate subtest on purpose. An engine that returns a fresh object per call fails the
+  // test above; it should still be shown to return the right VALUE, so that a failure
+  // above reads as an identity difference and not as data loss.
+  test(function() {
+    const list = getList();
+    const read = item => item.value !== undefined ? item.value
+                       : item.x !== undefined ? item.x
+                       : item.matrix.e;
+    for (let i = 0; i < list.numberOfItems; ++i)
+      assert_equals(read(list.getItem(i)), read(list.getItem(i)),
+                    "getItem(" + i + ") twice should report the same value, which it does even where the objects differ");
+  }, name + ": two getItem calls for one index report the same value");
+
+  // The indexed getter is defined to return the same element as getItem, so it is the
+  // same requirement reached by a second route.
+  test(function() {
+    const list = getList();
+    for (let i = 0; i < list.numberOfItems; ++i)
+      assert_equals(list[i], list.getItem(i),
+                    "list[" + i + "] should be the very same object as getItem(" + i + ")");
+  }, name + ": the indexed getter returns the same object as getItem");
+
+  test(function() {
+    const list = getList();
+    assert_not_equals(list.getItem(0), list.getItem(1),
+                      "index 0 and index 1 should be different objects");
+  }, name + ": different indices return different objects");
+}
+
+// A list belongs to one element. Two elements carrying the same attribute value must not
+// share item objects, which is what makes the assertions above about identity rather
+// than about some global interning of equal values.
+test(function() {
+  const a = $("text").x.baseVal;
+  const other = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  other.setAttribute("x", "10 20 30");
+  $("svg").appendChild(other);
+  assert_equals(other.x.baseVal.numberOfItems, 3);
+  assert_not_equals(other.x.baseVal.getItem(0), a.getItem(0),
+                    "two elements with equal attribute values should not share item objects");
+}, "SVGLengthList: item objects are not shared between elements");
+
+// The carve-out, with the opposite expectation.
+test(function() {
+  const list = $("rect").requiredExtensions;
+  assert_equals(list.numberOfItems, 3, "the markup should give three items");
+  assert_equals(typeof list.getItem(0), "string",
+                "SVGStringList holds DOMString, so getItem returns a string");
+  assert_equals(list.getItem(0), list.getItem(0),
+                "strings compare by value, so this holds without an identity requirement");
+}, "SVGStringList: getItem returns a string, so identity is not a meaningful question");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative-expected.txt
@@ -1,0 +1,19 @@
+
+PASS SVGNumberList (text rotate): a freshly read item reports the new value after the attribute changes
+FAIL SVGNumberList (text rotate): a held item reports the new value when the count is unchanged assert_equals: the held item should report the new value, per step 4.4 expected 40 but got 1
+FAIL SVGNumberList (text rotate): a held item is still the element at its index when the count is unchanged assert_equals: the held object should still be the very same object at index 0 expected object "[object SVGNumber]" but got object "[object SVGNumber]"
+FAIL SVGNumberList (text rotate): a shrink detaches only the items at or above the new length assert_equals: an item below the new length survives and takes the new value expected 40 but got 1
+PASS SVGLengthList (text x): a freshly read item reports the new value after the attribute changes
+FAIL SVGLengthList (text x): a held item reports the new value when the count is unchanged assert_equals: the held item should report the new value, per step 4.4 expected 40 but got 10
+FAIL SVGLengthList (text x): a held item is still the element at its index when the count is unchanged assert_equals: the held object should still be the very same object at index 0 expected object "[object SVGLength]" but got object "[object SVGLength]"
+FAIL SVGLengthList (text x): a shrink detaches only the items at or above the new length assert_equals: an item below the new length survives and takes the new value expected 40 but got 10
+PASS SVGPointList (polyline points): a freshly read item reports the new value after the attribute changes
+FAIL SVGPointList (polyline points): a held item reports the new value when the count is unchanged assert_equals: the held item should report the new value, per step 4.4 expected 40 but got 1
+FAIL SVGPointList (polyline points): a held item is still the element at its index when the count is unchanged assert_equals: the held object should still be the very same object at index 0 expected object "[object SVGPoint]" but got object "[object SVGPoint]"
+FAIL SVGPointList (polyline points): a shrink detaches only the items at or above the new length assert_equals: an item below the new length survives and takes the new value expected 40 but got 1
+PASS SVGTransformList (rect transform): a freshly read item reports the new value after the attribute changes
+PASS SVGTransformList (rect transform): a held item reports the new value when the count is unchanged
+PASS SVGTransformList (rect transform): a held item is still the element at its index when the count is unchanged
+PASS SVGTransformList (rect transform): a shrink detaches only the items at or above the new length
+PASS SVGStringList: the list is replaced on an attribute change, per step 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative.html
@@ -1,0 +1,147 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>SVG list interfaces: a held item survives an attribute change that keeps the item count (tentative)</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermSynchronizeList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermDetach">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1169">
+<!--
+  TENTATIVE, for the same reason as the sibling identity file: the requirement follows from
+  the algorithm rather than from a sentence, so w3c/svgwg#1169 asks for it to be stated.
+
+  Synchronizing a list interface object runs whenever the reflected content attribute's
+  base value changes. For an object element type, step 4.1 detaches items ONLY when the new
+  value has fewer of them. When the count is unchanged, steps 4.1 and 4.2 are both skipped
+  and step 4.4 runs over every index: "Let item be the object in the list at index index.
+  Let v be the value in value at index index. Set item's value to v."
+
+  So an item held across a same-count attribute change must survive AND report the new
+  value. This file asserts both halves separately, because they fail independently: an
+  engine can hand back a fresh object per getItem call (an identity difference) while still
+  routing values correctly, and another can lose the value while keeping the object.
+
+  The shrink case is deliberately included with the OPPOSITE expectation. Truncated items
+  ARE detached, and a detached item keeps its old value, so a test that expected the new
+  value there would be asserting a violation. Getting that backwards is easy: a
+  WebKit-local test from 2010 asserts that all three items of a 3-to-2 shrink keep their
+  old values, which is right for the truncated one and wrong for the two survivors.
+
+  The text elements below carry no content on purpose. WebKit's test harness dumps the
+  rendered text of the page before the harness output, so any content would land in the
+  baseline, and in a file that builds one element per subtest the number of those lines
+  would track the subtest count. Measured: an empty text element gives the same item
+  counts, values and identity behaviour, so nothing is lost.
+-->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="200" height="200"></svg>
+<script>
+const SVGNS = "http://www.w3.org/2000/svg";
+const svg = document.getElementById("svg");
+
+function make(tag, attrs) {
+  const el = document.createElementNS(SVGNS, tag);
+  for (const k in attrs)
+    el.setAttribute(k, attrs[k]);
+  svg.appendChild(el);
+  return el;
+}
+
+// name, attribute, starting value, a same-count replacement, the expected new value at
+// index 0, a shorter replacement, and how to read an item's value.
+const subjects = [
+  {
+    name: "SVGNumberList (text rotate)",
+    build: () => make("text", { rotate: "1 2 3", x: "5", y: "20" }),
+    list: el => el.rotate.baseVal,
+    same: "40 50 60", shorter: "40 50", expect0: 40,
+    read: item => item.value,
+  },
+  {
+    name: "SVGLengthList (text x)",
+    build: () => make("text", { x: "10 20 30", y: "40" }),
+    list: el => el.x.baseVal,
+    same: "40 50 60", shorter: "40 50", expect0: 40,
+    read: item => item.value,
+  },
+  {
+    name: "SVGPointList (polyline points)",
+    build: () => make("polyline", { points: "1,2 3,4 5,6" }),
+    list: el => el.points,
+    same: "40,41 42,43 44,45", shorter: "40,41 42,43", expect0: 40,
+    read: item => item.x,
+  },
+  {
+    name: "SVGTransformList (rect transform)",
+    build: () => make("rect", { width: "10", height: "10",
+                                transform: "translate(1) translate(2) translate(3)" }),
+    list: el => el.transform.baseVal,
+    same: "translate(40) translate(41) translate(42)",
+    shorter: "translate(40) translate(41)", expect0: 40,
+    read: item => item.matrix.e,
+  },
+];
+
+for (const s of subjects) {
+  const attr = s.name.match(/\(([a-z]+) ([a-zA-Z]+)\)/)[2];
+
+  // Control. Nothing is held, and a freshly read item must report the new value. If this
+  // fails, the attribute change never took effect and the rest of this file means nothing.
+  test(function() {
+    const el = s.build();
+    const list = s.list(el);
+    el.setAttribute(attr, s.same);
+    assert_equals(list.numberOfItems, 3, "the item count should be unchanged");
+    assert_equals(s.read(list.getItem(0)), s.expect0,
+                  "a freshly read item should report the new value");
+  }, s.name + ": a freshly read item reports the new value after the attribute changes");
+
+  test(function() {
+    const el = s.build();
+    const list = s.list(el);
+    const held = list.getItem(0);
+    el.setAttribute(attr, s.same);
+    assert_equals(list.numberOfItems, 3, "the item count should be unchanged");
+    assert_equals(s.read(held), s.expect0,
+                  "the held item should report the new value, per step 4.4");
+  }, s.name + ": a held item reports the new value when the count is unchanged");
+
+  test(function() {
+    const el = s.build();
+    const list = s.list(el);
+    const held = list.getItem(0);
+    el.setAttribute(attr, s.same);
+    assert_equals(list.getItem(0), held,
+                  "the held object should still be the very same object at index 0");
+  }, s.name + ": a held item is still the element at its index when the count is unchanged");
+
+  // The shrink, with the opposite expectation for the truncated item.
+  test(function() {
+    const el = s.build();
+    const list = s.list(el);
+    const survivor = list.getItem(0);
+    const truncated = list.getItem(2);
+    const before = s.read(truncated);
+    el.setAttribute(attr, s.shorter);
+    assert_equals(list.numberOfItems, 2, "the list should have been truncated");
+    assert_equals(s.read(survivor), s.expect0,
+                  "an item below the new length survives and takes the new value");
+    assert_equals(s.read(truncated), before,
+                  "the truncated item is detached, so it keeps its old value");
+  }, s.name + ": a shrink detaches only the items at or above the new length");
+}
+
+// The DOMString branch is the deliberate opposite, and step 5 states it directly:
+// "Replace the list with a new list consisting of the values in value." So a string read
+// before the change is simply the old string, and the list reports the new ones.
+test(function() {
+  const el = make("rect", { width: "10", height: "10",
+                            requiredExtensions: "alpha beta gamma" });
+  const list = el.requiredExtensions;
+  const before = list.getItem(0);
+  assert_equals(before, "alpha");
+  el.setAttribute("requiredExtensions", "delta epsilon zeta");
+  assert_equals(list.numberOfItems, 3, "the item count should be unchanged");
+  assert_equals(list.getItem(0), "delta", "the list should report the new strings");
+  assert_equals(before, "alpha", "the string read earlier is unaffected, being a value");
+}, "SVGStringList: the list is replaced on an attribute change, per step 5");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative-expected.txt
@@ -1,0 +1,20 @@
+
+PASS SVGNumberList (text rotate): appendItem returns the element it appended
+PASS SVGNumberList (text rotate): insertItemBefore returns the element it inserted
+PASS SVGNumberList (text rotate): replaceItem returns the element it placed
+PASS SVGNumberList (text rotate): initialize returns the element it placed
+PASS SVGLengthList (text dx): appendItem returns the element it appended
+PASS SVGLengthList (text dx): insertItemBefore returns the element it inserted
+PASS SVGLengthList (text dx): replaceItem returns the element it placed
+PASS SVGLengthList (text dx): initialize returns the element it placed
+PASS SVGPointList (polyline points): appendItem returns the element it appended
+PASS SVGPointList (polyline points): insertItemBefore returns the element it inserted
+PASS SVGPointList (polyline points): replaceItem returns the element it placed
+PASS SVGPointList (polyline points): initialize returns the element it placed
+PASS SVGTransformList (rect transform): appendItem returns the element it appended
+PASS SVGTransformList (rect transform): insertItemBefore returns the element it inserted
+PASS SVGTransformList (rect transform): replaceItem returns the element it placed
+PASS SVGTransformList (rect transform): initialize returns the element it placed
+PASS SVGStringList: appendItem returns the string it appended
+PASS An item that is already in a list is copied on insertion, not moved
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative.html
@@ -1,0 +1,122 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>SVG list interfaces: a mutating method returns the element it placed in the list (tentative)</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1169">
+<!--
+  TENTATIVE, and for a narrower reason than the getItem identity file.
+
+  initialize, insertItemBefore, replaceItem and appendItem each end with the normative
+  step "Return newItem", after newItem has been attached and placed in the list. So the
+  value returned IS the element at that position, and getItem for that index has to return
+  the same object. The step is normative; what is unstated is that item identity is
+  observable at all, which is what this test relies on. So it stays .tentative alongside
+  w3c/svgwg#1169.
+
+  ONE SUBTLETY THAT WOULD OTHERWISE MAKE THIS TEST WRONG. Each of these methods begins:
+  "If newItem is an object type, and newItem is not a detached object, then set newItem to
+  be a newly created object of the same type as newItem and which has the same value."
+  Passing an item that is already in a list therefore makes a COPY, and the return value
+  is correctly NOT the object passed in. Every item passed below is freshly created by a
+  createSVG* factory and so is detached, which is the only case where the object handed in
+  is the object placed in the list. The last subtest pins the copying rule itself, so that
+  a future edit cannot quietly reintroduce the mistake.
+
+  The text elements below carry no content on purpose. WebKit's test harness dumps the
+  rendered text of the page before the harness output, so any content would land in the
+  baseline, and in a file that builds one element per subtest the number of those lines
+  would track the subtest count. Measured: an empty text element gives the same item
+  counts, values and identity behaviour, so nothing is lost.
+-->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="200" height="200">
+  <text id="text" x="10 20 30" y="20" rotate="1 2 3" dx="1 2 3" dy="4 5 6"/>
+  <polyline id="polyline" points="1,2 3,4 5,6"/>
+  <rect id="rect" width="10" height="10" transform="translate(1) translate(2) translate(3)"/>
+  <rect id="rect2" width="10" height="10" transform="translate(9)"/>
+</svg>
+<script>
+const $ = id => document.getElementById(id);
+const svg = $("svg");
+
+// A fresh, detached item per list type, so no copy is made on insertion.
+const subjects = [
+  ["SVGNumberList (text rotate)", () => $("text").rotate.baseVal,
+   () => { const n = svg.createSVGNumber(); n.value = 42; return n; }],
+  ["SVGLengthList (text dx)", () => $("text").dx.baseVal,
+   () => { const l = svg.createSVGLength(); l.value = 42; return l; }],
+  ["SVGPointList (polyline points)", () => $("polyline").points,
+   () => { const p = svg.createSVGPoint(); p.x = 42; p.y = 43; return p; }],
+  ["SVGTransformList (rect transform)", () => $("rect").transform.baseVal,
+   () => { const t = svg.createSVGTransform(); t.setTranslate(42, 0); return t; }],
+];
+
+for (const [name, getList, makeItem] of subjects) {
+  test(function() {
+    const list = getList();
+    const item = makeItem();
+    const returned = list.appendItem(item);
+    assert_equals(returned, item, "appendItem should return the item it was given");
+    assert_equals(returned, list.getItem(list.numberOfItems - 1),
+                  "the returned object should be the very same object as the last element");
+  }, name + ": appendItem returns the element it appended");
+
+  test(function() {
+    const list = getList();
+    const item = makeItem();
+    const returned = list.insertItemBefore(item, 1);
+    assert_equals(returned, item, "insertItemBefore should return the item it was given");
+    assert_equals(returned, list.getItem(1),
+                  "the returned object should be the very same object as the element at index 1");
+  }, name + ": insertItemBefore returns the element it inserted");
+
+  test(function() {
+    const list = getList();
+    const item = makeItem();
+    const returned = list.replaceItem(item, 0);
+    assert_equals(returned, item, "replaceItem should return the item it was given");
+    assert_equals(returned, list.getItem(0),
+                  "the returned object should be the very same object as the element at index 0");
+  }, name + ": replaceItem returns the element it placed");
+
+  test(function() {
+    const list = getList();
+    const item = makeItem();
+    const returned = list.initialize(item);
+    assert_equals(returned, item, "initialize should return the item it was given");
+    assert_equals(list.numberOfItems, 1, "initialize should clear the list first");
+    assert_equals(returned, list.getItem(0),
+                  "the returned object should be the very same object as the only element");
+  }, name + ": initialize returns the element it placed");
+}
+
+// SVGStringList holds DOMString, so the return value compares by value. Worth asserting
+// because nothing upstream covers SVGStringList's methods at all.
+test(function() {
+  const list = $("rect").requiredExtensions;
+  const returned = list.appendItem("delta");
+  assert_equals(returned, "delta", "appendItem should return the string it was given");
+  assert_equals(list.getItem(list.numberOfItems - 1), "delta",
+                "and that string should be the last element");
+}, "SVGStringList: appendItem returns the string it appended");
+
+// The copying rule, pinned so the reasoning above cannot be lost. Passing an item that is
+// already in a list is required to insert a copy, so the return value is a different
+// object from the one passed in, and the original list is untouched.
+test(function() {
+  const source = $("rect").transform.baseVal;
+  const target = $("rect2").transform.baseVal;
+  const held = source.getItem(0);
+  const returned = target.appendItem(held);
+  assert_not_equals(returned, held,
+                    "an item already in a list must be copied, so a different object comes back");
+  assert_equals(returned, target.getItem(target.numberOfItems - 1),
+                "the copy, not the original, is the element that was appended");
+  assert_equals(source.getItem(0), held,
+                "the source list should be unchanged");
+}, "An item that is already in a list is copied on insertion, not moved");
+</script>


### PR DESCRIPTION
#### bce61d8f431e8840ff25d826dc2d8ec192360e85
<pre>
WPT: add coverage for per-index getItem identity on the SVG list interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=323065">https://bugs.webkit.org/show_bug.cgi?id=323065</a>

Reviewed by Nikolas Zimmermann.

Nothing in WPT checks that an SVG list returns the same object twice for the
same index, or that appendItem and friends return the element they just placed.
This adds three tests across SVGNumberList, SVGLengthList, SVGPointList,
SVGTransformList and SVGStringList.

SVG 2 requires this but never says it in one sentence, so the files are
.tentative while <a href="https://github.com/w3c/svgwg/issues/1169">https://github.com/w3c/svgwg/issues/1169</a> is open.

Nine subtests in SVGList-identity-across-attribute-change fail. That is bug
322973: a held item is dropped when the attribute is re-parsed, on every list
except SVGTransformList. The failures are in the baseline rather than
TestExpectations, so fixing 322973 will show up as a rebaseline.

This will be exported to WPT.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-getItem-identity.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-identity-across-attribute-change.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-mutator-return-identity.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/320323@main">https://commits.webkit.org/320323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15044510a5ab51bc4350e4fcf1a9baba33472e9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148457 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143765 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99909 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124184 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46253 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44461 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156648 "Found 3 new API test failures: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIRuntime.ConnectFromContentScriptWithMultipleListeners, TestWebKitAPI.WebAuthenticationPanel.LAError (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44037 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5570 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41122 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58463 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152996 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47530 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127232 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56971 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19049 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->