### PR TITLE
[JSC] Clean up after JSValueRegs removal

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -3343,14 +3343,14 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             if (Options::useJITCage()) {
                 jit.setupArguments<GetValueFuncWithPtr>(
                     CCallHelpers::TrustedImmPtr(globalObject),
-                    CCallHelpers::CellValue(baseForCustom),
+                    baseForCustom,
                     CCallHelpers::TrustedImmPtr(accessCase.uid()),
                     CCallHelpers::TrustedImmPtr(customAccessor.taggedPtr()));
                 jit.callOperation<OperationPtrTag>(vmEntryCustomGetter);
             } else {
                 jit.setupArguments<GetValueFunc>(
                     CCallHelpers::TrustedImmPtr(globalObject),
-                    CCallHelpers::CellValue(baseForCustom),
+                    baseForCustom,
                     CCallHelpers::TrustedImmPtr(accessCase.uid()));
                 jit.callOperation<CustomAccessorPtrTag>(customAccessor);
             }
@@ -3359,7 +3359,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             if (Options::useJITCage()) {
                 jit.setupArguments<PutValueFuncWithPtr>(
                     CCallHelpers::TrustedImmPtr(globalObject),
-                    CCallHelpers::CellValue(baseForCustom),
+                    baseForCustom,
                     valueGPR,
                     CCallHelpers::TrustedImmPtr(accessCase.uid()),
                     CCallHelpers::TrustedImmPtr(customAccessor.taggedPtr()));
@@ -3367,7 +3367,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             } else {
                 jit.setupArguments<PutValueFunc>(
                     CCallHelpers::TrustedImmPtr(globalObject),
-                    CCallHelpers::CellValue(baseForCustom),
+                    baseForCustom,
                     valueGPR,
                     CCallHelpers::TrustedImmPtr(accessCase.uid()));
                 jit.callOperation<CustomAccessorPtrTag>(customAccessor);
@@ -3535,9 +3535,9 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
         jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + LowWordOffset));
 
-        jit.storeCell(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
+        jit.storeValue(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 
-        jit.storeCell(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
+        jit.storeValue(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
 
         if (!isGetter)
             jit.storeValue(valueGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
@@ -4190,7 +4190,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + LowWordOffset));
 
-    jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
+    jit.storeValue(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
 
     if (!hasConstantIdentifier(m_propertyCache.accessType))
         jit.storeValue(m_propertyCache.propertyGPR(), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
@@ -4203,11 +4203,11 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         break;
     case AccessCase::ProxyObjectLoad:
     case AccessCase::IndexedProxyObjectLoad:
-        jit.storeCell(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
+        jit.storeValue(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
         break;
     case AccessCase::ProxyObjectStore:
     case AccessCase::IndexedProxyObjectStore:
-        jit.storeCell(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
+        jit.storeValue(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
         jit.storeValue(valueGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(3).offset() * sizeof(Register)));
         break;
     default:
@@ -4273,7 +4273,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    jit.storeCell(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
+    jit.storeValue(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 
     if (useHandlerIC()) {
         // handlerGPR can be the same to BaselineJITRegisters::Call::calleeGPR.
@@ -5339,10 +5339,10 @@ static void customGetterHandlerImpl(VM& vm, CCallHelpers& jit, GPRReg baseGPR, G
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch2GPR);
     if (Options::useJITCage()) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), scratch3GPR);
-        jit.setupArguments<GetValueFuncWithPtr>(scratch1GPR, CCallHelpers::CellValue(baseGPR), scratch2GPR, scratch3GPR);
+        jit.setupArguments<GetValueFuncWithPtr>(scratch1GPR, baseGPR, scratch2GPR, scratch3GPR);
         jit.callOperation<OperationPtrTag>(vmEntryCustomGetter);
     } else {
-        jit.setupArguments<GetValueFunc>(scratch1GPR, CCallHelpers::CellValue(baseGPR), scratch2GPR);
+        jit.setupArguments<GetValueFunc>(scratch1GPR, baseGPR, scratch2GPR);
         jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), CustomAccessorPtrTag);
     }
     jit.setupResults(resultGPR);
@@ -5415,8 +5415,8 @@ static void getterCallFromGetterSetterImpl(CCallHelpers& jit, GPRReg baseGPR, [[
     jit.subPtr(CCallHelpers::TrustedImm32(alignedNumberOfBytesForCall), CCallHelpers::stackPointerRegister);
     CCallHelpers::Address calleeFrame = CCallHelpers::Address(CCallHelpers::stackPointerRegister, -static_cast<ptrdiff_t>(sizeof(CallerFrameAndPC)));
     jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + LowWordOffset));
-    jit.storeCell(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
-    jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
+    jit.storeValue(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
+    jit.storeValue(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
 
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeGPR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeGPR) {
@@ -5552,12 +5552,12 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler()
     jit.subPtr(CCallHelpers::TrustedImm32(alignedNumberOfBytesForCall), CCallHelpers::stackPointerRegister);
     CCallHelpers::Address calleeFrame = CCallHelpers::Address(CCallHelpers::stackPointerRegister, -static_cast<ptrdiff_t>(sizeof(CallerFrameAndPC)));
     jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + LowWordOffset));
-    jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
+    jit.storeValue(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
     jit.transferPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
-    jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
+    jit.storeValue(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
     jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratch1GPR);
     jit.loadPtr(CCallHelpers::Address(scratch1GPR, JSGlobalObject::offsetOfPerformProxyObjectGetFunction()), scratch1GPR);
-    jit.storeCell(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
+    jit.storeValue(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeGPR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeGPR) {
@@ -5843,10 +5843,10 @@ static void customSetterHandlerImpl(VM& vm, CCallHelpers& jit, GPRReg baseGPR, G
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch2GPR);
     if (Options::useJITCage()) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), scratch3GPR);
-        jit.setupArguments<PutValueFuncWithPtr>(scratch1GPR, CCallHelpers::CellValue(baseGPR), valueGPR, scratch2GPR, scratch3GPR);
+        jit.setupArguments<PutValueFuncWithPtr>(scratch1GPR, baseGPR, valueGPR, scratch2GPR, scratch3GPR);
         jit.callOperation<OperationPtrTag>(vmEntryCustomSetter);
     } else {
-        jit.setupArguments<PutValueFunc>(scratch1GPR, CCallHelpers::CellValue(baseGPR), valueGPR, scratch2GPR);
+        jit.setupArguments<PutValueFunc>(scratch1GPR, baseGPR, valueGPR, scratch2GPR);
         jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), CustomAccessorPtrTag);
     }
 
@@ -5944,8 +5944,8 @@ static void setterHandlerImpl(CCallHelpers& jit, GPRReg baseGPR, GPRReg valueGPR
     jit.subPtr(CCallHelpers::TrustedImm32(alignedNumberOfBytesForCall), CCallHelpers::stackPointerRegister);
     CCallHelpers::Address calleeFrame = CCallHelpers::Address(CCallHelpers::stackPointerRegister, -static_cast<ptrdiff_t>(sizeof(CallerFrameAndPC)));
     jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + LowWordOffset));
-    jit.storeCell(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
-    jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
+    jit.storeValue(scratch1GPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
+    jit.storeValue(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
     jit.storeValue(valueGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
 
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeGPR.

--- a/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
@@ -66,7 +66,7 @@ public:
                 break;
             }
         }
-        m_badIndexingTypeJump = jit->speculationCheck(BadIndexingType, JSValueSource::unboxedCell(m_baseGPR), nullptr);
+        m_badIndexingTypeJump = jit->speculationCheck(BadIndexingType, JSValueSource(m_baseGPR), nullptr);
     }
     
 private:

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -135,7 +135,7 @@ void OSRExit::emitRestoreArguments(CCallHelpers& jit, VM& vm, const Operands<Val
             break;
         }
         jit.call(GPRInfo::nonArgGPR0, OperationPtrTag);
-        jit.storeCell(GPRInfo::returnValueGPR, AssemblyHelpers::addressFor(operand));
+        jit.storeValue(GPRInfo::returnValueGPR, AssemblyHelpers::addressFor(operand));
 
         alreadyAllocatedArguments.add(id, operand.virtualRegister());
     }

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -404,7 +404,7 @@ void reifyInlinedCallFrames(CCallHelpers& jit, const OSRExitBase& exit)
         uint32_t locationBits = CallSiteIndex(exitIndex).bits();
         jit.store32(AssemblyHelpers::TrustedImm32(locationBits), AssemblyHelpers::highWordFor(VirtualRegister(inlineCallFrame->stackOffset + CallFrameSlot::argumentCountIncludingThis)));
         if (!inlineCallFrame->isClosureCall)
-            jit.storeCell(AssemblyHelpers::TrustedImmPtr(inlineCallFrame->calleeConstant()), AssemblyHelpers::addressFor(VirtualRegister(inlineCallFrame->stackOffset + CallFrameSlot::callee)));
+            jit.storeTrustedValue(JSValue(inlineCallFrame->calleeConstant()), AssemblyHelpers::addressFor(VirtualRegister(inlineCallFrame->stackOffset + CallFrameSlot::callee)));
     }
 
     // Don't need to set the toplevel code origin if we only did inline tail calls

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1085,7 +1085,7 @@ void SpeculativeJIT::checkArray(Node* node)
     case Array::SlowPutArrayStorage: {
         load8(Address(baseReg, JSCell::indexingTypeAndMiscOffset()), tempGPR.value());
         speculationCheck(
-            BadIndexingType, JSValueSource::unboxedCell(baseReg), nullptr,
+            BadIndexingType, JSValueSource(baseReg), nullptr,
             jumpSlowForUnwantedArrayMode(tempGPR.value(), arrayMode));
         break;
     }
@@ -1099,7 +1099,7 @@ void SpeculativeJIT::checkArray(Node* node)
         DFG_ASSERT(m_graph, node, arrayMode.isSomeTypedArrayView());
 
         if (arrayMode.type() == Array::AnyTypedArray)
-            speculationCheck(BadType, JSValueSource::unboxedCell(baseReg), nullptr, branchIfNotType(baseReg, JSTypeRange { JSType(FirstTypedArrayType), JSType(LastTypedArrayTypeExcludingDataView) }));
+            speculationCheck(BadType, JSValueSource(baseReg), nullptr, branchIfNotType(baseReg, JSTypeRange { JSType(FirstTypedArrayType), JSType(LastTypedArrayTypeExcludingDataView) }));
         else
             speculateCellTypeWithoutTypeFiltering(node->child1(), baseReg, typeForTypedArrayType(arrayMode.typedArrayType()));
         break;
@@ -1440,19 +1440,19 @@ void SpeculativeJIT::compilePeepHoleObjectEquality(Node* node, Node* branchNode)
     if (masqueradesAsUndefinedWatchpointSetIsStillValid()) {
         if (m_state.forNode(node->child1()).m_type & ~SpecObject) {
             speculationCheck(
-                BadType, JSValueSource::unboxedCell(op1GPR), node->child1(), branchIfNotObject(op1GPR));
+                BadType, JSValueSource(op1GPR), node->child1(), branchIfNotObject(op1GPR));
         }
         if (m_state.forNode(node->child2()).m_type & ~SpecObject) {
             speculationCheck(
-                BadType, JSValueSource::unboxedCell(op2GPR), node->child2(), branchIfNotObject(op2GPR));
+                BadType, JSValueSource(op2GPR), node->child2(), branchIfNotObject(op2GPR));
         }
     } else {
         if (m_state.forNode(node->child1()).m_type & ~SpecObject) {
             speculationCheck(
-                BadType, JSValueSource::unboxedCell(op1GPR), node->child1(),
+                BadType, JSValueSource(op1GPR), node->child1(),
                 branchIfNotObject(op1GPR));
         }
-        speculationCheck(BadType, JSValueSource::unboxedCell(op1GPR), node->child1(),
+        speculationCheck(BadType, JSValueSource(op1GPR), node->child1(),
             branchTest8(
                 NonZero,
                 Address(op1GPR, JSCell::typeInfoFlagsOffset()),
@@ -1460,10 +1460,10 @@ void SpeculativeJIT::compilePeepHoleObjectEquality(Node* node, Node* branchNode)
 
         if (m_state.forNode(node->child2()).m_type & ~SpecObject) {
             speculationCheck(
-                BadType, JSValueSource::unboxedCell(op2GPR), node->child2(),
+                BadType, JSValueSource(op2GPR), node->child2(),
                 branchIfNotObject(op2GPR));
         }
-        speculationCheck(BadType, JSValueSource::unboxedCell(op2GPR), node->child2(),
+        speculationCheck(BadType, JSValueSource(op2GPR), node->child2(),
             branchTest8(
                 NonZero,
                 Address(op2GPR, JSCell::typeInfoFlagsOffset()),
@@ -2087,7 +2087,7 @@ void SpeculativeJIT::compileCheckDetached(Node* node)
     GPRReg baseReg = base.gpr();
 
     speculationCheck(
-        BadIndexingType, JSValueSource::unboxedCell(baseReg), node->child1(), 
+        BadIndexingType, JSValueSource(baseReg), node->child1(),
         branchTestPtr(Zero, Address(baseReg, JSArrayBufferView::offsetOfVector())));
 
     noResult(node);
@@ -3177,7 +3177,7 @@ JITCompiler::Jump SpeculativeJIT::jumpForTypedArrayOutOfBounds(Node* node, GPRRe
     }
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(edge)))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 
 #if USE(LARGE_TYPED_ARRAYS)
     signExtend32ToPtr(indexGPR, scratchGPR);
@@ -7210,21 +7210,21 @@ void SpeculativeJIT::compileObjectEquality(Node* node)
 
     if (masqueradesAsUndefinedWatchpointSetIsStillValid()) {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), node->child1(), SpecObject, branchIfNotObject(op1GPR));
+            JSValueSource(op1GPR), node->child1(), SpecObject, branchIfNotObject(op1GPR));
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op2GPR), node->child2(), SpecObject, branchIfNotObject(op2GPR));
+            JSValueSource(op2GPR), node->child2(), SpecObject, branchIfNotObject(op2GPR));
     } else {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), node->child1(), SpecObject, branchIfNotObject(op1GPR));
-        speculationCheck(BadType, JSValueSource::unboxedCell(op1GPR), node->child1(),
+            JSValueSource(op1GPR), node->child1(), SpecObject, branchIfNotObject(op1GPR));
+        speculationCheck(BadType, JSValueSource(op1GPR), node->child1(),
             branchTest8(
                 NonZero,
                 Address(op1GPR, JSCell::typeInfoFlagsOffset()),
                 TrustedImm32(MasqueradesAsUndefined)));
 
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op2GPR), node->child2(), SpecObject, branchIfNotObject(op2GPR));
-        speculationCheck(BadType, JSValueSource::unboxedCell(op2GPR), node->child2(),
+            JSValueSource(op2GPR), node->child2(), SpecObject, branchIfNotObject(op2GPR));
+        speculationCheck(BadType, JSValueSource(op2GPR), node->child2(),
             branchTest8(
                 NonZero,
                 Address(op2GPR, JSCell::typeInfoFlagsOffset()),
@@ -7897,7 +7897,7 @@ void SpeculativeJIT::compileGetTypedArrayByteOffset(Node* node)
 
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 
 #if USE(LARGE_TYPED_ARRAYS)
     load64(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
@@ -8237,7 +8237,7 @@ void SpeculativeJIT::compileGetArrayLength(Node* node)
         GPRReg resultGPR = result.gpr();
 
         if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-            speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+            speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
         load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), resultGPR);
         speculationCheck(ExitKind::Overflow, JSValueSource(), nullptr, branch64(Above, resultGPR, TrustedImm64(std::numeric_limits<int32_t>::max())));
@@ -8263,7 +8263,7 @@ void SpeculativeJIT::compileDataViewGetByteLength(Node* node)
         speculateDataViewObject(node->child1(), baseGPR);
 
         auto [outOfBounds, doneCases] = loadDataViewByteLength(baseGPR, resultGPR, scratch1GPR, resultGPR, TypeDataView);
-        speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), node, outOfBounds);
+        speculationCheck(OutOfBounds, JSValueSource(baseGPR), node, outOfBounds);
         doneCases.link(this);
 
         speculationCheck(ExitKind::Overflow, JSValueSource(), nullptr, branch64(Above, resultGPR, TrustedImm64(std::numeric_limits<int32_t>::max())));
@@ -8279,7 +8279,7 @@ void SpeculativeJIT::compileDataViewGetByteLength(Node* node)
     speculateDataViewObject(node->child1(), baseGPR);
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
     load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), resultGPR);
     speculationCheck(ExitKind::Overflow, JSValueSource(), nullptr, branch64(Above, resultGPR, TrustedImm64(std::numeric_limits<int32_t>::max())));
@@ -9446,7 +9446,7 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
         if (bitVector->get(i)) {
             SpeculateCellOperand immutableButterfly(this, use);
             GPRReg immutableButterflyGPR = immutableButterfly.gpr();
-            storeCell(immutableButterflyGPR, &buffer[i]);
+            storeValue(immutableButterflyGPR, &buffer[i]);
         } else {
             JSValueOperand input(this, use);
             GPRReg inputGPR = input.gpr();
@@ -10562,7 +10562,7 @@ void SpeculativeJIT::emitStructureCheck(Node* node, GPRReg cellGPR, GPRReg tempG
     
     if (node->structureSet().size() == 1) {
         speculationCheck(
-            BadCache, JSValueSource::unboxedCell(cellGPR), nullptr,
+            BadCache, JSValueSource(cellGPR), nullptr,
             branchWeakStructure(
                 NotEqual,
                 Address(cellGPR, JSCell::structureIDOffset()),
@@ -10587,7 +10587,7 @@ void SpeculativeJIT::emitStructureCheck(Node* node, GPRReg cellGPR, GPRReg tempG
         }
         
         speculationCheck(
-            BadCache, JSValueSource::unboxedCell(cellGPR), nullptr,
+            BadCache, JSValueSource(cellGPR), nullptr,
             branchWeakStructure(
                 NotEqual, structureGPR, node->structureSet().last()));
         
@@ -10599,7 +10599,7 @@ void SpeculativeJIT::compileCheckIsConstant(Node* node)
 {
     if (node->child1().useKind() == CellUse) {
         SpeculateCellOperand cell(this, node->child1());
-        speculationCheck(BadConstantValue, JSValueSource::unboxedCell(cell.gpr()), node->child1(), branchLinkableConstant(NotEqual, cell.gpr(), LinkableConstant(*this, node->cellOperand()->cell())));
+        speculationCheck(BadConstantValue, JSValueSource(cell.gpr()), node->child1(), branchLinkableConstant(NotEqual, cell.gpr(), LinkableConstant(*this, node->cellOperand()->cell())));
     } else {
         ASSERT(!node->constant()->value().isCell() || !node->constant()->value());
         JSValueOperand operand(this, node->child1());
@@ -10895,10 +10895,10 @@ void SpeculativeJIT::compileCallDOMGetter(Node* node)
         storePtr(GPRInfo::callFrameRegister, &vm().topCallFrame);
         emitStoreCodeOrigin(m_currentNode->origin.semantic);
         if (Options::useJITCage())
-            callOperation(vmEntryCustomGetter, resultGPR, LinkableConstant::globalObject(*this, node), CellValue(baseGPR), TrustedImmPtr(identifierUID(node->callDOMGetterData()->identifierNumber)), TrustedImmPtr(getter.taggedPtr()));
+            callOperation(vmEntryCustomGetter, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, TrustedImmPtr(identifierUID(node->callDOMGetterData()->identifierNumber)), TrustedImmPtr(getter.taggedPtr()));
         else {
             CodePtr<OperationPtrTag> bypassedFunction(WTF::tagNativeCodePtrImpl<OperationPtrTag>(WTF::untagNativeCodePtrImpl<CustomAccessorPtrTag>(getter.taggedPtr())));
-            callOperation<J_JITOperation_GJI>(bypassedFunction, resultGPR, LinkableConstant::globalObject(*this, node), CellValue(baseGPR), TrustedImmPtr(identifierUID(node->callDOMGetterData()->identifierNumber)));
+            callOperation<J_JITOperation_GJI>(bypassedFunction, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, TrustedImmPtr(identifierUID(node->callDOMGetterData()->identifierNumber)));
         }
 
         jsValueResult(resultGPR, node);
@@ -10944,7 +10944,7 @@ void SpeculativeJIT::compileCheckJSCast(Node* node)
             checkFailed = branchIfNotType(baseGPR, classInfo->inheritsJSTypeRange.value());
         else
             checkFailed = branchIfType(baseGPR, classInfo->inheritsJSTypeRange.value());
-        speculationCheck(BadType, JSValueSource::unboxedCell(baseGPR), node->child1(), checkFailed);
+        speculationCheck(BadType, JSValueSource(baseGPR), node->child1(), checkFailed);
         noResult(node);
         return;
     }
@@ -10967,11 +10967,11 @@ void SpeculativeJIT::compileCheckJSCast(Node* node)
         loadPtr(Address(otherGPR, ClassInfo::offsetOfParentClass()), otherGPR);
         branchTestPtr(NonZero, otherGPR).linkTo(loop, this);
         if (node->op() == CheckJSCast) {
-            speculationCheck(BadType, JSValueSource::unboxedCell(baseGPR), node->child1(), jump());
+            speculationCheck(BadType, JSValueSource(baseGPR), node->child1(), jump());
             found.link(this);
         } else {
             auto notFound = jump();
-            speculationCheck(BadType, JSValueSource::unboxedCell(baseGPR), node->child1(), found);
+            speculationCheck(BadType, JSValueSource(baseGPR), node->child1(), found);
             notFound.link(this);
         }
         noResult(node);
@@ -10995,9 +10995,9 @@ void SpeculativeJIT::compileCheckJSCast(Node* node)
     SnippetParams params(this, WTF::move(regs), WTF::move(gpScratch), WTF::move(fpScratch));
     JumpList failureCases = snippet->generator()->run(*this, params);
     if (node->op() == CheckJSCast)
-        speculationCheck(BadType, JSValueSource::unboxedCell(baseGPR), node->child1(), failureCases);
+        speculationCheck(BadType, JSValueSource(baseGPR), node->child1(), failureCases);
     else {
-        speculationCheck(BadType, JSValueSource::unboxedCell(baseGPR), node->child1(), jump());
+        speculationCheck(BadType, JSValueSource(baseGPR), node->child1(), jump());
         failureCases.link(this);
     }
     noResult(node);
@@ -11196,7 +11196,7 @@ void SpeculativeJIT::compileToStringOrCallStringConstructorOrStringValueOf(Node*
 
         load8(Address(op1GPR, JSCell::typeInfoTypeOffset()), resultGPR);
         Jump isString = branch32(Equal, resultGPR, TrustedImm32(StringType));
-        DFG_TYPE_CHECK(JSValueSource::unboxedCell(op1GPR), node->child1(), (SpecString | SpecStringObject), branch32(NotEqual, resultGPR, TrustedImm32(StringObjectType)));
+        DFG_TYPE_CHECK(JSValueSource(op1GPR), node->child1(), (SpecString | SpecStringObject), branch32(NotEqual, resultGPR, TrustedImm32(StringObjectType)));
         loadPtr(Address(op1GPR, JSWrapperObject::internalValueCellOffset()), resultGPR);
         Jump done = jump();
 
@@ -11394,7 +11394,7 @@ void SpeculativeJIT::compileNewStringObject(Node* node)
         resultGPR, TrustedImmPtr(node->structure()), butterfly, scratch1GPR, scratch2GPR,
         slowPath, SlowAllocationResult::UndefinedBehavior);
     
-    storeCell(operandGPR, Address(resultGPR, JSWrapperObject::internalValueOffset()));
+    storeValue(operandGPR, Address(resultGPR, JSWrapperObject::internalValueOffset()));
 
     mutatorFence(vm());
     
@@ -11727,7 +11727,7 @@ void SpeculativeJIT::speculateCellTypeWithoutTypeFiltering(
     Edge edge, GPRReg cellGPR, JSType jsType)
 {
     speculationCheck(
-        BadType, JSValueSource::unboxedCell(cellGPR), edge,
+        BadType, JSValueSource(cellGPR), edge,
         branchIfNotType(cellGPR, jsType));
 }
 
@@ -11735,7 +11735,7 @@ void SpeculativeJIT::speculateCellType(
     Edge edge, GPRReg cellGPR, SpeculatedType specType, JSType jsType)
 {
     DFG_TYPE_CHECK(
-        JSValueSource::unboxedCell(cellGPR), edge, specType,
+        JSValueSource(cellGPR), edge, specType,
         branchIfNotType(cellGPR, jsType));
 }
 
@@ -11827,7 +11827,7 @@ void SpeculativeJIT::speculateCellOrOther(Edge edge)
 
 void SpeculativeJIT::speculateObject(Edge edge, GPRReg cell)
 {
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(cell), edge, SpecObject, branchIfNotObject(cell));
+    DFG_TYPE_CHECK(JSValueSource(cell), edge, SpecObject, branchIfNotObject(cell));
 }
 
 void SpeculativeJIT::speculateObject(Edge edge)
@@ -12100,7 +12100,7 @@ void SpeculativeJIT::speculateObjectOrOther(Edge edge)
 void SpeculativeJIT::speculateString(Edge edge, GPRReg cell)
 {
     DFG_TYPE_CHECK(
-        JSValueSource::unboxedCell(cell), edge, SpecString | ~SpecCellCheck, branchIfNotString(cell));
+        JSValueSource(cell), edge, SpecString | ~SpecCellCheck, branchIfNotString(cell));
 }
 
 void SpeculativeJIT::speculateStringOrOther(Edge edge, GPRReg valueGPR, GPRReg scratch)
@@ -12133,7 +12133,7 @@ void SpeculativeJIT::speculateStringIdentAndLoadStorage(Edge edge, GPRReg string
     if (!needsTypeCheck(edge, SpecStringIdent | ~SpecString))
         return;
 
-    speculationCheck(BadStringType, JSValueSource::unboxedCell(string), edge, branchIfNotAtomStringImpl(string, storage, canBeRope(edge)));
+    speculationCheck(BadStringType, JSValueSource(string), edge, branchIfNotAtomStringImpl(string, storage, canBeRope(edge)));
 
     m_interpreter.filter(edge, SpecStringIdent | ~SpecString);
 }
@@ -12169,7 +12169,7 @@ void SpeculativeJIT::speculateString(Edge edge)
 
 void SpeculativeJIT::speculateStringObject(Edge edge, GPRReg cellGPR)
 {
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(cellGPR), edge, ~SpecCellCheck | SpecStringObject, branchIfNotType(cellGPR, StringObjectType));
+    DFG_TYPE_CHECK(JSValueSource(cellGPR), edge, ~SpecCellCheck | SpecStringObject, branchIfNotType(cellGPR, StringObjectType));
 }
 
 void SpeculativeJIT::speculateStringObject(Edge edge)
@@ -12198,7 +12198,7 @@ void SpeculativeJIT::speculateStringOrStringObject(Edge edge)
     load8(Address(gpr, JSCell::typeInfoTypeOffset()), typeGPR);
 
     Jump isString = branch32(Equal, typeGPR, TrustedImm32(StringType));
-    speculationCheck(BadType, JSValueSource::unboxedCell(gpr), edge.node(), branch32(NotEqual, typeGPR, TrustedImm32(StringObjectType)));
+    speculationCheck(BadType, JSValueSource(gpr), edge.node(), branch32(NotEqual, typeGPR, TrustedImm32(StringObjectType)));
     isString.link(this);
     
     m_interpreter.filter(edge, SpecString | SpecStringObject);
@@ -12235,7 +12235,7 @@ void SpeculativeJIT::speculateNotSymbol(Edge edge)
     if (needsCellCheck)
         notCell = branchIfNotCell(valueGPR);
 
-    speculationCheck(BadType, JSValueSource::unboxedCell(value), edge.node(), branchIfSymbol(value));
+    speculationCheck(BadType, JSValueSource(value), edge.node(), branchIfSymbol(value));
 
     if (needsCellCheck)
         notCell.link(this);
@@ -12245,7 +12245,7 @@ void SpeculativeJIT::speculateNotSymbol(Edge edge)
 
 void SpeculativeJIT::speculateSymbol(Edge edge, GPRReg cell)
 {
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(cell), edge, ~SpecCellCheck | SpecSymbol, branchIfNotSymbol(cell));
+    DFG_TYPE_CHECK(JSValueSource(cell), edge, ~SpecCellCheck | SpecSymbol, branchIfNotSymbol(cell));
 }
 
 void SpeculativeJIT::speculateSymbol(Edge edge)
@@ -12259,7 +12259,7 @@ void SpeculativeJIT::speculateSymbol(Edge edge)
 
 void SpeculativeJIT::speculateHeapBigInt(Edge edge, GPRReg cell)
 {
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(cell), edge, ~SpecCellCheck | SpecHeapBigInt, branchIfNotHeapBigInt(cell));
+    DFG_TYPE_CHECK(JSValueSource(cell), edge, ~SpecCellCheck | SpecHeapBigInt, branchIfNotHeapBigInt(cell));
 }
 
 void SpeculativeJIT::speculateHeapBigInt(Edge edge)
@@ -13627,7 +13627,7 @@ void SpeculativeJIT::compileStringReplace(Node* node)
 
         flushRegisters();
         GPRFlushedCallResult result(this);
-        callOperation(node->op() == StringReplaceAll ? operationStringProtoFuncReplaceAllGeneric : operationStringProtoFuncReplaceGeneric, result.gpr(), LinkableConstant::globalObject(*this, node), stringGPR, CellValue(searchGPR), replaceGPR);
+        callOperation(node->op() == StringReplaceAll ? operationStringProtoFuncReplaceAllGeneric : operationStringProtoFuncReplaceGeneric, result.gpr(), LinkableConstant::globalObject(*this, node), stringGPR, searchGPR, replaceGPR);
         cellResult(result.gpr(), node);
         break;
     }
@@ -14811,7 +14811,7 @@ void SpeculativeJIT::compileEnumeratorHasProperty(Node* node, SlowPathFunctionTy
 
         operationCases.link(this);
 
-        callOperation(slowPathFunction, resultGPR, LinkableConstant::globalObject(*this, node), CellValue(baseGPR), propertyNameGPR, indexGPR, modeGPR);
+        callOperation(slowPathFunction, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, propertyNameGPR, indexGPR, modeGPR);
 
         done.link(this);
 
@@ -15084,7 +15084,7 @@ void SpeculativeJIT::compileGetCallee(Node* node)
 void SpeculativeJIT::compileSetCallee(Node* node)
 {
     SpeculateCellOperand callee(this, node->child1());
-    storeCell(callee.gpr(), lowWordFor(CallFrameSlot::callee));
+    storeValue(callee.gpr(), lowWordFor(CallFrameSlot::callee));
     noResult(node);
 }
 
@@ -17475,7 +17475,7 @@ void SpeculativeJIT::compileEnumeratorGetByVal(Node* node)
         ASSERT(generationInfo(node).gpr() == resultGPR && generationInfo(node).registerFormat() == DataFormatJS);
 
         if (!recoverGenericCase.empty()) {
-            addSlowPathGenerator(slowPathCall(recoverGenericCase, this, operationEnumeratorRecoverNameAndGetByVal, resultGPR, LinkableConstant::globalObject(*this, node), CellValue(baseGPR), indexGPR, enumeratorGPR));
+            addSlowPathGenerator(slowPathCall(recoverGenericCase, this, operationEnumeratorRecoverNameAndGetByVal, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, indexGPR, enumeratorGPR));
         }
 
         doneCases.link(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1778,7 +1778,7 @@ void SpeculativeJIT::compileObjectStrictEquality(Edge objectChild, Edge otherChi
     GPRReg op2GPR = op2.gpr();
     GPRReg resultGPR = result.gpr();
 
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(op1GPR), objectChild, SpecObject, branchIfNotObject(op1GPR));
+    DFG_TYPE_CHECK(JSValueSource(op1GPR), objectChild, SpecObject, branchIfNotObject(op1GPR));
 
     // At this point we know that we can perform a straight-forward equality comparison on pointer
     // values because we are doing strict equality.
@@ -1798,7 +1798,7 @@ void SpeculativeJIT::compilePeepHoleObjectStrictEquality(Edge objectChild, Edge 
     GPRReg op1GPR = op1.gpr();
     GPRReg op2GPR = op2.gpr();
     
-    DFG_TYPE_CHECK(JSValueSource::unboxedCell(op1GPR), objectChild, SpecObject, branchIfNotObject(op1GPR));
+    DFG_TYPE_CHECK(JSValueSource(op1GPR), objectChild, SpecObject, branchIfNotObject(op1GPR));
 
     if (taken == nextBlock()) {
         branchPtr(NotEqual, op1GPR, op2GPR, notTaken);
@@ -1824,11 +1824,11 @@ void SpeculativeJIT::compileObjectToObjectOrOtherEquality(Edge leftChild, Edge r
 
     if (masqueradesAsUndefinedWatchpointSetValid) {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
+            JSValueSource(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
     } else {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
-        speculationCheck(BadType, JSValueSource::unboxedCell(op1GPR), leftChild,
+            JSValueSource(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
+        speculationCheck(BadType, JSValueSource(op1GPR), leftChild,
             branchTest8(
                 NonZero,
                 Address(op1GPR, JSCell::typeInfoFlagsOffset()),
@@ -1897,11 +1897,11 @@ void SpeculativeJIT::compilePeepHoleObjectToObjectOrOtherEquality(Edge leftChild
 
     if (masqueradesAsUndefinedWatchpointSetValid) {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
+            JSValueSource(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
     } else {
         DFG_TYPE_CHECK(
-            JSValueSource::unboxedCell(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
-        speculationCheck(BadType, JSValueSource::unboxedCell(op1GPR), leftChild, 
+            JSValueSource(op1GPR), leftChild, SpecObject, branchIfNotObject(op1GPR));
+        speculationCheck(BadType, JSValueSource(op1GPR), leftChild,
             branchTest8(
                 NonZero,
                 Address(op1GPR, JSCell::typeInfoFlagsOffset()),
@@ -3207,7 +3207,7 @@ void SpeculativeJIT::compileDataViewGetByteLengthAsInt52(Node* node)
         speculateDataViewObject(node->child1(), baseGPR);
 
         auto [outOfBounds, doneCases] = loadDataViewByteLength(baseGPR, resultGPR, scratch1GPR, resultGPR, TypeDataView);
-        speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), node, outOfBounds);
+        speculationCheck(OutOfBounds, JSValueSource(baseGPR), node, outOfBounds);
         doneCases.link(this);
 
         strictInt52Result(resultGPR, node);
@@ -3222,7 +3222,7 @@ void SpeculativeJIT::compileDataViewGetByteLengthAsInt52(Node* node)
     speculateDataViewObject(node->child1(), baseGPR);
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
     load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), resultGPR);
     static_assert(MAX_ARRAY_BUFFER_SIZE < (1ull << 52), "there is a risk that the size of a array buffer won't fit in an Int52");
     strictInt52Result(resultGPR, node);
@@ -3253,7 +3253,7 @@ void SpeculativeJIT::compileGetTypedArrayLengthAsInt52(Node* node)
     GPRReg resultGPR = result.gpr();
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
     load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), resultGPR);
     static_assert(MAX_ARRAY_BUFFER_SIZE < (1ull << 52), "there is a risk that the size of a typed array won't fit in an Int52");
     strictInt52Result(resultGPR, node);
@@ -3290,7 +3290,7 @@ void SpeculativeJIT::compileGetTypedArrayByteOffsetAsInt52(Node* node)
     GPRReg resultGPR = result.gpr();
 
     if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+        speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 
     load64(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
     strictInt52Result(resultGPR, node);
@@ -6362,7 +6362,7 @@ void SpeculativeJIT::compile(Node* node)
             loadTypedArrayLength(dataViewGPR, t1, t2, t1, TypeDataView);
         else {
             if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(node->child1())))
-                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(dataViewGPR), node, branchTest8(NonZero, Address(dataViewGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(dataViewGPR), node, branchTest8(NonZero, Address(dataViewGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
             load64(Address(dataViewGPR, JSArrayBufferView::offsetOfLength()), t1);
 #else
@@ -6659,7 +6659,7 @@ void SpeculativeJIT::compile(Node* node)
             loadTypedArrayLength(dataViewGPR, t1, t2, t1, TypeDataView);
         else {
             if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(m_graph.varArgChild(node, 0))))
-                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(dataViewGPR), node, branchTest8(NonZero, Address(dataViewGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(dataViewGPR), node, branchTest8(NonZero, Address(dataViewGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
             load64(Address(dataViewGPR, JSArrayBufferView::offsetOfLength()), t1);
 #else
@@ -8008,7 +8008,7 @@ void SpeculativeJIT::compilePutPrivateName(Node* node)
 
         flushRegisters();
         auto operation = node->privateFieldPutKind().isDefine() ? operationPutByValDefinePrivateFieldGeneric : operationPutByValSetPrivateFieldGeneric;
-        callOperation(operation, LinkableConstant::globalObject(*this, node), baseGPR, CellValue(propertyGPR), valueGPR);
+        callOperation(operation, LinkableConstant::globalObject(*this, node), baseGPR, propertyGPR, valueGPR);
 
         noResult(node);
         return;
@@ -8729,7 +8729,7 @@ void SpeculativeJIT::compileEnumeratorPutByVal(Node* node)
         }
 
         if (!recoverGenericCase.empty()) {
-            addSlowPathGenerator(slowPathCall(recoverGenericCase, this, operationEnumeratorRecoverNameAndPutByVal, NoResult, LinkableConstant::globalObject(*this, node), CellValue(baseGPR), valueGPR, TrustedImm32(ecmaMode.isStrict()), indexGPR, enumeratorGPR));
+            addSlowPathGenerator(slowPathCall(recoverGenericCase, this, operationEnumeratorRecoverNameAndPutByVal, NoResult, LinkableConstant::globalObject(*this, node), baseGPR, valueGPR, TrustedImm32(ecmaMode.isStrict()), indexGPR, enumeratorGPR));
         }
 
         doneCases.link(this);
@@ -9559,7 +9559,7 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
             Jump outOfBounds = branch32(AboveOrEqual, indexGPR, Address(scratch2GPR, Butterfly::offsetOfPublicLength()));
 
             if (arrayMode.isInBounds()) {
-                speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), nullptr, outOfBounds);
+                speculationCheck(OutOfBounds, JSValueSource(baseGPR), nullptr, outOfBounds);
 
                 if (expectedType == ArrayWithDouble) {
                     loadDouble(BaseIndex(scratch2GPR, indexGPR, TimesEight), resultFPR);
@@ -9572,7 +9572,7 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
                             moveConditionallyDouble(DoubleNotEqualOrUnordered, resultFPR, resultFPR, scratch1GPR, resultGPR, resultGPR);
                         }
                     } else {
-                        speculationCheck(LoadFromHole, JSValueSource::unboxedCell(baseGPR), nullptr, branchIfNaN(resultFPR));
+                        speculationCheck(LoadFromHole, JSValueSource(baseGPR), nullptr, branchIfNaN(resultFPR));
                         if (!node->hasDoubleResult())
                             boxDouble(resultFPR, resultGPR);
                     }
@@ -9582,7 +9582,7 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
                         move(TrustedImm64(JSValue::encode(jsUndefined())), scratch1GPR);
                         moveConditionally64(Equal, resultGPR, TrustedImm32(0), scratch1GPR, resultGPR, resultGPR);
                     } else
-                        speculationCheck(LoadFromHole, JSValueSource::unboxedCell(baseGPR), nullptr, branchIfEmpty(resultGPR));
+                        speculationCheck(LoadFromHole, JSValueSource(baseGPR), nullptr, branchIfEmpty(resultGPR));
                 }
                 doneCases.append(jump());
                 return;
@@ -9632,7 +9632,7 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
 
         if (!arrayMode.mayBeResizableOrGrowableSharedTypedArray()) {
             if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(baseEdge)))
-                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
             load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratch1GPR);
 #else
@@ -9653,7 +9653,7 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
             ASSERT(!node->hasDoubleResult());
             typedArrayUndefinedCases.append(typedArrayOutOfBounds);
         } else
-            speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), nullptr, typedArrayOutOfBounds);
+            speculationCheck(OutOfBounds, JSValueSource(baseGPR), nullptr, typedArrayOutOfBounds);
 
         loadPtr(Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
         cageTypedArrayStorage(baseGPR, scratch2GPR);
@@ -9713,11 +9713,11 @@ void SpeculativeJIT::compileMultiGetByVal(Node* node)
     }
 
     bailoutCases.append(jump());
-    speculationCheck(BadIndexingType, JSValueSource::unboxedCell(baseGPR), nullptr, bailoutCases);
+    speculationCheck(BadIndexingType, JSValueSource(baseGPR), nullptr, bailoutCases);
 
     if (!jsArrayUndefinedCases.empty()) {
         jsArrayUndefinedCases.link(this);
-        speculationCheck(NegativeIndex, JSValueSource::unboxedCell(baseGPR), nullptr, branch32(LessThan, indexGPR, TrustedImm32(0)));
+        speculationCheck(NegativeIndex, JSValueSource(baseGPR), nullptr, branch32(LessThan, indexGPR, TrustedImm32(0)));
         // Fall through to the typedArrayUndefinedCases handler below (or directly to the move).
     }
 
@@ -9813,7 +9813,7 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
             loadPtr(Address(baseGPR, JSObject::butterflyOffset()), scratch2GPR);
 
             if (arrayMode.isInBounds())
-                speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), nullptr, branch32(AboveOrEqual, indexGPR, Address(scratch2GPR, Butterfly::offsetOfPublicLength())));
+                speculationCheck(OutOfBounds, JSValueSource(baseGPR), nullptr, branch32(AboveOrEqual, indexGPR, Address(scratch2GPR, Butterfly::offsetOfPublicLength())));
             else {
                 Jump inBoundsCase = branch32(Below, indexGPR, Address(scratch2GPR, Butterfly::offsetOfPublicLength()));
 
@@ -9821,7 +9821,7 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
                 if (arrayMode.isOutOfBounds())
                     jsArraySlowCases.append(outOfVector);
                 else
-                    speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), nullptr, outOfVector);
+                    speculationCheck(OutOfBounds, JSValueSource(baseGPR), nullptr, outOfVector);
 
                 add32(TrustedImm32(1), indexGPR, lengthScratchGPR);
                 store32(lengthScratchGPR, Address(scratch2GPR, Butterfly::offsetOfPublicLength()));
@@ -9865,7 +9865,7 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
 
         if (!arrayMode.mayBeResizableOrGrowableSharedTypedArray()) {
             if (!m_graph.isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(m_state.forNode(baseEdge)))
-                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource::unboxedCell(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
+                speculationCheck(UnexpectedResizableArrayBufferView, JSValueSource(baseGPR), node, branchTest8(NonZero, Address(baseGPR, JSArrayBufferView::offsetOfMode()), TrustedImm32(isResizableOrGrowableSharedMode)));
 #if USE(LARGE_TYPED_ARRAYS)
             load64(Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratch1GPR);
 #else
@@ -9885,7 +9885,7 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
         if (arrayMode.isOutOfBounds())
             doneCases.append(typedArrayOutOfBounds);
         else
-            speculationCheck(OutOfBounds, JSValueSource::unboxedCell(baseGPR), nullptr, typedArrayOutOfBounds);
+            speculationCheck(OutOfBounds, JSValueSource(baseGPR), nullptr, typedArrayOutOfBounds);
 
         loadPtr(Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
         cageTypedArrayStorage(baseGPR, scratch2GPR);
@@ -9948,7 +9948,7 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
     }
 
     bailoutCases.append(jump());
-    speculationCheck(BadIndexingType, JSValueSource::unboxedCell(baseGPR), nullptr, bailoutCases);
+    speculationCheck(BadIndexingType, JSValueSource(baseGPR), nullptr, bailoutCases);
 
     doneCases.link(this);
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -155,23 +155,6 @@ public:
         load64ToReg(src, dst);
     }
 
-    template<typename T, typename U>
-    void storeCell(T cell, U address)
-    {
-        store64(cell, address);
-    }
-
-    template<typename U>
-    void storeCell(GPRReg cell, U address)
-    {
-        store64(cell, address);
-    }
-
-    void loadCell(Address address, GPRReg gpr)
-    {
-        load64(address, gpr);
-    }
-
     void storeValue(GPRReg valueGPR, Address address)
     {
         store64(valueGPR, address);
@@ -491,7 +474,7 @@ public:
     void emitPutCellToCallFrameHeader(GPRReg from, VirtualRegister entry)
     {
         ASSERT(entry.isHeader());
-        storeCell(from, Address(GPRInfo::callFrameRegister, entry.offset() * sizeof(Register)));
+        storeValue(from, Address(GPRInfo::callFrameRegister, entry.offset() * sizeof(Register)));
     }
 
     void emitZeroToCallFrameHeader(VirtualRegister entry)
@@ -1092,11 +1075,6 @@ public:
     void unboxDouble(GPRReg gpr, FPRReg fpr)
     {
         unboxDouble(gpr, gpr, fpr);
-    }
-
-    void unboxDoubleNonDestructive(GPRReg gpr, FPRReg destFPR, GPRReg resultGPR)
-    {
-        unboxDouble(gpr, resultGPR, destFPR);
     }
 
     Jump isStrictInt52(GPRReg valueGPR, GPRReg scratchGPR)

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -58,9 +58,10 @@ namespace CheckTraps {
 }
 
 namespace Enter {
-    static constexpr GPRReg scratch1GPR { GPRInfo::regT4 };
-    static constexpr GPRReg scratch2GPR { GPRInfo::regT5 };
-    static constexpr GPRReg scratch3GPR { GPRInfo::regT2 };
+    static constexpr GPRReg scratch1GPR { GPRInfo::regT1 };
+    static constexpr GPRReg scratch2GPR { GPRInfo::regT2 };
+    static constexpr GPRReg scratch3GPR { GPRInfo::regT3 };
+    static_assert(noOverlap(scratch1GPR, scratch2GPR, scratch3GPR));
 }
 
 namespace Instanceof {
@@ -86,13 +87,13 @@ namespace Instanceof {
 
 namespace JFalse {
     static constexpr GPRReg valueGPR { GPRInfo::regT2 };
-    static constexpr GPRReg scratch1GPR { GPRInfo::regT5 };
+    static constexpr GPRReg scratch1GPR { GPRInfo::regT1 };
     static_assert(noOverlap(valueGPR, scratch1GPR));
 }
 
 namespace JTrue {
     static constexpr GPRReg valueGPR { GPRInfo::regT2 };
-    static constexpr GPRReg scratch1GPR { GPRInfo::regT5 };
+    static constexpr GPRReg scratch1GPR { GPRInfo::regT1 };
     static_assert(noOverlap(valueGPR, scratch1GPR));
 }
 

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -57,20 +57,6 @@ public:
     {
     }
 
-    // Wrapper to encode JSCell GPR into JSValue.
-    class CellValue {
-    public:
-        explicit CellValue(GPRReg gpr)
-            : m_gpr(gpr)
-        {
-        }
-
-        GPRReg gpr() const { return m_gpr; }
-
-    private:
-        GPRReg m_gpr;
-    };
-
     // Base class for constant materializers.
     // It offers DerivedClass::materialize and poke functions.
     class ConstantMaterializer { };
@@ -367,13 +353,6 @@ private:
     {
         marshallArgumentRegister<OperationType>(argSourceRegs, arg, args...);
     }
-
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, CellValue arg, Args... args)
-    {
-        marshallArgumentRegister<OperationType>(argSourceRegs, arg.gpr(), args...);
-    }
-
 
     template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires DerivedFromOrConvertibleTo<Arg, TrustedImm> // DerivedFromOrConvertibleTo instead of derived_from since DFGSpeculativeJIT has its own implementation of TrustedImmPtr

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -70,11 +70,6 @@ public:
         ASSERT(m_base != InvalidGPRReg);
     }
     
-    static JSValueSource unboxedCell(GPRReg gpr)
-    {
-        return JSValueSource(gpr);
-    }
-    
     bool operator!() const { return m_base == InvalidGPRReg; }
     explicit operator bool() const { return m_base != InvalidGPRReg; }
     
@@ -645,21 +640,9 @@ constexpr GPRReg preferredArgumentGPR()
 template<typename RegisterBank, auto... registers>
 struct StaticScratchRegisterAllocator {
     static_assert(noOverlap(registers...));
-    static constexpr size_t countRegisters(typename RegisterBank::RegisterType)
-    {
-        return 1;
-    }
+    static_assert((std::is_same_v<decltype(registers), typename RegisterBank::RegisterType> && ...), "Every reserved register must belong to the bank being allocated from");
 
-    template<auto reg, auto... args>
-    static constexpr size_t countRegisters()
-    {
-        if constexpr (!sizeof...(args))
-            return countRegisters(reg);
-        else
-            return countRegisters(reg) + countRegisters<args...>();
-    }
-
-    static constexpr size_t size = RegisterBank::numberOfRegisters - countRegisters<registers...>();
+    static constexpr size_t size = RegisterBank::numberOfRegisters - sizeof...(registers);
     using ArrayType = std::array<typename RegisterBank::RegisterType, size>;
 
     static constexpr ArrayType constructScratchRegisters()

--- a/Source/JavaScriptCore/jit/JITAddGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITAddGenerator.cpp
@@ -104,7 +104,7 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         if (!varOpr.definitelyIsNumber())
             slowPathJumpList.append(jit.branchIfNotNumber(var));
 
-        jit.unboxDoubleNonDestructive(var, m_leftFPR, m_scratchGPR);
+        jit.unboxDouble(var, m_scratchGPR, m_leftFPR);
 
         jit.move(CCallHelpers::Imm32(constOpr.asConstInt32()), m_scratchGPR);
         jit.convertInt32ToDouble(m_scratchGPR, m_rightFPR);
@@ -134,7 +134,7 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         if (!m_rightOperand.definitelyIsNumber())
             slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
-        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+        jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
         CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
 
         jit.convertInt32ToDouble(m_right, m_rightFPR);
@@ -147,7 +147,7 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         jit.convertInt32ToDouble(m_left, m_leftFPR);
 
         rightIsDouble.link(&jit);
-        jit.unboxDoubleNonDestructive(m_right, m_rightFPR, m_scratchGPR);
+        jit.unboxDouble(m_right, m_scratchGPR, m_rightFPR);
 
         rightWasInteger.link(&jit);
 

--- a/Source/JavaScriptCore/jit/JITDivGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITDivGenerator.cpp
@@ -53,7 +53,7 @@ void JITDivGenerator::loadOperand(CCallHelpers& jit, SnippetOperand& opr, GPRReg
         jit.convertInt32ToDouble(oprGPR, destFPR);
         CCallHelpers::Jump oprIsLoaded = jit.jump();
         notInt32.link(&jit);
-        jit.unboxDoubleNonDestructive(oprGPR, destFPR, m_scratchGPR);
+        jit.unboxDouble(oprGPR, m_scratchGPR, destFPR);
         oprIsLoaded.link(&jit);
     }
 }

--- a/Source/JavaScriptCore/jit/JITMulGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITMulGenerator.cpp
@@ -55,8 +55,8 @@ JITMathICInlineResult JITMulGenerator::generateInline(CCallHelpers& jit, MathICG
             state.slowPathJumps.append(jit.branchIfNotNumber(m_right));
         state.slowPathJumps.append(jit.branchIfInt32(m_left));
         state.slowPathJumps.append(jit.branchIfInt32(m_right));
-        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
-        jit.unboxDoubleNonDestructive(m_right, m_rightFPR, m_scratchGPR);
+        jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
+        jit.unboxDouble(m_right, m_scratchGPR, m_rightFPR);
         jit.mulDouble(m_rightFPR, m_leftFPR);
         jit.boxDouble(m_leftFPR, m_result);
 
@@ -120,7 +120,7 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         if (!varOpr.definitelyIsNumber())
             slowPathJumpList.append(jit.branchIfNotNumber(var));
 
-        jit.unboxDoubleNonDestructive(var, m_leftFPR, m_scratchGPR);
+        jit.unboxDouble(var, m_scratchGPR, m_leftFPR);
 
         jit.move(CCallHelpers::Imm32(constOpr.asConstInt32()), m_scratchGPR);
         jit.convertInt32ToDouble(m_scratchGPR, m_rightFPR);
@@ -149,7 +149,7 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         if (!m_rightOperand.definitelyIsNumber())
             slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
-        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+        jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
         CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
 
         jit.convertInt32ToDouble(m_right, m_rightFPR);
@@ -162,7 +162,7 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         jit.convertInt32ToDouble(m_left, m_leftFPR);
 
         rightIsDouble.link(&jit);
-        jit.unboxDoubleNonDestructive(m_right, m_rightFPR, m_scratchGPR);
+        jit.unboxDouble(m_right, m_scratchGPR, m_rightFPR);
 
         rightWasInteger.link(&jit);
 

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -409,7 +409,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JIT::valueIsFalseyGenerator(VM& vm)
 
     using BaselineJITRegisters::JFalse::valueGPR; // Incoming
     constexpr GPRReg scratch1GPR = regT1;
-    constexpr GPRReg scratch2GPR = regT5;
+    constexpr GPRReg scratch2GPR = regT3;
     constexpr GPRReg globalObjectGPR = regT4;
     static_assert(noOverlap(valueGPR, scratch1GPR, scratch2GPR, globalObjectGPR));
 
@@ -552,7 +552,7 @@ void JIT::emit_op_jtrue(const JSInstruction* currentInstruction)
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
 
     using BaselineJITRegisters::JTrue::valueGPR;
-    using BaselineJITRegisters::JFalse::scratch1GPR;
+    using BaselineJITRegisters::JTrue::scratch1GPR;
 
     emitGetVirtualRegister(bytecode.m_condition, valueGPR);
 
@@ -585,7 +585,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JIT::valueIsTruthyGenerator(VM& vm)
 
     using BaselineJITRegisters::JTrue::valueGPR; // Incoming
     constexpr GPRReg scratch1GPR = regT1;
-    constexpr GPRReg scratch2GPR = regT5;
+    constexpr GPRReg scratch2GPR = regT3;
     constexpr GPRReg globalObjectGPR = regT4;
     static_assert(noOverlap(valueGPR, scratch1GPR, scratch2GPR, globalObjectGPR));
 

--- a/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
@@ -58,7 +58,7 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
         // Try to do (doubleVar >> intConstant).
         notInt.link(&jit);
         m_slowPathJumpList.append(jit.branchIfNotNumber(m_left));
-        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+        jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
 #if CPU(ARM64)
         if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
             jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);
@@ -100,7 +100,7 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
     // Try to do (doubleVar >> intVar).
     leftNotInt.link(&jit);
     m_slowPathJumpList.append(jit.branchIfNotNumber(m_left));
-    jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+    jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
 #if CPU(ARM64)
     if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
         jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);

--- a/Source/JavaScriptCore/jit/JITSubGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITSubGenerator.cpp
@@ -53,8 +53,8 @@ JITMathICInlineResult JITSubGenerator::generateInline(CCallHelpers& jit, MathICG
             state.slowPathJumps.append(jit.branchIfNotNumber(m_right));
         state.slowPathJumps.append(jit.branchIfInt32(m_left));
         state.slowPathJumps.append(jit.branchIfInt32(m_right));
-        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
-        jit.unboxDoubleNonDestructive(m_right, m_rightFPR, m_scratchGPR);
+        jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
+        jit.unboxDouble(m_right, m_scratchGPR, m_rightFPR);
         jit.subDouble(m_rightFPR, m_leftFPR);
         jit.boxDouble(m_leftFPR, m_result);
 
@@ -102,7 +102,7 @@ bool JITSubGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
     if (!m_rightOperand.definitelyIsNumber())
         slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
-    jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+    jit.unboxDouble(m_left, m_scratchGPR, m_leftFPR);
     CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
 
     jit.convertInt32ToDouble(m_right, m_rightFPR);
@@ -115,7 +115,7 @@ bool JITSubGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
     jit.convertInt32ToDouble(m_left, m_leftFPR);
 
     rightIsDouble.link(&jit);
-    jit.unboxDoubleNonDestructive(m_right, m_rightFPR, m_scratchGPR);
+    jit.unboxDouble(m_right, m_scratchGPR, m_rightFPR);
 
     rightWasInteger.link(&jit);
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -1306,7 +1306,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> boundFunctionCallGenerator(VM& vm)
     //
     // That's really all there is to this. We have all the registers we need to do it.
     
-    jit.loadCell(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
+    jit.loadValue(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
     jit.load32(CCallHelpers::Address(GPRInfo::regT0, JSBoundFunction::offsetOfBoundArgsLength()), GPRInfo::regT2);
     jit.load32(CCallHelpers::lowWordFor(CallFrameSlot::argumentCountIncludingThis), GPRInfo::regT1);
     jit.move(GPRInfo::regT1, GPRInfo::regT3);
@@ -1385,7 +1385,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> boundFunctionCallGenerator(VM& vm)
     argsPushed.link(&jit);
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, JSBoundFunction::offsetOfTargetFunction()), GPRInfo::regT2);
-    jit.storeCell(GPRInfo::regT2, CCallHelpers::calleeFrameSlot(CallFrameSlot::callee));
+    jit.storeValue(GPRInfo::regT2, CCallHelpers::calleeFrameSlot(CallFrameSlot::callee));
     
     jit.loadPtr(CCallHelpers::Address(GPRInfo::regT2, JSFunction::offsetOfExecutableOrRareData()), GPRInfo::regT1);
     auto hasExecutable = jit.branchTestPtr(CCallHelpers::Zero, GPRInfo::regT1, CCallHelpers::TrustedImm32(JSFunction::rareDataTag));
@@ -1472,7 +1472,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
     static constexpr int numFrameLocals = 1;
     VirtualRegister loopIndex = virtualRegisterForLocal(0);
 
-    jit.loadCell(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
+    jit.loadValue(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
     jit.load32(CCallHelpers::lowWordFor(CallFrameSlot::argumentCountIncludingThis), GPRInfo::regT1);
 
     jit.add32(CCallHelpers::TrustedImm32(CallFrame::headerSizeInRegisters - CallerFrameAndPC::sizeInRegisters + numFrameLocals), GPRInfo::regT1, GPRInfo::regT2);
@@ -1552,7 +1552,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
         exceptionChecks.append(jit.emitJumpIfException(vm));
 
         jit.setupResults(valueGPR);
-        jit.loadCell(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
+        jit.loadValue(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT0);
 
         jit.loadPtr(jit.addressFor(loopIndex), GPRInfo::regT1);
 
@@ -1564,7 +1564,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
     }
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, JSRemoteFunction::offsetOfTargetFunction()), GPRInfo::regT2);
-    jit.storeCell(GPRInfo::regT2, CCallHelpers::calleeFrameSlot(CallFrameSlot::callee));
+    jit.storeValue(GPRInfo::regT2, CCallHelpers::calleeFrameSlot(CallFrameSlot::callee));
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::regT2, JSFunction::offsetOfExecutableOrRareData()), GPRInfo::regT1);
     auto hasExecutable = jit.branchTestPtr(CCallHelpers::Zero, GPRInfo::regT1, CCallHelpers::TrustedImm32(JSFunction::rareDataTag));
@@ -1621,7 +1621,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
     resultIsPrimitive.append(jit.branchIfNotCell(resultGPR, DoNotHaveTagRegisters));
     resultIsPrimitive.append(jit.branchIfNotObject(resultGPR));
 
-    jit.loadCell(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT2);
+    jit.loadValue(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT2);
     jit.setupArguments<decltype(operationGetWrappedValueForCaller)>(GPRInfo::regT2, resultGPR);
     jit.prepareCallOperation(vm);
     jit.move(CCallHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationGetWrappedValueForCaller)), GPRInfo::nonArgGPR0);
@@ -1712,13 +1712,13 @@ MacroAssemblerCodeRef<JITThunkPtrTag> maxThunkGenerator(VM& vm)
 
         notInt32RHS.link(&jit);
         jit.convertInt32ToDouble(GPRInfo::regT0, FPRInfo::fpRegT0);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT2, FPRInfo::fpRegT1, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT2, GPRInfo::regT4, FPRInfo::fpRegT1);
         jit.doubleMax(FPRInfo::fpRegT0, FPRInfo::fpRegT1, FPRInfo::fpRegT0);
         jit.returnDouble(FPRInfo::fpRegT0);
     }
     {
         notInt32LHS.link(&jit);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT0, FPRInfo::fpRegT0, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT0, GPRInfo::regT4, FPRInfo::fpRegT0);
         auto notInt32RHS = jit.branchIfNotInt32(GPRInfo::regT2);
 
         jit.convertInt32ToDouble(GPRInfo::regT2, FPRInfo::fpRegT1);
@@ -1726,7 +1726,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> maxThunkGenerator(VM& vm)
         jit.returnDouble(FPRInfo::fpRegT0);
 
         notInt32RHS.link(&jit);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT2, FPRInfo::fpRegT1, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT2, GPRInfo::regT4, FPRInfo::fpRegT1);
         jit.doubleMax(FPRInfo::fpRegT0, FPRInfo::fpRegT1, FPRInfo::fpRegT0);
         jit.returnDouble(FPRInfo::fpRegT0);
     }
@@ -1763,13 +1763,13 @@ MacroAssemblerCodeRef<JITThunkPtrTag> minThunkGenerator(VM& vm)
 
         notInt32RHS.link(&jit);
         jit.convertInt32ToDouble(GPRInfo::regT0, FPRInfo::fpRegT0);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT2, FPRInfo::fpRegT1, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT2, GPRInfo::regT4, FPRInfo::fpRegT1);
         jit.doubleMin(FPRInfo::fpRegT0, FPRInfo::fpRegT1, FPRInfo::fpRegT0);
         jit.returnDouble(FPRInfo::fpRegT0);
     }
     {
         notInt32LHS.link(&jit);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT0, FPRInfo::fpRegT0, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT0, GPRInfo::regT4, FPRInfo::fpRegT0);
         auto notInt32RHS = jit.branchIfNotInt32(GPRInfo::regT2);
 
         jit.convertInt32ToDouble(GPRInfo::regT2, FPRInfo::fpRegT1);
@@ -1777,7 +1777,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> minThunkGenerator(VM& vm)
         jit.returnDouble(FPRInfo::fpRegT0);
 
         notInt32RHS.link(&jit);
-        jit.unboxDoubleNonDestructive(GPRInfo::regT2, FPRInfo::fpRegT1, GPRInfo::regT4);
+        jit.unboxDouble(GPRInfo::regT2, GPRInfo::regT4, FPRInfo::fpRegT1);
         jit.doubleMin(FPRInfo::fpRegT0, FPRInfo::fpRegT1, FPRInfo::fpRegT0);
         jit.returnDouble(FPRInfo::fpRegT0);
     }

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -300,7 +300,7 @@ std::expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(c
     jit.storeValue(jsUndefined(), calleeFrame.withOffset(CallFrameSlot::thisArgument * static_cast<int>(sizeof(Register))));
     ASSERT(!wasmCC.calleeSaveRegisters.contains(importJSCellGPRReg, IgnoreVectors));
     materializeImportJSCell(jit, info, importIndex, importJSCellGPRReg);
-    jit.storeCell(importJSCellGPRReg, calleeFrame.withOffset(CallFrameSlot::callee * static_cast<int>(sizeof(Register))));
+    jit.storeValue(importJSCellGPRReg, calleeFrame.withOffset(CallFrameSlot::callee * static_cast<int>(sizeof(Register))));
     jit.store32(JIT::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * static_cast<int>(sizeof(Register)) + LowWordOffset));
 
     // FIXME Tail call if the wasm return type is void and no registers were spilled. https://bugs.webkit.org/show_bug.cgi?id=165488


### PR DESCRIPTION
#### 2e70118515f795b836fbaccf366370370394da47
<pre>
[JSC] Clean up after JSValueRegs removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=323068">https://bugs.webkit.org/show_bug.cgi?id=323068</a>
<a href="https://rdar.apple.com/186329487">rdar://186329487</a>

Reviewed by Mark Lam.

Now JSValueRegs is removed, we can clean up a bit more,

1. Remove CCallHelpers::CellValue. This existed only for 32bit.
2. Remove StaticScratchRegisterAllocator::countRegisters JSValueRegs handling
3. Remove JSValueSource::unboxedCell
4. Remoev unboxDoubleNonDestructive

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::customGetterHandlerImpl):
(JSC::getterCallFromGetterSetterImpl):
(JSC::getByIdProxyObjectLoadHandler):
(JSC::customSetterHandlerImpl):
(JSC::setterHandlerImpl):
* Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::emitRestoreArguments):
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::reifyInlinedCallFrames):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::checkArray):
(JSC::DFG::SpeculativeJIT::compilePeepHoleObjectEquality):
(JSC::DFG::SpeculativeJIT::compileCheckDetached):
(JSC::DFG::SpeculativeJIT::jumpForTypedArrayOutOfBounds):
(JSC::DFG::SpeculativeJIT::compileObjectEquality):
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayByteOffset):
(JSC::DFG::SpeculativeJIT::compileGetArrayLength):
(JSC::DFG::SpeculativeJIT::compileDataViewGetByteLength):
(JSC::DFG::SpeculativeJIT::compileNewArrayWithSpread):
(JSC::DFG::SpeculativeJIT::emitStructureCheck):
(JSC::DFG::SpeculativeJIT::compileCheckIsConstant):
(JSC::DFG::SpeculativeJIT::compileCallDOMGetter):
(JSC::DFG::SpeculativeJIT::compileCheckJSCast):
(JSC::DFG::SpeculativeJIT::compileToStringOrCallStringConstructorOrStringValueOf):
(JSC::DFG::SpeculativeJIT::compileNewStringObject):
(JSC::DFG::SpeculativeJIT::speculateCellTypeWithoutTypeFiltering):
(JSC::DFG::SpeculativeJIT::speculateCellType):
(JSC::DFG::SpeculativeJIT::speculateObject):
(JSC::DFG::SpeculativeJIT::speculateString):
(JSC::DFG::SpeculativeJIT::speculateStringIdentAndLoadStorage):
(JSC::DFG::SpeculativeJIT::speculateStringObject):
(JSC::DFG::SpeculativeJIT::speculateStringOrStringObject):
(JSC::DFG::SpeculativeJIT::speculateNotSymbol):
(JSC::DFG::SpeculativeJIT::speculateSymbol):
(JSC::DFG::SpeculativeJIT::speculateHeapBigInt):
(JSC::DFG::SpeculativeJIT::compileStringReplace):
(JSC::DFG::SpeculativeJIT::compileEnumeratorHasProperty):
(JSC::DFG::SpeculativeJIT::compileSetCallee):
(JSC::DFG::SpeculativeJIT::compileEnumeratorGetByVal):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileObjectStrictEquality):
(JSC::DFG::SpeculativeJIT::compilePeepHoleObjectStrictEquality):
(JSC::DFG::SpeculativeJIT::compileObjectToObjectOrOtherEquality):
(JSC::DFG::SpeculativeJIT::compilePeepHoleObjectToObjectOrOtherEquality):
(JSC::DFG::SpeculativeJIT::compileDataViewGetByteLengthAsInt52):
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayLengthAsInt52):
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayByteOffsetAsInt52):
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compilePutPrivateName):
(JSC::DFG::SpeculativeJIT::compileEnumeratorPutByVal):
(JSC::DFG::SpeculativeJIT::compileMultiGetByVal):
(JSC::DFG::SpeculativeJIT::compileMultiPutByVal):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::emitPutCellToCallFrameHeader):
(JSC::AssemblyHelpers::storeCell): Deleted.
(JSC::AssemblyHelpers::loadCell): Deleted.
(JSC::AssemblyHelpers::unboxDoubleNonDestructive): Deleted.
* Source/JavaScriptCore/jit/BaselineJITRegisters.h:
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::CellValue::CellValue): Deleted.
(JSC::CCallHelpers::CellValue::gpr const): Deleted.
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::JSValueSource::unboxedCell): Deleted.
(JSC::StaticScratchRegisterAllocator::countRegisters): Deleted.
* Source/JavaScriptCore/jit/JITAddGenerator.cpp:
(JSC::JITAddGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITDivGenerator.cpp:
(JSC::JITDivGenerator::loadOperand):
* Source/JavaScriptCore/jit/JITMulGenerator.cpp:
(JSC::JITMulGenerator::generateInline):
(JSC::JITMulGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::valueIsFalseyGenerator):
(JSC::JIT::emit_op_jtrue):
(JSC::JIT::valueIsTruthyGenerator):
* Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp:
(JSC::JITRightShiftGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITSubGenerator.cpp:
(JSC::JITSubGenerator::generateInline):
(JSC::JITSubGenerator::generateFastPath):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::boundFunctionCallGenerator):
(JSC::remoteFunctionCallGenerator):
(JSC::maxThunkGenerator):
(JSC::minThunkGenerator):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):

Canonical link: <a href="https://commits.webkit.org/320294@main">https://commits.webkit.org/320294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df029de0bfbfc16a49eeb1f08d0d10db24db3bfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51928 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194410 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148479 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78d9aa48-5437-4ad6-a60a-c9cc6d855f74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99932 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e70cbff-af15-4c1a-b868-7fdd7d0d6fbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80a662b1-5c07-4f57-8094-44242cfc1105) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46277 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44485 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6178 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13006 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156687 "Found 2 new API test failures: TestWebKitAPI.WKScrollViewTests.WheelEventDispatchedToSubframe, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44066 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5592 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45463 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196348 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57781 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153346 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58485 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153020 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47558 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130776 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127250 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19078 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56431 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->