### PR TITLE
[scroll-animations] style-originated timelines defined outside of `timeline-scope` hierarchy should yield an inactive timeline

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL timeline-scope:all scopes all names (basic) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.timeline')"
-FAIL timeline-scope:all scopes all names (multiple) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim1.timeline')"
+PASS timeline-scope:all scopes all names (basic)
+PASS timeline-scope:all scopes all names (multiple)
 PASS Inner scope is isolated from outer scope
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -123,8 +123,10 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
             return matchedTimelines.last().unsafePtr();
         }
         // Has blocking timeline scope element
-        if (timelineScopeElement == element.get())
-            return nullptr;
+        if (timelineScopeElement == element.get()) {
+            ASSERT(!ancestorTimelines.isEmpty());
+            return &inactiveNamedTimeline(ancestorTimelines.first()->name().name);
+        }
         element = element->parentElementInComposedTree();
     }
 


### PR DESCRIPTION
#### 8c1a483a7d847d462954a51fd3cf92168f1da673
<pre>
[scroll-animations] style-originated timelines defined outside of `timeline-scope` hierarchy should yield an inactive timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=323071">https://bugs.webkit.org/show_bug.cgi?id=323071</a>
<a href="https://rdar.apple.com/186330965">rdar://186330965</a>

Reviewed by Anne van Kesteren.

When dealing with an animation target with an ancestor that has a `timeline-scope` property set,
we would previously return a null timeline if we failed to find a timeline matching the provided
name. However, now that style-originated timelines match globally and not just within the ancestor
chain [0], we should treat such cases as yielding an inactive (or deferred as it&apos;s sometimes called)
timeline.

This fixes the failures in the WPT test `scroll-animations/css/timeline-scope-all.html` introduced
by the WPT changes in <a href="https://github.com/web-platform-tests/wpt/pull/61776.">https://github.com/web-platform-tests/wpt/pull/61776.</a>

[0] <a href="https://github.com/w3c/csswg-drafts/pull/13624">https://github.com/w3c/csswg-drafts/pull/13624</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-all-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):

Canonical link: <a href="https://commits.webkit.org/320227@main">https://commits.webkit.org/320227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e687633949b7394b7cb90baff4e8ddb549d93bc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148469 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1593505-4492-46db-8b0b-6777af0cc696) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143772 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99921 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69ca58d4-6d15-4725-85cf-3fcb359de6aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e18f471d-d3f0-46f2-bf5e-4b345f0f96fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46260 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44048 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5582 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196338 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57771 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58475 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40679 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153007 "Found 1 new API test failure: TestWTF.WTF_ThreadSafeWeakPtr.GetRacingWithLastWeakReferenceRelease (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27961 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47541 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130766 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19060 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56354 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->