### PR TITLE
[scroll-animations] changed `timeline-scope` values should update timelines for animations globally

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -9,6 +9,6 @@ PASS Dynamically re-attaching
 PASS Dynamically detaching
 PASS Removing/inserting element with attaching timeline
 PASS Ancestor attached element becoming display:none/block
-FAIL A timline scope in the ancestor chain assert_equals: expected "100px" but got "0px"
+PASS A timline scope in the ancestor chain
 PASS Timeline search prioritizes ancestors
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -444,13 +444,18 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
         m_cssAnimationsPendingAttachment.append(animation);
 }
 
-static void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries, const Styleable& styleable)
+void StyleOriginatedTimelinesController::updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries, const Styleable& styleable)
 {
     for (auto& entry : entries) {
         if (auto entryElement = originatingElementExcludingTimelineScope(entry).styleable()) {
-            Ref protectedElement { styleable.element };
-            if (entryElement->element.isComposedTreeDescendantOf(protectedElement.get()))
-                entry->setTimelineScopeElement(protectedElement.get());
+            Ref element { styleable.element };
+            if (entryElement->element.isComposedTreeDescendantOf(element)) {
+                entry->setTimelineScopeElement(element);
+                for (Ref animation : copyToVector(entry->relevantAnimations())) {
+                    if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation))
+                        attachAnimation(*cssAnimation, AllowsDeferral::Yes);
+                }
+            }
         }
     }
 }
@@ -465,25 +470,15 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
     // subtree—​for example, by siblings, cousins, or ancestors.
     switch (scope.type) {
     case Style::NameScope::Type::None: {
-        HashSet<Ref<ScrollTimeline>> namedTimelinesToUnregister;
         for (auto& entry : m_nameToTimelineMap) {
             for (auto& timeline : entry.value) {
-                if (timeline->timelineScopeDeclaredElement() == &styleable.element) {
+                if (timeline->timelineScopeDeclaredElement() == &styleable.element)
                     timeline->clearTimelineScopeDeclaredElement();
-                    // Make sure to track this time to be unregistered in a separate
-                    // step as it would modify the map we're currently iterating over.
-                    namedTimelinesToUnregister.add(timeline.get());
-                }
             }
         }
         m_timelineScopeEntries.removeAllMatching([&](const std::pair<Style::NameScope, WeakStyleable> entry) {
             return entry.second == styleable;
         });
-        // We need to unregister all timelines that are no longer within this scope.
-        for (auto& timeline : namedTimelinesToUnregister) {
-            if (auto associatedElement = originatingElement(timeline).styleable())
-                unregisterNamedTimeline(timeline->name().name, *associatedElement);
-        }
         break;
     }
     case Style::NameScope::Type::All:

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -81,6 +81,7 @@ private:
     Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&) LIFETIME_BOUND;
     Vector<WeakStyleable> relatedTimelineScopeElements(const Style::CustomIdent&);
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
+    void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>>, const Styleable&);
 
     enum class AllowsDeferral : bool { No, Yes };
     void attachAnimation(CSSAnimation&, AllowsDeferral);


### PR DESCRIPTION
#### 7e80c02cd2997f2a81f9efa62913cf47e78e07ad
<pre>
[scroll-animations] changed `timeline-scope` values should update timelines for animations globally
<a href="https://bugs.webkit.org/show_bug.cgi?id=323073">https://bugs.webkit.org/show_bug.cgi?id=323073</a>
<a href="https://rdar.apple.com/186331685">rdar://186331685</a>

Reviewed by Anne van Kesteren.

Because style-originated timeline would only match within an animation&apos;s target ancestor chain,
or in the subtree of an element with a `timeline-scope` property, we would only consider the hierarchy
of the element that had its `timeline-scope` change. Now that style-originated timelines match
globally [0] we must update any animation for a name contained in the `timeline-scope` property
that changed.

This fixes the final failure in the WPT test `scroll-animations/css/timeline-scope.html` introduced
by the WPT changes in <a href="https://github.com/web-platform-tests/wpt/pull/61776.">https://github.com/web-platform-tests/wpt/pull/61776.</a>

[0] <a href="https://github.com/w3c/csswg-drafts/pull/13624">https://github.com/w3c/csswg-drafts/pull/13624</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::updateTimelinesForTimelineScope):
(WebCore::StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope):
(WebCore::updateTimelinesForTimelineScope): Deleted.
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/320231@main">https://commits.webkit.org/320231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abbcdd78c543bcd560811358c0e82a87182b2f15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8cf811a-4d40-4b16-ad76-b937b13741fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99929 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/daf2ce62-6bfe-4a11-9503-016a4a1c2d2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1af5af65-8563-48ec-8cb3-022f7567f8a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46273 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44062 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5594 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196350 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57783 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58487 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153018 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130778 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56995 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19074 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->