### PR TITLE
[Site Isolation] Fix location of color input picker, take 2

### DIFF
--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -341,14 +341,17 @@ HTMLElement* ColorInputType::shadowColorSwatch() const
     return wrapper ? downcast<HTMLElement>(wrapper->firstChild()) : nullptr;
 }
 
-IntRect ColorInputType::elementRectRelativeToRootView() const
+IntRect ColorInputType::elementRectRelativeToMainFrameView() const
 {
     ASSERT(element());
     Ref element = *this->element();
     CheckedPtr renderer = element->renderer();
     if (!renderer)
         return IntRect();
-    return protect(element->document().view())->contentsToRootView(renderer->absoluteBoundingBoxRect());
+
+    Ref document = element->document();
+    RefPtr view = element->document().view();
+    return view->contentsToMainFrameView(renderer->absoluteBoundingBoxRect());
 }
 
 std::optional<FrameIdentifier> ColorInputType::rootFrameID() const

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -67,7 +67,7 @@ private:
 
     void didChooseColor(const Color&) final;
     void didEndChooser() final;
-    IntRect elementRectRelativeToRootView() const final;
+    IntRect elementRectRelativeToMainFrameView() const final;
     std::optional<FrameIdentifier> rootFrameID() const final;
     bool isMouseFocusable() const final;
     bool isKeyboardFocusable(const FocusEventData&) const final;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -585,6 +585,24 @@ FloatRect FrameView::convertToRootViewAcrossIsolatedFrames(FloatRect rect) const
     return parentView->convertToRootViewAcrossIsolatedFrames(parentRect);
 }
 
+IntRect FrameView::convertToRootViewAcrossIsolatedFrames(IntRect rect) const
+{
+    RefPtr parentView = siteIsolationAwareParentView(*this);
+    if (!parentView)
+        return rect;
+
+    IntRect parentRect;
+    if (is<LocalFrameView>(*parentView))
+        parentRect = convertToContainingView(rect);
+    else {
+        Ref frame = this->frame();
+        rect.moveBy(roundedIntPoint(parentView->childFrameOwnerContentBoxLocation(frame)));
+        parentRect = roundedIntRect(parentView->contentsToView(parentView->childFrameOwnerToRootContentTransform(frame).projectQuad(FloatQuad { rect }).boundingBox()));
+    }
+
+    return parentView->convertToRootViewAcrossIsolatedFrames(parentRect);
+}
+
 FloatQuad FrameView::convertToRootViewAcrossIsolatedFrames(const FloatQuad& quad) const
 {
     // Map each corner independently so a CSS transform (which need not preserve axis alignment) is
@@ -600,6 +618,11 @@ FloatQuad FrameView::convertToRootViewAcrossIsolatedFrames(const FloatQuad& quad
 FloatRect FrameView::rootViewToContentsAcrossIsolatedFrames(FloatRect rect) const
 {
     return viewToContents(convertFromRootViewAcrossIsolatedFrames(rect));
+}
+
+IntRect FrameView::contentsToMainFrameView(const IntRect& rect) const
+{
+    return convertToRootViewAcrossIsolatedFrames(contentsToView(rect));
 }
 
 }

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -127,10 +127,17 @@ public:
     // equivalent to the plain convertFromRootView / rootViewToContents.
     WEBCORE_EXPORT FloatPoint convertFromRootViewAcrossIsolatedFrames(FloatPoint) const;
     WEBCORE_EXPORT FloatRect convertFromRootViewAcrossIsolatedFrames(FloatRect) const;
+
     WEBCORE_EXPORT FloatPoint convertToRootViewAcrossIsolatedFrames(FloatPoint) const;
     WEBCORE_EXPORT FloatRect convertToRootViewAcrossIsolatedFrames(FloatRect) const;
     WEBCORE_EXPORT FloatQuad convertToRootViewAcrossIsolatedFrames(const FloatQuad&) const;
+    WEBCORE_EXPORT IntRect convertToRootViewAcrossIsolatedFrames(IntRect) const;
+
     WEBCORE_EXPORT FloatRect rootViewToContentsAcrossIsolatedFrames(FloatRect) const;
+
+    // Similar to contentsToRootView, but also works in Site Isolation mode and will
+    // convert all the way to the main frame.
+    WEBCORE_EXPORT IntRect contentsToMainFrameView(const IntRect&) const;
 
     WEBCORE_EXPORT virtual LayoutRect layoutViewportRect() const = 0;
 

--- a/Source/WebCore/platform/ColorChooserClient.h
+++ b/Source/WebCore/platform/ColorChooserClient.h
@@ -46,7 +46,7 @@ public:
 
     virtual void didChooseColor(const Color&) = 0;
     virtual void didEndChooser() = 0;
-    virtual IntRect elementRectRelativeToRootView() const = 0;
+    virtual IntRect elementRectRelativeToMainFrameView() const = 0;
     virtual bool supportsAlpha() const = 0;
     virtual Vector<Color> suggestedColors() const = 0;
     virtual std::optional<FrameIdentifier> rootFrameID() const = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12315,17 +12315,12 @@ void WebPageProxy::showColorPicker(IPC::Connection& connection, const WebCore::C
     if (!pageClient)
         return;
 
-    internals().colorPicker = pageClient->createColorPicker(*this, initialColor, elementRect, supportsAlpha, WTF::move(suggestions), rootFrameID);
+    RefPtr colorPicker = pageClient->createColorPicker(*this, initialColor, elementRect, supportsAlpha, WTF::move(suggestions), rootFrameID);
+    internals().colorPicker = colorPicker;
 
-    convertRectToMainFrameCoordinates(elementRect, rootFrameID, [weakThis = WeakPtr { *this }, initialColor](std::optional<FloatRect> convertedRect) mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !convertedRect)
-            return;
-
-        // FIXME: Remove this conditional once all ports have a functional PageClientImpl::createColorPicker.
-        if (RefPtr colorPicker = protectedThis->internals().colorPicker)
-            colorPicker->showColorPicker(initialColor, IntRect(*convertedRect));
-    });
+    // FIXME: Remove this conditional once all ports have a functional PageClientImpl::createColorPicker.
+    if (colorPicker)
+        colorPicker->showColorPicker(initialColor, elementRect);
 }
 
 void WebPageProxy::setColorPickerColor(const WebCore::Color& color)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
@@ -46,7 +46,7 @@ WebColorChooser::WebColorChooser(WebPage* page, ColorChooserClient* client, cons
     page->setActiveColorChooser(this);
     auto supportsAlpha = client->supportsAlpha() ? ColorControlSupportsAlpha::Yes : ColorControlSupportsAlpha::No;
 
-    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(initialColor, client->elementRectRelativeToRootView(), supportsAlpha, client->suggestedColors(), client->rootFrameID()), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(initialColor, client->elementRectRelativeToMainFrameView(), supportsAlpha, client->suggestedColors(), client->rootFrameID()), page->identifier());
 }
 
 WebColorChooser::~WebColorChooser()
@@ -79,7 +79,7 @@ void WebColorChooser::reattachColorChooser(const Color& color)
 
     Ref colorChooserClient = *m_colorChooserClient;
     auto supportsAlpha = colorChooserClient->supportsAlpha() ? ColorControlSupportsAlpha::Yes : ColorControlSupportsAlpha::No;
-    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(color, colorChooserClient->elementRectRelativeToRootView(), supportsAlpha, colorChooserClient->suggestedColors(), colorChooserClient->rootFrameID()), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(color, colorChooserClient->elementRectRelativeToMainFrameView(), supportsAlpha, colorChooserClient->suggestedColors(), colorChooserClient->rootFrameID()), page->identifier());
 }
 
 void WebColorChooser::setSelectedColor(const Color& color)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -10302,6 +10302,53 @@ TEST(SiteIsolation, ColorInputPickerLocation)
     EXPECT_EQ(popoverPositioningViewBoundsInWebViewCoordinates, NSMakeRect(168, 168, 50, 50));
 }
 
+TEST(SiteIsolation, ColorInputPickerLocation2)
+{
+    auto mainPageSource =
+        "<iframe id=iframe style='margin: 100px; width: 400px; height: 300px;' src='https://webkit.org/iframe' onload='load()'></iframe>"_s
+        "<script>function load() { alert('loaded'); }</script>"_s;
+
+    auto iframeSource =
+        "<!DOCTYPE html>"_s
+        "<div style='height: 1000px'></div>"_s
+        "<input style='margin: 50px; appearance: none; width: 50px; height: 50px;' type='color'>"_s
+        "<div style='height: 1000px'></div>"_s
+        "<script>onload = () => window.scroll(0, 1000);</script>"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainPageSource } },
+        { "/iframe"_s, { iframeSource } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    __block bool done = false;
+    __block NSRect popoverPositioningRect = NSZeroRect;
+    __block RetainPtr<NSView> popoverPositioningView;
+
+    InstanceMethodSwizzler swizzler {
+        NSPopover.class,
+        @selector(showRelativeToRect:ofView:preferredEdge:),
+        imp_implementationWithBlock(^(id, NSRect positioningRect, NSView *positioningView, NSRectEdge) {
+            popoverPositioningRect = positioningRect;
+            popoverPositioningView = positioningView;
+            done = true;
+        })
+    };
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded");
+    [webView waitForNextPresentationUpdate];
+
+    [webView sendClickAtPoint:NSMakePoint(200, 400)];
+
+    Util::run(&done);
+
+    EXPECT_EQ(popoverPositioningRect, NSMakeRect(0, 0, 50, 50));
+
+    NSRect popoverPositioningViewBoundsInWebViewCoordinates = [popoverPositioningView convertRect:[popoverPositioningView bounds] toView:webView];
+    EXPECT_EQ(popoverPositioningViewBoundsInWebViewCoordinates, NSMakeRect(168, 168, 50, 50));
+}
+
 TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
 {
     auto mainframeHTML = "<body style='margin:0'>"


### PR DESCRIPTION
#### 08004ec9ed578de1c69d2733a63e9813aab81fc6
<pre>
[Site Isolation] Fix location of color input picker, take 2
<a href="https://rdar.apple.com/186284344">rdar://186284344</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323020">https://bugs.webkit.org/show_bug.cgi?id=323020</a>

Reviewed by Megan Gardner and Alex Christensen.

WebPageProxy::showColorPicker uses convertRectToMainFrameCoordinates to convert
the received coordinates to main frame view coordinates. There&apos;re two issues
with this:

1) convertRectToMainFrameCoordinates is wrong (won&apos;t go into details here)
2) More importantly, convertRectToMainFrameCoordinates requires sending messages
   from UI to web process.

The added test demonstrates a case where the color input picker is at the wrong
location. When the color input is in the middle of the page, instead of on top,
then the color input picker is placed way outside of the view (Y coordinate
is negative.)

Fix this by:

1) add a new method FrameView::contentsToMainFrameView. It&apos;s equivalent to
   ScrollView::contentsToRootView, except it uses convertToRootViewAcrossIsolatedFrames
   behind the scenes, so contentsToMainFrameView is guaranteed to convert all
   the way to the main frame.
2) On the web process side, change WebColorChooser to use contentsToMainFrameView
   to compute the picker location.
3) On the UI process side, directly use the rect sent by the web process This rect is
   already in main frame view coordinates, so no conversion is needed.
4) Rename ColorInputType::elementRectRelativeToRootView to elementRectRelativeToMainFrameView,
   to make clear that the rect is relative to main frame view coordinates.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::elementRectRelativeToMainFrameView const):
(WebCore::ColorInputType::elementRectRelativeToRootView const): Deleted.
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::convertToRootViewAcrossIsolatedFrames const):
(WebCore::FrameView::contentsToMainFrameView const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ColorChooserClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showColorPicker):
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp:
(WebKit::WebColorChooser::WebColorChooser):
(WebKit::WebColorChooser::reattachColorChooser):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ColorInputPickerLocation)):
(TestWebKitAPI::(SiteIsolation, ColorInputPickerLocation2)):

Canonical link: <a href="https://commits.webkit.org/320835@main">https://commits.webkit.org/320835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ddb7ad55425360636ceb3201ccf748f230ec735

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150619 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145335 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100755 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125652 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47762 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45756 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45474 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7362 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198268 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59551 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60260 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154541 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48991 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58708 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58328 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->