### PR TITLE
[CMake] Add missing headers in TestWebKitAPI to fix build errors

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "Helpers/Utilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebAuthnRelatedOriginsFetch.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebAuthnRelatedOriginsFetch.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"


### PR DESCRIPTION
#### ce152d77aec8d09703b8c16480f3f7a9ba6cb302
<pre>
[CMake] Add missing headers in TestWebKitAPI to fix build errors
<a href="https://rdar.apple.com/186334109">rdar://186334109</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323081">https://bugs.webkit.org/show_bug.cgi?id=323081</a>

Reviewed by Keith Miller.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessJetsamPriority.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebAuthnRelatedOriginsFetch.mm:

Canonical link: <a href="https://commits.webkit.org/320252@main">https://commits.webkit.org/320252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e22fb5d3ce83eaa0dd1b5c3ab9afbaee0180285

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148480 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143787 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99928 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164538 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124206 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46272 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44484 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156667 "Found 5 new API test failures: TestWebKitAPI.WKWebExtensionAPIWebNavigation.Errors, TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtensionAPIScripting.CSSAuthorOrigin, TestWebKitAPI.WKWebExtensionAPINamespace.NoWebNavigationObjectWithoutPermission (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44058 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5593 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196349 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57782 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58486 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153016 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47552 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56994 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19070 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56365 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->