### PR TITLE
Avoid redundant URL parsing and decoding on the navigation path

### DIFF
--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2933,6 +2933,12 @@ auto URLParser::parseHostAndPort(CodePointIterator<CharacterType> iterator) -> H
 
 std::optional<String> URLParser::formURLDecode(StringView input)
 {
+    // Fast path for input that decodes to itself. The general path below makes four full copies
+    // of the input, which is very expensive for long query parameter values. Restricted to ASCII
+    // because the UTF-8 round trip below is what rejects unpaired surrogates. rdar://185796614
+    if (input.containsOnlyASCII() && input.find('%') == notFound)
+        return input.toString();
+
     auto utf8 = input.utf8(StrictConversion);
     if (utf8.isNull())
         return std::nullopt;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2037,20 +2037,20 @@ bool Quirks::needsConsistentQueryParameterFilteringQuirk(const URL& url) const
         return false;
 
     static bool wasLoggedOnce { false };
-    URL lowercaseURL { url.string().foldCase() };
 
-    if (lowercaseURL.host() == "bundle-file"_s || RegistrableDomain { lowercaseURL } == "consistentqueryparameterfiltering.internal"_s)
+    if (equalLettersIgnoringASCIICase(url.host(), "bundle-file"_s)
+        || equalLettersIgnoringASCIICase(RegistrableDomain { url }.string(), "consistentqueryparameterfiltering.internal"_s))
         return true;
 
     bool enableQuirk = m_document->settings().consistentQueryParameterFilteringInternalQuirkEnabled()
-        && needsConsistentQueryParameterFilteringInternal(lowercaseURL);
+        && needsConsistentQueryParameterFilteringInternal(URL { url.string().foldCase() });
 
     if (RefPtr page = m_document->page())
         enableQuirk |= page->requiresConsistentPrivacyQuirkForDomain(url);
 
     if (enableQuirk && !wasLoggedOnce) {
         RELEASE_LOG(Loading, "Quirks::needsConsistentQueryParameterFilteringQuirk: Enabling consistent privacy protections");
-        protect(m_document)->addConsoleMessage(MessageSource::Other, MessageLevel::Info, makeString("Enabling consistent privacy protections on \""_s, lowercaseURL.string(), "\""_s));
+        protect(m_document)->addConsoleMessage(MessageSource::Other, MessageLevel::Info, makeString("Enabling consistent privacy protections on \""_s, url.string(), "\""_s));
         wasLoggedOnce = true;
     }
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -132,6 +132,9 @@ void ResourceRequestBase::setURL(URL&& url, bool didFilterLinkDecoration)
 {
     updateResourceRequest();
 
+    if (m_requestData.m_url == url && m_requestData.m_didFilterLinkDecoration == didFilterLinkDecoration)
+        return;
+
     m_requestData.m_url = WTF::move(url);
     m_requestData.m_didFilterLinkDecoration = didFilterLinkDecoration;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1225,12 +1225,12 @@ std::pair<URL, DidFilterLinkDecoration> WebPage::applyLinkDecorationFilteringWit
         return isLinkDecorationFilteringEnabled(mainFrame->loader().policyDocumentLoader());
     }();
 
+    if (!url.hasQuery())
+        return { url, DidFilterLinkDecoration::No };
+
     RefPtr document = mainFrame ? mainFrame->document() : nullptr;
     bool isConsistentQueryParameterFilteringQuirkEnabled = document && (document->quirks().needsConsistentQueryParameterFilteringQuirk(document->url()) || document->quirks().needsConsistentQueryParameterFilteringQuirk(url));
     if (!hasOptedInToLinkDecorationFiltering && !m_page->settings().filterLinkDecorationByDefaultEnabled() && !isConsistentQueryParameterFilteringQuirkEnabled)
-        return { url, DidFilterLinkDecoration::No };
-
-    if (!url.hasQuery())
         return { url, DidFilterLinkDecoration::No };
 
     auto sanitizedURL = url;
@@ -1254,7 +1254,10 @@ std::pair<URL, DidFilterLinkDecoration> WebPage::applyLinkDecorationFilteringWit
         return isEmptyOrFoundDomain && isEmptyOrFoundPath;
     });
 
-    if (!removedParameters.isEmpty() && trigger != LinkDecorationFilteringTrigger::Unspecified) {
+    if (removedParameters.isEmpty())
+        return { url, DidFilterLinkDecoration::No };
+
+    if (trigger != LinkDecorationFilteringTrigger::Unspecified) {
         if (trigger == LinkDecorationFilteringTrigger::Navigation)
             send(Messages::WebPageProxy::DidApplyLinkDecorationFiltering(url, sanitizedURL));
         auto removedParametersString = makeStringByJoining(removedParameters, ", "_s);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -811,6 +811,13 @@ WebCore::IntPoint WebPage::remoteFrameOffsetInMainFrame()
 
 bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)
 {
+    // CFNetwork's built-in protocols always handle these schemes, and a custom NSURLProtocol can
+    // only add handling, never take it away. Materializing the NSURLRequest just to ask is very
+    // expensive for URLs with a long query.
+    auto& url = request.url();
+    if (url.protocolIsInHTTPFamily() || url.protocolIsFile() || url.protocolIsData() || url.protocolIsAbout())
+        return true;
+
     RetainPtr nsRequest = request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
     if (!nsRequest.get().URL)
         return false;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -587,6 +587,13 @@ RefPtr<AXIsolatedTree> WebPage::isolatedTreeForFrame(WebCore::LocalFrame& frame)
 
 bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)
 {
+    // CFNetwork's built-in protocols always handle these schemes, and a custom NSURLProtocol can
+    // only add handling, never take it away. Materializing the NSURLRequest just to ask is very
+    // expensive for URLs with a long query.
+    auto& url = request.url();
+    if (url.protocolIsInHTTPFamily() || url.protocolIsFile() || url.protocolIsData() || url.protocolIsAbout())
+        return true;
+
     RetainPtr nsRequest = request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
     if (!nsRequest.get().URL)
         return false;
@@ -595,10 +602,10 @@ bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)
 
     // FIXME: Return true if this scheme is any one WebKit2 knows how to handle.
 #if ENABLE(SWIFT_DEMO_URI_SCHEME)
-    return request.url().protocolIs("applewebdata"_s)
-        || request.url().protocolIs("x-swift-demo"_s);
+    return url.protocolIs("applewebdata"_s)
+        || url.protocolIs("x-swift-demo"_s);
 #else
-    return request.url().protocolIs("applewebdata"_s);
+    return url.protocolIs("applewebdata"_s);
 #endif
 }
 


### PR DESCRIPTION
#### b48581fbde83d2d64cdb46b2d7b8720deaabd336
<pre>
Avoid redundant URL parsing and decoding on the navigation path
<a href="https://bugs.webkit.org/show_bug.cgi?id=323082">https://bugs.webkit.org/show_bug.cgi?id=323082</a>
<a href="https://rdar.apple.com/185796614">rdar://185796614</a>

Reviewed by Per Arne Vollan.

A single navigation re-parses, re-serializes and form-decodes its URL roughly a
dozen times between WebCore, WebKit and CFNetwork. Almost all of it is
redundant. This is invisible for ordinary URLs and pathological for long ones.

Hang reports show MobileSafari&apos;s main thread spending 2-3.6 seconds entirely
on-CPU decoding a single DecidePolicyForNavigationActionAsync message, and the
WebContent process spending the same interval producing it. Nothing is blocked;
the time goes into converting one navigation URL -- whose query string is
megabytes long -- back and forth between WTF::URL and NSURL/CFURL.

Quirks::needsConsistentQueryParameterFilteringQuirk (added in 306714@main) built
a case-folded copy of the entire URL and re-parsed it, purely to compare a host
and a registrable domain -- two O(URL length) passes plus two allocations, on
every navigation, since the outer setting defaults to true. Compare
case-insensitively against the original URL instead. Note that URLParser only
ASCII-lowercases hosts for special schemes; opaque hosts keep their case, so
these comparisons must be case-insensitive rather than assuming a lowercase
host. The remaining fold-case, which feeds a WebKitAdditions function whose
input contract we should not change, moves behind the internal setting that
gates it (default off), so it is not evaluated in shipping configurations.

WebPage::applyLinkDecorationFilteringWithResult consulted that quirk twice
before checking whether the URL even has a query. Hoist the hasQuery() early
return above it; both branches return the same value.

The same function also reported DidFilterLinkDecoration::Yes whenever filtering
merely ran, including when it removed nothing. That flag&apos;s sole consumer is
ResourceLoadStatisticsStore::logCrossSiteLoadWithLinkDecoration, which reads it
as &quot;a known tracking parameter was removed&quot; and relaxes the destination&apos;s
storage removal frequency from Short to Long when it is set. Reporting Yes for a
no-op filtering pass therefore weakened storage removal for cross-site
navigations from prevalent domains. Return No when nothing was removed. This
also stops PolicyChecker::checkNavigationPolicy (which gained this call in
307522@main) from calling setURL() with an unchanged URL on every navigation.

ResourceRequestBase::setURL cleared m_platformRequestUpdated unconditionally,
discarding the cached NSURLRequest even when setting an identical URL. Add the
same no-op guard the other setters in that file already use.

WebPage::platformCanHandleRequest materialized an NSURLRequest solely to ask
[NSURLConnection canHandleRequest:] a question that is answered by the scheme.
CFNetwork&apos;s built-in protocols always handle http(s)/file/data/about, and a
custom NSURLProtocol can only add handling via +canInitWithRequest:, never
remove it, so the answer for those schemes is true regardless of what is
registered. Return early for them.

That last change has a second effect worth calling out. nsURLRequest() is const
but caches into a mutable member, so calling it permanently attaches an
NSURLRequest to the request -- and encodingRequiresPlatformData() keys off
exactly that to choose between serializing a plain RequestData and the far more
expensive CoreIPCNSURLRequest path. Since platformCanHandleRequest was the only
caller of nsURLRequest() in the WebProcess, it was single-handedly forcing every
GET navigation onto the platform path. Verified with MiniBrowser against a local
http page with a long query: with the early return the navigation request
serializes 0 times via the platform path, without it 2 times.

Finally, URLParser::formURLDecode made four full allocating copies of its input
(replace &apos;+&apos;, UTF-8 convert, percent-decode, UTF-16 convert) with no
content-dependent fast path, and removeQueryParameters calls it on the value of
every query parameter. Add a fast path for ASCII input containing no &apos;%&apos;, which
decodes to itself. The ASCII restriction matters: the UTF-8 round trip is what
rejects unpaired surrogates.

* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::formURLDecode):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsConsistentQueryParameterFilteringQuirk):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setURL):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::applyLinkDecorationFilteringWithResult):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::platformCanHandleRequest):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::platformCanHandleRequest):

Canonical link: <a href="https://commits.webkit.org/320292@main">https://commits.webkit.org/320292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c77d577e7bb1beb633395180cfb935fa243efcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194413 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148482 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f114152-c29d-45e6-92c4-ce00034761a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143789 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99930 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2749ab42-6973-4b00-8131-75c07ab6a441) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124208 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ca3ad7f-8b39-40bf-bba8-49971c197dbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46275 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44487 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6179 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13004 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156670 "2 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44064 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45466 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196351 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57784 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41097 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153021 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47557 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130779 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127253 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56996 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19076 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->