### PR TITLE
Add AlphaFormat, a type for premul, unpremul, noalpha

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2477,6 +2477,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/generic/ScrollbarsControllerGeneric.h
 
+    platform/graphics/AlphaFormat.h
     platform/graphics/AlphaPremultiplication.h
     platform/graphics/AnimationFrameRate.h
     platform/graphics/ArrayPixelBuffer.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3045,6 +3045,7 @@
 		7287A84029879CF2004A50E2 /* SearchFieldResultsPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 7287A83A29879695004A50E2 /* SearchFieldResultsPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		728D4791279A48B700BA7C0E /* FilterEffectApplier.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A13A9F274C5CC700E2A88E /* FilterEffectApplier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72963B6D29510A38004FF6FB /* TextAreaPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 72963B6C29510287004FF6FB /* TextAreaPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6D071DB06AEAB47821168ECD /* AlphaFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = FE829344B3749078127971C6 /* AlphaFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7299BC6723D6A53200CC6883 /* AlphaPremultiplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 7299BC6423D686A600CC6883 /* AlphaPremultiplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7299BC6823D6A53E00CC6883 /* RenderingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 7299BC6623D686C600CC6883 /* RenderingMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		729D05302531424300422098 /* RenderingResourceIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 729D052E25313E2600422098 /* RenderingResourceIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14662,6 +14663,7 @@
 		7295D020E0F0C07C868B904C /* UnifiedSource63-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource63-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		72963B6C29510287004FF6FB /* TextAreaPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextAreaPart.h; sourceTree = "<group>"; };
 		729661A2275960A500E7DF9B /* FilterEffectGeometry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterEffectGeometry.h; sourceTree = "<group>"; };
+		FE829344B3749078127971C6 /* AlphaFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AlphaFormat.h; sourceTree = "<group>"; };
 		7299BC6423D686A600CC6883 /* AlphaPremultiplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AlphaPremultiplication.h; sourceTree = "<group>"; };
 		7299BC6623D686C600CC6883 /* RenderingMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderingMode.h; sourceTree = "<group>"; };
 		729D052E25313E2600422098 /* RenderingResourceIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderingResourceIdentifier.h; sourceTree = "<group>"; };
@@ -36790,6 +36792,7 @@
 				3721493318F0B6D600156EDC /* opentype */,
 				2DD797E62ABD176000EAB71A /* re */,
 				49E911B20EF86D27009D0CAF /* transforms */,
+				FE829344B3749078127971C6 /* AlphaFormat.h */,
 				BC635E91264C4760000EF33A /* AlphaPremultiplication.cpp */,
 				7299BC6423D686A600CC6883 /* AlphaPremultiplication.h */,
 				0F7E475125EEB79A0013F909 /* AnimationFrameRate.cpp */,
@@ -44282,6 +44285,7 @@
 				AEBAFFB02D65D478008311A5 /* AllAcceptedCredentialsOptions.h in Headers */,
 				83BB5C881D5D6F45005A71F4 /* AllDescendantsCollection.h in Headers */,
 				3AD4AB8C2C3CADF700A3E7F3 /* Allowlist.h in Headers */,
+				6D071DB06AEAB47821168ECD /* AlphaFormat.h in Headers */,
 				7299BC6723D6A53200CC6883 /* AlphaPremultiplication.h in Headers */,
 				CEDA12D7152CA1CB00D9E08D /* AlternativeTextClient.h in Headers */,
 				CE45946F24123C960078019F /* AlternativeTextContextController.h in Headers */,

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -425,11 +425,13 @@ static GraphicsContextGLAttributes resolveGraphicsContextGLAttributes(const WebG
 {
     UNUSED_PARAM(scriptExecutionContext);
     GraphicsContextGLAttributes glAttributes;
-    glAttributes.alpha = attributes.alpha;
+    if (!attributes.alpha)
+        glAttributes.alphaFormat = AlphaFormat::NoAlpha;
+    else
+        glAttributes.alphaFormat = attributes.premultipliedAlpha ? AlphaFormat::Premultiplied : AlphaFormat::Unpremultiplied;
     glAttributes.depth = attributes.depth;
     glAttributes.stencil = attributes.stencil;
     glAttributes.antialias = attributes.antialias;
-    glAttributes.premultipliedAlpha = attributes.premultipliedAlpha;
     glAttributes.preserveDrawingBuffer = attributes.preserveDrawingBuffer;
     glAttributes.powerPreference = attributes.powerPreference;
     glAttributes.isWebGL2 = isWebGL2;

--- a/Source/WebCore/platform/graphics/AlphaFormat.h
+++ b/Source/WebCore/platform/graphics/AlphaFormat.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace WebCore {
+
+enum class AlphaFormat : uint8_t {
+    Premultiplied,
+    Unpremultiplied,
+    NoAlpha
+};
+
+}

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Platform.h>
 #if ENABLE(WEBGL)
+#include <WebCore/AlphaFormat.h>
 #include <optional>
 
 namespace WebCore {
@@ -49,11 +50,10 @@ using PlatformGPUID = uint64_t;
 #endif
 
 struct GraphicsContextGLAttributes {
-    bool alpha { true };
+    AlphaFormat alphaFormat { AlphaFormat::Premultiplied };
     bool depth { true };
     bool stencil { false };
     bool antialias { true };
-    bool premultipliedAlpha { true };
     bool preserveDrawingBuffer { false };
     GraphicsContextGLPowerPreference powerPreference { GraphicsContextGLPowerPreference::Default };
     bool isWebGL2 { false };

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -382,7 +382,7 @@ RefPtr<PixelBuffer> GraphicsContextGLANGLE::readPixelsForPaintResults()
 void GraphicsContextGLANGLE::validateAttributes()
 {
     auto attrs = contextAttributes();
-    m_internalColorFormat = attrs.alpha ? GL_RGBA8 : GL_RGB8;
+    m_internalColorFormat = attrs.alphaFormat != AlphaFormat::NoAlpha ? GL_RGBA8 : GL_RGB8;
     if (attrs.stencil && attrs.depth) {
         if (supportsExtensionImpl("GL_OES_packed_depth_stencil"_s))
             m_internalDepthStencilFormat = GL_DEPTH24_STENCIL8_OES;
@@ -422,7 +422,7 @@ bool GraphicsContextGLANGLE::reshapeFBOs(const IntSize& size)
     auto attrs = contextAttributes();
     const int width = size.width();
     const int height = size.height();
-    GLuint colorFormat = attrs.alpha ? GL_RGBA : GL_RGB;
+    GLuint colorFormat = attrs.alphaFormat != AlphaFormat::NoAlpha ? GL_RGBA : GL_RGB;
 
     // Resize multisample FBO.
     if (attrs.antialias) {

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -114,7 +114,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     for (size_t i = 0; i < totalBytes; i += 4)
         std::swap(pixels[i], pixels[i + 2]);
 
-    if (!sourceContextAttributes.premultipliedAlpha) {
+    if (sourceContextAttributes.alphaFormat == AlphaFormat::Unpremultiplied) {
         for (size_t i = 0; i < totalBytes; i += 4) {
             pixels[i + 0] = std::min(255, pixels[i + 0] * pixels[i + 3] / 255);
             pixels[i + 1] = std::min(255, pixels[i + 1] * pixels[i + 3] / 255);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -61,18 +61,18 @@ enum SourceDataFormatBase {
     SourceFormatBaseNumFormats
 };
 
-enum AlphaFormat {
-    AlphaFormatNone = 0,
-    AlphaFormatFirst,
-    AlphaFormatLast,
-    AlphaFormatNumFormats
+enum AlphaChannelPosition {
+    AlphaChannelPositionNone = 0,
+    AlphaChannelPositionFirst,
+    AlphaChannelPositionLast,
+    AlphaChannelPositionNumPositions
 };
 
 // This returns SourceFormatNumFormats if the combination of input parameters is unsupported.
-static GraphicsContextGL::DataFormat NODELETE getSourceDataFormat(unsigned componentsPerPixel, AlphaFormat alphaFormat, bool is16BitFormat, bool bigEndian)
+static GraphicsContextGL::DataFormat NODELETE getSourceDataFormat(unsigned componentsPerPixel, AlphaChannelPosition alphaChannelPosition, bool is16BitFormat, bool bigEndian)
 {
-    static const std::array formatTableBase = { // componentsPerPixel x AlphaFormat
-        //           AlphaFormatNone             AlphaFormatFirst            AlphaFormatLast
+    static const std::array formatTableBase = { // componentsPerPixel x AlphaChannelPosition
+        //           AlphaChannelPositionNone             AlphaChannelPositionFirst            AlphaChannelPositionLast
         std::array { SourceFormatBaseR,          SourceFormatBaseA,          SourceFormatBaseA          }, // 1 componentsPerPixel
         std::array { SourceFormatBaseNumFormats, SourceFormatBaseAR,         SourceFormatBaseRA         }, // 2 componentsPerPixel
         std::array { SourceFormatBaseRGB,        SourceFormatBaseNumFormats, SourceFormatBaseNumFormats }, // 3 componentsPerPixel
@@ -90,7 +90,7 @@ static GraphicsContextGL::DataFormat NODELETE getSourceDataFormat(unsigned compo
     };
 
     ASSERT(componentsPerPixel <= 4 && componentsPerPixel > 0);
-    SourceDataFormatBase formatBase = formatTableBase[componentsPerPixel - 1][alphaFormat];
+    SourceDataFormatBase formatBase = formatTableBase[componentsPerPixel - 1][alphaChannelPosition];
     if (formatBase == SourceFormatBaseNumFormats)
         return GraphicsContextGL::DataFormat::NumFormats;
     return formatTable[formatBase][(is16BitFormat ? 2 : 0) + (bigEndian ? 1 : 0)];
@@ -418,48 +418,48 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
     }
 
     m_alphaOp = AlphaOp::DoNothing;
-    AlphaFormat alphaFormat = AlphaFormatNone;
+    AlphaChannelPosition alphaChannelPosition = AlphaChannelPositionNone;
     switch (CGImageGetAlphaInfo(decodedImage->platformImage().get())) {
     case kCGImageAlphaPremultipliedFirst:
         if (!premultiplyAlpha)
             m_alphaOp = AlphaOp::DoUnmultiply;
         else if (ignoreNativeImageAlphaPremultiplication)
             m_alphaOp = AlphaOp::DoPremultiply;
-        alphaFormat = AlphaFormatFirst;
+        alphaChannelPosition = AlphaChannelPositionFirst;
         break;
     case kCGImageAlphaFirst:
         // This path is only accessible for MacOS earlier than 10.6.4.
         if (premultiplyAlpha)
             m_alphaOp = AlphaOp::DoPremultiply;
-        alphaFormat = AlphaFormatFirst;
+        alphaChannelPosition = AlphaChannelPositionFirst;
         break;
     case kCGImageAlphaNoneSkipFirst:
         // This path is only accessible for MacOS earlier than 10.6.4.
-        alphaFormat = AlphaFormatFirst;
+        alphaChannelPosition = AlphaChannelPositionFirst;
         break;
     case kCGImageAlphaPremultipliedLast:
         if (!premultiplyAlpha)
             m_alphaOp = AlphaOp::DoUnmultiply;
         else if (ignoreNativeImageAlphaPremultiplication)
             m_alphaOp = AlphaOp::DoPremultiply;
-        alphaFormat = AlphaFormatLast;
+        alphaChannelPosition = AlphaChannelPositionLast;
         break;
     case kCGImageAlphaLast:
         if (premultiplyAlpha)
             m_alphaOp = AlphaOp::DoPremultiply;
-        alphaFormat = AlphaFormatLast;
+        alphaChannelPosition = AlphaChannelPositionLast;
         break;
     case kCGImageAlphaNoneSkipLast:
-        alphaFormat = AlphaFormatLast;
+        alphaChannelPosition = AlphaChannelPositionLast;
         break;
     case kCGImageAlphaNone:
-        alphaFormat = AlphaFormatNone;
+        alphaChannelPosition = AlphaChannelPositionNone;
         break;
     default:
         return false;
     }
 
-    m_imageSourceFormat = getSourceDataFormat(componentsPerPixel, alphaFormat, bitsPerComponent == 16, bigEndianSource);
+    m_imageSourceFormat = getSourceDataFormat(componentsPerPixel, alphaChannelPosition, bitsPerComponent == 16, bigEndianSource);
     if (m_imageSourceFormat == DataFormat::NumFormats)
         return false;
 
@@ -506,9 +506,9 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     // Input is GL_RGBA == kCGBitmapByteOrder32Big | kCGImageAlpha*Last.
     // GL_BGRA would be kCGBitmapByteOrder32Little | kCGImageAlpha*First.
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big;
-    if (!sourceContextAttributes.alpha)
+    if (sourceContextAttributes.alphaFormat == AlphaFormat::NoAlpha)
         bitmapInfo |= kCGImageAlphaNoneSkipLast;
-    else if (sourceContextAttributes.premultipliedAlpha)
+    else if (sourceContextAttributes.alphaFormat == AlphaFormat::Premultiplied)
         bitmapInfo |= kCGImageAlphaPremultipliedLast;
     else
         bitmapInfo |= kCGImageAlphaLast;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -493,7 +493,7 @@ IOSurfacePbuffer GraphicsContextGLCocoa::createDrawingBuffer()
     if (m_resourceOwner)
         surface->setOwnershipIdentity(m_resourceOwner);
 
-    const bool usingAlpha = contextAttributes().alpha;
+    const bool usingAlpha = contextAttributes().alphaFormat != AlphaFormat::NoAlpha;
     const EGLint surfaceAttributes[] = {
         EGL_WIDTH, size.width(),
         EGL_HEIGHT, size.height(),
@@ -894,9 +894,9 @@ void GraphicsContextGLCocoa::invalidateKnownTextureContent(GCGLuint texture)
 // Says how the alpha of the contents of the surface buffers is to be interpreted.
 static CGImageAlphaInfo alphaInfoForSurfaceBufferContents(const GraphicsContextGLAttributes& attributes)
 {
-    if (!attributes.alpha)
+    if (attributes.alphaFormat == AlphaFormat::NoAlpha)
         return kCGImageAlphaNoneSkipFirst;
-    if (attributes.premultipliedAlpha)
+    if (attributes.alphaFormat == AlphaFormat::Premultiplied)
         return kCGImageAlphaPremultipliedFirst;
     return kCGImageAlphaFirst;
 }

--- a/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
@@ -152,7 +152,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcessGraphicsContextGLCocoa);
 
 WebProcessGraphicsContextGLCocoa::WebProcessGraphicsContextGLCocoa(GraphicsContextGLAttributes&& attributes)
     : GraphicsContextGLCocoa(WTF::move(attributes), { })
-    , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create(!attributes.alpha))
+    , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create(attributes.alphaFormat == AlphaFormat::NoAlpha))
 {
 }
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -88,7 +88,7 @@ bool GraphicsContextGLTextureMapperGBM::platformInitialize()
             && fourcc != DRM_FORMAT_ABGR16161616F;
     };
 
-    bool isOpaque = !contextAttributes().alpha;
+    bool isOpaque = contextAttributes().alphaFormat == AlphaFormat::NoAlpha;
     const auto& supportedFormats = PlatformDisplay::sharedDisplay().bufferFormats();
     for (const auto& format : supportedFormats) {
         bool matchesOpacity = isOpaqueFormat(format.fourcc) == isOpaque;
@@ -229,7 +229,7 @@ void GraphicsContextGLTextureMapperGBM::prepareForDisplay()
 
     RELEASE_ASSERT(m_layerContentsDisplayDelegate);
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
-    if (contextAttributes().alpha)
+    if (contextAttributes().alphaFormat != AlphaFormat::NoAlpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
 #if USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -152,9 +152,9 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     ASSERT(!pixelBuffer->size().isEmpty());
     auto imageSize = pixelBuffer->size();
     SkAlphaType alphaType = kUnpremul_SkAlphaType;
-    if (!sourceContextAttributes.alpha)
+    if (sourceContextAttributes.alphaFormat == AlphaFormat::NoAlpha)
         alphaType = kOpaque_SkAlphaType;
-    else if (sourceContextAttributes.premultipliedAlpha)
+    else if (sourceContextAttributes.alphaFormat == AlphaFormat::Premultiplied)
         alphaType = kPremul_SkAlphaType;
     auto imageInfo = SkImageInfo::Make(imageSize.width(), imageSize.height(), kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -399,7 +399,7 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
     const auto size = getInternalFramebufferSize();
     const int width = size.width();
     const int height = size.height();
-    GLuint colorFormat = attrs.alpha ? GL_RGBA : GL_RGB;
+    GLuint colorFormat = attrs.alphaFormat != AlphaFormat::NoAlpha ? GL_RGBA : GL_RGB;
     GLenum textureTarget = GL_TEXTURE_2D;
     GLuint internalColorFormat = colorFormat;
     ScopedRestoreTextureBinding restoreBinding(TEXTURE_BINDING_2D, TEXTURE_2D);
@@ -424,7 +424,7 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 
 #if USE(COORDINATED_GRAPHICS)
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
-    if (contextAttributes().alpha)
+    if (contextAttributes().alphaFormat != AlphaFormat::NoAlpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     auto fboSize = getInternalFramebufferSize();
     auto fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
@@ -53,7 +53,7 @@ void TextureMapperGCGLPlatformLayer::paintToTextureMapper(TextureMapper& texture
 
     auto attrs = m_context.contextAttributes();
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
-    if (attrs.alpha)
+    if (attrs.alphaFormat != AlphaFormat::NoAlpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     textureMapper.drawTexture(m_context.m_compositorTexture, flags, targetRect, matrix, opacity);
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1617,6 +1617,14 @@ enum class WebCore::AlphaPremultiplication : uint8_t {
     Unpremultiplied
 };
 
+header: <WebCore/AlphaFormat.h>
+
+enum class WebCore::AlphaFormat : uint8_t {
+    Premultiplied,
+    Unpremultiplied,
+    NoAlpha
+};
+
 enum class WebCore::PixelFormat : uint8_t {
     RGBA8,
     BGRX8,

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -137,11 +137,10 @@ header: <WebCore/GraphicsContextGLAttributes.h>
 };
 
 struct WebCore::GraphicsContextGLAttributes {
-    bool alpha;
+    WebCore::AlphaFormat alphaFormat;
     bool depth;
     bool stencil;
     bool antialias;
-    bool premultipliedAlpha;
     bool preserveDrawingBuffer;
     WebCore::GraphicsContextGLPowerPreference powerPreference;
     bool isWebGL2;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -209,7 +209,7 @@ RefPtr<NativeImage> RemoteGraphicsContextGLProxy::copyNativeImage(SurfaceBuffer 
     auto attributes = contextAttributes();
     // The image contents will be published in the shared resource cache by the GPU process. Adopt it
     // into this backend's cache right away, so that drawing it needs no further set up.
-    Ref nativeImage = RemoteNativeImageProxy::create(size, m_drawingBufferColorSpace.platformColorSpace(), attributes.alpha, sharedResourceCache.releaseNonNull());
+    Ref nativeImage = RemoteNativeImageProxy::create(size, m_drawingBufferColorSpace.platformColorSpace(), attributes.alphaFormat != AlphaFormat::NoAlpha, sharedResourceCache.releaseNonNull());
     renderingBackend->cacheNativeImageFromSharedNativeImage(nativeImage);
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyNativeImage(buffer, nativeImage->reference()));
     if (sendResult != IPC::Error::NoError) [[unlikely]] {

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -142,7 +142,7 @@ public:
 private:
     explicit RemoteGraphicsContextGLProxyCocoa(const WebCore::GraphicsContextGLAttributes& attributes, RemoteRenderingBackendProxy& renderingBackend)
         : RemoteGraphicsContextGLProxy(attributes, renderingBackend)
-        , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create(!attributes.alpha))
+        , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create(attributes.alphaFormat == WebCore::AlphaFormat::NoAlpha))
     {
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -81,7 +81,7 @@ void RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
         return;
 
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
-    if (contextAttributes().alpha)
+    if (contextAttributes().alphaFormat != AlphaFormat::NoAlpha)
         flags.add(TextureMapperFlags::ShouldBlend);
 #if USE(TEXTURE_MAPPER)
     m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer), flags, WTF::move(fenceFD)));

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -94,20 +94,18 @@ private:
     std::optional<ScopedSetAuxiliaryProcessTypeForTesting> m_scopedProcessType;
 };
 
-// The ways the contents of a context can describe their alpha. premultipliedAlpha does not
+// The ways the contents of a context can describe their alpha. Premultiplication does not
 // apply to a context without alpha, so there are three cases and not four.
-enum class AlphaMode : uint8_t { NoAlpha, Unpremultiplied, Premultiplied };
-
-class AnyContextAttributeTest : public testing::TestWithParam<std::tuple<bool, bool, bool, AlphaMode>> {
+class AnyContextAttributeTest : public testing::TestWithParam<std::tuple<bool, bool, bool, AlphaFormat>> {
 protected:
     bool antialias() const { return std::get<0>(GetParam()); }
     bool preserveDrawingBuffer() const { return std::get<1>(GetParam()); }
     bool isWebGL2() const { return std::get<2>(GetParam()); }
-    AlphaMode alphaMode() const { return std::get<3>(GetParam()); }
-    bool hasAlpha() const { return alphaMode() != AlphaMode::NoAlpha; }
+    AlphaFormat alphaFormat() const { return std::get<3>(GetParam()); }
+    bool hasAlpha() const { return alphaFormat() != AlphaFormat::NoAlpha; }
     // How the contents of the drawing buffer describe their alpha. Without alpha the
     // contents are opaque, so premultiplication does not apply to them.
-    AlphaPremultiplication contentsAlphaPremultiplication() const { return alphaMode() == AlphaMode::Premultiplied ? AlphaPremultiplication::Premultiplied : AlphaPremultiplication::Unpremultiplied; }
+    AlphaPremultiplication contentsAlphaPremultiplication() const { return alphaFormat() == AlphaFormat::Premultiplied ? AlphaPremultiplication::Premultiplied : AlphaPremultiplication::Unpremultiplied; }
     GraphicsContextGLAttributes attributes();
     RefPtr<TestedGraphicsContextGLCocoa> createTestContext(IntSize contextSize);
 
@@ -131,8 +129,7 @@ GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
     attributes.antialias = antialias();
     attributes.depth = false;
     attributes.stencil = false;
-    attributes.alpha = hasAlpha();
-    attributes.premultipliedAlpha = alphaMode() != AlphaMode::Unpremultiplied;
+    attributes.alphaFormat = alphaFormat();
     attributes.preserveDrawingBuffer = preserveDrawingBuffer();
     return attributes;
 }
@@ -508,7 +505,7 @@ TEST_P(AnyContextAttributeTest, CopyNativeImage)
     CGImageAlphaInfo expectedAlphaInfo;
     if (!hasAlpha())
         expectedAlphaInfo = kCGImageAlphaNoneSkipFirst;
-    else if (alphaMode() == AlphaMode::Premultiplied)
+    else if (alphaFormat() == AlphaFormat::Premultiplied)
         expectedAlphaInfo = kCGImageAlphaPremultipliedFirst;
     else
         expectedAlphaInfo = kCGImageAlphaFirst;
@@ -812,20 +809,20 @@ TEST_P(AnyContextAttributeTest, WebXRBlitTest)
 
 static std::string anyContextAttributeTestName(const testing::TestParamInfo<AnyContextAttributeTest::ParamType>& info)
 {
-    auto [antialias, preserveDrawingBuffer, isWebGL2, alphaMode] = info.param;
+    auto [antialias, preserveDrawingBuffer, isWebGL2, alphaFormat] = info.param;
     std::string name = isWebGL2 ? "WebGL2" : "WebGL1";
     if (antialias)
         name += "_Antialias";
     if (preserveDrawingBuffer)
         name += "_PreserveDrawingBuffer";
-    switch (alphaMode) {
-    case AlphaMode::NoAlpha:
+    switch (alphaFormat) {
+    case AlphaFormat::NoAlpha:
         name += "_NoAlpha";
         break;
-    case AlphaMode::Unpremultiplied:
+    case AlphaFormat::Unpremultiplied:
         name += "_Unpremultiplied";
         break;
-    case AlphaMode::Premultiplied:
+    case AlphaFormat::Premultiplied:
         name += "_Premultiplied";
         break;
     }
@@ -838,7 +835,7 @@ INSTANTIATE_TEST_SUITE_P(GraphicsContextGLCocoaTest,
         testing::Values(true, false),
         testing::Values(true, false),
         testing::Values(true, false),
-        testing::Values(AlphaMode::NoAlpha, AlphaMode::Unpremultiplied, AlphaMode::Premultiplied)),
+        testing::Values(AlphaFormat::NoAlpha, AlphaFormat::Unpremultiplied, AlphaFormat::Premultiplied)),
     anyContextAttributeTestName);
 
 class GraphicsContextGLCocoaReadPixelsTest : public ::testing::Test {

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -116,7 +116,7 @@ GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
     attributes.antialias = antialias();
     attributes.depth = false;
     attributes.stencil = false;
-    attributes.alpha = true;
+    attributes.alphaFormat = AlphaFormat::Premultiplied;
     attributes.preserveDrawingBuffer = preserveDrawingBuffer();
     return attributes;
 }


### PR DESCRIPTION
#### 062a74646d9382c1d9adfc33fe193f5cdc4b5bb8
<pre>
Add AlphaFormat, a type for premul, unpremul, noalpha
<a href="https://bugs.webkit.org/show_bug.cgi?id=323083">https://bugs.webkit.org/show_bug.cgi?id=323083</a>
<a href="https://rdar.apple.com/186337446">rdar://186337446</a>

Reviewed by NOBODY (OOPS!).

Add WebCore::AlphaFormat to describe WebCore::AlphaPremultiplication
and no alpha.

Use the type in WebGL context metadata, as an example.
In future, the type is added to PixelBufferFormat to describe
buffers without alpha.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::resolveGraphicsContextGLAttributes):
* Source/WebCore/platform/graphics/AlphaFormat.h: Added.
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
(WebCore::GraphicsContextGLAttributes::hasAlpha const):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::validateAttributes):
(WebCore::GraphicsContextGLANGLE::reshapeFBOs):
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::getSourceDataFormat):
(WebCore::GraphicsContextGLImageExtractor::extractImage):
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createDrawingBuffer):
(WebCore::alphaInfoForSurfaceBufferContents):
* Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperGBM::prepareForDisplay):
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer):
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp:
(WebCore::TextureMapperGCGLPlatformLayer::paintToTextureMapper):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebGL.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::copyNativeImage):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::RemoteGraphicsContextGLProxyGBM::prepareForDisplay):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::WebCore::AnyContextAttributeTest::alphaFormat const):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::hasAlpha const):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::contentsAlphaPremultiplication const):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::attributes):
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::anyContextAttributeTestName):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::alphaMode const): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:
(TestWebKitAPI::WebCore::AnyContextAttributeTest::attributes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/062a74646d9382c1d9adfc33fe193f5cdc4b5bb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148508 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1549e01a-bb0b-4de7-8394-ffba37cd73d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57874 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143816 "Found 1 new test failure: http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99952 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b6f4e9a-89fb-4684-80e1-8e5a5dde8a3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7e923e0-ee66-46c8-b064-b97cb20e4f83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44532 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44088 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5621 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50796 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 26976 issues") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48798 "Found 1 new test failure: http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196377 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57810 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153373 "Found 1 new test failure: http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58514 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153047 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47581 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130806 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127277 "Failed to checkout and rebase branch from PR 72923") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57022 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19100 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->