### PR TITLE
[JSC] Fix Structure transition wrong checking issues

### DIFF
--- a/JSTests/stress/proxy-handler-traps-cache-poly-proto-handler.js
+++ b/JSTests/stress/proxy-handler-traps-cache-poly-proto-handler.js
@@ -1,0 +1,73 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}`);
+}
+
+function makePolyProtoObject() {
+    function foo() {
+        class C {
+            constructor() { this._field = 42; }
+        };
+        return new C;
+    }
+    for (let i = 0; i < 15; ++i)
+        foo();
+    return foo();
+}
+
+// A poly-proto object stores its prototype in the object rather than in its structure, so
+// Object.setPrototypeOf leaves its StructureID untouched. The Proxy handler-traps cache must not
+// treat a matching StructureID as proof that the prototype is still an object.
+
+{
+    let handler = makePolyProtoObject();
+    Object.setPrototypeOf(handler, Object.prototype);
+    handler.get = (target, key) => `got ${key}`;
+
+    let proxy = new Proxy({ }, handler);
+    shouldBe(proxy.foo, "got foo");
+
+    Object.setPrototypeOf(handler, null);
+    shouldBe(proxy.foo, "got foo");
+    shouldBe(proxy.bar, "got bar");
+}
+
+{
+    let handler = makePolyProtoObject();
+    Object.setPrototypeOf(handler, Object.prototype);
+
+    let proxy = new Proxy({ a: 1 }, handler);
+    shouldBe(Object.keys(proxy).join(), "a");
+
+    Object.setPrototypeOf(handler, null);
+    shouldBe(Object.keys(proxy).join(), "a");
+
+    handler.ownKeys = () => ["b"];
+    handler.getOwnPropertyDescriptor = () => ({ value: 2, enumerable: true, configurable: true });
+    shouldBe(Object.keys(proxy).join(), "b");
+}
+
+{
+    let handler = makePolyProtoObject();
+    Object.setPrototypeOf(handler, Object.prototype);
+    handler.get = function (target, key) {
+        Object.setPrototypeOf(handler, null);
+        return 42;
+    };
+
+    let proxy = new Proxy({ }, handler);
+    shouldBe(proxy.foo, 42);
+    shouldBe(proxy.foo, 42);
+}
+
+// A poly-proto handler whose prototype gains a trap must pick the new trap up.
+{
+    let handler = makePolyProtoObject();
+    Object.setPrototypeOf(handler, Object.prototype);
+
+    let proxy = new Proxy({ foo: 1 }, handler);
+    shouldBe(proxy.foo, 1);
+
+    Object.setPrototypeOf(handler, { get: () => "from prototype" });
+    shouldBe(proxy.foo, "from prototype");
+}

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -1831,8 +1831,8 @@ static ALWAYS_INLINE void directPutByValOptimize(JSGlobalObject* globalObject, C
             AccessType accessType = static_cast<AccessType>(propertyCache->accessType);
             PutPropertySlot slot(baseValue, isStrict, codeBlock->putByIdContext());
 
-            Structure* structure = CommonSlowPaths::originalStructureBeforePut(baseValue);
-            CommonSlowPaths::putDirectWithReify(vm, globalObject, baseObject, identifier, value, slot);
+            Structure* structure = nullptr;
+            CommonSlowPaths::putDirectWithReify(vm, globalObject, baseObject, identifier, value, slot, &structure);
 
             RETURN_IF_EXCEPTION(scope, void());
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1079,7 +1079,7 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_id)
 
     Structure* oldStructure = baseValue.isCell() ? baseValue.asCell()->structure() : nullptr;
     if (bytecode.m_flags.isDirect())
-        CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), ident, getOperand(callFrame, bytecode.m_value), slot);
+        CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), ident, getOperand(callFrame, bytecode.m_value), slot, &oldStructure);
     else
         baseValue.putInline(globalObject, ident, getOperand(callFrame, bytecode.m_value), slot);
     LLINT_CHECK_EXCEPTION();

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -124,7 +124,9 @@ JSObject* ProxyObject::getHandlerTrap(JSGlobalObject* globalObject, JSObject* ha
     bool isSlotCacheable = slot.isUnset() || (slot.isCacheableValue() && slot.slotBase() == handler);
     if (isSlotCacheable) {
         JSValue handlerPrototype = handler->getPrototypeDirect();
-        bool isHandlerPrototypeChainCacheable = handler->type() == FinalObjectType && !handler->structure()->isDictionary()
+        // isHandlerTrapsCacheValid treats a matching handler StructureID as proof that the prototype is
+        // unchanged, which only holds for mono-proto: setPrototypeOf on a poly-proto object keeps its structure.
+        bool isHandlerPrototypeChainCacheable = handler->type() == FinalObjectType && handler->structure()->hasMonoProto() && !handler->structure()->isDictionary()
             && handlerPrototype.inherits<ObjectPrototype>() && !asObject(handlerPrototype)->structure()->isDictionary();
         if (isHandlerPrototypeChainCacheable) {
             ASSERT(slot.cachedOffset() != emptyHandlerTrapCache);

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -144,7 +144,10 @@ private:
 
 ALWAYS_INLINE bool ProxyObject::isHandlerTrapsCacheValid(JSObject* handler)
 {
-    return handler->structureID() == m_handlerStructureID.value() && asObject(handler->getPrototypeDirect())->structureID() == m_handlerPrototypeStructureID.value();
+    if (handler->structureID() != m_handlerStructureID.value())
+        return false;
+    ASSERT(handler->structure()->hasMonoProto());
+    return asObject(handler->getPrototypeDirect())->structureID() == m_handlerPrototypeStructureID.value();
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 731652af64ff40f6fd4063d6e1969ed25b1df9c1
<pre>
[JSC] Fix Structure transition wrong checking issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=323085">https://bugs.webkit.org/show_bug.cgi?id=323085</a>
<a href="https://rdar.apple.com/186339983">rdar://186339983</a>

Reviewed by Marcus Plutowski and Keith Miller.

Adding MonoProto condition to isHandlerPrototypeChainCacheable.
Otherwise we may get a structure which has differnt [[Prototype]] (due
to PolyProto). In that case, worst case is having jsNull as a JSObject*,
so crash issue with a deterministic address. Also updating oldStructure
by passing it to CommonSlowPaths::putDirectWithReify. This is not an
actual issue, but it makes oldStructure more solid.

Test: JSTests/stress/proxy-handler-traps-cache-poly-proto-handler.js

* JSTests/stress/proxy-handler-traps-cache-poly-proto-handler.js: Added.
(shouldBe):
(makePolyProtoObject.foo.C):
(makePolyProtoObject.foo):
(return.foo):
(shouldBe.handler):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::directPutByValOptimize):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::getHandlerTrap):
* Source/JavaScriptCore/runtime/ProxyObject.h:
(JSC::ProxyObject::isHandlerTrapsCacheValid):

Canonical link: <a href="https://commits.webkit.org/320251@main">https://commits.webkit.org/320251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e4a3a7fb6d707bb3c7411fa75f04f829356dc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148489 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59465 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57855 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143799 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99936 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124218 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46281 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44491 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6189 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13011 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156690 "Found 1 new API test failure: TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44071 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5602 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45473 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196358 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57791 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58495 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153030 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47562 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130786 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19083 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->