### PR TITLE
Foster parenting should use the table's current parent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Table moved to a div: the tree stays well-formed
+PASS Table moved to a div: the second foster-parented element follows it
+PASS Table moved to a template element: the tree stays well-formed
+PASS Table moved to a template element: the second foster-parented element follows it
+PASS Table removed from the tree: the tree stays well-formed
+PASS Table removed from the tree: the second foster-parented element follows it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.js
@@ -1,0 +1,141 @@
+// META: title=Foster parenting: script moves the table between two insertions for one token
+
+// Spec: https://html.spec.whatwg.org/#appropriate-place-for-inserting-a-node
+//       https://html.spec.whatwg.org/#reconstruct-the-active-formatting-elements
+//       https://html.spec.whatwg.org/#adoption-agency-algorithm
+//
+// A single "nobr" start tag foster parents twice: once when reconstructing the active
+// formatting elements, and again after the adoption agency algorithm finds no furthest
+// block and pops the stack of open elements back to the <tr>. The <script> holding the
+// table is therefore the foster parent, and inserting into it runs it, so the script can
+// move or remove the table in between. The appropriate place for inserting a node is
+// computed per insertion, so the second one has to account for that.
+
+const variants = [
+  {
+    name: "moved to a div",
+    container: `<div id="destination"></div>`,
+    move: `destination.append(table)`,
+    // The table's new parent is not a template, so it keeps the table as reference child.
+    parent: "destination",
+    beforeTable: true,
+  },
+  {
+    name: "moved to a template element",
+    container: `<template id="destination"></template>`,
+    move: `destination.append(table)`,
+    // A template's insertion target is null, so this redirects into its template contents
+    // and discards the reference child.
+    parent: "template contents",
+  },
+  {
+    name: "removed from the tree",
+    container: ``,
+    move: `table.remove()`,
+    // With no parent to use, the foster parent is the element above the table on the
+    // stack of open elements.
+    parent: "body",
+  },
+];
+
+const markupFor = variant => `${variant.container}<table><nobr><b><tr><script>
+window.moveTable = () => {
+  const table = document.querySelector("table");
+  window.tableParentWhenRun = table.parentNode.id;
+  ${variant.move};
+};
+const fosterParent = document.createElement("script");
+fosterParent.id = "foster-parent";
+// An unknown type makes "prepare the script element" return before it sets "already
+// started", so correcting the type below leaves the script still runnable.
+fosterParent.type = "unknown/type";
+fosterParent.append("moveTable()");
+document.head.append(fosterParent);
+fosterParent.append(document.querySelector("table"));
+fosterParent.type = "";
+</script><nobr></table>`;
+
+function parse(markup) {
+  const iframe = document.createElement("iframe");
+  iframe.srcdoc = markup;
+  return new Promise(resolve => {
+    iframe.onload = () => resolve(iframe);
+    document.body.append(iframe);
+  });
+}
+
+// The document tree plus any template contents, which are a separate tree.
+function roots(doc) {
+  return [doc, ...[...doc.querySelectorAll("template")].map(template => template.content)];
+}
+
+// Every parent/child/sibling link that disagrees. Inserting before a reference child
+// that has moved away shows up here as a node listed among a parent's children whose
+// parentNode is something else.
+function brokenLinks(doc) {
+  const name = node => `<${node.nodeName.toLowerCase()}${node.id ? "#" + node.id : ""}>`;
+  const problems = [];
+  const seen = new Set();
+  const walk = node => {
+    if (seen.has(node)) {
+      problems.push(`${name(node)} has two parents`);
+      return;
+    }
+    seen.add(node);
+    const children = [];
+    for (let child = node.firstChild; child && children.length < 100; child = child.nextSibling)
+      children.push(child);
+    children.forEach((child, i) => {
+      if (child.parentNode !== node)
+        problems.push(`${name(node)} lists ${name(child)}, whose parentNode is elsewhere`);
+      if (child.previousSibling !== (children[i - 1] ?? null))
+        problems.push(`${name(node)} has a broken previousSibling at ${name(child)}`);
+      walk(child);
+    });
+    if (node.lastChild !== (children.at(-1) ?? null))
+      problems.push(`${name(node)}'s lastChild is not the end of its child list`);
+  };
+  roots(doc).forEach(walk);
+  return problems;
+}
+
+// The second foster-parented element is the only <b> with a <nobr> child, and it is
+// reachable only if it was inserted at all.
+function secondInsertion(doc) {
+  for (const root of roots(doc)) {
+    const b = [...root.querySelectorAll("b")].find(b => b.firstElementChild?.localName === "nobr");
+    if (b)
+      return b;
+  }
+  return null;
+}
+
+function placement(node) {
+  if (!node)
+    return "not inserted";
+  const parent = node.parentNode;
+  if (parent.nodeType === Node.DOCUMENT_FRAGMENT_NODE)
+    return "template contents";
+  return parent.id || parent.localName;
+}
+
+for (const variant of variants) {
+  const parsed = parse(markupFor(variant));
+
+  promise_test(async () => {
+    const doc = (await parsed).contentDocument;
+    assert_equals(brokenLinks(doc).join("; "), "", "the tree is well-formed");
+  }, `Table ${variant.name}: the tree stays well-formed`);
+
+  promise_test(async () => {
+    const iframe = await parsed;
+    const doc = iframe.contentDocument;
+    assert_equals(iframe.contentWindow.tableParentWhenRun, "foster-parent",
+      "the script ran while the parser was foster parenting into it");
+    const inserted = secondInsertion(doc);
+    assert_equals(placement(inserted), variant.parent,
+      "the second foster-parented element follows the table");
+    if (variant.beforeTable)
+      assert_equals(inserted.nextSibling, doc.querySelector("table"), "immediately before the table");
+  }, `Table ${variant.name}: the second foster-parented element follows it`);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/w3c-import.log
@@ -41,6 +41,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foreign_content_011.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foreign_content_013.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-into-document-with-element-child.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_url.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_write.html

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -133,19 +133,29 @@ static inline bool NODELETE causesFosterParenting(const HTMLStackItem& item)
     }
 }
 
+// Resolves the DOM-derived part of the foster site recorded by recordFosterSite(): script can move
+// or remove the table before the task runs.
+static inline void resolveFosterSite(HTMLConstructionSiteTask& task)
+{
+    if (!task.nextChild) [[likely]]
+        return;
+
+    if (RefPtr referenceParent = task.nextChild->parentNode())
+        task.parent = WTF::move(referenceParent);
+    else
+        task.nextChild = nullptr;
+}
+
 static inline void insert(HTMLConstructionSiteTask& task)
 {
+    resolveFosterSite(task);
+
     if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(task.parent)) [[unlikely]] {
         task.parent = templateElement->fragmentForInsertion();
         task.nextChild = nullptr;
-    } else {
-        if (task.nextChild && task.nextChild->parentNode() != task.parent) [[unlikely]]
+    } else if (RefPtr document = dynamicDowncast<Document>(task.parent)) [[unlikely]] {
+        if (!document->canAcceptChild(*task.child, task.nextChild, AcceptChildOperation::InsertOrAdd))
             return;
-
-        if (RefPtr document = dynamicDowncast<Document>(task.parent)) [[unlikely]] {
-            if (!document->canAcceptChild(*task.child, task.nextChild.get(), AcceptChildOperation::InsertOrAdd))
-                return;
-        }
     }
 
     Ref child = *task.child;
@@ -704,8 +714,11 @@ void HTMLConstructionSite::insertTextNode(const String& characters)
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::Insert);
     task.parent = currentNode();
 
-    if (shouldFosterParent())
-        findFosterSite(task);
+    if (shouldFosterParent()) {
+        recordFosterSite(task);
+        // The parent is read below and these tasks run inline, so resolve now rather than in insert().
+        resolveFosterSite(task);
+    }
 
     unsigned currentPosition = 0;
     unsigned lengthLimit = shouldUseLengthLimit(*task.parent) ? Text::defaultLengthLimit : std::numeric_limits<unsigned>::max();
@@ -770,7 +783,7 @@ void HTMLConstructionSite::insertAlreadyParsedChild(HTMLStackItem& newParent, HT
 {
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::InsertAlreadyParsedChild);
     if (causesFosterParenting(newParent)) {
-        findFosterSite(task);
+        recordFosterSite(task);
         ASSERT(task.parent);
     } else
         task.parent = newParent.node();
@@ -972,11 +985,13 @@ void HTMLConstructionSite::generateImpliedEndTags()
         m_openElements.pop();
 }
 
-// Adjusts |task| to match the "adjusted insertion location" determined by the foster parenting algorithm,
-// laid out as the substeps of step 2 of https://html.spec.whatwg.org/#appropriate-place-for-inserting-a-node
-void HTMLConstructionSite::findFosterSite(HTMLConstructionSiteTask& task)
+// Records the stack-derived part of the "adjusted insertion location" for foster parenting, the
+// substeps of step 3 of https://html.spec.whatwg.org/#appropriate-place-for-inserting-a-node
+// resolveFosterSite() derives the rest from the DOM, so task.parent is not final here.
+void HTMLConstructionSite::recordFosterSite(HTMLConstructionSiteTask& task)
 {
-    // When a node is to be foster parented, the last template element with no table element is below it in the stack of open elements is the foster parent element (NOT the template's parent!)
+    // If the last template or table element on the stack of open elements is a template, that
+    // element is the foster parent, not its parent.
     auto* lastTemplate = m_openElements.topmost(HTML::template_);
     auto* lastTable = m_openElements.topmost(HTML::table);
     if (lastTemplate && (!lastTable || lastTemplate->isAbove(*lastTable))) {
@@ -990,13 +1005,11 @@ void HTMLConstructionSite::findFosterSite(HTMLConstructionSiteTask& task)
         return;
     }
 
-    if (RefPtr parent = lastTable->element().parentNode()) {
-        task.parent = parent;
-        task.nextChild = lastTable->element();
-        return;
-    }
-
-    task.parent = lastTable->next()->element();
+    // The table's parent is read when the task runs, so record the element immediately above the
+    // table in the stack of open elements as the fallback for when it has no parent by then.
+    ASSERT(lastTable->next());
+    task.parent = lastTable->next()->node();
+    task.nextChild = lastTable->element();
 }
 
 bool HTMLConstructionSite::shouldFosterParent() const
@@ -1007,7 +1020,7 @@ bool HTMLConstructionSite::shouldFosterParent() const
 void HTMLConstructionSite::fosterParent(Ref<Node>&& node)
 {
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::Insert);
-    findFosterSite(task);
+    recordFosterSite(task);
     task.child = WTF::move(node);
     ASSERT(task.parent);
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -206,7 +206,7 @@ private:
 
     void attachLater(Ref<ContainerNode>&& parent, Ref<Node>&& child, bool selfClosing = false);
 
-    void findFosterSite(HTMLConstructionSiteTask&);
+    void recordFosterSite(HTMLConstructionSiteTask&);
 
     std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomElementRegistry>> createHTMLElementOrFindCustomElementInterface(AtomHTMLToken&);
     Ref<HTMLElement> createHTMLElement(AtomHTMLToken&);


### PR DESCRIPTION
#### e3fd423207b7044c4c2a238a3dc9c89170e32a87
<pre>
Foster parenting should use the table&apos;s current parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=323086">https://bugs.webkit.org/show_bug.cgi?id=323086</a>
<a href="https://rdar.apple.com/186340113">rdar://186340113</a>

Reviewed by Chris Dumez.

The appropriate place for inserting a node is computed for every insertion, and with
foster parenting enabled it is derived from the on-stack table&apos;s current parent. We
computed it when queueing the task instead, so script running from an earlier task in
the same flush could move the table and leave a later task holding a parent and a
reference child that no longer belong together.

Processing a single &quot;nobr&quot; start tag reaches this. It foster parents once while
reconstructing the active formatting elements, and again after the adoption agency
algorithm finds no furthest block and pops the stack of open elements back to the &quot;tr&quot;.
When script has made a script element the table&apos;s parent, that element is the foster
parent, so the first of those insertions runs it.

319453@main stopped the resulting tree corruption by dropping the later insertion on the
floor. That is safe but is not what the standard asks for. Split the computation
instead: recordFosterSite() keeps the parts derived from the stack of open elements, and
resolveFosterSite() derives the parent from the table when the task runs. This also
covers the table having no parent by then, where the foster parent is the element
immediately above it in the stack of open elements.

The reference child check has to happen before the template element branch, because the
parent it resolves to can be a template element, and insertions then have to be
redirected into its template contents. Without that ordering the case asserts in
ContainerNode::parserInsertBefore().

insertTextNode() runs its tasks inline rather than queueing them and reads the parent
first, so it resolves the foster site itself.

Tests: imported/w3c/web-platform-tests/html/syntax/parsing/foster-parenting-moved-table.window.html

Tests upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62346">https://github.com/web-platform-tests/wpt/pull/62346</a>

Canonical link: <a href="https://commits.webkit.org/320643@main">https://commits.webkit.org/320643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26066e63296053b51ab376f09cafee0fe184665a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150234 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144937 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100484 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125229 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45404 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45093 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197741 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41358 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59754 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154111 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48587 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132097 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128981 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20115 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->