### PR TITLE
[Safer CPP] Drop some suppression macros now that rdar://160259918 has been fixed in the static analyzer

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -259,8 +259,7 @@ static void* lib##Library(bool = false) \
     _Pragma("clang diagnostic ignored \"-Wunused-function\"") \
     static className *alloc##className##Instance() NS_RETURNS_RETAINED \
     { \
-        /* FIXME: This is a static analysis false positive (rdar://160259918). */ \
-        SUPPRESS_UNRETAINED_ARG return [get##className##ClassSingleton() alloc]; \
+        return [get##className##ClassSingleton() alloc]; \
     } \
     _Pragma("clang diagnostic pop")
 
@@ -288,8 +287,7 @@ static void* lib##Library(bool = false) \
     _Pragma("clang diagnostic ignored \"-Wunused-function\"") \
     static className *alloc##className##Instance() NS_RETURNS_RETAINED \
     { \
-        /* FIXME: This is a static analysis false positive (rdar://160259918). */ \
-        SUPPRESS_UNRETAINED_ARG return [get##className##ClassSingleton() alloc]; \
+        return [get##className##ClassSingleton() alloc]; \
     } \
     _Pragma("clang diagnostic pop")
 

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
@@ -77,8 +77,7 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
     for (VNComputeStage computeStage in supportedComputeStageDevices.get()) {
         bool set = false;
         for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices.get()[computeStage]) {
-            // FIXME: This is a safer cpp false positive (rdar://160259918).
-            SUPPRESS_UNRETAINED_ARG if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
+            if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
                 [request setComputeDevice:device forComputeStage:computeStage];
                 set = true;
                 break;
@@ -86,8 +85,7 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
         }
         if (!set) {
             for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices.get()[computeStage]) {
-                // FIXME: This is a safer cpp false positive (rdar://160259918).
-                SUPPRESS_UNRETAINED_ARG if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
+                if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
                     [request setComputeDevice:device forComputeStage:computeStage];
                     break;
                 }

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -151,8 +151,7 @@ static RetainPtr<id> makeNSArrayElement(const ApplePayInstallmentItem& item)
 
 static std::optional<ApplePayInstallmentItem> makeVectorElement(const ApplePayInstallmentItem*, id arrayElement)
 {
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG if (![arrayElement isKindOfClass:PAL::getPKPaymentInstallmentItemClassSingleton()])
+    if (![arrayElement isKindOfClass:PAL::getPKPaymentInstallmentItemClassSingleton()])
         return std::nullopt;
 
     PKPaymentInstallmentItem *item = arrayElement;

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -88,8 +88,7 @@ static NSCalendarUnit NODELETE toCalendarUnit(ApplePayRecurringPaymentDateUnit u
 RetainPtr<PKRecurringPaymentSummaryItem> platformRecurringSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Recurring);
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.recurringPaymentStartDate.isNaN())
         summaryItem.get().startDate = protect(toDate(lineItem.recurringPaymentStartDate)).get();
     summaryItem.get().intervalUnit = toCalendarUnit(lineItem.recurringPaymentIntervalUnit);
@@ -106,8 +105,7 @@ RetainPtr<PKRecurringPaymentSummaryItem> platformRecurringSummaryItem(const Appl
 RetainPtr<PKDeferredPaymentSummaryItem> platformDeferredSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Deferred);
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.deferredPaymentDate.isNaN())
         summaryItem.get().deferredDate = protect(toDate(lineItem.deferredPaymentDate)).get();
     return summaryItem;
@@ -120,8 +118,7 @@ RetainPtr<PKDeferredPaymentSummaryItem> platformDeferredSummaryItem(const AppleP
 RetainPtr<PKAutomaticReloadPaymentSummaryItem> platformAutomaticReloadSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::AutomaticReload);
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     summaryItem.get().thresholdAmount = protect(toDecimalNumber(lineItem.automaticReloadPaymentThresholdAmount)).get();
     return summaryItem;
 }
@@ -133,15 +130,13 @@ RetainPtr<PKAutomaticReloadPaymentSummaryItem> platformAutomaticReloadSummaryIte
 PKDisbursementSummaryItem *platformDisbursementSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::Disbursement);
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKDisbursementSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
+    return [PAL::getPKDisbursementSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
 }
 
 PKInstantFundsOutFeeSummaryItem *platformInstantFundsOutFeeSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::InstantFundsOutFee);
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKInstantFundsOutFeeSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
+    return [PAL::getPKInstantFundsOutFeeSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
 }
 
 #endif // HAVE(PASSKIT_DISBURSEMENTS)
@@ -179,8 +174,7 @@ RetainPtr<PKPaymentSummaryItem> platformSummaryItem(const ApplePayLineItem& line
 #endif
     }
 
-    // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    return [PAL::getPKPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
 }
 
 #if HAVE(PASSKIT_DISBURSEMENTS)

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -52,15 +52,13 @@ void AudioSessionCocoa::setEligibleForSmartRoutingInternal(bool eligible)
     if (!AudioSession::shouldManageAudioSessionCategory())
         return;
 
-    // FIXME: This is a safer cpp false positive (160259918).
-    SUPPRESS_UNRETAINED_ARG static bool supportsEligibleForBT = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)] && [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
+    static bool supportsEligibleForBT = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)] && [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
     if (!supportsEligibleForBT)
         return;
 
     RELEASE_LOG(Media, "AudioSession::setEligibleForSmartRouting() %s", eligible ? "true" : "false");
 
-    // FIXME: This is a safer cpp false positive (160259918).
-    SUPPRESS_UNRETAINED_ARG AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
+    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     if (session.eligibleForBTSmartRoutingConsideration == eligible)
         return;
 
@@ -95,10 +93,8 @@ void AudioSessionCocoa::setEligibleForSmartRouting(bool isEligible, ForceUpdate 
 
 Ref<AudioSession::SetActivePromise> AudioSessionCocoa::tryToSetActiveInternal(bool active)
 {
-    // FIXME: This is a safer cpp false positive (160259918).
-    SUPPRESS_UNRETAINED_ARG static bool supportsSharedInstance = [PAL::getAVAudioSessionClassSingleton() respondsToSelector:@selector(sharedInstance)];
-    // FIXME: This is a safer cpp false positive (160259918).
-    SUPPRESS_UNRETAINED_ARG static bool supportsSetActive = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
+    static bool supportsSharedInstance = [PAL::getAVAudioSessionClassSingleton() respondsToSelector:@selector(sharedInstance)];
+    static bool supportsSetActive = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
 
     if (!supportsSharedInstance)
         return SetActivePromise::createAndResolve();
@@ -116,8 +112,7 @@ Ref<AudioSession::SetActivePromise> AudioSessionCocoa::tryToSetActiveInternal(bo
         m_workQueue->dispatchSync([&success] {
             NSError *error = nil;
             if (supportsSetActive) {
-                // FIXME: This is a safer cpp false positive (160259918).
-                SUPPRESS_UNRETAINED_ARG [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:YES withOptions:0 error:&error];
+                [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:YES withOptions:0 error:&error];
             }
             if (error)
                 RELEASE_LOG_ERROR(Media, "failed to activate audio session, error: %@", error.localizedDescription);
@@ -129,8 +124,7 @@ Ref<AudioSession::SetActivePromise> AudioSessionCocoa::tryToSetActiveInternal(bo
     m_workQueue->dispatch([] {
         NSError *error = nil;
         if (supportsSetActive) {
-            // FIXME: This is a safer cpp false positive (160259918).
-            SUPPRESS_UNRETAINED_ARG [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:NO withOptions:0 error:&error];
+            [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:NO withOptions:0 error:&error];
         }
         if (error)
             RELEASE_LOG_ERROR(Media, "failed to deactivate audio session, error: %@", error.localizedDescription);


### PR DESCRIPTION
#### d11e9e17a1e181a8ad70653207a87e64c1bdd132
<pre>
[Safer CPP] Drop some suppression macros now that <a href="https://rdar.apple.com/160259918">rdar://160259918</a> has been fixed in the static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=323087">https://bugs.webkit.org/show_bug.cgi?id=323087</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm:
(WebCore::ShapeDetection::configureRequestToUseCPUOrGPU):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::makeVectorElement):
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
(WebCore::platformRecurringSummaryItem):
(WebCore::platformDeferredSummaryItem):
(WebCore::platformAutomaticReloadSummaryItem):
(WebCore::platformDisbursementSummaryItem):
(WebCore::platformInstantFundsOutFeeSummaryItem):
(WebCore::platformSummaryItem):
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::setEligibleForSmartRoutingInternal):
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):

Canonical link: <a href="https://commits.webkit.org/320299@main">https://commits.webkit.org/320299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9b1257c7032392c78cb4ef0fc65953e728cddc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148491 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4dd813c-ab65-4b8c-bec8-a4e881123b83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143794 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99938 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ce803cc-a80e-4d63-adbe-c78a63b51c5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef96af02-15d7-4043-a2d2-f9d05c27501c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46282 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44493 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6184 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13014 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156691 "Found 5 new API test failures: TestWebKitAPI.WebAuthenticationPanel.LAError, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WKWebExtension.MultipleContentScriptsInjectedWhenMatched, TestWebKitAPI.WKWebView.LocalStorageGroup, TestWebKitAPI.WKWebExtensionAPIWebRequest.AllEventsFired (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44074 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5604 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45475 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57793 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41101 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153029 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47566 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130788 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127262 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57005 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56376 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->