### PR TITLE
REGRESSION(204269@main): Content changing inside an element with a blur filter doesn't properly repaint https://bugs.webkit.org/show_bug.cgi?id=322424

### DIFF
--- a/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt
@@ -1,0 +1,7 @@
+(repaint rects
+  (rect 97 97 106 106)
+)
+(repaint rects
+  (rect 97 397 106 106)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        filter: blur(10px);
+    }
+
+    #first {
+        left: 100px;
+        top: 100px;
+    }
+
+    #second {
+        left: 100px;
+        top: 400px;
+    }
+
+    .inner {
+        position: absolute;
+        left: 25px;
+        top: 25px;
+        width: 50px;
+        height: 50px;
+        background-color: green;
+    }
+
+    .before {
+        background-color: red;
+    }
+</style>
+<script>
+// Neither of the shared repaint helpers fits here: both start tracking at load, while
+// the second measurement must only begin tracking once the first paint has happened...
+let dumpedRects = "";
+
+function trackRepaintRects(mutate)
+{
+    internals.startTrackingRepaints();
+    mutate();
+    document.body.offsetTop;
+    dumpedRects += internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+}
+
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+
+addEventListener("load", () => {
+    if (!window.testRunner || !window.internals)
+        return;
+
+    trackRepaintRects(() => {
+        document.querySelector("#first .inner").classList.remove("before");
+    });
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            trackRepaintRects(() => {
+                document.querySelector("#second .inner").classList.remove("before");
+            });
+
+            const pre = document.createElement("pre");
+            pre.textContent = dumpedRects;
+            document.body.appendChild(pre);
+            testRunner.notifyDone();
+        });
+    });
+});
+</script>
+</head>
+<body>
+<div class="blurred" id="first"><div class="inner before"></div></div>
+<div class="blurred" id="second"><div class="inner before"></div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 96 96 108 108)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    canvas {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        filter: blur(10px);
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    const context = document.querySelector("canvas").getContext("2d");
+    context.fillStyle = "green";
+    context.fillRect(25, 25, 50, 50);
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <canvas width="100" height="100"></canvas>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt
@@ -1,0 +1,5 @@
+AAAA
+(repaint rects
+  (rect 72 72 216 96)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-inline.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inline.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+        font: 40px Ahem;
+    }
+
+    .box {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+    }
+
+    span {
+        color: green;
+        filter: blur(10px);
+    }
+
+    .before {
+        color: red;
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    document.querySelector("span").classList.remove("before");
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <div class="box"><span class="before">AAAA</span></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 122 122 156 156)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+
+    .inner.before {
+        background-color: red;
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    document.querySelector(".inner").classList.remove("before");
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <div class="blurred">
+        <div class="inner before"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 (repaint rects
-  (rect 200 200 100 100)
+  (rect 172 174 156 156)
   (rect 172 174 156 156)
 )
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1041,6 +1041,15 @@ void RenderElement::styleWillChange(Style::Difference diff, const Style::Compute
             view().decrementRendersWithOutline();
     }
 
+    bool hadPixelMovingFilter = oldStyle && oldStyle->filter().hasFilterThatMovesPixels();
+    bool hasPixelMovingFilter = newStyle.filter().hasFilterThatMovesPixels();
+    if (hadPixelMovingFilter != hasPixelMovingFilter) {
+        if (hasPixelMovingFilter)
+            view().incrementRenderersWithPixelMovingFilter();
+        else
+            view().decrementRenderersWithPixelMovingFilter();
+    }
+
     bool newStyleSlowScroll = false;
     if (Style::hasImageWithAttachment(newStyle.backgroundLayers(), FillAttachment::FixedBackground) && !settings().fixedBackgroundsPaintRelativeToDocument()) {
         newStyleSlowScroll = true;
@@ -1317,6 +1326,9 @@ void RenderElement::willBeDestroyed()
 
         if (style().hasOutline())
             view().decrementRendersWithOutline();
+
+        if (style().filter().hasFilterThatMovesPixels())
+            view().decrementRenderersWithPixelMovingFilter();
 
         if (auto* firstLineStyle = style().pseudoElementStyle({ PseudoElementType::FirstLine }))
             unregisterImages(*firstLineStyle);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1074,7 +1074,7 @@ bool RenderLayer::requiresFullLayerImageForFilters() const
     if (!shouldPaintWithFilters())
         return false;
 
-    return m_filters && m_filters->hasFilterThatMovesPixels();
+    return renderer().style().filter().hasFilterThatMovesPixels();
 }
 
 OptionSet<RenderLayer::UpdateLayerPositionsFlag> RenderLayer::flagsForUpdateLayerPositions(RenderLayer& startingLayer)
@@ -2519,18 +2519,19 @@ RenderLayer* RenderLayer::enclosingFilterRepaintLayer() const
 }
 
 // FIXME: This needs a better name.
-void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect)
+void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect, FilterOutsets outsets)
 {
     ASSERT(requiresFullLayerImageForFilters());
-    ASSERT(m_filters);
 
     if (rect.isEmpty())
         return;
     
     LayoutRect rectForRepaint = rect;
-    rectForRepaint.expand(toLayoutBoxExtent(filterOutsets()));
+    if (outsets == FilterOutsets::Add)
+        rectForRepaint.expand(toLayoutBoxExtent(filterOutsets()));
 
-    m_filters->expandDirtySourceRect(rectForRepaint);
+    if (m_filters)
+        m_filters->expandDirtySourceRect(rectForRepaint);
     
     RenderLayer* parentLayer = enclosingFilterRepaintLayer();
     ASSERT(parentLayer);
@@ -6503,10 +6504,7 @@ IntOutsets RenderLayer::filterOutsets() const
     if (m_filters)
         return m_filters->calculateOutsets(renderer(), localBoundingBox());
 
-    if (CheckedPtr boxRenderer = renderBox())
-        return boxRenderer->computeFilterOutsets();
-
-    return { };
+    return renderer().computeFilterOutsets();
 }
 
 void RenderLayer::clearFilters()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -680,7 +680,8 @@ public:
 
     RenderLayer* enclosingFilterLayer(IncludeSelfOrNot = IncludeSelf) const;
     RenderLayer* enclosingFilterRepaintLayer() const;
-    void setFilterBackendNeedsRepaintingInRect(const LayoutRect&);
+    enum class FilterOutsets : bool { Add, AlreadyIncluded };
+    void setFilterBackendNeedsRepaintingInRect(const LayoutRect&, FilterOutsets = FilterOutsets::Add);
 
     inline bool NODELETE canUseOffsetFromAncestor() const;
     bool NODELETE canUseOffsetFromAncestor(const RenderLayer& ancestor) const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -910,7 +910,7 @@ RenderObject::RepaintContainerStatus RenderObject::containerForRepaint() const
             }
         }
     }
-    if (view().hasSoftwareFilters()) {
+    if (view().hasRenderersWithPixelMovingFilter()) {
         if (CheckedPtr parentLayer = enclosingLayer()) {
             if (CheckedPtr enclosingFilterLayer = parentLayer->enclosingFilterLayer()) {
                 fullRepaintAlreadyScheduled = parentLayer->needsFullRepaint() && canRelyOnAncestorLayerFullRepaint(*this, *parentLayer);
@@ -971,7 +971,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     ASSERT_NOT_REACHED();
 }
 
-void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect& r, bool shouldClipToLayer) const
+void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect& r, ClipRepaintToLayer clipRepaintToLayer, RepaintRectIsPartial rectIsPartial) const
 {
     if (r.isEmpty())
         return;
@@ -990,7 +990,11 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     propagateRepaintToParentWithOutlineAutoIfNeeded(*repaintContainer, r);
 
     if (repaintContainer->hasFilter() && repaintContainer->layer() && repaintContainer->layer()->requiresFullLayerImageForFilters()) {
-        protect(repaintContainer->layer())->setFilterBackendNeedsRepaintingInRect(r);
+        // The full repaint rect of a RenderBox is its visual overflow, which already includes the filter outsets.
+        auto outsets = RenderLayer::FilterOutsets::Add;
+        if (rectIsPartial == RepaintRectIsPartial::No && repaintContainer.get() == this && is<RenderBox>(*this))
+            outsets = RenderLayer::FilterOutsets::AlreadyIncluded;
+        protect(repaintContainer->layer())->setFilterBackendNeedsRepaintingInRect(r, outsets);
         return;
     }
 
@@ -1010,7 +1014,7 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     if (view().usesCompositing()) {
         ASSERT(repaintContainer->isComposited());
         if (CheckedPtr layer = repaintContainer->layer())
-            layer->setBackingNeedsRepaintInRect(r, shouldClipToLayer ? GraphicsLayer::ShouldClipToLayer::Clip : GraphicsLayer::ShouldClipToLayer::DoNotClip);
+            layer->setBackingNeedsRepaintInRect(r, clipRepaintToLayer == ClipRepaintToLayer::Yes ? GraphicsLayer::ShouldClipToLayer::Clip : GraphicsLayer::ShouldClipToLayer::DoNotClip);
     }
 }
 
@@ -1043,7 +1047,7 @@ void RenderObject::issueRepaint(std::optional<LayoutRect> partialRepaintRect, Cl
     } else
         repaintRect = clippedOverflowRectForRepaint(repaintContainer.renderer.get());
 
-    repaintUsingContainer(repaintContainer.renderer.get(), repaintRect, clipRepaintToLayer == ClipRepaintToLayer::Yes);
+    repaintUsingContainer(repaintContainer.renderer.get(), repaintRect, clipRepaintToLayer, partialRepaintRect ? RepaintRectIsPartial::Yes : RepaintRectIsPartial::No);
 }
 
 void RenderObject::repaint(ForceRepaint forceRepaint) const
@@ -1087,17 +1091,17 @@ void RenderObject::repaintSlowRepaintObject() const
 
     CheckedPtr repaintContainer = containerForRepaint().renderer;
 
-    bool shouldClipToLayer = true;
+    auto clipRepaintToLayer = ClipRepaintToLayer::Yes;
     IntRect repaintRect;
     // If this is the root background, we need to check if there is an extended background rect. If
     // there is, then we should not allow painting to clip to the layer size.
     if (isDocumentElementRenderer() || isBody()) {
-        shouldClipToLayer = !protect(view->frameView())->hasExtendedBackgroundRectForPainting();
+        clipRepaintToLayer = protect(view->frameView())->hasExtendedBackgroundRectForPainting() ? ClipRepaintToLayer::No : ClipRepaintToLayer::Yes;
         repaintRect = snappedIntRect(view->backgroundRect());
     } else
         repaintRect = snappedIntRect(clippedOverflowRectForRepaint(repaintContainer.get()));
 
-    repaintUsingContainer(repaintContainer.get(), repaintRect, shouldClipToLayer);
+    repaintUsingContainer(repaintContainer.get(), repaintRect, clipRepaintToLayer);
 }
 
 IntRect RenderObject::pixelSnappedAbsoluteClippedOverflowRect() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -883,7 +883,9 @@ public:
     RepaintContainerStatus containerForRepaint() const;
     // Actually do the repaint of rect r for this object which has been computed in the coordinate space
     // of repaintContainer. If repaintContainer is nullptr, repaint via the view.
-    void repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect&, bool shouldClipToLayer = true) const;
+    enum class ClipRepaintToLayer : bool { No, Yes };
+    enum class RepaintRectIsPartial : bool { No, Yes };
+    void repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect&, ClipRepaintToLayer = ClipRepaintToLayer::Yes, RepaintRectIsPartial = RepaintRectIsPartial::No) const;
 
     // Repaint the entire object.  Called when, e.g., the color of a border changes, or when a border
     // style changes.
@@ -893,7 +895,6 @@ public:
     // Repaint a specific subrectangle within a given object.  The rect |r| is in the object's coordinate space.
     WEBCORE_EXPORT void repaintRectangle(const LayoutRect&, bool shouldClipToLayer = true) const;
 
-    enum class ClipRepaintToLayer : bool { No, Yes };
     void repaintRectangle(const LayoutRect&, ClipRepaintToLayer, ForceRepaint, std::optional<LayoutBoxExtent> additionalRepaintOutsets = std::nullopt) const;
 
     // Repaint a slow repaint object, which, at this time, means we are repainting an object with background-attachment:fixed.

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -178,8 +178,9 @@ public:
 
     ImageQualityController& imageQualityController() LIFETIME_BOUND;
 
-    void setHasSoftwareFilters(bool hasSoftwareFilters) { m_hasSoftwareFilters = hasSoftwareFilters; }
-    bool hasSoftwareFilters() const { return m_hasSoftwareFilters; }
+    void incrementRenderersWithPixelMovingFilter() { ++m_renderersWithPixelMovingFilterCount; }
+    void decrementRenderersWithPixelMovingFilter() { ASSERT(m_renderersWithPixelMovingFilterCount > 0); --m_renderersWithPixelMovingFilterCount; }
+    bool hasRenderersWithPixelMovingFilter() const { return m_renderersWithPixelMovingFilterCount; }
 
     uint64_t rendererCount() const { return m_rendererCount; }
     void didCreateRenderer() { ++m_rendererCount; }
@@ -293,7 +294,7 @@ private:
     SingleThreadWeakHashSet<RenderCounter> m_countersNeedingUpdate;
     unsigned m_renderersWithOutlineCount { 0 };
 
-    bool m_hasSoftwareFilters { false };
+    unsigned m_renderersWithPixelMovingFilterCount { 0 };
     bool m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly { false };
     bool m_needsEventRegionUpdateForNonCompositedFrame { false };
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -792,6 +792,23 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
             // necessarily enclose this box.
             return destroyRootWithLayer->layer()->needsFullRepaint() || destroyRootWithLayer->isOutOfFlowPositioned();
         };
+    
+        auto repaintUsingCachedRectIfNeeded = [&] {
+            if (!destroyRoot.hasLayer() || !destroyRoot.isOutOfFlowPositioned())
+                return false;
+            CheckedPtr container = destroyRoot.container();
+            if (!container || !container->isInFlowPositioned() || !is<RenderInline>(*container))
+                return false;
+            CheckedPtr layer = downcast<RenderLayerModelObject>(destroyRoot).layer();
+            auto cachedRepaintRect = layer->cachedClippedOverflowRect();
+            if (!cachedRepaintRect)
+                return false;
+            destroyRoot.repaintUsingContainer(layer->repaintContainer(), *cachedRepaintRect, RenderObject::ClipRepaintToLayer::No);
+            return true;
+        };
+        if (repaintUsingCachedRectIfNeeded())
+            return;
+
         destroyRoot.repaint(shouldForceRepaint() ? RenderObject::ForceRepaint::Yes : RenderObject::ForceRepaint::No);
     };
 


### PR DESCRIPTION
#### 473a618f9b376cd8056cfb7eb04b697f69fd8642
<pre>
REGRESSION(<a href="https://commits.webkit.org/204269@main">204269@main</a>): Content changing inside an element with a blur filter doesn&apos;t properly repaint <a href="https://bugs.webkit.org/show_bug.cgi?id=322424">https://bugs.webkit.org/show_bug.cgi?id=322424</a>

Reviewed by NOBODY (OOPS!).

The ticket contains a reduction obtained from YouTube Shorts, when dark
mode + ambient mode is enabled. Around the video a glow effect is
visible, which left stale pixels on our ports while the video was
running.

Testcase:

  #glow { position: absolute; left: 50%; top: 50%; width: 380px; height: 660px;
          margin: -330px 0 0 -190px; transform: scale(1.8, 1.3);
          filter: blur(40px); pointer-events: none; }
  #glow canvas { position: absolute; width: 100%; height: 100%; }

&lt;div id=&quot;glow&quot;&gt;
  &lt;canvas id=&quot;ca&quot; width=&quot;86&quot; height=&quot;126&quot;&gt;&lt;/canvas&gt;
  &lt;canvas id=&quot;cb&quot; width=&quot;86&quot; height=&quot;126&quot;&gt;&lt;/canvas&gt;
&lt;/div&gt;

macOS repaints it correctly, because #glow ends up composited as the canvases
are composited and the platform layer applies the blur filter. On GTK/WPE they
are not: the canvas backing store size is 86 * 126px, below the minimum area
we impose for acceleration (CanvasBase::shouldAccelerate(), queries
Settings::minimumAccelerated2DContextArea which is 128 * 129 with Skia,
0 elsewhere). Both canvases are drawn in software, into the enclosing layer.

The code path our ports take has a bug since <a href="https://commits.webkit.org/204269@main">204269@main</a>: we no longer set
setHasSoftwareFilters() anywhere. RenderObject::containerForRepaint() only looks
for an enclosing filter layer while that flag is set, so it never sees #glow.
The repaint is issued against the root layer of the page instead, and
repaintUsingContainer() never calls RenderLayer::setFilterBackendNeedsRepaintingInRect().
That is the only place that expands the repaint rect by filterOutsets() and was
missing for us.

Instead of bringing back the setHasSoftwareFilters() mechanism, mimic
the outline counter concept: count the renderers with a pixel moving
filter, and maintain the count properly, instead of keeping a flag on all
the time as it used to be in the past.

Add some new tests covering the logic.

Tests: css3/filters/filter-repaint-blur-before-first-paint.html
       css3/filters/filter-repaint-blur-canvas-partial.html
       css3/filters/filter-repaint-blur-inline.html
       css3/filters/filter-repaint-blur-inner-content-change.html

* LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt: Added.
* LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html: Added.
* LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt: Added.
* LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html: Added.
* LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt: Added.
* LayoutTests/css3/filters/filter-repaint-blur-inline.html: Added.
* LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt: Added.
* LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt:
  The first repaint rect dumped was wrong, this fixes it as side-effect.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):
(WebCore::RenderElement::willBeDestroyed):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::requiresFullLayerImageForFilters const):
(WebCore::RenderLayer::setFilterBackendNeedsRepaintingInRect):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::containerForRepaint const):
(WebCore::RenderObject::repaintUsingContainer const):
(WebCore::RenderObject::issueRepaint const):
(WebCore::RenderObject::repaintSlowRepaintObject const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::repaintAndMarkContainingBlockDirtyBeforeTearDown):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/473a618f9b376cd8056cfb7eb04b697f69fd8642

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184202 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58126 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148495 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186065 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59471 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57861 "The change is no longer eligible for processing.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143802 "Found 2 new test failures: fast/repaint/out-of-flow-inside-relative-inline.html imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148495 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59471 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124221 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59471 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/57861 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59471 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5608 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50783 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/57861 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196364 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57797 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153359 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003.html (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58501 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153033 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58501 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130792 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127266 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57009 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51944 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56380 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56619 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56447 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->