### PR TITLE
[iPad] fast/quirks/active-quirks-by-domain.html is a consistent text failure

### DIFF
--- a/LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt
@@ -1,0 +1,359 @@
+https://www.example.com/
+    (none)
+https://webkit.org/
+    (none)
+https://amazon.com.attacker.com/
+    (none)
+https://www.notamazon.com/
+    (none)
+https://www.365scores.com/
+    ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting
+https://actesting.org/
+    ShouldEnableLegacyGetUserMediaQuirk
+https://www.airindiaexpress.com/
+    NeedsAirIndiaExpressLayeringQuirk
+https://www.amazon.com/
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://sub.amazon.com/
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://www.amazon.co.uk/
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://amazon.design/
+    NeedsAmazonDesignMenuViewportUnitQuirk
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://www.apple.com/
+    EnsureCaptionVisibilityInFullscreenAndPictureInPicture
+https://as.com/
+    (none)
+https://www.att.com/
+    ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk
+https://www.bbc.co.uk/
+    ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk
+https://www.bbc.com/
+    ReturnNullPictureInPictureElementDuringFullscreenChangeQuirk
+https://codepen.io/
+    ShouldEnableSpeakerSelectionPermissionsPolicyQuirk
+https://www.codepen.io/
+    (none)
+https://www.bankofamerica.com/
+    MaybeBypassBackForwardCache
+https://www.bestbuy.com/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.bing.com/
+    MaybeBypassBackForwardCache
+    NeedsMediaRewriteRangeRequestQuirk
+https://bungalow.com/
+    ShouldBypassAsyncScriptDeferring
+https://www.capitalgroup.com/
+    ShouldDelayReloadWhenRegisteringServiceWorker
+https://www.cbssports.com/
+    ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk
+https://www.cnn.com/
+    NeedsCNNCaptionQuirk
+    NeedsFullscreenObjectFitQuirk
+    ShouldDisableThreadedAnimationsQuirk
+https://www.digitaltrends.com/
+    (none)
+https://discord.com/
+    ShouldUseLayoutViewportForClientRectsQuirk
+https://store.steampowered.com/
+    ShouldTreatAddingMouseOutEventListenerAsContentChange
+https://www.crunchyroll.com/
+    NeedsSuppressPostLayoutBoundaryEventsQuirk
+https://digits.t-mobile.com/
+    NeedsCustomUserAgentData
+    NeedsNavigatorUserAgentDataQuirk
+https://www.t-mobile.com/
+    (none)
+https://www.descript.com/
+    ShouldDisableDOMAudioSession
+https://www.dictionary.com/
+    NeedsAnchorToBeMouseFocusableQuirk
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.disneyplus.com/
+    ShouldHideCoarsePointerCharacteristicsQuirk
+https://www.ea.com/
+    (none)
+https://www.espn.com/
+    AllowLayeredFullscreenVideos
+    NeedsSuppressedPauseEventOnFullscreenExitQuirk
+    ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk
+https://www.facebook.com/
+    NeedsFacebookRemoveNotSupportedQuirk
+    RequiresUserGestureToPauseInPictureInPictureQuirk
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+    ShouldEnableCameraAndMicrophonePermissionStateQuirk
+    ShouldEnableEnumerateDeviceQuirk
+    ShouldEnableFacebookFlagQuirk
+    ShouldEnableRTCEncodedStreamsQuirk
+    ShouldEnableRemoteTrackLabelQuirk
+https://www.forbes.com/
+    RequiresUserGestureToPauseInPictureInPictureQuirk
+https://gizmodo.com/
+    NeedsFullscreenDisplayNoneQuirk
+https://play.geforcenow.com/
+    NeedsGeforcenowWarningDisplayNoneQuirk
+https://www.google.com/
+    MaybeBypassBackForwardCache
+https://www.google.com/maps/
+    MayNeedToIgnoreContentObservation
+    MaybeBypassBackForwardCache
+    NeedsGoogleMapsScrollingQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://maps.google.com/maps/
+    MayNeedToIgnoreContentObservation
+    MaybeBypassBackForwardCache
+    NeedsGoogleMapsScrollingQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://docs.google.com/
+    InputMethodUsesCorrectKeyEventOrder
+    MaybeBypassBackForwardCache
+    ShouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk
+https://translate.google.com/
+    MaybeBypassBackForwardCache
+    NeedsGoogleTranslateScrollingQuirk
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://mail.google.com/
+    MaybeBypassBackForwardCache
+    NeedsGMailOverflowScrollQuirk
+https://sites.google.com/
+    MaybeBypassBackForwardCache
+    ShouldPreventDispatchOfTouchEventQuirk
+https://meet.google.com/
+    MaybeBypassBackForwardCache
+    ShouldEnableCameraBackgroundPlayback
+https://www.google.co.uk/
+    MaybeBypassBackForwardCache
+https://www.hbomax.com/
+    ShouldEnableFontLoadingAPIQuirk
+https://play.hbomax.com/
+    ShouldEnableFontLoadingAPIQuirk
+https://www.carrentals.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.cheaptickets.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.chess.com/
+    (none)
+https://www.ebookers.de/
+    NeedsExpediaGroupAnimationQuirk
+https://www.expedia.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.expedia.fr/
+    NeedsExpediaGroupAnimationQuirk
+https://www.hoteis.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.hoteles.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.hotels.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.mrjet.se/
+    NeedsExpediaGroupAnimationQuirk
+https://www.orbitz.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.travelocity.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.travelocity.ca/
+    NeedsExpediaGroupAnimationQuirk
+https://www.wotif.com/
+    NeedsExpediaGroupAnimationQuirk
+https://www.wotif.co.nz/
+    NeedsExpediaGroupAnimationQuirk
+https://www.hulu.com/
+    ImplicitMuteWhenVolumeSetToZero
+    NeedsCanPlayAfterSeekedQuirk
+    NeedsVideoShouldMaintainAspectRatioQuirk
+https://www.icloud.com/
+    (none)
+https://www.iheart.com/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.imdb.com/
+    NeedsChromeMediaControlsPseudoElementQuirk
+    NeedsZeroMaxTouchPointsQuirk
+https://www.instagram.com/
+    NeedsInstagramResizingReelsQuirk
+    ShouldDisableElementFullscreenQuirk
+    ShouldSendFakeTouchForceChangeEvent
+https://invideo.io/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.linkedin.com/
+    (none)
+https://outlook.live.com/
+    MayNeedToIgnoreContentObservation
+    NeedsChromeOSNavigatorUserAgentQuirk
+    NeedsMozillaFileTypeForDataTransferQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+https://live.com/
+    NeedsChromeOSNavigatorUserAgentQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+https://onedrive.live.com/
+    NeedsChromeOSNavigatorUserAgentQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDisableDataURLPaddingValidation
+https://officeapps.live.com/
+    NeedsChromeOSNavigatorUserAgentQuirk
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+    ShouldDisableDataURLPaddingValidation
+https://madisoncity.k12.al.us/
+    (none)
+https://mailchimp.com/
+    ShouldDisablePointerEventsQuirk
+https://www.marcus.com/
+    ShouldExposeShowModalDialog
+    ShouldNavigatorPluginsBeEmpty
+https://medium.com/
+    ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk
+https://m365.cloud.microsoft/
+    ShouldAllowPopupFromMicrosoftOfficeToOneDrive
+https://cloud.microsoft/
+    (none)
+https://safe.menlosecurity.com/
+    ShouldDisableWritingSuggestionsByDefaultQuirk
+https://www.menlosecurity.com/
+    (none)
+https://www.messenger.com/
+    ShouldEnableCameraAndMicrophonePermissionStateQuirk
+    ShouldEnableEnumerateDeviceQuirk
+    ShouldEnableRTCEncodedStreamsQuirk
+    ShouldEnableRemoteTrackLabelQuirk
+https://www.netflix.com/
+    NeedsNetflixVolumeSliderQuirk
+    NeedsSeekingSupportDisabledQuirk
+https://www.nba.com/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.nfl.com/
+    ShouldSuppressHLSSubtitles
+https://www.nhl.com/
+    NeedsWebKitMediaTextTrackDisplayQuirk
+https://www.nytimes.com/
+    ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting
+https://www.pandora.com/
+    ShouldExposeShowModalDialog
+https://www.pinterest.com/
+    ShouldAllowNotificationPermissionWithoutUserGesture
+https://www.premierleague.com/
+    ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
+    ShouldDispatchPlayPauseEventsOnResume
+    ShouldIgnorePlaysInlineRequirementQuirk
+https://www.ralphlauren.com/
+    ShouldIgnoreAriaForFastPathContentObservationCheckQuirk
+https://www.reddit.com/
+    RequiresUserGestureToPauseInPictureInPictureQuirk
+    ShouldDisableScrollAnchoringQuirk
+https://www.scribd.com/
+    NeedsReuseLiveRangeForSelectionUpdateQuirk
+https://www.sfusd.edu/
+    ShouldBypassAsyncScriptDeferring
+https://app.slack.com/
+    ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk
+    ShouldUseDynamicViewportUnitsAsDefaultQuirk
+https://www.sharepoint.com/
+    ShouldAvoidResizingWhenInputViewBoundsChangeQuirk
+https://soundcloud.com/
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+    ShouldExposeShowModalDialog
+https://soylent.com/
+    (none)
+https://open.spotify.com/
+    NeedsBodyScrollbarWidthNoneDisabledQuirk
+    NeedsWebKitMediaKeysTransportStreamIsTypeSupportedQuirk
+    NeedsWebKitMediaTextTrackDisplayQuirk
+    ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
+    ShouldBlockAudiblePlaybackWhileAudioIsPlaying
+    ShouldDeferIntersectionObserversDuringResize
+    ShouldLimitHLSPlaybackRate
+https://www.spotify.com/
+    (none)
+https://ceac.state.gov/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://sub.ceac.state.gov/
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.state.gov/
+    (none)
+https://www.theguardian.com/
+    ShouldHideSoftTopScrollEdgeEffectDuringFocusQuirk
+https://www.thesaurus.com/
+    NeedsAnchorToBeMouseFocusableQuirk
+    NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk
+https://www.tiktok.com/
+    NeedsTikTokOverflowingContentQuirk
+    ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
+    ShouldDispatchSimulatedMouseEventsQuirk
+https://trix-editor.org/
+    (none)
+https://www.twitch.tv/
+    ShouldReportDocumentAsVisibleIfActivePIPQuirk
+https://tympanus.net/
+    ShouldBlockFetchWithNewlineAndLessThan
+https://www.victoriassecret.com/
+    ShouldDisableFetchMetadata
+https://vimeo.com/
+    BlocksEnteringStandardFullscreenFromPictureInPictureQuirk
+    BlocksReturnToFullscreenFromPictureInPictureQuirk
+    MaybeBypassBackForwardCache
+    NeedsPreloadAutoQuirk
+    ShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk
+https://www.walmart.com/
+    MayNeedToIgnoreContentObservation
+https://en.wikipedia.org/
+    ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk
+    ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk
+https://weather.com/
+    (none)
+https://www.webex.com/
+    (none)
+https://www.weebly.com/
+    ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk
+https://workspaces.xyz/
+    ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions
+https://wpdevelopment.ca/
+    (none)
+https://x.com/
+    RequiresUserGestureToLoadInPictureInPictureQuirk
+    RequiresUserGestureToPauseInPictureInPictureQuirk
+    ShouldAvoidProgrammaticScrollClampingQuirk
+    ShouldSilenceMediaQueryListChangeEvents
+    ShouldSilenceWindowResizeEventsDuringApplicationSnapshotting
+https://twitter.com/
+    (none)
+https://www.yahoo.com/
+    NeedsYahooVolumeSliderQuirk
+    ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor
+https://news.ycombinator.com/
+    ShouldIgnoreTextAutoSizingQuirk
+https://ycombinator.com/
+    (none)
+https://www.youtube.com/
+    HasBrokenEncryptedMediaAPISupportQuirk
+    NeedsScrollbarWidthThinDisabledQuirk
+    NeedsYouTubeCaptionQuirk
+    NeedsYouTubeMouseOutQuirk
+    NeedsYouTubeOverflowScrollQuirk
+    ShouldSilenceResizeObservers
+https://www.youtube-nocookie.com/
+    (none)
+https://www.zillow.com/
+    ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk
+    ShouldSilenceResizeObservers
+https://www.zomato.com/
+    (none)
+https://zoom.us/
+    ShouldAllowMediaStreamTrackSerializationQuirk
+    ShouldAutoplayWebAudioForArbitraryUserGestureQuirk
+    ShouldDisableImageCaptureQuirk
+https://www.dailymail.co.uk/
+    ShouldUnloadHeavyFrames
+https://claude.ai/
+    NeedsClaudeSidebarViewportUnitQuirk
+    NeedsHideSelectionDuringOverflowScrollQuirk
+    NeedsLogoutCookieCleanupQuirk
+https://claude.com/
+    NeedsHideSelectionDuringOverflowScrollQuirk
+


### PR DESCRIPTION
#### 68aa96e1c138022dc3f20aa13667e7bcbf42df88
<pre>
[iPad] fast/quirks/active-quirks-by-domain.html is a consistent text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=323093">https://bugs.webkit.org/show_bug.cgi?id=323093</a>

Reviewed by Cole Carley.

This test has been failing uniquely on iPad since it was introduced,
and most recently after 320170@main. This is because there are certain
quirks that are enabled conditional on the screen idiom, i.e.
ShouldEnterNativeFullscreenWhenCallingElementRequestFullscreen.

To respect these differences, we introduce a platform-specific baseline.

* LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/320256@main">https://commits.webkit.org/320256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/115cf6f9c80600b15f9a71f9b2303a2001c7a568

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28c11af0-7cc0-4b21-a14e-d0d6a6760948) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143803 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99941 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d58ab64-f976-429d-8f32-37c20053c0c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124222 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f47482ce-704a-498f-8a05-a78d1cfbe93d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46287 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44497 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156694 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PanelHidCancel, TestWebKitAPI.KeyboardInputTests.KeyboardTypeForInput, TestWebKitAPI.WebAuthenticationPanel.LAError (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44075 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5609 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57798 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153360 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41067 "Failed to push commit to Webkit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153034 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47568 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57010 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19087 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->