### PR TITLE
AXBoundsForRange returns incorrect bounds after inline boundaries in stitched accessibility text

### DIFF
--- a/LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text-expected.txt
@@ -1,0 +1,16 @@
+This test ensures AXBoundsForRange spans the full text of a stitch-group representative, and does not escape the group when the range is out of bounds.
+
+PASS: sentenceText.boundsForRange(0, 10) was equal or approximately equal to (x: -1, y: -1, w: 69, h: 18).
+PASS: sentenceText.boundsForRange(10, 5) was equal or approximately equal to (x: -1, y: -1, w: 47, h: 18).
+PASS: sentenceText.boundsForRange(16, 3) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 18).
+PASS: sentenceText.boundsForRange(40, 3) was equal or approximately equal to (x: -1, y: -1, w: 26, h: 18).
+PASS: sentenceText.boundsForRange(0, 44) was equal or approximately equal to (x: -1, y: -1, w: 301, h: 18).
+PASS: trailingText.boundsForRange(0, 17) was equal or approximately equal to (x: -1, y: -1, w: 126, h: 19).
+PASS: trailingText.boundsForRange(0, 1000) was equal or approximately equal to (x: -1, y: -1, w: 126, h: 19).
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The quick brown fox jumps over the lazy dog.
+
+Alpha beta gamma Go delta epsilon zeta.

--- a/LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="sentence">The quick <strong>brown</strong> fox jumps over the lazy dog.</p>
+<div id="trailing">Alpha beta gamma <button>Go</button> delta epsilon zeta.</div>
+
+<script>
+var output = "This test ensures AXBoundsForRange spans the full text of a stitch-group representative, and does not escape the group when the range is out of bounds.\n\n";
+
+if (window.accessibilityController) {
+    // The three inline pieces stitch into one StaticText whose value is the whole sentence. The first run
+    // is "The quick " (0-9), "brown" is the second member (10-14), the rest is the third. Position is
+    // masked to (-1, -1) in the test harness, so only width and height are asserted.
+    var sentenceText = accessibilityController.accessibleElementById("sentence").childAtIndex(0);
+
+    // "The quick ", the first run.
+    output += expectRectWithVariance("sentenceText.boundsForRange(0, 10)", -1, -1, 69, 18, /* allowedVariance */ 2);
+    // "brown", the second member; it starts at the first run's boundary, where the bug collapsed the rect (webkit.org/b/323121).
+    output += expectRectWithVariance("sentenceText.boundsForRange(10, 5)", -1, -1, 47, 18, /* allowedVariance */ 2);
+    // "fox", inside the third member, well past the first inline boundary.
+    output += expectRectWithVariance("sentenceText.boundsForRange(16, 3)", -1, -1, 23, 18, /* allowedVariance */ 2);
+    // "dog", the last word.
+    output += expectRectWithVariance("sentenceText.boundsForRange(40, 3)", -1, -1, 26, 18, /* allowedVariance */ 2);
+    // The whole stitched line, wider than any single word above.
+    output += expectRectWithVariance("sentenceText.boundsForRange(0, 44)", -1, -1, 301, 18, /* allowedVariance */ 2);
+
+    // "Alpha beta gamma " is one representative, followed by a button and a second group in the same block
+    // flow. An out-of-bounds range must clamp to this text (width 126), not grow into what follows.
+    var trailingText = accessibilityController.accessibleElementById("trailing").childAtIndex(0);
+    output += expectRectWithVariance("trailingText.boundsForRange(0, 17)", -1, -1, 126, 19, /* allowedVariance */ 2);
+    output += expectRectWithVariance("trailingText.boundsForRange(0, 1000)", -1, -1, 126, 19, /* allowedVariance */ 2);
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1301,7 +1301,10 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
 {
     const auto* runs = object->textRuns();
     auto relativeFrame = object->relativeFrame();
-    if (!start && end == runs->totalLength()) {
+    // A representative's relativeFrame() is the union of all its members (the whole stitched line), so
+    // it can't be returned as the frame of this object's own run.
+    bool isStitchRepresentative = object->stitchGroupIfRepresentative().has_value();
+    if (!isStitchRepresentative && !start && end == runs->totalLength()) {
         // If the caller wants the entirety of this object's text, we don't need to to do any estimating,
         // and can just return the relative frame.
         return relativeFrame;
@@ -1347,10 +1350,13 @@ FloatRect AXTextMarkerRange::viewportRelativeFrame() const
     }
 
     // The range spans multiple objects, so we'll need to traverse objects with text runs
-    // from start to end and accumulate the final bounds.
+    // from start to end and accumulate the final bounds. The start object contributes only from
+    // start.offset() (handled here); the intermediate objects contribute in full; the end object
+    // contributes up to end.offset() (handled after the loop). Begin the loop at the object after
+    // start so we do not re-add the start object from offset 0 and lose start.offset().
     FloatRect result = viewportRelativeFrameFromRuns(*start.isolatedObject(), start.offset());
 
-    RefPtr current = start.isolatedObject();
+    RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, /* stopAtID */ *end.objectID());
     while (current && current->objectID() != *end.objectID()) {
         result.unite(viewportRelativeFrameFromRuns(*current, /* offset */ 0));
         RefPtr next = findObjectWithRuns(*current, AXDirection::Next, /* stopAtID */ *end.objectID());

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -736,6 +736,21 @@ PlatformRoleMap createPlatformRoleMap()
 std::optional<AXTextMarkerRange> markerRangeFrom(NSRange range, const AXCoreObject& object)
 {
     std::optional stopAtID = object.idOfNextSiblingIncludingIgnoredOrParent();
+    if (object.stitchGroupIfRepresentative()) {
+        // The range can span every member, and members may be nested in inline wrappers (e.g. <strong>),
+        // so neither the representative's nor the last member's sibling is a safe stop. A stitch group
+        // never crosses its block flow, so stop past the block-flow ancestor.
+        if (RefPtr blockFlow = object.blockFlowAncestorForStitchable())
+            stopAtID = blockFlow->idOfNextSiblingIncludingIgnoredOrParent();
+
+        // But that boundary can also include content after the group, so clamp to the stitched length
+        // (the length of the concatenated member text) to keep the walk inside the group.
+        NSUInteger stitchedLength = object.stringValue().length();
+        range.location = std::min<NSUInteger>(range.location, stitchedLength);
+        // range.location is clamped to stitchedLength above, so this unsigned subtraction never wraps.
+        range.length = std::min<NSUInteger>(range.length, stitchedLength - range.location);
+    }
+
     auto markerToLocation = AXTextMarker { object, 0 }.nextMarkerFromOffset(range.location, ForceSingleOffsetMovement::Yes, stopAtID);
     if (!markerToLocation.isValid())
         return std::nullopt;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3603,6 +3603,13 @@ static bool isMatchingPlugin(AXCoreObject& axObject, const AccessibilitySearchCr
         return markerRange ? static_cast<CGRect>(markerRange->viewportRelativeFrame()) : CGRectZero;
     }
 
+    // For a representative, offsets can address text past its own node, so resolve them against
+    // simpleRange() (the whole stitched text). visiblePositionForIndex would clamp to its first run.
+    if (backingObject.stitchGroupIfRepresentative()) {
+        if (std::optional stitchScope = backingObject.simpleRange())
+            return FloatRect(backingObject.boundsForRange(resolveCharacterRange(*stitchScope, CharacterRange(range.location, range.length))));
+    }
+
     auto start = backingObject.visiblePositionForIndex(range.location);
     auto end = backingObject.visiblePositionForIndex(range.location + range.length);
     auto webRange = makeSimpleRange({ start, end });


### PR DESCRIPTION
#### d843c238e992864a057149c5a14c0c191629b4b6
<pre>
AXBoundsForRange returns incorrect bounds after inline boundaries in stitched accessibility text
<a href="https://bugs.webkit.org/show_bug.cgi?id=323121">https://bugs.webkit.org/show_bug.cgi?id=323121</a>
<a href="https://rdar.apple.com/186383833">rdar://186383833</a>

Reviewed by Tyler Wilcock.

With Accessibility Text Stitching enabled, a line of inline text is merged into
one AXStaticText (the stitch-group representative), whose value is the
concatenation of all its members. AXBoundsForRange returned correct bounds only
for offsets inside the first run: any range past the first inline boundary
collapsed to a ~2px sliver at the end of that run. This misplaced marks that an
assistive technology draws over text ranges, such as spell-check underlines.

The offset was being scoped to the representative&apos;s own node instead of the full
stitched value. Fix both accessibility paths:

Main thread: for a representative, resolve the offsets against simpleRange()
(the whole stitched text) instead of visiblePositionForIndex, which clamps the
offset to the representative&apos;s own node.

Isolated tree: let the NSRange-to-marker walk cross every member by stopping
past the block-flow ancestor (a stitch group never crosses its block flow), and
clamp the offsets to the stitched length so the walk cannot escape into content
after the group. When turning a marker range into a rect, take a
representative&apos;s own run width from localRect rather than its union frame. Also
start the multi-object accumulation loop at the object after the start object, so
the bounds do not incorrectly include text before the requested start offset.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(viewportRelativeFrameFromRuns):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::Accessibility::markerRangeFrom):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper computeTextBoundsForRange:backingObject:]):
* LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text.html: Added.
* LayoutTests/accessibility/mac/bounds-for-range-on-stitched-text-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/320653@main">https://commits.webkit.org/320653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0fcd19c6ad97e1d89df79e29a08c1728266576d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144895 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100448 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47302 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45358 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45049 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6786 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197683 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41366 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59695 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154059 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48543 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132027 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128881 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58173 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->