### PR TITLE
Remove SUPPRESS_RETAINPTR_CTOR_ADOPT for dispatch_*_create() false positives

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -125,10 +125,8 @@
 
 #if PLATFORM(COCOA)
 #include <crt_externs.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/cocoa/CrashReporter.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
-#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 #if PLATFORM(GTK)
@@ -4647,11 +4645,7 @@ int jscmain(int argc, char** argv)
 
 #if PLATFORM(COCOA)
     auto& memoryPressureHandler = MemoryPressureHandler::singleton();
-    {
-        // FIXME: This is a false positive. rdar://160931336
-        SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr queue = adoptOSObject(dispatch_queue_create("jsc shell memory pressure handler", serialQueueWithAutoreleasePoolAttrSingleton()));
-        memoryPressureHandler.setDispatchQueue(WTF::move(queue));
-    }
+    memoryPressureHandler.setDispatchQueueWithLabel("jsc shell memory pressure handler"_s);
     Box<Critical> memoryPressureCriticalState = Box<Critical>::create(Critical::No);
     Box<Synchronous> memoryPressureSynchronousState = Box<Synchronous>::create(Synchronous::No);
     memoryPressureHandler.setLowMemoryHandler([=] (Critical critical, Synchronous synchronous) {

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -967,7 +967,7 @@
 		E3EE4E982E8A34BC00398282 /* ulocbuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = E3EE4E8D2E8A34BC00398282 /* ulocbuilder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E42785652E9BC0F200A0DEF4 /* EnumSet.h in Headers */ = {isa = PBXBuildFile; fileRef = E42785642E9BC0F200A0DEF4 /* EnumSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD371A96245500536DF6 /* WorkQueue.cpp */; };
-		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
+		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.mm */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
 		EB33ED2E2D2DD91B00521B7B /* ContinuousTime.h in Headers */ = {isa = PBXBuildFile; fileRef = EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB33ED2F2D2DD91B00521B7B /* ContinuousTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB33ED2D2D2DD91B00521B7B /* ContinuousTime.cpp */; };
@@ -1415,7 +1415,7 @@
 		46BEB6E922FFDDD50026DEAD /* RefTrackerMixin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RefTrackerMixin.h; sourceTree = "<group>"; };
 		46CA18392D83C17A00B68573 /* FileHandlePOSIX.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileHandlePOSIX.cpp; sourceTree = "<group>"; };
 		46CE0CB52D8BD18500B8A1DD /* FileLockMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileLockMode.h; sourceTree = "<group>"; };
-		46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpanCocoa.mm; sourceTree = "<group>"; };
+		46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanCocoa.mm; sourceTree = "<group>"; };
 		46E43646271F10AA00C88C90 /* SafeStrerror.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SafeStrerror.h; sourceTree = "<group>"; };
 		46E43647271F10AA00C88C90 /* SafeStrerror.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SafeStrerror.cpp; sourceTree = "<group>"; };
 		46E915212CD2E26C00C437B7 /* UnicodeExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnicodeExtras.h; sourceTree = "<group>"; };
@@ -2107,7 +2107,7 @@
 		E42785642E9BC0F200A0DEF4 /* EnumSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnumSet.h; sourceTree = "<group>"; };
 		E4A0AD371A96245500536DF6 /* WorkQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkQueue.cpp; sourceTree = "<group>"; };
 		E4A0AD381A96245500536DF6 /* WorkQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkQueue.h; sourceTree = "<group>"; };
-		E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkQueueCocoa.cpp; sourceTree = "<group>"; };
+		E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WorkQueueCocoa.mm; sourceTree = "<group>"; };
 		E4D2AE4D268A4C7F00DFEA02 /* SystemMalloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemMalloc.h; sourceTree = "<group>"; };
 		EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CPUTimePOSIX.cpp; sourceTree = "<group>"; };
 		EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContinuousTime.h; sourceTree = "<group>"; };
@@ -3498,7 +3498,7 @@
 				5CC0EE862162BC2200A1A842 /* URLCocoa.mm */,
 				93E4A13628F6B75A006AD994 /* UUIDCocoa.mm */,
 				93241657243BC2E50032FAAE /* VectorCocoa.h */,
-				E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */,
+				E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.mm */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";
@@ -4776,7 +4776,7 @@
 				0FE4479C1B7AAA03009498EB /* WordLock.cpp in Sources */,
 				E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */,
 				E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */,
-				E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */,
+				E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.mm in Sources */,
 				07D49BE82F41B5DC00263E9A /* wtf.swift in Sources */,
 				FE05FAFF1FE5007500093230 /* WTFAssertions.cpp in Sources */,
 				FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */,

--- a/Source/WTF/wtf/BlockObjCExceptions.mm
+++ b/Source/WTF/wtf/BlockObjCExceptions.mm
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import "BlockObjCExceptions.h"
 

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -138,6 +138,8 @@ public:
         RELEASE_ASSERT(!m_installed);
         m_dispatchQueue = WTF::move(queue);
     }
+
+    WTF_EXPORT_PRIVATE void setDispatchQueueWithLabel(ASCIILiteral);
 #endif
 
     class ReliefLogger {

--- a/Source/WTF/wtf/ObjCRuntimeExtras.mm
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import "ObjCRuntimeExtras.h"
 

--- a/Source/WTF/wtf/PlatformCocoa.cmake
+++ b/Source/WTF/wtf/PlatformCocoa.cmake
@@ -42,7 +42,7 @@ list(APPEND WTF_SOURCES
     cocoa/TimeZoneCocoa.cpp
     cocoa/URLCocoa.mm
     cocoa/UUIDCocoa.mm
-    cocoa/WorkQueueCocoa.cpp
+    cocoa/WorkQueueCocoa.mm
 
     darwin/LibraryPathDiagnostics.mm
 
@@ -175,5 +175,9 @@ else ()
         ios/WebCoreThread.h
     )
 endif ()
+
+# Matches CLANG_ENABLE_OBJC_ARC in the Xcode build. Set before the prefix header below so the
+# OBJCXX precompiled header is built with the same flag as the sources that use it.
+target_compile_options(WTF PRIVATE $<$<COMPILE_LANGUAGE:OBJC,OBJCXX>:-fobjc-arc>)
 
 WEBKIT_ADD_PREFIX_HEADER(WTF WTFPrefix.h PREFIX_LANGUAGES CXX OBJCXX PREFIX_NO_CODEGEN)

--- a/Source/WTF/wtf/cocoa/AuditToken.mm
+++ b/Source/WTF/wtf/cocoa/AuditToken.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/cocoa/AuditToken.h>
 

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/cocoa/Entitlements.h>
 

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -26,6 +26,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/FileSystem.h>
 

--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/Language.h>
 

--- a/Source/WTF/wtf/cocoa/LoggingCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LoggingCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/LogInitialization.h>
 

--- a/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
@@ -26,6 +26,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/MainThread.h>
 

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/MemoryPressureHandler.h>
 
@@ -31,6 +35,7 @@
 #import <malloc/malloc.h>
 #import <notify.h>
 #import <wtf/Logging.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/darwin/DispatchSPI.h>
 
 #define ENABLE_FMW_FOOTPRINT_COMPARISON 0
@@ -38,6 +43,11 @@
 extern "C" void cache_simulate_memory_warning_event(uint64_t);
 
 namespace WTF {
+
+void MemoryPressureHandler::setDispatchQueueWithLabel(ASCIILiteral label)
+{
+    setDispatchQueue(dispatch_queue_create(label, serialQueueWithAutoreleasePoolAttrSingleton()));
+}
 
 void MemoryPressureHandler::platformReleaseMemory(Critical critical)
 {
@@ -83,8 +93,7 @@ void MemoryPressureHandler::install()
 
     dispatch_async(m_dispatchQueue.get(), ^{
         auto memoryStatusFlags = DISPATCH_MEMORYPRESSURE_NORMAL | DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL;
-        // FIXME: This is a false positive. rdar://160931336
-        SUPPRESS_RETAINPTR_CTOR_ADOPT memoryPressureEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get()));
+        memoryPressureEventSource() = dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get());
 
         dispatch_source_set_event_handler(memoryPressureEventSource().get(), ^{
             auto status = dispatch_source_get_data(memoryPressureEventSource().get());
@@ -197,8 +206,7 @@ void MemoryPressureHandler::uninstall()
 void MemoryPressureHandler::holdOff(Seconds seconds)
 {
     dispatch_async(m_dispatchQueue.get(), ^{
-        // FIXME: This is a false positive. rdar://160931336
-        SUPPRESS_RETAINPTR_CTOR_ADOPT timerEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get()));
+        timerEventSource() = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get());
         if (timerEventSource()) {
             dispatch_set_context(timerEventSource().get(), this);
             // FIXME: The final argument `s_minimumHoldOffTime.seconds()` seems wrong.

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -26,6 +26,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import "NSURLExtras.h"
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import "RuntimeApplicationChecksCocoa.h"
 

--- a/Source/WTF/wtf/cocoa/SchedulePairCocoa.mm
+++ b/Source/WTF/wtf/cocoa/SchedulePairCocoa.mm
@@ -26,6 +26,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/SchedulePair.h>
 

--- a/Source/WTF/wtf/cocoa/SpanCocoa.mm
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import "SpanCocoa.h"
 

--- a/Source/WTF/wtf/cocoa/URLCocoa.mm
+++ b/Source/WTF/wtf/cocoa/URLCocoa.mm
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/URL.h>
 

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/UUID.h>
 

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.mm
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #include "config.h"
 #include <wtf/WorkQueue.h>
 
@@ -56,12 +60,11 @@ void WorkQueueBase::dispatch(Function<void()>&& function)
 
 void WorkQueueBase::dispatchWithQOS(Function<void()>&& function, QOS qos)
 {
-    // FIXME: This is a false positive. rdar://160931336
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto blockWithQOS = adoptOSObject(dispatch_block_create_with_qos_class(DISPATCH_BLOCK_ENFORCE_QOS_CLASS, Thread::dispatchQOSClass(qos), 0, makeBlockPtr([function = WTF::move(function)] () mutable {
+    dispatch_block_t blockWithQOS = dispatch_block_create_with_qos_class(DISPATCH_BLOCK_ENFORCE_QOS_CLASS, Thread::dispatchQOSClass(qos), 0, makeBlockPtr([function = WTF::move(function)] () mutable {
         function();
         function = { };
-    }).get()));
-    dispatch_async(m_dispatchQueue.get(), blockWithQOS.get());
+    }).get());
+    dispatch_async(m_dispatchQueue.get(), blockWithQOS);
 }
 
 void WorkQueueBase::dispatchAfter(Seconds duration, Function<void()>&& function)
@@ -84,8 +87,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type type, QOS qos)
 {
     dispatch_queue_attr_t attr = type == Type::Concurrent ? concurrentQueueWithAutoreleasePoolAttrSingleton() : serialQueueWithAutoreleasePoolAttrSingleton();
     attr = dispatch_queue_attr_make_with_qos_class(attr, Thread::dispatchQOSClass(qos), 0);
-    // FIXME: This is a false positive. rdar://160931336
-    SUPPRESS_RETAINPTR_CTOR_ADOPT lazyInitialize(m_dispatchQueue, adoptOSObject(dispatch_queue_create(name, attr)));
+    lazyInitialize(m_dispatchQueue, OSObjectPtr<dispatch_queue_t> { dispatch_queue_create(name, attr) });
     dispatch_set_context(m_dispatchQueue.get(), this);
     // We use &s_uid for the key, since it's convenient. Dispatch does not dereference it.
     // We use s_uid to generate the id so that WorkQueues and Threads share the id namespace.

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #include "config.h"
 #include <wtf/darwin/LibraryPathDiagnostics.h>
 

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #include "config.h"
 #include <wtf/darwin/OSLogPrintStream.h>
 

--- a/Source/WTF/wtf/mac/FileSystemMac.mm
+++ b/Source/WTF/wtf/mac/FileSystemMac.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/FileSystem.h>
 

--- a/Source/WTF/wtf/text/cocoa/ASCIILiteralCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/ASCIILiteralCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/ASCIILiteral.h>
 

--- a/Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/cocoa/ContextualizedCFString.h>
 

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/cocoa/ContextualizedNSString.h>
 

--- a/Source/WTF/wtf/text/cocoa/StringCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringCocoa.mm
@@ -18,6 +18,10 @@
  *
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/WTFString.h>
 

--- a/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
@@ -18,6 +18,10 @@
  *
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/StringImpl.h>
 

--- a/Source/WTF/wtf/text/cocoa/StringViewCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringViewCocoa.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/StringView.h>
 

--- a/Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm
@@ -18,6 +18,10 @@
  *
  */
 
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
 #import "config.h"
 #import <wtf/text/TextStream.h>
 

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -608,7 +608,7 @@ list(APPEND WebCore_SOURCES
     platform/mac/PlatformEventFactoryMac.mm
     platform/mac/PlatformPasteboardMac.mm
     platform/mac/PlatformScreenMac.mm
-    platform/mac/PowerObserverMac.cpp
+    platform/mac/PowerObserverMac.mm
     platform/mac/RevealUtilities.mm
     platform/mac/ScrollAnimatorMac.mm
     platform/mac/ScrollViewMac.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -637,7 +637,7 @@ platform/mac/PlatformEventFactoryMac.mm @nonARC
 platform/mac/PlatformPasteboardMac.mm @nonARC
 platform/mac/PlatformScreenMac.mm @nonARC
 platform/mac/PlaybackSessionInterfaceMac.mm @nonARC @no-unify-when(bundle<=8)
-platform/mac/PowerObserverMac.cpp
+platform/mac/PowerObserverMac.mm @nonARC
 platform/mac/RevealUtilities.mm @nonARC
 platform/mac/ScrollAnimatorMac.mm @nonARC @no-unify-when(bundle<=8) @cost:3
 platform/mac/ScrollAnimationRubberBand.mm @nonARC

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -12019,7 +12019,7 @@
 		46273CAE260E59DF006FAA91 /* SWScriptStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWScriptStorage.cpp; sourceTree = "<group>"; };
 		462E4C4D2616A801003A2C67 /* ScriptBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptBuffer.h; sourceTree = "<group>"; };
 		462E4C4F2616A801003A2C67 /* ScriptBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScriptBuffer.cpp; sourceTree = "<group>"; };
-		4634592B1AC2271000ECB71C /* PowerObserverMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PowerObserverMac.cpp; sourceTree = "<group>"; };
+		4634592B1AC2271000ECB71C /* PowerObserverMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PowerObserverMac.mm; sourceTree = "<group>"; };
 		463521AA2081090B00C28922 /* WindowProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WindowProxy.h; sourceTree = "<group>"; };
 		463521AC2081090E00C28922 /* WindowProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WindowProxy.cpp; sourceTree = "<group>"; };
 		463642A329687D47003D43F2 /* CoreHapticsSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreHapticsSoftLink.h; sourceTree = "<group>"; };
@@ -31140,8 +31140,8 @@
 				BC94D1070C274F88006BC617 /* PlatformScreenMac.mm */,
 				CDA29A151CBDA56C00901CCF /* PlaybackSessionInterfaceMac.h */,
 				CDA29A141CBDA56C00901CCF /* PlaybackSessionInterfaceMac.mm */,
-				4634592B1AC2271000ECB71C /* PowerObserverMac.cpp */,
 				46DBB64E1AB8C96F00D9A813 /* PowerObserverMac.h */,
+				4634592B1AC2271000ECB71C /* PowerObserverMac.mm */,
 				F49532D828FB4FA600D52F09 /* RevealUtilities.h */,
 				F49532D928FB4FA600D52F09 /* RevealUtilities.mm */,
 				0F38186C2708D20200414F32 /* ScrollAnimationRubberBand.h */,

--- a/Source/WebCore/platform/mac/PowerObserverMac.mm
+++ b/Source/WebCore/platform/mac/PowerObserverMac.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 #import "PowerObserverMac.h"
+
 #import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/darwin/DispatchExtras.h>
@@ -41,8 +42,7 @@ PowerObserver::PowerObserver(Function<void()>&& powerOnHander)
     , m_notificationPort(nullptr)
     , m_notifierReference(0)
 {
-    // FIXME: This is a false positive for dispatch_queue_create. rdar://160931336
-    SUPPRESS_RETAINPTR_CTOR_ADOPT m_dispatchQueue = adoptOSObject(dispatch_queue_create("com.apple.WebKit.PowerObserver", serialQueueWithAutoreleasePoolAttrSingleton()));
+    m_dispatchQueue = adoptOSObject(dispatch_queue_create("com.apple.WebKit.PowerObserver", serialQueueWithAutoreleasePoolAttrSingleton()));
     m_powerConnection = IORegisterForSystemPower(this, &m_notificationPort, [](void* context, io_service_t service, uint32_t messageType, void* messageArgument) {
         static_cast<PowerObserver*>(context)->didReceiveSystemPowerNotification(service, messageType, messageArgument);
     }, &m_notifierReference);


### PR DESCRIPTION
#### 6f9fb91d518b0f68ab13c57687c250ed2e8dc154
<pre>
Remove SUPPRESS_RETAINPTR_CTOR_ADOPT for dispatch_*_create() false positives
<a href="https://bugs.webkit.org/show_bug.cgi?id=323095">https://bugs.webkit.org/show_bug.cgi?id=323095</a>

Reviewed by David Kilzer.

alpha.webkit.RetainPtrCtorAdoptChecker flagged every adoptOSObject(dispatch_*_create())
call site, and each one was papered over with SUPPRESS_RETAINPTR_CTOR_ADOPT and a FIXME
pointing at <a href="https://rdar.apple.com/160931336">rdar://160931336</a>. The warnings turn out to be gated on ARC rather than on the
file extension:

  - Plain C++ (.cpp): warns. DISPATCH_RETURNS_RETAINED is gated on OS_OBJECT_USE_OBJC,
    which requires __OBJC__, so ns_returns_retained is not visible and the argument looks
    like +0.
  - Objective-C++ without ARC: clean. adoptOSObject() is correct and the checker agrees.
  - Objective-C++ with ARC: adopting warns. Under ARC adopt and the plain constructor are
    equivalent -- RetainTraits::retain/release are no-ops and the __strong store on m_ptr
    holds the +1 -- so the constructor is both correct and what the checker expects.

Each site is therefore fixed by compiling it as Objective-C++ and then matching the
target&apos;s ARC state, with no suppression left behind. This also covers
dispatch_block_create_with_qos_class(), which is annotated ns_returns_retained in every
mode but which the checker only accepts when the result is not adopted.

WebCore compiles all of its Objective-C++ without ARC and WTF compiles all of its with
ARC, so the two frameworks are handled differently here.

While adding the ARC guard that Source/WebKit already uses to the rest of WTF&apos;s
Objective-C++, it caught SpanCocoa.mm, which was declared as sourcecode.cpp.cpp and so was
built with -x c++ despite its extension, while CMake built it as Objective-C++.

* Source/JavaScriptCore/jsc.cpp:
(jscmain):
jsc.cpp cannot become Objective-C++, so it now uses setDispatchQueueWithLabel() instead of
creating the queue itself.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
Corrected SpanCocoa.mm to sourcecode.cpp.objcpp. The file contains no Objective-C
constructs, so this only changes which language the two builds agree it is.
* Source/WTF/wtf/BlockObjCExceptions.mm:
* Source/WTF/wtf/MemoryPressureHandler.h:
Declared setDispatchQueueWithLabel() so that callers in plain C++ translation units can
get a dedicated serial queue without naming dispatch_queue_create() themselves.
* Source/WTF/wtf/ObjCRuntimeExtras.mm:
* Source/WTF/wtf/PlatformCocoa.cmake:
WTF&apos;s Objective-C++ was built with ARC by Xcode (CLANG_ENABLE_OBJC_ARC in Base.xcconfig)
but without it by CMake, which never passed -fobjc-arc for this framework. Set the flag
target-wide so the two builds agree. It has to be set before WEBKIT_ADD_PREFIX_HEADER()
below, because the OBJCXX precompiled header must be built with the same flag as the
sources that include it.
* Source/WTF/wtf/cocoa/AuditToken.mm:
* Source/WTF/wtf/cocoa/Entitlements.mm:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
* Source/WTF/wtf/cocoa/LanguageCocoa.mm:
* Source/WTF/wtf/cocoa/LoggingCocoa.mm:
* Source/WTF/wtf/cocoa/MainThreadCocoa.mm:
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::MemoryPressureHandler::setDispatchQueueWithLabel):
(WTF::MemoryPressureHandler::install):
(WTF::MemoryPressureHandler::holdOff):
Dropped the adoptOSObject() calls and added setDispatchQueueWithLabel().
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
* Source/WTF/wtf/cocoa/SchedulePairCocoa.mm:
* Source/WTF/wtf/cocoa/SpanCocoa.mm:
* Source/WTF/wtf/cocoa/URLCocoa.mm:
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
* Source/WTF/wtf/cocoa/WorkQueueCocoa.mm: Renamed from Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp.
(WTF::dispatchWorkItem):
(WTF::WorkQueueBase::dispatch):
(WTF::WorkQueueBase::dispatchWithQOS):
(WTF::WorkQueueBase::dispatchAfter):
(WTF::WorkQueueBase::dispatchSync):
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueueBase::platformInvalidate):
(WTF::WorkQueue::WorkQueue):
(WTF::ConcurrentWorkQueue::apply):
Renamed to Objective-C++ and dropped the adoptOSObject() calls. blockWithQOS no longer
needs an OSObjectPtr at all, since ARC owns the block.
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
* Source/WTF/wtf/mac/FileSystemMac.mm:
* Source/WTF/wtf/text/cocoa/ASCIILiteralCocoa.mm:
* Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm:
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm:
* Source/WTF/wtf/text/cocoa/StringCocoa.mm:
* Source/WTF/wtf/text/cocoa/StringImplCocoa.mm:
* Source/WTF/wtf/text/cocoa/StringViewCocoa.mm:
* Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm:
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Marked PowerObserverMac.mm @nonARC, matching every other Objective-C++ file in WebCore.
* Source/WebCore/platform/mac/PowerObserverMac.mm: Renamed from Source/WebCore/platform/mac/PowerObserverMac.cpp.
(WebCore::PowerObserver::PowerObserver):
(WebCore::PowerObserver::~PowerObserver):
(WebCore::PowerObserver::didReceiveSystemPowerNotification):
The file was already PLATFORM(MAC)-only and already using #import, so renaming it is
enough. It keeps adoptOSObject(), which is correct in a non-ARC Objective-C++ file.

Canonical link: <a href="https://commits.webkit.org/320307@main">https://commits.webkit.org/320307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88581e401ed7d37196021cf58903c2c3310e8656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194701 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47730 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124353 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46440 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13163 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44227 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5774 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45651 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50959 "Found 1 new failure in css/ShorthandSerializer.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196642 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57967 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153516 "Found 4 new test failures: compositing/animation/busy-indicator.html compositing/animation/state-at-end-event-transform-layer.html compositing/reflections/animation-inside-reflection.html fast/block/positioning/auto/002.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58672 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153181 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47710 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130966 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57178 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56546 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56788 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56613 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->