### PR TITLE
PixelBuffer should support non-renderable color spaces

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -391,7 +391,7 @@ static void getImageBytesFromImageBuffer(const RefPtr<ImageBuffer>& imageBuffer,
     if (!size.width() || !size.height())
         return callback({ }, 0, 0);
 
-    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() }, { { }, size });
+    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() }, { { }, size });
     if (!pixelBuffer)
         return callback({ }, 0, 0);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -256,7 +256,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
 
 ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, ImageBuffer& buffer, IntSize size, WebCodecsVideoFrame::Init&& init)
 {
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, platformColorSpaceSRGB() };
     IntRect region { IntPoint::zero(), size };
 
     auto pixelBuffer = buffer.getPixelBuffer(format, region);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3334,7 +3334,7 @@ RefPtr<SharedBuffer> AccessibilityObject::imageData(const AXImageDataParameters&
         extractionRect = IntRect(IntPoint(), IntSize(targetWidth, targetHeight));
 
     // Extract pixels as unpremultiplied RGBA8.
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     auto pixelBuffer = imageBuffer->getPixelBuffer(format, extractionRect);
     if (!pixelBuffer)
         return nullptr;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -928,7 +928,7 @@ private:
         }
 
         // FIXME: We should try to avoid converting pixel format.
-        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, buffer->colorSpace() };
+        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, buffer->colorSpace().platformColorSpace() };
         const IntSize& logicalSize = buffer->truncatedLogicalSize();
         auto pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, { IntPoint::zero(), logicalSize }));
         if (!pixelBuffer) {
@@ -3468,7 +3468,7 @@ private:
             return JSValue();
         }
 
-        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, colorSpace };
+        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, colorSpace.platformColorSpace() };
         auto pixelBuffer = ByteArrayPixelBuffer::tryCreate(format, imageDataSize, arrayBuffer.releaseNonNull());
         if (!pixelBuffer) {
             SERIALIZE_TRACE("FAIL deserialize");

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -197,7 +197,7 @@ void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer
 
     auto dirtyRect = postProcessArea == CanvasNoiseInjectionPostProcessArea::DirtyRect ? m_postProcessDirtyRect : IntRect(IntPoint::zero(), imageBuffer->truncatedLogicalSize());
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace().platformColorSpace() };
     auto pixelBuffer = imageBuffer->getPixelBuffer(format, dirtyRect);
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -820,7 +820,7 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
     // FIXME: This can likely be optimized quite a bit, especially in the cases where
     // the ImageBuffer is backed by GPU memory already and/or is in the GPU process by
     // specializing toVideoFrame() in ImageBufferBackend to not use getPixelBuffer().
-    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }, { { }, imageBuffer->truncatedLogicalSize() });
+    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, platformColorSpaceSRGB() }, { { }, imageBuffer->truncatedLogicalSize() });
     if (!pixelBuffer)
         return nullptr;
 

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "ImageData.h"
 
+#include "DestinationColorSpace.h"
 #include "ExceptionOr.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
@@ -57,7 +58,7 @@ static ImageDataPixelFormat NODELETE computePixelFormat(std::optional<ImageDataS
 Ref<ImageData> ImageData::create(Ref<ArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
 {
     auto size = pixelBuffer->size();
-    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
+    auto colorSpace = toPredefinedColorSpace(DestinationColorSpace { pixelBuffer->colorSpace() });
     return adoptRef(*new ImageData(size, ImageDataArray(WTF::move(pixelBuffer.get()).takeData()), *colorSpace, overridingPixelFormat));
 }
 
@@ -173,7 +174,7 @@ ImageData::~ImageData() = default;
 Ref<ByteArrayPixelBuffer> ImageData::byteArrayPixelBuffer() const
 {
     Ref uint8Data = m_data.asUint8ClampedArray();
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_colorSpace) };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toPlatformColorSpace(m_colorSpace) };
     return ByteArrayPixelBuffer::create(format, m_size, uint8Data.get());
 }
 
@@ -181,7 +182,7 @@ Ref<ByteArrayPixelBuffer> ImageData::byteArrayPixelBuffer() const
 Ref<Float16ArrayPixelBuffer> ImageData::float16ArrayPixelBuffer() const
 {
     Ref float16Data = m_data.asFloat16Array();
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toExtendedDestinationColorSpace(m_colorSpace) };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toExtendedPlatformColorSpace(m_colorSpace) };
     return Float16ArrayPixelBuffer::create(format, m_size, float16Data.get());
 }
 #endif // ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2571,7 +2571,7 @@ RefPtr<ArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(
     // This computation can be used for cache retrieval as well as the real putImageData.
     // We're not doing RGBA -> BGRA swizzle here, as that is not needed for cache retrieval and
     // the swizzle copy can be made at the putImageData copy site.
-    auto colorSpace = toDestinationColorSpace(imageData.colorSpace());
+    auto colorSpace = toPlatformColorSpace(imageData.colorSpace());
     auto pixelFormat = toPixelFormat(imageData.pixelFormat());
     unsigned bytesPerRow = static_cast<unsigned>(size.width()) * PixelBuffer::bytesPerPixel(pixelFormat);
     PixelBufferFormat cachedFormat { AlphaPremultiplication::Premultiplied, pixelFormat, colorSpace };
@@ -2627,7 +2627,7 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
         .rows = data->span(),
     };
     PixelBufferConversionView destination {
-        .format = { AlphaPremultiplication::Unpremultiplied, pixelFormat, pixelBuffer->format().colorSpace },
+        .format = { AlphaPremultiplication::Unpremultiplied, pixelFormat, pixelBuffer->colorSpace() },
         .bytesPerRow = bytesPerRow,
         .rows = data->mutableSpan(),
     };
@@ -2665,7 +2665,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
         if (!buffer)
             return Exception { ExceptionCode::InvalidStateError };
 
-        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, buffer->colorSpace() };
+        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, buffer->colorSpace().platformColorSpace() };
         RefPtr pixelBuffer = dynamicDowncast<ArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
         if (!pixelBuffer)
             return Exception { ExceptionCode::InvalidStateError };
@@ -2684,7 +2684,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (!buffer)
         return ImageData::create(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toDestinationColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)) };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toPlatformColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)) };
     RefPtr pixelBuffer = buffer->getPixelBuffer(format, imageDataRect);
     if (!pixelBuffer) {
         scriptContext->addConsoleMessage(MessageSource::Rendering, MessageLevel::Error,
@@ -2692,7 +2692,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
         return Exception { ExceptionCode::InvalidStateError };
     }
 
-    ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)));
+    ASSERT(equalPlatformColorSpaces(pixelBuffer->colorSpace(), toPlatformColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat))));
 
     if (RefPtr imageData = ImageData::create(pixelBuffer.releaseNonNull(), outputImageDataPixelFormat))
         return { { imageData.releaseNonNull() } };

--- a/Source/WebCore/html/canvas/PredefinedColorSpace.cpp
+++ b/Source/WebCore/html/canvas/PredefinedColorSpace.cpp
@@ -86,6 +86,61 @@ DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace colorSpace, A
     return (allowExtendedColorSpace == AllowExtendedColorSpace::No) ? toDestinationColorSpace(colorSpace) : toExtendedDestinationColorSpace(colorSpace);
 }
 
+PlatformColorSpace toPlatformColorSpace(PredefinedColorSpace colorSpace)
+{
+    switch (colorSpace) {
+    case PredefinedColorSpace::SRGB:
+        return platformColorSpaceSRGB();
+    case PredefinedColorSpace::SRGBLinear:
+        return platformColorSpaceLinearSRGB();
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    case PredefinedColorSpace::DisplayP3:
+        return platformColorSpaceDisplayP3();
+    case PredefinedColorSpace::DisplayP3Linear:
+        return platformColorSpaceLinearDisplayP3();
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+    return platformColorSpaceSRGB();
+}
+
+PlatformColorSpace toExtendedPlatformColorSpace(PredefinedColorSpace colorSpace)
+{
+    switch (colorSpace) {
+    case PredefinedColorSpace::SRGB:
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+        return platformColorSpaceExtendedSRGB();
+#else
+        return platformColorSpaceSRGB();
+#endif
+    case PredefinedColorSpace::SRGBLinear:
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+        return platformColorSpaceExtendedLinearSRGB();
+#else
+        return platformColorSpaceLinearSRGB();
+#endif
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    case PredefinedColorSpace::DisplayP3:
+        return platformColorSpaceExtendedDisplayP3();
+    case PredefinedColorSpace::DisplayP3Linear:
+        return platformColorSpaceExtendedLinearDisplayP3();
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+    return platformColorSpaceExtendedSRGB();
+#else
+    return platformColorSpaceSRGB();
+#endif
+}
+
+PlatformColorSpace toPlatformColorSpace(PredefinedColorSpace colorSpace, AllowExtendedColorSpace allowExtendedColorSpace)
+{
+    return (allowExtendedColorSpace == AllowExtendedColorSpace::No) ? toPlatformColorSpace(colorSpace) : toExtendedPlatformColorSpace(colorSpace);
+}
+
 std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColorSpace& colorSpace)
 {
     if (colorSpace == DestinationColorSpace::SRGB())

--- a/Source/WebCore/html/canvas/PredefinedColorSpace.h
+++ b/Source/WebCore/html/canvas/PredefinedColorSpace.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/PlatformColorSpace.h>
 #include <optional>
 
 namespace WebCore {
@@ -44,6 +45,10 @@ DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace);
 DestinationColorSpace toExtendedDestinationColorSpace(PredefinedColorSpace);
 enum class AllowExtendedColorSpace : bool;
 DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace, AllowExtendedColorSpace);
+
+PlatformColorSpace toPlatformColorSpace(PredefinedColorSpace);
+PlatformColorSpace toExtendedPlatformColorSpace(PredefinedColorSpace);
+PlatformColorSpace toPlatformColorSpace(PredefinedColorSpace, AllowExtendedColorSpace);
 
 std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColorSpace&);
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -858,7 +858,7 @@ RefPtr<ByteArrayPixelBuffer> WebGLRenderingContextBase::drawingBufferToPixelBuff
     auto size = clampedCanvasSize();
     if (size.isEmpty())
         return nullptr;
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     auto pixelBuffer = ByteArrayPixelBuffer::tryCreate(format, size);
     if (!pixelBuffer)
         return nullptr;

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -135,7 +135,7 @@ static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& loca
     if (!snapshot)
         return std::nullopt;
 
-    auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace }, { { }, snapshot->truncatedLogicalSize() });
+    auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace.platformColorSpace() }, { { }, snapshot->truncatedLogicalSize() });
     if (!pixelBuffer)
         return std::nullopt;
 
@@ -323,7 +323,7 @@ Variant<PredominantColorType, Color> PageColorSampler::predominantColor(Page& pa
     if (!snapshot)
         return PredominantColorType::None;
 
-    auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace }, { { }, snapshot->truncatedLogicalSize() });
+    auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace.platformColorSpace() }, { { }, snapshot->truncatedLogicalSize() });
     if (!pixelBuffer)
         return PredominantColorType::None;
 

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -58,6 +58,18 @@ template<PlatformColorSpace::Name name> static const DestinationColorSpace& know
 }
 #endif
 
+#if USE(CG) || USE(SKIA)
+template<KnownColorSpaceAccessor accessor> static PlatformColorSpace knownPlatformColorSpace()
+{
+    return knownColorSpace<accessor>().platformColorSpace();
+}
+#else
+template<PlatformColorSpace::Name name> static PlatformColorSpace knownPlatformColorSpace()
+{
+    return knownColorSpace<name>().platformColorSpace();
+}
+#endif
+
 const DestinationColorSpace& DestinationColorSpace::SRGB()
 {
 #if USE(CG) || USE(SKIA)
@@ -145,6 +157,93 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedRec2020()
 }
 #endif
 
+PlatformColorSpace platformColorSpaceSRGB()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<sRGBColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::SRGB>();
+#endif
+}
+
+PlatformColorSpace platformColorSpaceLinearSRGB()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<linearSRGBColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::LinearSRGB>();
+#endif
+}
+
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+PlatformColorSpace platformColorSpaceDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<displayP3ColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::DisplayP3>();
+#endif
+}
+
+PlatformColorSpace platformColorSpaceExtendedDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<extendedDisplayP3ColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::ExtendedDisplayP3>();
+#endif
+}
+
+PlatformColorSpace platformColorSpaceLinearDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<linearDisplayP3ColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::LinearDisplayP3>();
+#endif
+}
+
+PlatformColorSpace platformColorSpaceExtendedLinearDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<extendedLinearDisplayP3ColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::ExtendedLinearDisplayP3>();
+#endif
+}
+#endif
+
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+PlatformColorSpace platformColorSpaceExtendedSRGB()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<extendedSRGBColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::ExtendedSRGB>();
+#endif
+}
+
+PlatformColorSpace platformColorSpaceExtendedLinearSRGB()
+{
+#if USE(CG) || USE(SKIA)
+    return knownPlatformColorSpace<extendedLinearSRGBColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::ExtendedLinearSRGB>();
+#endif
+}
+#endif
+
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_REC_2020)
+PlatformColorSpace platformColorSpaceExtendedRec2020()
+{
+#if USE(CG)
+    return knownPlatformColorSpace<ITUR_2020ColorSpaceSingleton>();
+#else
+    return knownPlatformColorSpace<PlatformColorSpace::Name::ExtendedRec2020>();
+#endif
+}
+#endif
+
 bool operator==(const DestinationColorSpace& a, const DestinationColorSpace& b)
 {
 #if USE(CG)
@@ -155,6 +254,19 @@ bool operator==(const DestinationColorSpace& a, const DestinationColorSpace& b)
     return SkColorSpace::Equals(a.platformColorSpace().get(), b.platformColorSpace().get());
 #else
     return a.platformColorSpace() == b.platformColorSpace();
+#endif
+}
+
+bool equalPlatformColorSpaces(const PlatformColorSpace& a, const PlatformColorSpace& b)
+{
+#if USE(CG)
+    // Do not protect the color spaces here as it is not strictly required for safety and
+    // this code is performance sensitive.
+    SUPPRESS_UNRETAINED_ARG return CGColorSpaceEqualToColorSpace(a.get(), b.get());
+#elif USE(SKIA)
+    return SkColorSpace::Equals(a.get(), b.get());
+#else
+    return a.get() == b.get();
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferAllocator.h
+++ b/Source/WebCore/platform/graphics/ImageBufferAllocator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/PixelBufferFormat.h>
 #include <WebCore/RenderingMode.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -83,7 +83,7 @@ void ImageBufferBackend::convertToLuminanceMaskFloat16()
 void ImageBufferBackend::convertToLuminanceMaskUint8()
 {
     IntRect sourceRect { { }, size() };
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace().platformColorSpace() };
     auto pixelBuffer = ImageBufferAllocator().createPixelBuffer(format, sourceRect.size());
     if (!pixelBuffer)
         return;
@@ -133,7 +133,7 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, std::span<con
     auto sourcePixelFormat = pixelFormat();
     unsigned sourceBytesPerRow = bytesPerRow();
     ConstPixelBufferConversionView source {
-        { AlphaPremultiplication::Premultiplied, sourcePixelFormat, colorSpace() },
+        { AlphaPremultiplication::Premultiplied, sourcePixelFormat, colorSpace().platformColorSpace() },
         sourceBytesPerRow,
         sourceData.subspan(sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * PixelBuffer::bytesPerPixel(sourcePixelFormat))
     };
@@ -179,7 +179,7 @@ void ImageBufferBackend::putPixelBuffer(const PixelBufferSourceView& sourcePixel
     auto destinationPixelFormat = pixelFormat();
     unsigned destinationBytesPerRow = bytesPerRow();
     PixelBufferConversionView destination {
-        { destinationAlphaFormat, destinationPixelFormat, colorSpace() },
+        { destinationAlphaFormat, destinationPixelFormat, colorSpace().platformColorSpace() },
         destinationBytesPerRow,
         destinationData.subspan(destinationRect.y() * destinationBytesPerRow + destinationRect.x() * PixelBuffer::bytesPerPixel(destinationPixelFormat))
     };

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -55,6 +55,7 @@ public:
     virtual ~PixelBuffer() = default;
 
     const PixelBufferFormat& format() const LIFETIME_BOUND { return m_format; }
+    const PlatformColorSpace& colorSpace() const LIFETIME_BOUND { return m_format.colorSpace; }
     const IntSize& size() const LIFETIME_BOUND { return m_size; }
 
     std::span<uint8_t> bytes() const { return m_bytes; }
@@ -106,6 +107,7 @@ public:
     }
 
     const PixelBufferFormat& format() const LIFETIME_BOUND { return m_format; }
+    const PlatformColorSpace& colorSpace() const LIFETIME_BOUND { return m_format.colorSpace; }
     IntSize size() const { return m_size; }
     std::span<const uint8_t> bytes() const LIFETIME_BOUND { return m_bytes; }
 

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -216,7 +216,7 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
 
     result.bitsPerComponent = bitsPerComponent;
     result.bitsPerPixel = bitsPerPixel;
-    result.colorSpace = format.colorSpace.platformColorSpace();
+    result.colorSpace = format.colorSpace.get();
     result.bitmapInfo = bitmapInfo;
     result.version = 0;
     result.decode = nullptr;
@@ -345,7 +345,7 @@ static constexpr ConvertImagePixelsFunctionTable<ConvertImagePixelsAcceleratedFu
 
 static bool convertImagePixelsAccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    if (source.format.colorSpace != destination.format.colorSpace)
+    if (!equalPlatformColorSpaces(source.format.colorSpace, destination.format.colorSpace))
         return convertImagePixelsAcceleratedAnyToAny(source, destination, destinationSize);
 
     return convertImagePixelsFunctionTable.invoke(source, destination, destinationSize);
@@ -384,7 +384,7 @@ static bool convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
         destinationSize.height(),
         *sourceSkiaColorType,
         toSkiaAlphaType(source.format.alphaFormat),
-        source.format.colorSpace.platformColorSpace()
+        source.format.colorSpace
     );
     auto destinationSkiaColorType = toSkiaColorType(destination.format.pixelFormat);
     if (!destinationSkiaColorType)
@@ -396,7 +396,7 @@ static bool convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
         destinationSize.height(),
         *destinationSkiaColorType,
         toSkiaAlphaType(destination.format.alphaFormat),
-        destination.format.colorSpace.platformColorSpace()
+        destination.format.colorSpace
     );
     // Read pixels from source to destination and convert pixels if necessary.
     sourcePixmap.readPixels(destinationImageInfo, destination.rows.data(), destination.bytesPerRow);
@@ -532,7 +532,7 @@ static bool convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView
 {
     // FIXME: We don't currently support converting pixel data between different color spaces in the non-accelerated path.
     // This could be added using conversion functions from ColorConversion.h.
-    ASSERT(source.format.colorSpace == destination.format.colorSpace);
+    ASSERT(equalPlatformColorSpaces(source.format.colorSpace, destination.format.colorSpace));
 
     return convertImagePixelsFunctionTable.invoke(source, destination, destinationSize);
 }
@@ -590,7 +590,7 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
     if (!convertImagePixelsAccelerated(source, destination, destinationSize))
         zeroImagePixels(destination, destinationSize);
 #else
-    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace) {
+    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && equalPlatformColorSpaces(source.format.colorSpace, destination.format.colorSpace)) {
         copyImagePixels(source, destination, destinationSize);
         return;
     }

--- a/Source/WebCore/platform/graphics/PixelBufferFormat.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferFormat.cpp
@@ -26,13 +26,35 @@
 #include "config.h"
 #include "PixelBufferFormat.h"
 
+#include "DestinationColorSpace.h"
 #include <wtf/text/TextStream.h>
+
+#if USE(CG)
+#include <pal/spi/cg/CoreGraphicsSPI.h>
+#endif
 
 namespace WebCore {
 
 TextStream& operator<<(TextStream& ts, const PixelBufferFormat& pixelBuffer)
 {
-    return ts << pixelBuffer.alphaFormat << ' ' << pixelBuffer.pixelFormat << ' ' << pixelBuffer.colorSpace;
+    ts << pixelBuffer.alphaFormat << ' ' << pixelBuffer.pixelFormat << ' ';
+#if USE(CG) || USE(SKIA)
+    if (!pixelBuffer.colorSpace)
+        return ts << "null color space"_s;
+#endif
+    return ts << DestinationColorSpace { pixelBuffer.colorSpace };
+}
+
+bool isValidPixelBufferColorSpace(const PlatformColorSpace& colorSpace)
+{
+#if USE(CG)
+    SUPPRESS_UNRETAINED_ARG return colorSpace && CGColorSpaceGetModel(colorSpace.get()) == kCGColorSpaceModelRGB;
+#elif USE(SKIA)
+    return !!colorSpace;
+#else
+    UNUSED_PARAM(colorSpace);
+    return true;
+#endif
 }
 
 }

--- a/Source/WebCore/platform/graphics/PixelBufferFormat.h
+++ b/Source/WebCore/platform/graphics/PixelBufferFormat.h
@@ -26,8 +26,9 @@
 #pragma once
 
 #include <WebCore/AlphaPremultiplication.h>
-#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/PixelFormat.h>
+#include <WebCore/PlatformColorSpace.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -35,8 +36,13 @@ namespace WebCore {
 struct PixelBufferFormat {
     AlphaPremultiplication alphaFormat;
     PixelFormat pixelFormat;
-    DestinationColorSpace colorSpace;
+    // Note: this is the color space of the pixel data, so unlike DestinationColorSpace it is not
+    // restricted to color spaces that can be rendered to.
+    PlatformColorSpace colorSpace;
 };
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, const PixelBufferFormat&);
+
+// Returns true if the color space can describe the contents of a pixel buffer.
+WEBCORE_EXPORT bool isValidPixelBufferColorSpace(const PlatformColorSpace&);
 }

--- a/Source/WebCore/platform/graphics/PlatformColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformColorSpace.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
+#include <wtf/Platform.h>
+
 #if USE(CG)
 #include <wtf/RetainPtr.h>
 typedef struct CGColorSpace* CGColorSpaceRef;
@@ -75,5 +78,25 @@ private:
 using PlatformColorSpaceValue = PlatformColorSpace::Name;
 
 #endif
+
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceSRGB();
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceLinearSRGB();
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceDisplayP3();
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceExtendedDisplayP3();
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceLinearDisplayP3();
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceExtendedLinearDisplayP3();
+#endif
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceExtendedSRGB();
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceExtendedLinearSRGB();
+#endif
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_REC_2020)
+WEBCORE_EXPORT PlatformColorSpace platformColorSpaceExtendedRec2020();
+#endif
+
+// Compares two platform color spaces by value, i.e. two distinct objects describing the same
+// color space compare equal.
+WEBCORE_EXPORT bool equalPlatformColorSpaces(const PlatformColorSpace&, const PlatformColorSpace&);
 
 }

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -910,7 +910,7 @@ void ShadowBlur::blurShadowBuffer(ImageBuffer& layerImage, const IntSize& templa
     if (m_type != BlurShadow)
         return;
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     IntRect blurRect(IntPoint(), templateSize);
     auto layerData = layerImage.getPixelBuffer(format, blurRect);
     if (!layerData)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -369,7 +369,7 @@ bool GraphicsContextGLANGLE::releaseThreadResources(ReleaseThreadResourceBehavio
 
 RefPtr<PixelBuffer> GraphicsContextGLANGLE::readPixelsForPaintResults()
 {
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     auto pixelBuffer = ByteArrayPixelBuffer::tryCreate(format, getInternalFramebufferSize());
     if (!pixelBuffer)
         return nullptr;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -523,7 +523,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     }));
 
     auto imageSize = pixelBuffer->size();
-    return NativeImage::create(adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->format().colorSpace.platformColorSpace(), bitmapInfo, dataProvider.get(), 0, false, kCGRenderingIntentDefault)));
+    return NativeImage::create(adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->colorSpace().get(), bitmapInfo, dataProvider.get(), 0, false, kCGRenderingIntentDefault)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -532,7 +532,7 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
         return false;
 
     auto imageSize = source.size();
-    auto image = adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), protect(source.format().colorSpace.platformColorSpace()).get(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(dataAlphaInfo), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
+    RetainPtr image = adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), source.colorSpace().get(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(dataAlphaInfo), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
 
     return encode(image.get(), mimeType, quality, function);
 }

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -223,7 +223,7 @@ static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, Alp
 
     // Color space conversion happens internally when drawing from one image buffer to another
     convertedImageBuffer->context().drawImageBuffer(imageBuffer, sourceRect);
-    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, colorSpace };
+    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, colorSpace.platformColorSpace() };
     return convertedImageBuffer->getPixelBuffer(format, sourceRect, allocator);
 }
 
@@ -232,7 +232,7 @@ static RefPtr<PixelBuffer> getConvertedPixelBuffer(PixelBuffer& sourcePixelBuffe
     auto sourceRect = IntRect { { } , sourcePixelBuffer.size() };
     auto clampedSize = ImageBuffer::clampedSize(sourceRect.size());
 
-    auto& sourceColorSpace = sourcePixelBuffer.format().colorSpace;
+    DestinationColorSpace sourceColorSpace { sourcePixelBuffer.colorSpace() };
     auto imageBuffer = allocator.createImageBuffer(clampedSize, sourceColorSpace, RenderingMode::Unaccelerated);
     if (!imageBuffer)
         return nullptr;
@@ -266,7 +266,7 @@ PixelBuffer* FilterImage::pixelBuffer(AlphaPremultiplication alphaFormat)
     if (pixelBuffer)
         return pixelBuffer.get();
 
-    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, m_colorSpace };
+    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, m_colorSpace.platformColorSpace() };
 
     if (RefPtr imageBuffer = m_imageBuffer) {
         pixelBuffer = imageBuffer->getPixelBuffer(format, { { }, m_absoluteImageRect.size() }, m_allocator);
@@ -301,7 +301,7 @@ RefPtr<PixelBuffer> FilterImage::getPixelBuffer(AlphaPremultiplication alphaForm
 {
     ASSERT(!ImageBuffer::sizeNeedsClamping(sourceRect.size()));
 
-    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, colorSpace? *colorSpace : m_colorSpace };
+    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, (colorSpace ? *colorSpace : m_colorSpace).platformColorSpace() };
 
     auto pixelBuffer = m_allocator.createPixelBuffer(format, sourceRect.size());
     if (!pixelBuffer)
@@ -316,7 +316,7 @@ RefPtr<PixelBuffer> FilterImage::getPixelBuffer(AlphaPremultiplication alphaForm
 bool FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
 {
     auto alphaFormat = destinationPixelBuffer.format().alphaFormat;
-    auto& colorSpace = destinationPixelBuffer.format().colorSpace;
+    DestinationColorSpace colorSpace { destinationPixelBuffer.colorSpace() };
 
     RefPtr sourcePixelBuffer = pixelBufferSlot(alphaFormat) ? pixelBufferSlot(alphaFormat).get() : nullptr;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -272,7 +272,7 @@ bool FEColorMatrixSoftwareApplier::apply(const Filter&, std::span<const Ref<Filt
         resultImage->context().drawImageBuffer(*inputImage, inputImageRect);
     }
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, result.colorSpace() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, result.colorSpace().platformColorSpace() };
     IntRect imageRect(IntPoint(), resultImage->truncatedLogicalSize());
     auto pixelBuffer = resultImage->getPixelBuffer(format, imageRect);
     if (!pixelBuffer)

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -62,7 +62,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, std::span<const Re
 
     ShadowBlur contextShadow(blurRadius, absoluteOffset, m_effect->shadowColor());
 
-    PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, result.colorSpace() };
+    PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, result.colorSpace().platformColorSpace() };
     IntRect shadowArea(IntPoint(), resultImage->truncatedLogicalSize());
     auto pixelBuffer = resultImage->getPixelBuffer(format, shadowArea);
     if (!pixelBuffer)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -345,7 +345,7 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
         ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
 
     auto destinationInfo = SkImageInfo::Make(destination.size().width(), destination.size().height(),
-        destinationColorType, destinationAlphaType, destination.format().colorSpace.platformColorSpace());
+        destinationColorType, destinationAlphaType, destination.colorSpace());
     SkPixmap pixmap(destinationInfo, destination.bytes().data(), destination.size().width() * 4);
 
     SkPixmap dstPixmap;
@@ -394,7 +394,7 @@ void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceVi
     sourceRectClipped.setSize(destinationRect.size());
 
     auto pixelBufferInfo = SkImageInfo::Make(pixelBuffer.size().width(), pixelBuffer.size().height(),
-        colorType, alphaType, pixelBuffer.format().colorSpace.platformColorSpace());
+        colorType, alphaType, pixelBuffer.colorSpace());
     SkPixmap pixmap(pixelBufferInfo, pixelBuffer.bytes().data(), pixelBuffer.size().width() * 4);
 
     SkPixmap srcPixmap;

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -519,7 +519,7 @@ void JPEGXLImageDecoder::maybePerformColorSpaceConversion(std::span<uint8_t> inp
         .format = {
             .alphaFormat = alphaFormat,
             .pixelFormat = PixelFormat::BGRA8,
-            .colorSpace = DestinationColorSpace(m_profile.get()),
+            .colorSpace = m_profile,
         },
         .bytesPerRow = static_cast<unsigned>(4 * size().width()),
         .rows = inputBuffer,
@@ -528,7 +528,7 @@ void JPEGXLImageDecoder::maybePerformColorSpaceConversion(std::span<uint8_t> inp
         .format = {
             .alphaFormat = alphaFormat,
             .pixelFormat = PixelFormat::BGRA8,
-            .colorSpace = DestinationColorSpace::SRGB(),
+            .colorSpace = platformColorSpaceSRGB(),
         },
         .bytesPerRow = static_cast<unsigned>(4 * size().width()),
         .rows = intermediateBuffer.mutableSpan()

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -118,7 +118,7 @@ void MockRealtimeVideoSourceGStreamer::updateSampleBuffer()
     if (!imageBuffer)
         return;
 
-    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }, { { }, imageBuffer->truncatedLogicalSize() });
+    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, platformColorSpaceSRGB() }, { { }, imageBuffer->truncatedLogicalSize() });
     if (!pixelBuffer)
         return;
 

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -194,7 +194,7 @@ Ref<const LayoutShape> LayoutShape::createRasterShape(Image* image, float thresh
     if (image)
         graphicsContext.drawImage(*image, IntRect({ }, snappedPhysicalImageSize));
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     auto pixelBuffer = imageBuffer->getPixelBuffer(format, { { }, snappedPhysicalImageSize });
 
     // We could get to a value where PixelBuffer could be nullptr because snappedPhysicalImageSize

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2328,7 +2328,7 @@ ExceptionOr<RefPtr<ImageData>> Internals::snapshotNode(Node& node)
     PixelBufferFormat destinationFormat {
         AlphaPremultiplication::Unpremultiplied,
         PixelFormat::RGBA8,
-        DestinationColorSpace::SRGB()
+        platformColorSpaceSRGB()
     };
 
     auto pixelBuffer = imageBuffer->getPixelBuffer(destinationFormat, sourceRect);

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -145,7 +145,7 @@ void RemoteVideoFrameObjectHeap::pixelBuffer(RemoteVideoFrameReadReference&& rea
 
 void RemoteVideoFrameObjectHeap::convertFrameBuffer(SharedVideoFrame&& sharedVideoFrame, CompletionHandler<void(WebCore::DestinationColorSpace)>&& callback)
 {
-    DestinationColorSpace destinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() };
+    DestinationColorSpace destinationColorSpace { platformColorSpaceSRGB() };
     auto scope = makeScopeExit([&callback, &destinationColorSpace] { callback(destinationColorSpace); });
 
     RefPtr<VideoFrame> frame;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1644,7 +1644,7 @@ enum class WebCore::UseLosslessCompression : bool;
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PixelBufferFormat {
     WebCore::AlphaPremultiplication alphaFormat;
     WebCore::PixelFormat pixelFormat;
-    [Validator='colorSpace->usesRGBColorModel()'] WebCore::DestinationColorSpace colorSpace;
+    [Validator='WebCore::isValidPixelBufferColorSpace(*colorSpace)'] WebCore::PlatformColorSpace colorSpace;
 };
 
 [RefCounted] class WebCore::TextIndicator {

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -167,7 +167,7 @@ RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(con
         return nullptr;
     }
 
-    auto [destinationColorSpace] = sendResult.takeReplyOr(DestinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() });
+    auto [destinationColorSpace] = sendResult.takeReplyOr(DestinationColorSpace { platformColorSpaceSRGB() });
 
     m_conversionSemaphore.wait();
 

--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
@@ -38,7 +38,7 @@ using namespace WebCore;
 
 ::testing::AssertionResult imageBufferPixelIs(Color expected, const ImageBuffer& imageBuffer, FloatPoint point)
 {
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, platformColorSpaceSRGB() };
     auto pixelBuffer = imageBuffer.getPixelBuffer(format, enclosingIntRect(FloatRect { point, FloatSize { 1, 1 } }));
     auto got = Color { SRGBA<uint8_t> { pixelBuffer->item(0), pixelBuffer->item(1), pixelBuffer->item(2), pixelBuffer->item(3) } };
     if (got != expected) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -108,7 +108,7 @@ static RefPtr<PixelBuffer> createPixelBufferTestPattern(IntSize size, AlphaPremu
         ASSERT_NOT_REACHED();
         return nullptr;
     }
-    PixelBufferFormat testFormat { alphaFormat, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat testFormat { alphaFormat, PixelFormat::BGRA8, platformColorSpaceSRGB() };
     return pattern->getPixelBuffer(testFormat, { { }, size }); 
 }
 
@@ -272,7 +272,7 @@ TEST_P(AnyScaleTest, GetPixelBufferDimensionsContainScale)
     drawTestPattern(*buffer, 0);
 
     // Test that ImageBuffer::getPixelBuffer() returns pixel buffer with dimensions that are scaled to resolutionScale() of the source.
-    PixelBufferFormat testFormat { AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+    PixelBufferFormat testFormat { AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, platformColorSpaceSRGB() };
     auto pixelBuffer = buffer->getPixelBuffer(testFormat, { { }, testSize });
     IntSize expectedSize = testSize;
     expectedSize.scale(deviceScaleFactor());
@@ -345,7 +345,7 @@ TEST(ImageBufferTests, GetPixelBufferAllZeros)
     auto getPixelBufferAllZeros = [&](const FloatRect& rect) {
         RetainPtr platformColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceGenericCMYK));
         auto destinationColorSpace = DestinationColorSpace(WTF::move(platformColorSpace));
-        PixelBufferFormat destinationPixelFormat { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, destinationColorSpace };
+        PixelBufferFormat destinationPixelFormat { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, destinationColorSpace.platformColorSpace() };
 
         RefPtr pixelBuffer = imageBuffer->getPixelBuffer(destinationPixelFormat, enclosingIntRect(rect));
         EXPECT_NE(nullptr, pixelBuffer);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/PixelBufferConversion.h>
 #include <vector>
@@ -47,8 +48,8 @@ TEST(PixelBufferConversionTests, convertImagePixels)
     const std::vector<uint8_t> reorderedBytesOpaqueAlpha = { 0, 95, 191, 255 };
 
     auto convert = [&](PixelFormat sourceFormat, AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat destinationFormat, AlphaPremultiplication destinationAlphaPremultiplication, bool removeAlpha = false) -> std::vector<uint8_t> {
-        const PixelBufferFormat sourcePixelBufferFormat { sourceAlphaPremultiplication, sourceFormat, DestinationColorSpace::SRGB() };
-        const PixelBufferFormat destinationPixelBufferFormat { destinationAlphaPremultiplication, destinationFormat, DestinationColorSpace::SRGB() };
+        const PixelBufferFormat sourcePixelBufferFormat { sourceAlphaPremultiplication, sourceFormat, platformColorSpaceSRGB() };
+        const PixelBufferFormat destinationPixelBufferFormat { destinationAlphaPremultiplication, destinationFormat, platformColorSpaceSRGB() };
         const std::vector<uint8_t> sourceBytes =
             pixelFormatIsOpaque(sourceFormat)
                 ? orderedBytesPremultiplied
@@ -118,8 +119,8 @@ TEST(PixelBufferConversionTests, convertImagePixels)
 TEST(PixelBufferConversionTests, convertImagePixels2)
 {
     auto convert = [&](PixelFormat sourceFormat, PixelFormat destinationFormat) -> std::vector<uint8_t> {
-        const PixelBufferFormat sourcePixelBufferFormat { AlphaPremultiplication::Unpremultiplied, sourceFormat, DestinationColorSpace::SRGB() };
-        const PixelBufferFormat destinationPixelBufferFormat { AlphaPremultiplication::Unpremultiplied, destinationFormat, DestinationColorSpace::SRGB() };
+        const PixelBufferFormat sourcePixelBufferFormat { AlphaPremultiplication::Unpremultiplied, sourceFormat, platformColorSpaceSRGB() };
+        const PixelBufferFormat destinationPixelBufferFormat { AlphaPremultiplication::Unpremultiplied, destinationFormat, platformColorSpaceSRGB() };
         const std::vector<uint8_t> sourceBytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         std::vector<uint8_t> destinationBytes(8);
         constexpr int sourceBytesPerRow = 8;
@@ -159,8 +160,8 @@ static std::vector<Float16> convertFloat16s(AlphaPremultiplication sourceAlphaFo
     auto sourceBytes = byteVectorFromFloat16s(components);
     unsigned bytesPerRow = sourceBytes.size();
     std::vector<uint8_t> destinationBytes(bytesPerRow);
-    ConstPixelBufferConversionView source { PixelBufferFormat { .alphaFormat = sourceAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = sourceColorSpace }, bytesPerRow, sourceBytes };
-    PixelBufferConversionView destination { PixelBufferFormat { .alphaFormat = destinationAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = destinationDestinationColorSpace }, bytesPerRow, destinationBytes };
+    ConstPixelBufferConversionView source { PixelBufferFormat { .alphaFormat = sourceAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = sourceColorSpace.platformColorSpace() }, bytesPerRow, sourceBytes };
+    PixelBufferConversionView destination { PixelBufferFormat { .alphaFormat = destinationAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = destinationDestinationColorSpace.platformColorSpace() }, bytesPerRow, destinationBytes };
 
     convertImagePixels(source, destination, size);
 
@@ -204,7 +205,7 @@ TEST(PixelBufferConversionTests, convertImagePixelsFloat16ColorSpaceConversion)
 
 TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)
 {
-    const auto colorSpace = DestinationColorSpace::SRGB();
+    const PlatformColorSpace colorSpace = platformColorSpaceSRGB();
     constexpr int float16BytesPerRow = 4 * sizeof(Float16);
     constexpr int u8BytesPerRow = 4;
 
@@ -238,7 +239,7 @@ TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)
 
 TEST(PixelBufferConversionTests, convertImagePixelsFloat16PaddedRows)
 {
-    const auto colorSpace = DestinationColorSpace::SRGB();
+    const PlatformColorSpace colorSpace = platformColorSpaceSRGB();
     const auto sourceBytes = byteVectorFromFloat16s({
         1.0, 0.0, 0.0, 1.0, /* padding: */ 0.0, 0.0,
         0.0, 1.0, 0.0, 1.0, /* padding: */ 0.0, 0.0,


### PR DESCRIPTION
#### 77b619c06194098984ff7f6a01df07d7d86692b9
<pre>
PixelBuffer should support non-renderable color spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=323094">https://bugs.webkit.org/show_bug.cgi?id=323094</a>
<a href="https://rdar.apple.com/186345542">rdar://186345542</a>

Reviewed by NOBODY (OOPS!).

Make PixelBufferFormat hold a PlatformColorSpace instead of
DestinationColorSpace. DestinationColorSpace is for rasterization
targets, i.e. results of ImageBuffer drawing.
PixelBuffer might hold any arbitrary pixel image, not necessarily
one that comes from rasterization. Use PlatformColorSpace, as that
is the arbitrary color space abstraction currently used.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromImageBuffer):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::imageData const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneDeserializer::readImageBitmap):
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toVideoFrame):
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
(WebCore::ImageData::byteArrayPixelBuffer const):
(WebCore::ImageData::float16ArrayPixelBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Source/WebCore/html/canvas/PredefinedColorSpace.cpp:
(WebCore::toPlatformColorSpace):
(WebCore::toExtendedPlatformColorSpace):
* Source/WebCore/html/canvas/PredefinedColorSpace.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::drawingBufferToPixelBuffer):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor):
(WebCore::PageColorSampler::predominantColor):
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::knownPlatformColorSpace):
(WebCore::platformColorSpaceSRGB):
(WebCore::platformColorSpaceLinearSRGB):
(WebCore::platformColorSpaceDisplayP3):
(WebCore::platformColorSpaceExtendedDisplayP3):
(WebCore::platformColorSpaceLinearDisplayP3):
(WebCore::platformColorSpaceExtendedLinearDisplayP3):
(WebCore::platformColorSpaceExtendedSRGB):
(WebCore::platformColorSpaceExtendedLinearSRGB):
(WebCore::platformColorSpaceExtendedRec2020):
(WebCore::equalPlatformColorSpaces):
* Source/WebCore/platform/graphics/ImageBufferAllocator.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::convertToLuminanceMaskUint8):
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/PixelBuffer.h:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixelsAccelerated):
(WebCore::convertImagePixelsSkia):
(WebCore::convertImagePixelsUnaccelerated):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/PixelBufferFormat.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::isValidPixelBufferColorSpace):
* Source/WebCore/platform/graphics/PixelBufferFormat.h:
* Source/WebCore/platform/graphics/PlatformColorSpace.h:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::blurShadowBuffer):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::readPixelsForPaintResults):
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::encode):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::getConvertedPixelBuffer):
(WebCore::FilterImage::pixelBuffer):
(WebCore::FilterImage::getPixelBuffer):
(WebCore::FilterImage::copyPixelBuffer):
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp:
(WebCore::FEDropShadowSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::maybePerformColorSpaceConversion):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::updateSampleBuffer):
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createRasterShape):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::snapshotNode):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::convertFrameBuffer):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp:
(TestWebKitAPI::imageBufferPixelIs):
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::createPixelBufferTestPattern):
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::TEST(ImageBufferTests, GetPixelBufferAllZeros)):
* Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp:
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixels)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixels2)):
(TestWebKitAPI::convertFloat16s):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16PaddedRows)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77b619c06194098984ff7f6a01df07d7d86692b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184209 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148502 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d7a6142-34fc-46de-bfbd-e70f6a3221cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143814 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99949 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f88bc235-180a-413c-8b4b-58f10c3d67db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124233 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e6e0288-8924-4c87-86b1-5971263b0539) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44510 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156724 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44083 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50790 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48796 "Found 1 new test failure: ipc/rgba16f-getpixelbuffer-colorspace-mismatch-heap-disclosure.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196371 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57804 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153367 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58508 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153041 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47576 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130800 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127271 "Failed to checkout and rebase branch from PR 72932") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57016 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19095 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->