### PR TITLE
[JSC][Wasm] Inline OMG array.init_data

### DIFF
--- a/JSTests/wasm/stress/array-init-data-inline.js
+++ b/JSTests/wasm/stress/array-init-data-inline.js
@@ -1,0 +1,90 @@
+//@ requireOptions("--useConcurrentJIT=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+import { instantiate } from "../gc/wast-wrapper.js"
+import * as assert from "../assert.js"
+
+function test() {
+    const instance = instantiate(`
+      (module
+        (type $i8 (array (mut i8)))
+        (type $i32 (array (mut i32)))
+        (data $d "\\00\\01\\02\\03\\04\\05\\06\\07")
+        (func (export "initI8") (param (ref $i8) i32 i32 i32)
+          (array.init_data $i8 $d (local.get 0) (local.get 1) (local.get 2) (local.get 3)))
+        (func (export "initI32") (param (ref $i32) i32 i32 i32)
+          (array.init_data $i32 $d (local.get 0) (local.get 1) (local.get 2) (local.get 3)))
+        (func (export "newI8") (param i32) (result (ref $i8))
+          (array.new_default $i8 (local.get 0)))
+        (func (export "newI32") (param i32) (result (ref $i32))
+          (array.new_default $i32 (local.get 0)))
+        (func (export "getI8") (param (ref $i8) i32) (result i32)
+          (array.get_u $i8 (local.get 0) (local.get 1)))
+        (func (export "getI32") (param (ref $i32) i32) (result i32)
+          (array.get $i32 (local.get 0) (local.get 1)))
+        (func (export "drop")
+          (data.drop $d)))
+    `);
+    const { initI8, initI32, newI8, newI32, getI8, getI32, drop } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        const bytes = newI8(10);
+        initI8(bytes, 0, 0, 8);
+        for (let j = 0; j < 8; j++)
+            assert.eq(getI8(bytes, j), j);
+        assert.eq(getI8(bytes, 8), 0);
+
+        initI8(bytes, 2, 2, 3);
+        assert.eq(getI8(bytes, 2), 2);
+        assert.eq(getI8(bytes, 3), 3);
+        assert.eq(getI8(bytes, 4), 4);
+
+        initI8(bytes, 10, 0, 0);
+        initI8(bytes, 0, 8, 0);
+        assert.throws(() => initI8(bytes, 11, 0, 0), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+        assert.throws(() => initI8(bytes, 9, 0, 2), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+        assert.throws(() => initI8(bytes, 0, 8, 1), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+        assert.throws(() => initI8(bytes, 0, 0, 9), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+        assert.throws(() => initI8(bytes, 0, 0xffffffff, 1), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+
+        const words = newI32(4);
+        initI32(words, 1, 0, 2);
+        assert.eq(getI32(words, 0), 0);
+        assert.eq(getI32(words, 1), 0x03020100);
+        assert.eq(getI32(words, 2), 0x07060504);
+        assert.eq(getI32(words, 3), 0);
+        assert.throws(() => initI32(words, 0, 0, 3), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+        assert.throws(() => initI32(words, 0, 1, 2), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+    }
+
+    const afterDrop = newI8(4);
+    drop();
+    initI8(afterDrop, 0, 0, 0);
+    assert.throws(() => initI8(afterDrop, 0, 0, 1), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+    assert.throws(() => initI8(afterDrop, 0, 1, 0), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+
+    const nullable = instantiate(`
+      (module
+        (type $i8 (array (mut i8)))
+        (data $d "\\00")
+        (func (export "init") (param (ref null $i8))
+          (array.init_data $i8 $d (local.get 0) (i32.const 0) (i32.const 0) (i32.const 0))))
+    `);
+    assert.throws(() => nullable.exports.init(null), WebAssembly.RuntimeError, "array.init_data to a null reference");
+
+    const active = instantiate(`
+      (module
+        (memory 1)
+        (type $i8 (array (mut i8)))
+        (data (i32.const 0) "xy")
+        (func (export "init") (param (ref $i8) i32 i32 i32)
+          (array.init_data $i8 0 (local.get 0) (local.get 1) (local.get 2) (local.get 3)))
+        (func (export "new") (param i32) (result (ref $i8))
+          (array.new_default $i8 (local.get 0))))
+    `);
+    const arr = active.exports.new(2);
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        active.exports.init(arr, 0, 0, 0);
+        assert.throws(() => active.exports.init(arr, 0, 0, 1), WebAssembly.RuntimeError, "Out of bounds array.init_data");
+    }
+}
+
+test();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4195,8 +4195,13 @@ auto OMGIRGenerator::addArrayInitElem(TypeSignatureIndex, TypedExpression dst, E
     return { };
 }
 
-auto OMGIRGenerator::addArrayInitData(TypeSignatureIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size) -> PartialResult
+auto OMGIRGenerator::addArrayInitData(TypeSignatureIndex dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size) -> PartialResult
 {
+    StorageType elementType;
+    getArrayElementType(dstTypeIndex, elementType);
+    size_t elementSize = elementType.elementSize();
+    ASSERT(!isRefType(elementType.unpacked()));
+
     auto dstValue = get(dst);
     auto dstOffsetValue = get(dstOffset);
     auto srcOffsetValue = get(srcOffset);
@@ -4205,21 +4210,79 @@ auto OMGIRGenerator::addArrayInitData(TypeSignatureIndex, TypedExpression dst, E
     if (dst.type().isNullable())
         emitNullCheck(dstValue, ExceptionType::NullArrayInitData);
 
-    Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmArrayInitData,
-        instanceValue(),
-        dstValue, dstOffsetValue,
-        constant(Int32, srcDataIndex), srcOffsetValue,
-        sizeValue);
+    auto emitCCall = [&] {
+        Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmArrayInitData,
+            instanceValue(),
+            dstValue, dstOffsetValue,
+            constant(Int32, srcDataIndex), srcOffsetValue,
+            sizeValue);
 
-    {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, constant(Int32, 0)));
-
         check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsArrayInitData);
         });
+    };
+
+    if (srcDataIndex >= BitVector::maxInlineBitCount()) {
+        emitCCall();
+        return { };
     }
 
+    auto* bits = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfPassiveDataSegments()));
+    auto* isInline = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), BitVector::inlineBitMask()));
+
+    auto* inlinePath = m_proc.addBlock();
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), isInline,
+        FrequentedBlock(inlinePath), FrequentedBlock(slowPath, FrequencyClass::Rare));
+    inlinePath->addPredecessor(m_currentBlock);
+    slowPath->addPredecessor(m_currentBlock);
+
+    m_currentBlock = inlinePath;
+    emitArrayRangeCheck(emitGetArraySize(dstValue, false), dstOffsetValue, sizeValue, ExceptionType::OutOfBoundsArrayInitData);
+
+    auto* srcOffsetPtr = pointerOfInt32(srcOffsetValue);
+    auto* byteCount = m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), pointerOfInt32(sizeValue),
+        m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), elementSize));
+    auto* srcSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), srcOffsetPtr, byteCount);
+    auto* dropped = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), static_cast<uintptr_t>(1) << srcDataIndex)),
+        constant(pointerType(), 0));
+    auto* segmentSize = m_currentBlock->appendNew<Value>(m_proc, B3::Select, origin(), dropped,
+        constant(pointerType(), 0),
+        constant(pointerType(), m_info.data[srcDataIndex]->sizeInBytes()));
+    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, Below, origin(), srcSum, srcOffsetPtr),
+        m_currentBlock->appendNew<Value>(m_proc, Above, origin(), srcSum, segmentSize));
+    if (elementSize > 1) {
+        outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Above, origin(), pointerOfInt32(sizeValue),
+                constant(pointerType(), static_cast<uintptr_t>(-1) / elementSize)),
+            outOfBounds);
+    }
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsArrayInitData);
+    });
+
+    m_currentBlock->appendNew<BulkMemoryValue>(m_proc, MemoryCopy, origin(),
+        emitArrayElementAddress(elementType, dstValue, dstOffsetValue),
+        m_currentBlock->appendNew<Value>(m_proc, Add, origin(),
+            constant(pointerType(), std::bit_cast<uintptr_t>(m_info.data[srcDataIndex]->span().data())),
+            srcOffsetPtr),
+        byteCount);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    emitCCall();
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -329,6 +329,7 @@ public:
 #endif
     static constexpr ptrdiff_t offsetOfMemoryIsMemory64Bits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_memoryIsMemory64Bits); }
     static constexpr ptrdiff_t offsetOfCachedMemory0Size() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory0Size); }
+    static constexpr ptrdiff_t offsetOfPassiveDataSegments() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_passiveDataSegments); }
 
     // Tail accessors.
     static_assert(sizeof(WasmMemoryBaseAndSize) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(WasmMemoryBaseAndSize)), "We rely on this for the alignment to be correct");

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -396,7 +396,10 @@ public:
         return byteCount(bitCount);
     }
     unsigned outOfLineMemoryUse() const { return outOfLineMemoryUse(size()); }
-        
+
+    static constexpr unsigned maxInlineBitCount() { return maxInlineBits(); }
+    static constexpr uintptr_t inlineBitMask() { return static_cast<uintptr_t>(1) << maxInlineBitCount(); }
+
     WTF_EXPORT_PRIVATE void shiftRightByMultipleOf64(size_t);
 
 private:


### PR DESCRIPTION
#### 1955bb74ca8589e7afdadf50aca12797db8401e7
<pre>
[JSC][Wasm] Inline OMG array.init_data
<a href="https://bugs.webkit.org/show_bug.cgi?id=322804">https://bugs.webkit.org/show_bug.cgi?id=322804</a>

Reviewed by NOBODY (OOPS!).

OMG bounds-checks array.init_data and copies from the data segment
with the existing memcpy helper. The inline path runs only when the
passive-data BitVector is still inline. Otherwise it uses the runtime
operation. BBQ and array.init_elem stay on the operation.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/WTF/wtf/BitVector.h:
* JSTests/wasm/stress/array-init-data-inline.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1955bb74ca8589e7afdadf50aca12797db8401e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100640 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47564 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45599 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7342 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14230 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45298 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7113 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46990 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59310 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154692 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60018 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154344 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48805 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132369 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->