### PR TITLE
REGRESSION(294049@main): paused and seeked animation finishes when resumed after a rate-adjusted animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation-expected.txt
@@ -11,4 +11,5 @@ PASS If a pause operation is interrupted, the ready promise is reused
 PASS A pending playback rate is used when determining auto-rewind behavior
 PASS Playing a canceled animation sets the start time
 PASS Playing a canceled animation backwards sets the start time
+PASS Resuming a paused animation after enough time has elapsed that it would have ended if playing remains running
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation.html
@@ -173,5 +173,21 @@ promise_test(async t => {
                       'The start time of the playing animation should be set');
 }, 'Playing a canceled animation backwards sets the start time');
 
+promise_test(async t => {
+  const main = createDiv(t).animate(null, 100);
+  main.pause();
+  main.currentTime = 50;
+
+  const support = createDiv(t).animate(null, 100);
+  await support.finished;
+
+  await new Promise(setTimeout);
+  main.play();
+  await main.ready;
+
+  assert_equals(main.playState, 'running');
+}, 'Resuming a paused animation after enough time has elapsed'
+  + ' that it would have ended if playing remains running');
+
 </script>
 </body>

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1258,8 +1258,12 @@ ExceptionOr<void> WebAnimation::play(AutoRewind autoRewind)
     }
 
     // 8. If animation’s hold time is resolved, let its start time be unresolved.
-    if (m_holdTime)
+    if (m_holdTime) {
         m_startTime = std::nullopt;
+        // We also reset the pending start time since a previous call to pause() would
+        // have recorded one which is now stale.
+        m_pendingStartTime = std::nullopt;
+    }
 
     // 9. If animation has a pending play task or a pending pause task,
     //     - Cancel that task.


### PR DESCRIPTION
#### 1aa3db9eb328a98f42496707ecf28d4a850ebf7f
<pre>
REGRESSION(294049@main): paused and seeked animation finishes when resumed after a rate-adjusted animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322936">https://bugs.webkit.org/show_bug.cgi?id=322936</a>
<a href="https://rdar.apple.com/186339093">rdar://186339093</a>

Reviewed by Anne van Kesteren.

Ensure we reset the pending start time when calling `WebAnimation::play()` since a previous call
to `WebAnimation::pause()` would have recorded one that would be stale and yield an incorrect
updated start time when the pending play task is run.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/playing-an-animation.html:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::play):

Canonical link: <a href="https://commits.webkit.org/320238@main">https://commits.webkit.org/320238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163dcdd0da80f2384c8e2cad25c2c27330ad40c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148507 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/567a2f35-4f9a-4d9e-a840-23aaeb9908d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143813 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99951 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dba9d73-9660-430d-8122-d17af062cf94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124232 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7b2ed06-120f-4909-8285-4edf7f19d246) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46297 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44085 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5620 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196376 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153371 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58513 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153045 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27969 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47578 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130805 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57021 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56631 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->