### PR TITLE
[JSC] Support `BigInt` for `Intl.PluralRules.select` and `Intl.PluralRules.selectRange`

### DIFF
--- a/JSTests/stress/intl-pluralrules-mathematical-value.js
+++ b/JSTests/stress/intl-pluralrules-mathematical-value.js
@@ -1,0 +1,76 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected}, but got ${actual}`);
+}
+
+const locales = ["en", "fr", "pl", "zh"];
+const numbers = [0, 1, 2, 3, 4, 5, 10, 100, 1e3, 1e4, 1e5, 1e6];
+
+function representations(number) {
+    return [
+        `${number}`,
+        `0b${number.toString(2)}`,
+        `0B${number.toString(2)}`,
+        `0o${number.toString(8)}`,
+        `0O${number.toString(8)}`,
+        `0x${number.toString(16)}`,
+        `0X${number.toString(16)}`,
+    ];
+}
+
+const whitespaceCharacters = [
+    "\u0009", "\u000B", "\u000C", "\uFEFF", "\u0020", "\u00A0", "\u1680",
+    "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005", "\u2006",
+    "\u2007", "\u2008", "\u2009", "\u200A", "\u202F", "\u205F", "\u3000",
+    "\u000A", "\u000D", "\u2028", "\u2029",
+];
+
+for (const locale of locales) {
+    const pluralRules = new Intl.PluralRules(locale);
+
+    for (const number of numbers) {
+        const expected = pluralRules.select(number);
+
+        shouldBe(pluralRules.select(BigInt(number)), expected, `${locale}: BigInt ${number}`);
+
+        for (const representation of representations(number)) {
+            shouldBe(pluralRules.select(representation), expected, `${locale}: string ${representation}`);
+
+            for (const whitespace of whitespaceCharacters) {
+                const codePoint = whitespace.codePointAt(0).toString(16).padStart(4, "0");
+                shouldBe(pluralRules.select(whitespace + representation), expected, `${locale}: leading U+${codePoint} and ${representation}`);
+                shouldBe(pluralRules.select(representation + whitespace), expected, `${locale}: trailing U+${codePoint} and ${representation}`);
+                shouldBe(pluralRules.select(whitespace + representation + whitespace), expected, `${locale}: surrounding U+${codePoint} and ${representation}`);
+            }
+        }
+    }
+
+    if (Intl.PluralRules.prototype.selectRange) {
+        for (const start of numbers) {
+            for (const end of numbers) {
+                const expected = pluralRules.selectRange(start, end);
+
+                shouldBe(pluralRules.selectRange(BigInt(start), BigInt(end)), expected, `${locale}: BigInt range ${start}-${end}`);
+                shouldBe(pluralRules.selectRange(start, BigInt(end)), expected, `${locale}: Number/BigInt range ${start}-${end}`);
+                shouldBe(pluralRules.selectRange(BigInt(start), end), expected, `${locale}: BigInt/Number range ${start}-${end}`);
+
+                for (const representation of representations(start))
+                    shouldBe(pluralRules.selectRange(representation, String(end)), expected, `${locale}: string range ${representation}-${end}`);
+            }
+        }
+    }
+}
+
+const ceilPluralRules = new Intl.PluralRules("en", {
+    roundingMode: "ceil",
+    maximumFractionDigits: 0,
+});
+shouldBe(ceilPluralRules.select(1.0000000000000001), ceilPluralRules.select(1), "Number input is rounded before selection");
+shouldBe(ceilPluralRules.select("1.0000000000000001"), ceilPluralRules.select(2), "precise string input rounds toward positive infinity");
+
+const floorPluralRules = new Intl.PluralRules("en", {
+    roundingMode: "floor",
+    maximumFractionDigits: 0,
+});
+shouldBe(floorPluralRules.select(0.99999999999999999), floorPluralRules.select(1), "Number input is rounded before selection");
+shouldBe(floorPluralRules.select("0.99999999999999999"), floorPluralRules.select(0), "precise string input rounds toward negative infinity");

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -246,14 +246,14 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
 }
 
 // https://tc39.es/ecma402/#sec-resolveplural
-JSValue IntlPluralRules::select(JSGlobalObject* globalObject, double value) const
+JSValue IntlPluralRules::select(JSGlobalObject* globalObject, double targetValue) const
 {
     ASSERT(m_pluralRules);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!std::isfinite(value))
+    if (!std::isfinite(targetValue))
         return jsNontrivialString(vm, "other"_s);
 
     UErrorCode status = U_ZERO_ERROR;
@@ -261,7 +261,36 @@ JSValue IntlPluralRules::select(JSGlobalObject* globalObject, double value) cons
     auto formattedNumber = std::unique_ptr<UFormattedNumber, ICUDeleter<unumf_closeResult>>(unumf_openResult(&status));
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select plural value"_s);
-    unumf_formatDouble(m_numberFormatter.get(), value, formattedNumber.get(), &status);
+    unumf_formatDouble(m_numberFormatter.get(), targetValue, formattedNumber.get(), &status);
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select plural value"_s);
+    Vector<char16_t, 32> buffer;
+    status = callBufferProducingFunction(uplrules_selectFormatted, m_pluralRules.get(), formattedNumber.get(), buffer);
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select plural value"_s);
+    return jsString(vm, String(WTF::move(buffer)));
+}
+
+
+JSValue IntlPluralRules::select(JSGlobalObject* globalObject, IntlMathematicalValue&& targetValue) const
+{
+    ASSERT(m_pluralRules);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (targetValue.numberType() == IntlMathematicalValue::NumberType::NaN || targetValue.numberType() == IntlMathematicalValue::NumberType::Infinity)
+        return jsNontrivialString(vm, "other"_s);
+
+    targetValue.ensureNonDouble();
+    const auto& string = targetValue.getString();
+
+    UErrorCode status = U_ZERO_ERROR;
+
+    auto formattedNumber = std::unique_ptr<UFormattedNumber, ICUDeleter<unumf_closeResult>>(unumf_openResult(&status));
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select plural value"_s);
+    unumf_formatDecimal(m_numberFormatter.get(), string.data(), string.length(), formattedNumber.get(), &status);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select plural value"_s);
     Vector<char16_t, 32> buffer;
@@ -287,6 +316,38 @@ JSValue IntlPluralRules::selectRange(JSGlobalObject* globalObject, double start,
         return throwTypeError(globalObject, scope, "failed to select range of plural value"_s);
 
     unumrf_formatDoubleRange(m_numberRangeFormatter.get(), start, end, range.get(), &status);
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select range of plural value"_s);
+
+    Vector<char16_t, 32> buffer;
+    status = callBufferProducingFunction(uplrules_selectForRange, m_pluralRules.get(), range.get(), buffer);
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select plural value"_s);
+    return jsString(vm, String(WTF::move(buffer)));
+}
+
+JSValue IntlPluralRules::selectRange(JSGlobalObject* globalObject, IntlMathematicalValue&& start, IntlMathematicalValue&& end) const
+{
+    ASSERT(m_numberRangeFormatter);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (start.numberType() == IntlMathematicalValue::NumberType::NaN || end.numberType() == IntlMathematicalValue::NumberType::NaN)
+        return throwRangeError(globalObject, scope, "Passed numbers are out of range"_s);
+
+    start.ensureNonDouble();
+    end.ensureNonDouble();
+
+    const auto& startString = start.getString();
+    const auto& endString = end.getString();
+
+    UErrorCode status = U_ZERO_ERROR;
+    auto range = std::unique_ptr<UFormattedNumberRange, ICUDeleter<unumrf_closeResult>>(unumrf_openResult(&status));
+    if (U_FAILURE(status))
+        return throwTypeError(globalObject, scope, "failed to select range of plural value"_s);
+
+    unumrf_formatDecimalRange(m_numberRangeFormatter.get(), startString.data(), startString.length(), endString.data(), endString.length(), range.get(), &status);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select range of plural value"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -72,8 +72,10 @@ public:
     friend void appendNumberFormatNotationOptionsToSkeleton(IntlType*, StringBuilder&);
 
     void initializePluralRules(JSGlobalObject*, JSValue locales, JSValue options);
-    JSValue select(JSGlobalObject*, double value) const;
+    JSValue select(JSGlobalObject*, double targetValue) const;
+    JSValue select(JSGlobalObject*, IntlMathematicalValue&& targetValue) const;
     JSValue selectRange(JSGlobalObject*, double start, double end) const;
+    JSValue selectRange(JSGlobalObject*, IntlMathematicalValue&& start, IntlMathematicalValue&& end) const;
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
 private:

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "IntlPluralRulesPrototype.h"
 
+#include "IntlNumberFormatInlines.h"
 #include "IntlPluralRules.h"
 #include "JSCInlines.h"
 
@@ -89,10 +90,14 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* gl
     if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.select called on value that's not a PluralRules"_s));
 
-    double value = callFrame->argument(0).toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    auto value = toIntlMathematicalValue(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->select(globalObject, value)));
+    auto number = value.tryGetDouble();
+    if (!number) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->select(globalObject, WTF::move(value))));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->select(globalObject, number.value())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -111,13 +116,19 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObjec
     if (startValue.isUndefined() || endValue.isUndefined())
         return throwVMTypeError(globalObject, scope, "start or end is undefined"_s);
 
-    double start = startValue.toNumber(globalObject);
+    auto start = toIntlMathematicalValue(globalObject, startValue);
     RETURN_IF_EXCEPTION(scope, { });
 
-    double end = endValue.toNumber(globalObject);
+    auto end = toIntlMathematicalValue(globalObject, endValue);
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->selectRange(globalObject, start, end)));
+    auto startNumber = start.tryGetDouble();
+    auto endNumber = end.tryGetDouble();
+
+    if (!startNumber || !endNumber) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->selectRange(globalObject, WTF::move(start), WTF::move(end))));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->selectRange(globalObject, startNumber.value(), endNumber.value())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### 2e5ec08882e660b34004f9b0d7825a579010d7c2
<pre>
[JSC] Support `BigInt` for `Intl.PluralRules.select` and `Intl.PluralRules.selectRange`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323092">https://bugs.webkit.org/show_bug.cgi?id=323092</a>

Reviewed by Yusuke Suzuki.

According to [1][2], the `Intl.PluralRules.select` and `Intl.PluralRules.selectRange` methods should support
`BigInt` values as their arguments, but the current implementation supports only `Number` values.
The test262 test suites has also been updated [3][4].

[1]: <a href="https://github.com/tc39/ecma402/pull/1026">https://github.com/tc39/ecma402/pull/1026</a>
[2]: <a href="https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.select">https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.select</a>
[3]: <a href="https://github.com/tc39/test262/pull/4912">https://github.com/tc39/test262/pull/4912</a>
[4]: <a href="https://github.com/tc39/test262/pull/4911">https://github.com/tc39/test262/pull/4911</a>

Test: JSTests/stress/intl-pluralrules-mathematical-value.js

* JSTests/stress/intl-pluralrules-mathematical-value.js: Added.
(shouldBe):
(representations):
(const.locale.of.locales.const.number.of.numbers.const.representation.of.representations):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::select const):
(JSC::IntlPluralRules::selectRange const):
* Source/JavaScriptCore/runtime/IntlPluralRules.h:
* Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/320396@main">https://commits.webkit.org/320396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13b80bda96a3b40745155f74e1ae3970bb2a4ebf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143977 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100055 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44666 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6359 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13197 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44261 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5825 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45703 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58018 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153223 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47747 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131013 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127427 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->