### PR TITLE
[JSC] Baseline JIT should not construct `GCOwnedDataScope` on the compiler thread

### DIFF
--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.cpp
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.cpp
@@ -36,6 +36,9 @@ void setTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope)
 {
     if (!cell)
         return;
+    ASSERT(!isCompilationThread());
+    if (Thread::mayBeGCThread())
+        return;
     if (!cell->vm().heap.m_topGCOwnedDataScope)
         cell->vm().heap.m_topGCOwnedDataScope = scope;
 }
@@ -43,6 +46,9 @@ void setTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope)
 void clearTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope)
 {
     if (!cell)
+        return;
+    ASSERT(!isCompilationThread());
+    if (Thread::mayBeGCThread())
         return;
     if (cell->vm().heap.m_topGCOwnedDataScope == scope)
         cell->vm().heap.m_topGCOwnedDataScope = nullptr;

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -233,17 +233,18 @@ ALWAYS_INLINE void JIT::emit_compareImpl(VirtualRegister op1, VirtualRegister op
     // - constant int immediate to int immediate
     // - int immediate to int immediate
 
-    constexpr bool disallowAllocation = false;
     auto handleConstantCharOperand = [&](VirtualRegister left, VirtualRegister right, RelationalCondition cond) {
         if (!isOperandConstantChar(left))
             return false;
+        JSString* string = asString(getConstantOperand(left));
+        RELEASE_ASSERT(!string->isRope());
 
         emitGetVirtualRegister(right, regT0);
         addSlowCase(branchIfNotCell(regT0));
         JumpList failures;
         emitLoadCharacterString(regT0, regT0, failures);
         addSlowCase(failures);
-        emitCompare(commute(cond), regT0, Imm32(asString(getConstantOperand(left))->tryGetValue(disallowAllocation).data[0]));
+        emitCompare(commute(cond), regT0, Imm32(string->tryGetValueImpl()->at(0)));
         return true;
     };
 

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -961,17 +961,18 @@ ALWAYS_INLINE void LOLJIT::emitCompareImpl(VirtualRegister op1, GPRReg op1GPR, V
     // - constant int immediate to int immediate
     // - int immediate to int immediate
 
-    constexpr bool disallowAllocation = false;
     auto handleConstantCharOperand = [&](VirtualRegister left, GPRReg rightGPR, RelationalCondition cond) {
         if (!isOperandConstantChar(left))
             return false;
+        JSString* string = asString(getConstantOperand(left));
+        RELEASE_ASSERT(!string->isRope());
 
         addSlowCase(branchIfNotCell(rightGPR));
         JumpList failures;
         // FIXME: We could deduplicate the String's data load in emitLoadCharacterString if we had an extra scratch but we'd have to teach the register allocator about constants to do that unless we wanted to have the scratch in all cases, which doesn't seem worth it.
         emitLoadCharacterString(rightGPR, s_scratch, failures);
         addSlowCase(failures);
-        emitCompare(commute(cond), s_scratch, Imm32(asString(getConstantOperand(left))->tryGetValue(disallowAllocation).data[0]));
+        emitCompare(commute(cond), s_scratch, Imm32(string->tryGetValueImpl()->at(0)));
         return true;
     };
 


### PR DESCRIPTION
#### 1edc620316f57c3c4539f58d5c9e00f33fcc29f6
<pre>
[JSC] Baseline JIT should not construct `GCOwnedDataScope` on the compiler thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=323102">https://bugs.webkit.org/show_bug.cgi?id=323102</a>

Reviewed by Yusuke Suzuki.

Heap::m_topGCOwnedDataScope is a debug-only, unsynchronized field that says
whether a GCOwnedDataScope is live on the mutator&apos;s stack, and
Heap::clearConcurrentRetainedDataIfPossible asserts it is null before dropping
the old StringImpls it keeps alive for such scopes. Compiler and GC threads are
covered by separate checks there. But JIT::emit_compareImpl and
LOLJIT::emitCompareImpl read a single-character string constant through
JSString::tryGetValue(), which returns a GCOwnedDataScope, so the JITWorker
thread writes the field too. If the IncrementalSweeper timer fires while the
JIT thread is inside that scope, the assertion aborts even though the
ongoing-compilation check would have kept the strings alive.

Read the constant through tryGetValueImpl() and StringImpl::at(0), as the DFG
already does, and assert in setTopGCOwnedDataScopeIfNeeded and
clearTopGCOwnedDataScopeIfNeeded that they never run on a compiler thread.
GC threads still construct such scopes, since
ErrorInstance::reconcileWeakReferencesAtGCEnd materializes stack traces into
strings on the collector thread, so the field keeps ignoring them.

This assertion fired in an ASan build in Bun&apos;s CI. Release builds are not
affected.

* Source/JavaScriptCore/heap/GCOwnedDataScope.cpp:
(JSC::setTopGCOwnedDataScopeIfNeeded):
(JSC::clearTopGCOwnedDataScopeIfNeeded):
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_compareImpl):
* Source/JavaScriptCore/lol/LOLJIT.cpp:
(JSC::LOL::LOLJIT::emitCompareImpl):

Canonical link: <a href="https://commits.webkit.org/320348@main">https://commits.webkit.org/320348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152420084c6258f78501da0f5b77db1fe29a4a93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148705 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186284 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143971 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100052 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124389 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44663 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6353 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13196 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44260 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5820 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45697 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58013 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41140 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153219 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47743 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131008 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127422 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56587 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->