### PR TITLE
[IPC] Add the UI process' origin validation procedures

### DIFF
--- a/Source/WebKit/Platform/IPC/Untrusted.h
+++ b/Source/WebKit/Platform/IPC/Untrusted.h
@@ -197,3 +197,17 @@ template<typename Validator, typename T, typename HashArg, typename TraitsArg, t
 struct IsValidationProcedureFor<Validator, HashSet<T, HashArg, TraitsArg, TableTraitsArg, shouldValidateKey>> : IsValidationProcedureFor<Validator, T> { };
 
 } // namespace IPC
+
+/* A translation unit that validates untrusted values defines the following over its own
+ * MESSAGE_CHECK, whose argument order varies between receivers. They expand to two
+ * declarations around a check, so they are statements that declare names and cannot be
+ * brace-less if/else bodies.
+ *
+ *     #define EXTRACT_WITH_MESSAGE_CHECK(name, untrusted, ...) \
+ *         auto name##Validated = WTF::move(untrusted).validate(__VA_ARGS__); \
+ *         MESSAGE_CHECK(name##Validated); \
+ *         auto name = WTF::move(*name##Validated)
+ *
+ * The validator is the trailing variadic argument because it is brace-initialised and the
+ * preprocessor splits on the commas inside the braces.
+ */

--- a/Source/WebKit/UIProcess/FirstPartyAuthority.h
+++ b/Source/WebKit/UIProcess/FirstPartyAuthority.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Untrusted.h"
+#include "WebProcessProxy.h"
+#include <WebCore/ClientOrigin.h>
+#include <WebCore/RegistrableDomain.h>
+#include <WebCore/SecurityOriginData.h>
+#include <WebCore/Site.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+// Maps WebProcessProxy's three-way answer onto a validation failure. SilentFailure
+// happens legitimately as a new load starts.
+inline std::optional<IPC::ValidationFailure> checkFirstPartyAccess(const WebProcessProxy& process, const WebCore::RegistrableDomain& domain)
+{
+    switch (process.allowsFirstPartyAccess(domain)) {
+    case WebProcessProxy::FirstPartyAccessResult::Pass:
+        return std::nullopt;
+    case WebProcessProxy::FirstPartyAccessResult::SilentFailure:
+        return IPC::ValidationFailure::Ignore;
+    case WebProcessProxy::FirstPartyAccessResult::HardFailure:
+        return IPC::ValidationFailure::Terminate;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// Use for any frame belonging to a process.
+class FirstPartyAuthority : public IPC::CanValidateUntrusted<FirstPartyAuthority> {
+public:
+    explicit FirstPartyAuthority(const WebProcessProxy& process)
+        : m_process(process)
+    {
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::SecurityOriginData& origin) const
+    {
+        return checkUntrustedDomain(WebCore::RegistrableDomain { origin });
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::RegistrableDomain& domain) const
+    {
+        return checkUntrustedDomain(domain);
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::Site& site) const
+    {
+        return checkUntrustedDomain(site.domain());
+    }
+
+private:
+    std::optional<IPC::ValidationFailure> checkUntrustedDomain(const WebCore::RegistrableDomain& domain) const
+    {
+        // Without site isolation, WebProcessProxy records only the main frame's site while the
+        // process hosts every site the page pulls in, so this question has no useful answer for a
+        // value that may name a subframe's origin.
+        RefPtr process = m_process.get();
+        if (!process)
+            return IPC::ValidationFailure::Ignore;
+
+        auto& preferences = process->sharedPreferencesForWebProcessValue();
+        if (!preferences.siteIsolationEnabled || preferences.usesSingleWebProcess)
+            return std::nullopt;
+
+        return checkFirstPartyAccess(*process, domain);
+    }
+
+    // Weak, so that constructing a validator cannot extend a process's life, and a validator that
+    // outlives its process drops the message rather than crashing.
+    WeakPtr<const WebProcessProxy> m_process;
+};
+
+// Use for the top-level frame belonging to a process.
+class TopLevelFirstPartyAuthority : public IPC::CanValidateUntrusted<TopLevelFirstPartyAuthority> {
+public:
+    explicit TopLevelFirstPartyAuthority(const WebProcessProxy& process)
+        : m_process(process)
+    {
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::SecurityOriginData& origin) const
+    {
+        RefPtr process = m_process.get();
+        if (!process)
+            return IPC::ValidationFailure::Ignore;
+
+        return checkFirstPartyAccess(*process, WebCore::RegistrableDomain { origin });
+    }
+
+private:
+    WeakPtr<const WebProcessProxy> m_process;
+};
+
+// Use to check if this process has committed a load for this exact (top origin, client origin) pair.
+class CommittedClientOriginAuthority : public IPC::CanValidateUntrusted<CommittedClientOriginAuthority> {
+public:
+    explicit CommittedClientOriginAuthority(const WebProcessProxy& process)
+        : m_process(process)
+    {
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::ClientOrigin& origin) const
+    {
+        RefPtr process = m_process.get();
+        if (!process)
+            return IPC::ValidationFailure::Ignore;
+
+        if (!process->hasCommittedClientOrigin(origin))
+            return IPC::ValidationFailure::Terminate;
+        return std::nullopt;
+    }
+
+private:
+    WeakPtr<const WebProcessProxy> m_process;
+};
+
+} // namespace WebKit
+
+namespace IPC {
+
+template<> struct IsValidationProcedureFor<WebKit::FirstPartyAuthority, WebCore::SecurityOriginData> : std::true_type { };
+template<> struct IsValidationProcedureFor<WebKit::FirstPartyAuthority, WebCore::RegistrableDomain> : std::true_type { };
+template<> struct IsValidationProcedureFor<WebKit::FirstPartyAuthority, WebCore::Site> : std::true_type { };
+
+template<> struct IsValidationProcedureFor<WebKit::TopLevelFirstPartyAuthority, WebCore::SecurityOriginData> : std::true_type { };
+
+template<> struct IsValidationProcedureFor<WebKit::CommittedClientOriginAuthority, WebCore::ClientOrigin> : std::true_type { };
+
+} // namespace IPC


### PR DESCRIPTION
#### aba0fcd53beabdfab961ba8ca5ee11565a9f2ca7
<pre>
[IPC] Add the UI process&apos; origin validation procedures
<a href="https://bugs.webkit.org/show_bug.cgi?id=323100">https://bugs.webkit.org/show_bug.cgi?id=323100</a>

Reviewed by Zak Ridouh.

This is the second in a series of commits which will eventually result in all
code paths provably validating origins sent from WCP to more privileged processes.

Adds the procedures by which the UI process recovers a trusted origin from an
IPC::Untrusted&lt;T&gt;. Nothing calls them yet - the burn-down is a later commit - so
there is no behavior change.

There is more than one because the UI process has different notions of authority and
they are not interchangeable:

- FirstPartyAuthority answers &quot;is this the registrable domain of the site this
  process is for&quot;, which is the question site isolation can answer, and it is the
  only question available for a bare SecurityOriginData, RegistrableDomain or Site.
  It defers to WebProcessProxy::allowsFirstPartyAccess().

- TopLevelFirstPartyAuthority asks the same question of allowsFirstPartyAccess(), but
  without the site-isolation guard described below, for the values where that guard
  would be wrong. See below.

- CommittedClientOriginAuthority answers &quot;has this process committed a load for
  this exact (top origin, client origin) pair&quot;, deferring to
  WebProcessProxy::hasCommittedClientOrigin(). It is strictly stronger, and it is
  only available for ClientOrigin, which is why it cannot be merged with the others.

Both functions already existed and are already used by a handful of hand-written
MESSAGE_CHECKs; this commit does not invent a policy, it makes the existing one
reachable through the type.

allowsFirstPartyAccess() is three-way: SilentFailure becomes
ValidationFailure::Ignore because it means the process is serving several sites
at once, which happens legitimately as a new load starts, and terminating there
would kill processes during normal navigation.

FirstPartyAuthority&apos;s site-isolation guard is the one piece of new logic, and it is
there because the value it is handed may name any origin on the page, including a
subframe&apos;s. Without site isolation a single process hosts a page and every cross-site
subframe it pulls in, while WebProcessProxy records only the main frame&apos;s site, so for
such a value the comparison has no useful answer and could only produce false denials.
FirstPartyAuthority therefore passes everything when siteIsolationEnabled is off or the
process is the single web process.

That guard must not silently weaken a check that ships today, so there is a third
procedure. TopLevelFirstPartyAuthority asks exactly the same question with no guard,
and is correct only for a value that is by construction the process&apos;s own top-level or
worker origin - where WebProcessProxy&apos;s record of the main frame&apos;s site is the right
thing to compare against with or without site isolation. The two app-badge messages,
SetAppBadgeFromWorker and WebFrameProxy::SetAppBadge, are the existing unconditional
callers of allowsFirstPartyAccess(), and they use this procedure, so their behaviour is
unchanged in every configuration. CommittedClientOriginAuthority needs no guard for the
same reason: hasCommittedClientOrigin() answers from what the process has actually
committed, which is exact either way, so the Web Locks checks that already call it are
unchanged too.

Alternative considered for CommittedClientOriginAuthority: validating only the top
origin, as the network process does. Rejected because storage and Web Locks
partition on both halves of a ClientOrigin, so the top origin alone is only half of
the key they are keyed on.

If the WebProcessProxy has gone away by the time we do one of these queries, we
assume that the process is already going through destruction rather than being
malicious. Alternative considered: hold a strong reference to the WebProcessProxy.
We don&apos;t want to do that because we don&apos;t want to inadvertently extend lifetimes
via this change.

Also documents, next to the primitive, the EXTRACT_WITH_MESSAGE_CHECK shape that
callers will use. It cannot live in a shared header: the macro has to expand to the
receiver&apos;s own MESSAGE_CHECK, whose argument order differs between translation
units, so each defines its own. The definitions land with their first users in a
later commit rather than sitting unused here.

* Source/WebKit/Platform/IPC/Untrusted.h:
* Source/WebKit/UIProcess/FirstPartyAuthority.h: Added.
(WebKit::checkFirstPartyAccess):
(WebKit::FirstPartyAuthority::FirstPartyAuthority):
(WebKit::FirstPartyAuthority::checkUntrusted const):
(WebKit::FirstPartyAuthority::checkUntrustedDomain const):
(WebKit::TopLevelFirstPartyAuthority::TopLevelFirstPartyAuthority):
(WebKit::TopLevelFirstPartyAuthority::checkUntrusted const):
(WebKit::CommittedClientOriginAuthority::CommittedClientOriginAuthority):
(WebKit::CommittedClientOriginAuthority::checkUntrusted const):

Canonical link: <a href="https://commits.webkit.org/320248@main">https://commits.webkit.org/320248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c391dd6e854d887e8c7764a4f1aaa77b94cac58a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194473 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74cac052-45d1-414f-9ec2-f0f71927b0a9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fb03249-436e-484e-b18c-993d9411afb6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124254 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c338433-2618-4649-ab9b-cf951760f038) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46329 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44117 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196409 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57841 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41061 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58546 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153073 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47604 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130845 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57053 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->