### PR TITLE
[CMake] Enable -Werror globally in DEVELOPER_MODE

### DIFF
--- a/Source/WebGPU/WGSL/CMakeLists.txt
+++ b/Source/WebGPU/WGSL/CMakeLists.txt
@@ -175,10 +175,6 @@ target_include_directories(WGSLCore PUBLIC
 target_link_libraries(WGSLCore PUBLIC WebKit::JavaScriptCore)
 add_dependencies(WGSLCore wgsl-types)
 
-if (DEVELOPER_MODE_CXX_FLAGS)
-    target_compile_options(WGSLCore PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
-endif ()
-
 # wgslc executable
 set(wgslc_SOURCES wgslc.cpp)
 set(wgslc_LIBRARIES WGSLCore)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -172,7 +172,6 @@ if (ENABLE_WPE_PLATFORM_WAYLAND)
 endif ()
 
 add_library(WPEPlatform OBJECT ${WPEPlatform_SOURCES})
-target_compile_options(WPEPlatform PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatform PRIVATE ${WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatform SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatform PRIVATE ${WPEPlatform_LIBRARIES})

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -48,7 +48,6 @@ set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
 )
 
 add_library(WPEPlatformDRM OBJECT ${WPEPlatformDRM_SOURCES})
-target_compile_options(WPEPlatformDRM PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformDRM PRIVATE ${WPEPlatformDRM_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformDRM SYSTEM PRIVATE ${WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformDRM ${WPEPlatform_LIBRARIES} ${WPEPlatformDRM_LIBRARIES})

--- a/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
@@ -25,7 +25,6 @@ set(WPEPlatformHeadless_SOURCES_FOR_INTROSPECTION
 )
 
 add_library(WPEPlatformHeadless OBJECT ${WPEPlatformHeadless_SOURCES})
-target_compile_options(WPEPlatformHeadless PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformHeadless PRIVATE ${WPEPlatformHeadless_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformHeadless SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformHeadless ${WPEPlatform_LIBRARIES})

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -164,12 +164,11 @@ option(ENABLE_UNSAFE_BUFFER_USAGE_WARNING "Build with -Wunsafe-buffer-usage" OFF
 option(ENABLE_THREAD_SAFETY_WARNING "Build with -Wthread-safety" OFF)
 
 option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER_MODE is also enabled" ON)
-set(DEVELOPER_MODE_CXX_FLAGS)
 if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
     if (MSVC)
-        set(DEVELOPER_MODE_CXX_FLAGS "/WX")
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(/WX)
     elseif (COMPILER_IS_GCC_OR_CLANG)
-        set(DEVELOPER_MODE_CXX_FLAGS "-Werror")
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Werror)
     endif ()
 endif ()
 

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -471,9 +471,11 @@ macro(_WEBKIT_TARGET_SETUP _target _logical_name)
     target_include_directories(${_target} SYSTEM PRIVATE "$<BUILD_INTERFACE:${${_logical_name}_SYSTEM_INCLUDE_DIRECTORIES}>")
     target_include_directories(${_target} PRIVATE "$<BUILD_INTERFACE:${${_logical_name}_PRIVATE_INCLUDE_DIRECTORIES}>")
 
-    if (DEVELOPER_MODE_CXX_FLAGS)
-        target_compile_options(${_target} PRIVATE
-            "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${DEVELOPER_MODE_CXX_FLAGS}>")
+    # Non-Swift languages get warnings-as-errors from the global flags; swiftc
+    # spells them as diagnostic groups, so it needs its own set.
+    # FIXME: We should do this globally somehow and get rid of custom error group disablement.
+    # Right now SWIFT_ENABLED is calculated after WebKitCompilerFlags.cmake so we can't verify Swift flags.
+    if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
         target_compile_options(${_target} PRIVATE
             "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${SWIFT_FATAL_DIAGNOSTIC_FLAGS}>")
     endif ()


### PR DESCRIPTION
#### 070356a60a77ee878b21ce8c9d2dda7a3d1c4257
<pre>
[CMake] Enable -Werror globally in DEVELOPER_MODE
<a href="https://bugs.webkit.org/show_bug.cgi?id=323109">https://bugs.webkit.org/show_bug.cgi?id=323109</a>
<a href="https://rdar.apple.com/186366829">rdar://186366829</a>

Reviewed by Elliott Williams.

Right now `-Werror` is set per-target. This is error prone (pun intended).
After this change when in DEVELOPER_MODE with fatal warnings, which is
the default, we prepend `-Werror`. This matches the xcodebuild&apos;s use
of `-Werror` which is set in every Base.xconfig, although, it should
probably move to CommonBase.xconfig.

I didn&apos;t move Swift&apos;s logic for setting the flags `-Werror` since
WebKitCompilerFlags.cmake is initialized before SWIFT_ENABLED is set
for a given port. If/when we require Swift for all ports we can
reconsider moving those definitions.

Canonical link: <a href="https://commits.webkit.org/320261@main">https://commits.webkit.org/320261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eea27e17edd2a9b2c8208aa7209bbbf178a1989c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148543 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99980 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124272 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183575 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44546 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6248 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13079 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44140 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5653 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45528 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196411 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183651 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164087 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153407 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58548 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153076 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130856 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57055 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19155 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56427 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->