### PR TITLE
Remove Prime Video user-select quirk

### DIFF
--- a/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
@@ -13,16 +13,12 @@ https://actesting.org/
 https://www.airindiaexpress.com/
     NeedsAirIndiaExpressLayeringQuirk
 https://www.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://sub.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.amazon.co.uk/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://amazon.design/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.apple.com/
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture

--- a/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
@@ -13,16 +13,12 @@ https://actesting.org/
 https://www.airindiaexpress.com/
     NeedsAirIndiaExpressLayeringQuirk
 https://www.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://sub.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.amazon.co.uk/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://amazon.design/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.apple.com/
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture

--- a/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
@@ -13,16 +13,12 @@ https://actesting.org/
 https://www.airindiaexpress.com/
     NeedsAirIndiaExpressLayeringQuirk
 https://www.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://sub.amazon.com/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.amazon.co.uk/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://amazon.design/
-    NeedsPrimeVideoUserSelectNoneQuirk
     ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk
 https://www.apple.com/
     EnsureCaptionVisibilityInFullscreenAndPictureInPicture

--- a/Source/WebCore/page/QuirkNames.h
+++ b/Source/WebCore/page/QuirkNames.h
@@ -128,9 +128,6 @@ enum class SiteSpecificQuirk {
     NeedsSuppressedPauseEventOnFullscreenExitQuirk,
     NeedsPreloadAutoQuirk,
 #endif
-#if PLATFORM(MAC)
-    NeedsPrimeVideoUserSelectNoneQuirk,
-#endif
     NeedsResettingTransitionCancelsRunningTransitionQuirk,
     NeedsReuseLiveRangeForSelectionUpdateQuirk,
     NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk,

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -78,10 +78,6 @@ static constexpr Quirk table[] = {
         .behaviors = {
             // amazon.com rdar://49124529
             ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
-#if PLATFORM(MAC)
-            // amazon.com rdar://128962002
-            NeedsPrimeVideoUserSelectNoneQuirk,
-#endif
 #if ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
             // amazon.com rdar://49124313
             ShouldDispatchSimulatedMouseEventsQuirk,

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -733,19 +733,6 @@ bool Quirks::needsWebExScrollabilityQuirk() const
     return false;
 #endif
 }
-
-// amazon.com rdar://128962002
-bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
-{
-#if PLATFORM(MAC)
-    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-
-    return m_quirksData.quirkIsEnabled(SiteSpecificQuirk::NeedsPrimeVideoUserSelectNoneQuirk);
-#else
-    return false;
-#endif
-}
-
 // facebook.com https://webkit.org/b/295071
 // FIXME: https://webkit.org/b/295318
 bool Quirks::needsFacebookRemoveNotSupportedQuirk() const

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -156,8 +156,6 @@ public:
 
     bool needsYahooVolumeSliderQuirk() const;
 
-    bool needsPrimeVideoUserSelectNoneQuirk() const;
-
     bool needsFacebookRemoveNotSupportedQuirk() const;
 
     bool needsScrollbarWidthThinDisabledQuirk() const;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1155,15 +1155,6 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
             style.setUsedZIndex(2);
     }
 
-    if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
-        static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
-        if (m_element->hasClassName(className)) {
-            // Not redundant: we don't know which one will be used:
-            style.setWebkitUserSelect(UserSelect::None);
-            style.setUserSelect(UserSelect::None);
-        }
-    }
-
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {
         if (*tikTokOverflowingContentQuery == Quirks::TikTokOverflowingContentQuirkType::CommentsSectionQuirk)  {
             style.setFlexShrink({ 1 });


### PR DESCRIPTION
#### 2e870702ed8dede211eee49c127422f392c3148c
<pre>
Remove Prime Video user-select quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=323112">https://bugs.webkit.org/show_bug.cgi?id=323112</a>
<a href="https://rdar.apple.com/186371399">rdar://186371399</a>

Reviewed by Zak Ridouh and Tim Nguyen.

Quirk seems outdated:
 - document.querySelector(&apos;.webPlayerSDKUiContainer&apos;) returns nothing,
   so the quirk doesn&apos;t match anything (see StyleAdjuster.cpp)
 - Cannot reproduce the behavior described on <a href="https://rdar.apple.com/128962002">rdar://128962002</a> by
   disabling site-specific quirks. (also tried with a disabled
   &quot;unprefixed user select&quot;)

* LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt:
* Source/WebCore/page/QuirkNames.h:
* Source/WebCore/page/QuirkTable.cpp:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/320268@main">https://commits.webkit.org/320268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e78075a1671023c82168c72d7eae89f7abe3a0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148546 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e476b20-a77c-45e8-bcb2-659b0a6b88b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99982 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55fa044b-8d15-4426-801b-50eac90a8802) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124258 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7be2cbfc-5941-461f-aded-6def8c2e08b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46346 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44550 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44130 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5657 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57847 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41084 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58552 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153079 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47610 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130859 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57059 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19138 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->