### PR TITLE
Revert "[Build] Clean up Apple platform port names in webkitdirs"

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -199,15 +199,23 @@ BEGIN {
        &updateGtkOrWpeLibs
        &usesCryptexPath
        &vcpkgArgsFromFeatures
+       &willUseAppleTVDeviceSDK
+       &willUseAppleTVSimulatorSDK
        &willUseIOSDeviceSDK
        &willUseIOSSimulatorSDK
+       &willUseWatchDeviceSDK
+       &willUseWatchSimulatorSDK
+       &willUseVisionDeviceSDK
+       &willUseVisionSimulatorSDK
        &winVersion
        &wrapperPrefixIfNeeded
        &xcodeSDK
        &xcodeSDKPlatformName
        &xcodeVersion
        DO_NOT_USE_OPEN_COMMAND
+       Mac
        USE_OPEN_COMMAND
+       iOS
    );
    %EXPORT_TAGS = ( );
    @EXPORT_OK   = ();
@@ -217,7 +225,12 @@ BEGIN {
 use constant {
     GTK         => "GTK",
     Haiku       => "Haiku",
-    Cocoa       => "Cocoa",
+    iOS         => "iOS",
+    tvOS        => "tvOS",
+    watchOS     => "watchOS",
+    visionOS    => "visionOS",
+    Mac         => "Mac",
+    MacCatalyst => "MacCatalyst",
     JSCOnly     => "JSCOnly",
     PlayStation => "PlayStation",
     Win         => "Win",
@@ -624,16 +637,30 @@ sub determineXcodeDestination
     my @architectures = split(' ', $architecture);
     my $generic = $xcodeSDKPlatformName =~ /os$/ || (scalar @architectures) > 1;
 
-    my $osName = sdkPlatformOSName();
-    $destination .= "platform=$osName";
-    $destination .= ' Simulator' if willUseSimulatorSDK();
-    if ($osName eq "macOS") {
+    if (willUseIOSDeviceSDK()) {
+        $destination .= 'platform=iOS';
+    } elsif (willUseIOSSimulatorSDK()) {
+        $destination .= 'platform=iOS Simulator';
+    } elsif (willUseAppleTVDeviceSDK()) {
+        $destination .= 'platform=tvOS';
+    } elsif (willUseAppleTVSimulatorSDK()) {
+        $destination .= 'platform=tvOS Simulator';
+    } elsif (willUseWatchDeviceSDK()) {
+        $destination .= 'platform=watchOS';
+    } elsif (willUseWatchSimulatorSDK()) {
+        $destination .= 'platform=watchOS Simulator';
+    } elsif (willUseVisionDeviceSDK()) {
+        $destination .= 'platform=visionOS';
+    } elsif (willUseVisionSimulatorSDK()) {
+        $destination .= 'platform=visionOS Simulator';
+    } else {
+        $destination .= 'platform=macOS';
         $destination .= ',devicetype=' . ($generic ? 'Any Mac' : 'Mac');
         $destination .= ',arch=' . $architectures[0] unless $generic;
         $destination .= ',variant=Mac Catalyst' if willUseMacCatalystSDK();
     }
 
-    if (!$generic && willUseSimulatorSDK()) {
+    if (!$generic && $xcodeSDKPlatformName =~ /simulator$/) {
         # Two goals:
         # 1. Find a simulator device to build for, to avoid building multiple architectures.
         # 2. Try to pick a simulator that's been used before (either by command-line or IDE builds) to avoid
@@ -660,7 +687,7 @@ sub determineXcodeDestination
         # If we found the previous device, check that the runtime being built has not changed (e.g. due to a
         # major SDK update). If it has changed, or if no previous device is available, fall back to the first
         # eligible device in the list.
-        my $runtime = simulatorRuntime();
+        my $runtime = simulatorRuntime($portName);
         my $device;
         if ($prevDevice && $prevDevice->{runtime} eq $runtime) {
             $device = $prevDevice;
@@ -839,8 +866,8 @@ sub argumentsForConfiguration()
     push(@args, '--debug') if ($configuration =~ "^Debug");
     push(@args, '--release') if ($configuration =~ "^Release");
     push(@args, '--ios-device') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'iphoneos');
-    push(@args, '--ios-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'iphonesimulator' && simulatorIdiom() eq "iPhone");
-    push(@args, '--ipad-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'iphonesimulator' && simulatorIdiom() eq "iPad");
+    push(@args, '--ios-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'iphonesimulator' && $simulatorIdiom eq "iPhone");
+    push(@args, '--ipad-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'iphonesimulator' && $simulatorIdiom eq "iPad");
     push(@args, '--tvos-device') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'appletvos');
     push(@args, '--tvos-simulator') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'appletvsimulator');
     push(@args, '--watchos-device') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'watchos');
@@ -940,27 +967,6 @@ sub isValidXcodeSDKPlatformName($) {
         maccatalyst
     );
     return grep { $_ eq $name } @platforms;
-}
-
-# Which OS each SDK platform targets, as simctl and xcodebuild spell it. Mac Catalyst
-# targets macOS; use xcodeSDKPlatformName() to tell the two SDK variants apart. Must
-# cover every name isValidXcodeSDKPlatformName() accepts, so this never returns undef.
-my %osNameBySDKPlatformName = (
-    appletvos        => "tvOS",
-    appletvsimulator => "tvOS",
-    iphoneos         => "iOS",
-    iphonesimulator  => "iOS",
-    maccatalyst      => "macOS",
-    macosx           => "macOS",
-    watchos          => "watchOS",
-    watchsimulator   => "watchOS",
-    xros             => "visionOS",
-    xrsimulator      => "visionOS",
-);
-
-sub sdkPlatformOSName()
-{
-    return $osNameBySDKPlatformName{xcodeSDKPlatformName()};
 }
 
 sub determineCrossTarget {
@@ -1828,10 +1834,20 @@ sub determinePortName()
     if (isAnyWindows()) {
         $portName = Win;
     } elsif (isDarwin()) {
-        # Resolve the platform here so that its arguments are consumed from @ARGV before
-        # any caller inspects what's left.
         determineXcodeSDKPlatformName();
-        $portName = Cocoa;
+        if (willUseIOSDeviceSDK() || willUseIOSSimulatorSDK()) {
+            $portName = iOS;
+        } elsif (willUseAppleTVDeviceSDK() || willUseAppleTVSimulatorSDK()) {
+            $portName = tvOS;
+        } elsif (willUseWatchDeviceSDK() || willUseWatchSimulatorSDK()) {
+            $portName = watchOS;
+        } elsif (willUseVisionDeviceSDK() || willUseVisionSimulatorSDK()) {
+            $portName = visionOS;
+        } elsif (willUseMacCatalystSDK()) {
+            $portName = MacCatalyst;
+        } else {
+            $portName = Mac;
+        }
     } else {
         if ($unknownPortProhibited) {
             my $portsChoice = join "\n\t", qw(
@@ -2020,27 +2036,27 @@ sub isCrossCompilation()
 
 sub isIOSWebKit()
 {
-    return isAppleCocoaWebKit() && sdkPlatformOSName() eq "iOS";
+    return portName() eq iOS;
 }
 
 sub isTVOSWebKit()
 {
-    return isAppleCocoaWebKit() && sdkPlatformOSName() eq "tvOS";
+    return portName() eq tvOS;
 }
 
 sub isWatchOSWebKit()
 {
-    return isAppleCocoaWebKit() && sdkPlatformOSName() eq "watchOS";
+    return portName() eq watchOS;
 }
 
 sub isVisionOSWebKit()
 {
-    return isAppleCocoaWebKit() && sdkPlatformOSName() eq "visionOS";
+    return portName() eq visionOS;
 }
 
 sub isEmbeddedWebKit()
 {
-    return isIOSWebKit() || isTVOSWebKit() || isWatchOSWebKit() || isVisionOSWebKit();
+    return isIOSWebKit() || isTVOSWebKit() || isWatchOSWebKit() || isVisionOSWebKit;
 }
 
 sub isAppleWebKit()
@@ -2048,22 +2064,19 @@ sub isAppleWebKit()
     return isAppleCocoaWebKit();
 }
 
-# Mac and Mac Catalyst both target macOS, so these two check the SDK variant, not the OS.
 sub isAppleMacWebKit()
 {
-    return isAppleCocoaWebKit() && xcodeSDKPlatformName() eq "macosx";
+    return portName() eq Mac;
 }
 
 sub isMacCatalystWebKit()
 {
-    return isAppleCocoaWebKit() && xcodeSDKPlatformName() eq "maccatalyst";
+    return portName() eq MacCatalyst;
 }
 
-# The anchor for every predicate above: they resolve an Xcode SDK, which only makes
-# sense once the Cocoa port is selected.
 sub isAppleCocoaWebKit()
 {
-    return portName() eq Cocoa;
+    return isAppleMacWebKit() || isEmbeddedWebKit() || isMacCatalystWebKit();
 }
 
 sub usesCryptexPath
@@ -2131,21 +2144,39 @@ sub willUseIOSSimulatorSDK()
     return xcodeSDKPlatformName() eq "iphonesimulator";
 }
 
+sub willUseAppleTVDeviceSDK()
+{
+    return xcodeSDKPlatformName() eq "appletvos";
+}
+
+sub willUseAppleTVSimulatorSDK()
+{
+    return xcodeSDKPlatformName() eq "appletvsimulator";
+}
+
+sub willUseWatchDeviceSDK()
+{
+    return xcodeSDKPlatformName() eq "watchos";
+}
+
+sub willUseWatchSimulatorSDK()
+{
+    return xcodeSDKPlatformName() eq "watchsimulator";
+}
+
+sub willUseVisionDeviceSDK()
+{
+    return xcodeSDKPlatformName() eq "xros";
+}
+
+sub willUseVisionSimulatorSDK()
+{
+    return xcodeSDKPlatformName() eq "xrsimulator";
+}
+
 sub willUseMacCatalystSDK()
 {
     return xcodeSDKPlatformName() eq "maccatalyst";
-}
-
-sub willUseSimulatorSDK()
-{
-    return xcodeSDKPlatformName() =~ /simulator$/;
-}
-
-# Only the --*-simulator arguments set an idiom; --sdk iphonesimulator leaves it unset.
-sub simulatorIdiom()
-{
-    determineXcodeSDKPlatformName();
-    return $simulatorIdiom // 'iPhone';
 }
 
 sub determineNmPath()
@@ -2880,7 +2911,6 @@ sub generateBuildSystemFromCMakeProject
 
     my @args;
     push @args, "-DPORT=\"$port\"";
-    push @args, "-DCMAKE_OSX_SYSROOT=\"" . xcodeSDK() . "\"" if isAppleCocoaWebKit();
     push @args, "-DCMAKE_INSTALL_PREFIX=\"$prefixPath\"" if $prefixPath;
     if ($config =~ /release/i) {
         push @args, "-DCMAKE_BUILD_TYPE=Release";
@@ -3487,7 +3517,7 @@ sub relaunchIOSSimulator($)
 sub iosSimulatorDeviceByName($)
 {
     my ($simulatorName) = @_;
-    my $simulatorRuntime = simulatorRuntime();
+    my $simulatorRuntime = iosSimulatorRuntime();
     my @devices = iOSSimulatorDevices();
     for my $device (@devices) {
         if ($device->{name} eq $simulatorName && $device->{runtime} eq $simulatorRuntime) {
@@ -3512,14 +3542,17 @@ sub iosSimulatorDeviceByUDID($)
     return undef;
 }
 
-sub simulatorRuntime()
+sub iosSimulatorRuntime
 {
-    die "Can't find a simulator runtime because the selected SDK isn't a simulator SDK" if !willUseSimulatorSDK();
-    my $platformName = sdkPlatformOSName();
-    my $xcodeSDKVersion = xcodeSDKVersion();
-    my $sdk = xcodeSDK();
+    return simulatorRuntime(iOS);
+}
 
-    my $output = `xcrun --sdk $sdk simctl list runtimes $platformName --json` or die "Failed to run find simulator runtime";
+sub simulatorRuntime($)
+{
+    my $platformName = shift;
+    my $xcodeSDKVersion = xcodeSDKVersion();
+
+    my $output = `xcrun --sdk $xcodeSDK simctl list runtimes $platformName --json` or die "Failed to run find simulator runtime";
     for my $runtime (@{decode_json($output)->{runtimes}}) {
         if ($runtime->{version} eq $xcodeSDKVersion) {
             return $runtime->{identifier};
@@ -3531,8 +3564,6 @@ sub simulatorRuntime()
             return $runtime_id;
         }
     }
-
-    die "No $platformName simulator runtime matches SDK version $xcodeSDKVersion";
 }
 
 sub findOrCreateSimulatorForIOSDevice($)
@@ -3542,7 +3573,7 @@ sub findOrCreateSimulatorForIOSDevice($)
     my $simulatorDeviceType;
 
     # These should match the DEFAULT_DEVICE_TYPES in webkitpy/port/ios_simulator.py.
-    if (simulatorIdiom() eq "iPad") {
+    if ($simulatorIdiom eq "iPad") {
         $simulatorName = "iPad (9th generation) " . $simulatorNameSuffix;
         $simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPad-9th-generation";
     } else {
@@ -3552,7 +3583,7 @@ sub findOrCreateSimulatorForIOSDevice($)
 
     my $simulatedDevice = iosSimulatorDeviceByName($simulatorName);
     return $simulatedDevice if $simulatedDevice;
-    return createiOSSimulatorDevice($simulatorName, $simulatorDeviceType, simulatorRuntime());
+    return createiOSSimulatorDevice($simulatorName, $simulatorDeviceType, iosSimulatorRuntime());
 }
 
 sub isIOSSimulatorSystemInstalledApp($)


### PR DESCRIPTION
#### 3c9e5c33aa6e2c9897e1327acb9a28d30fc4a7ab
<pre>
Revert &quot;[Build] Clean up Apple platform port names in webkitdirs&quot;

This reverts commit 7abb8a36f4ff27aea6d492f66f5e149855d96c94 since it is breaking internal spade script.

See <a href="https://rdar.apple.com/186372949">rdar://186372949</a> for failure in internal script.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c9e5c33aa6e2c9897e1327acb9a28d30fc4a7ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194480 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148547 "Failed to checkout and rebase branch from PR 72945") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143848 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148547 "Failed to checkout and rebase branch from PR 72945") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44551 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6236 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13070 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44129 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45537 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57848 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153418 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58553 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153081 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47612 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127305 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57060 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->