### PR TITLE
[IPC] Do not derive a registrable domain that FirstPartyAuthority will discard

### DIFF
--- a/Source/WebKit/UIProcess/FirstPartyAuthority.h
+++ b/Source/WebKit/UIProcess/FirstPartyAuthority.h
@@ -60,21 +60,30 @@ public:
 
     std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::SecurityOriginData& origin) const
     {
-        return checkUntrustedDomain(WebCore::RegistrableDomain { origin });
+        return checkUntrustedDomain([&] {
+            return WebCore::RegistrableDomain { origin };
+        });
     }
 
     std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::RegistrableDomain& domain) const
     {
-        return checkUntrustedDomain(domain);
+        return checkUntrustedDomain([&]() -> const WebCore::RegistrableDomain& {
+            return domain;
+        });
     }
 
     std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::Site& site) const
     {
-        return checkUntrustedDomain(site.domain());
+        return checkUntrustedDomain([&]() -> const WebCore::RegistrableDomain& {
+            return site.domain();
+        });
     }
 
 private:
-    std::optional<IPC::ValidationFailure> checkUntrustedDomain(const WebCore::RegistrableDomain& domain) const
+    // Takes the domain as a function rather than a value because deriving one from an origin
+    // consults the public suffix list under a global lock, and the guard below usually discards it.
+    template<typename DomainFunction>
+    std::optional<IPC::ValidationFailure> checkUntrustedDomain(NOESCAPE DomainFunction&& domain) const
     {
         // Without site isolation, WebProcessProxy records only the main frame's site while the
         // process hosts every site the page pulls in, so this question has no useful answer for a
@@ -87,7 +96,7 @@ private:
         if (!preferences.siteIsolationEnabled || preferences.usesSingleWebProcess)
             return std::nullopt;
 
-        return checkFirstPartyAccess(*process, domain);
+        return checkFirstPartyAccess(*process, domain());
     }
 
     // Weak, so that constructing a validator cannot extend a process's life, and a validator that


### PR DESCRIPTION
#### ee629dabaf61cdac72bad52e589b79c1de128b16
<pre>
[IPC] Do not derive a registrable domain that FirstPartyAuthority will discard
<a href="https://bugs.webkit.org/show_bug.cgi?id=323119">https://bugs.webkit.org/show_bug.cgi?id=323119</a>

Reviewed by Zak Ridouh.

FirstPartyAuthority::checkUntrusted derived the registrable domain before the
guard that throws it away. Deriving one from an origin calls
PublicSuffixStore::topPrivatelyControlledDomain(), which takes a global lock,
looks the host up in a 128-entry cache with random eviction, isolatedCopy()s
the result, and on a miss consults the platform public suffix list.
checkUntrustedDomain() then returns immediately whenever site isolation is off
- every shipping configuration today - so that work was wasted on every
origin-bearing message that reaches a validated receiver.

checkUntrustedDomain() now takes the domain as a NOESCAPE function and calls it
only once it has decided the question is worth asking. The overloads that
already hold a domain hand it back by const reference, so nothing is copied for
them either.

No behaviour change: the same values reach the same checks with the same
answers.

* Source/WebKit/UIProcess/FirstPartyAuthority.h:
(WebKit::FirstPartyAuthority::checkUntrusted const):
(WebKit::FirstPartyAuthority::checkUntrustedDomain const):

Canonical link: <a href="https://commits.webkit.org/320335@main">https://commits.webkit.org/320335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21d3f8b1803c85eaafba5e8705191a053c71e728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148557 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67b6c957-c7b3-451f-bc3f-2b37647fc565) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143856 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99990 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1f9fa76-6041-47f2-aa7b-af1e24ec5908) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbee36c0-873b-4740-b594-5d536de781c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46350 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44561 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44142 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5668 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196426 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57858 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153425 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41132 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153090 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47624 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130867 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57070 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->