### PR TITLE
GPUDevice.createBindGroup fast path is broken for external textures

### DIFF
--- a/LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry-expected.txt
+++ b/LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: bare GPUBuffer reused: true
+CONSOLE MESSAGE: GPUBufferBinding reused: true
+CONSOLE MESSAGE: different GPUBuffer reused: false
+CONSOLE MESSAGE: no validation error
+

--- a/LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry.html
+++ b/LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry.html
@@ -1,0 +1,49 @@
+<script>
+globalThis.testRunner?.waitUntilDone();
+globalThis.testRunner?.dumpAsText();
+const log = console.debug;
+
+// GPUDevice.createBindGroup() returns the previously created bind group, with only its external
+// texture refreshed, when every other entry in the descriptor compares equal. Reuse is therefore
+// observable as object identity.
+onload = async () => {
+    const adapter = await navigator.gpu.requestAdapter({});
+    const device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 16;
+    canvas.height = 16;
+    const context = canvas.getContext('2d');
+    context.fillStyle = 'green';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    const layout = device.createBindGroupLayout({ entries: [
+        { binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, externalTexture: { } },
+    ]});
+
+    const buffer = device.createBuffer({ size: 256, usage: GPUBufferUsage.UNIFORM });
+    const otherBuffer = device.createBuffer({ size: 256, usage: GPUBufferUsage.UNIFORM });
+    const externalTexture = device.importExternalTexture({ source: new VideoFrame(canvas, { timestamp: 0 }) });
+
+    const bindGroup = bufferResource => device.createBindGroup({ layout, entries: [
+        { binding: 0, resource: bufferResource },
+        { binding: 1, resource: externalTexture },
+    ]});
+
+    // A buffer bound directly as a GPUBuffer. This used to always compare unequal, so the bind
+    // group was recreated from scratch every time.
+    log(`bare GPUBuffer reused: ${bindGroup(buffer) === bindGroup(buffer)}`);
+
+    // The same buffer bound as a GPUBufferBinding, which has always been compared.
+    log(`GPUBufferBinding reused: ${bindGroup({ buffer }) === bindGroup({ buffer })}`);
+
+    // A different buffer must still force a new bind group.
+    log(`different GPUBuffer reused: ${bindGroup(buffer) === bindGroup(otherBuffer)}`);
+
+    const error = await device.popErrorScope();
+    log(error ? error.message : 'no validation error');
+    globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
@@ -160,6 +160,30 @@ struct GPUBindGroupEntry {
     {
         return (!a && !b) || (b && a == *b);
     }
+    static bool equal(const GPUBuffer& entry, const GPUBindingResource& otherEntry)
+    {
+        return WTF::switchOn(otherEntry,
+            [](const Ref<GPUSampler>&) {
+                return false;
+            },
+            [](const Ref<GPUTexture>&) {
+                return false;
+            },
+            [](const Ref<GPUTextureView>&) {
+                return false;
+            },
+            [&](const Ref<GPUBuffer>& buffer) {
+                return buffer.ptr() == &entry;
+            },
+            [&](const GPUBufferBinding& bufferBinding) {
+                // A bare buffer binds its entire contents, so it only matches a binding with no offset covering the whole buffer.
+                return bufferBinding.buffer.ptr() == &entry && !bufferBinding.offset && equalSizes(entry.size(), bufferBinding.size);
+            },
+            [](const Ref<GPUExternalTexture>&) {
+                return false;
+            }
+        );
+    }
     static bool equal(const GPUBufferBinding& entry, const GPUBindingResource& otherEntry)
     {
         return WTF::switchOn(otherEntry,
@@ -221,8 +245,8 @@ struct GPUBindGroupEntry {
             [&](const Ref<GPUTextureView>& textureView) {
                 return equal(textureView, otherEntry.resource);
             },
-            [](const Ref<GPUBuffer>&) {
-                return false;
+            [&](const Ref<GPUBuffer>& buffer) {
+                return equal(buffer, otherEntry.resource);
             },
             [&](const GPUBufferBinding& bufferBinding) {
                 return equal(bufferBinding, otherEntry.resource);


### PR DESCRIPTION
#### 0ad38fbf95da61a6e207e81b6d5a940f53ff6e71
<pre>
GPUDevice.createBindGroup fast path is broken for external textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=323117">https://bugs.webkit.org/show_bug.cgi?id=323117</a>
<a href="https://rdar.apple.com/186379208">rdar://186379208</a>

Reviewed by Dan Glastonbury.

GPUBuffer is now allowed in GPUBindingResource, but we always returned
false from the GPUBuffer path. This prevented bind group reuse for
external video textures.

Test: fast/webgpu/bind-group-reuse-with-buffer-entry.html

* LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry-expected.txt: Added.
* LayoutTests/fast/webgpu/bind-group-reuse-with-buffer-entry.html: Added.
* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h:
(WebCore::GPUBindGroupEntry::equal):

Canonical link: <a href="https://commits.webkit.org/320309@main">https://commits.webkit.org/320309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41df4ee77bee96d69b8f94d6cd2009a621faf58f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148561 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143863 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99994 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62d91b52-e817-4fa2-99b7-2e372d1adf47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0672d441-4d1b-4f6d-89a7-ec4c524b7992) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44562 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44145 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5672 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57862 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164092 "Exiting early after 10 failures. 116 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41108 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58568 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153096 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47625 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130871 "Found 1 new failure in css/ShorthandSerializer.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57074 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->