### PR TITLE
AX: Add layout tests for the AXPressDidSucceed, AXTitleChanged, and AXAutocorrectionOccurred notifications

### DIFF
--- a/LayoutTests/accessibility/mac/autocorrection-occurred-notification-expected.txt
+++ b/LayoutTests/accessibility/mac/autocorrection-occurred-notification-expected.txt
@@ -1,0 +1,10 @@
+This tests that autocorrection posts AXAutocorrectionOccurred, and that the corrected text is already exposed when the notification arrives.
+
+PASS: autocorrectionDeliveries() === 0
+PASS: autocorrectionDeliveries() === 1
+PASS: editorTextAtDelivery === 'You there?'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/autocorrection-occurred-notification.html
+++ b/LayoutTests/accessibility/mac/autocorrection-occurred-notification.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../editing/editing.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<div id="editor" contenteditable>
+    <div><br></div>
+    <div><br></div>
+</div>
+
+<script>
+var output = "This tests that autocorrection posts AXAutocorrectionOccurred, and that the corrected text is already exposed when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var autocorrectionCount = 0;
+    var autocorrectionListener = null;
+    var editorTextAtDelivery = null;
+
+    function editorText() {
+        var editor = accessibilityController.accessibleElementById("editor");
+        var staticText = traverseChildrenToFirstStaticText(editor);
+        return staticText ? stripAXPrefix(staticText.stringValue) : "";
+    }
+
+    // Editor::markAndReplaceFor replaces the text before posting, so the corrected string must
+    // already be exposed by delivery time.
+    function autocorrectionDeliveries() {
+        if (!autocorrectionListener) {
+            autocorrectionListener = function(element, notification, userInfo) {
+                if (notification != "AXAutocorrectionOccurred")
+                    return;
+                autocorrectionCount++;
+                editorTextAtDelivery = editorText();
+            };
+            accessibilityController.addNotificationListener(autocorrectionListener);
+        }
+        return autocorrectionCount;
+    }
+
+    // Also installs the listener, which must happen before any text is typed.
+    output += expect("autocorrectionDeliveries()", "0");
+
+    setTimeout(async function() {
+        internals.settings.setUnifiedTextCheckerEnabled(true);
+        internals.settings.setAsynchronousSpellCheckingEnabled(false);
+        internals.setAutomaticTextReplacementEnabled(true);
+        internals.setAutomaticSpellingCorrectionEnabled(true);
+        await UIHelper.setSpellCheckerResults({
+            "YT?": [{ replacement: "You there?", type: "replacement", from: 0, to: 3 }],
+            "YT?\n": [{ replacement: "You there?", type: "replacement", from: 0, to: 3 }],
+        });
+
+        document.getElementById("editor").focus();
+        for (const character of "YT?")
+            typeCharacterCommand(character);
+        await UIHelper.delayFor(0);
+
+        // Autocorrection applies on the following newline, not while the word is still being typed.
+        insertParagraphCommand();
+
+        output += await expectAsync("autocorrectionDeliveries()", "1");
+        output += expect("editorTextAtDelivery", "'You there?'");
+
+        document.getElementById("editor").style.display = "none";
+        accessibilityController.removeNotificationListener(autocorrectionListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/label-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/mac/label-changed-notification-expected.txt
@@ -1,0 +1,12 @@
+This tests that changing a label's text posts AXTitleChanged, and that the labeled control already resolves to the new label text when the notification arrives.
+
+PASS: labelTextForControl() === 'Original label'
+PASS: titleChangedDeliveries() >= 1 === true
+document.getElementById('label').textContent = 'Updated label';
+PASS: titleChangedDeliveries() === 1
+PASS: labelTextAtDelivery === 'Updated label'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/label-changed-notification.html
+++ b/LayoutTests/accessibility/mac/label-changed-notification.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<label id="label" for="control">Original label</label>
+<input id="control" type="text">
+
+<script>
+var output = "This tests that changing a label's text posts AXTitleChanged, and that the labeled control already resolves to the new label text when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var titleChangedCount = 0;
+    var titleChangedListener = null;
+    var labelTextAtDelivery = null;
+
+    function labelTextForControl() {
+        var control = accessibilityController.accessibleElementById("control");
+        var label = control ? control.titleUIElement() : null;
+        var staticText = label ? traverseChildrenToFirstStaticText(label) : null;
+        return staticText ? stripAXPrefix(staticText.stringValue) : "";
+    }
+
+    // AXObjectCache::handleLabelChanged re-resolves the label-for relation before posting, so
+    // the new label text must already be reachable from the control by delivery time.
+    function titleChangedDeliveries() {
+        if (!titleChangedListener) {
+            titleChangedListener = function(element, notification, userInfo) {
+                if (notification != "AXTitleChanged")
+                    return;
+                titleChangedCount++;
+                labelTextAtDelivery = labelTextForControl();
+            };
+            accessibilityController.addNotificationListener(titleChangedListener);
+        }
+        return titleChangedCount;
+    }
+
+    // Installs the listener, which must happen before the label is mutated.
+    titleChangedDeliveries();
+    output += expect("labelTextForControl()", "'Original label'");
+
+    setTimeout(async function() {
+        // Adding the label posts AXTitleChanged too, so wait that out and start counting from
+        // zero. Otherwise the initial notification alone would satisfy the assertions below.
+        output += await expectAsync("titleChangedDeliveries() >= 1", "true");
+        titleChangedCount = 0;
+        labelTextAtDelivery = null;
+
+        output += evalAndReturn("document.getElementById('label').textContent = 'Updated label';");
+        output += await expectAsync("titleChangedDeliveries()", "1");
+        output += expect("labelTextAtDelivery", "'Updated label'");
+
+        document.getElementById("label").style.display = "none";
+        accessibilityController.removeNotificationListener(titleChangedListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/press-did-succeed-notification-collapse-expected.txt
+++ b/LayoutTests/accessibility/mac/press-did-succeed-notification-collapse-expected.txt
@@ -1,0 +1,11 @@
+This tests that pressing an expanded select posts AXPressDidSucceed, and that it already reports itself collapsed when the notification arrives.
+
+PASS: pressDidSucceedDeliveries() === 0
+PASS: pressDidSucceedDeliveries() === 1
+PASS: pressDidSucceedDeliveries() === 2
+PASS: expandedAtDelivery === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/press-did-succeed-notification-collapse.html
+++ b/LayoutTests/accessibility/mac/press-did-succeed-notification-collapse.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This tests that pressing an expanded select posts AXPressDidSucceed, and that it already reports itself collapsed when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+    var pressDidSucceedCount = 0;
+    var pressListener = null;
+    // Sampled inside the listener, so this reports what an assistive technology would read
+    // at delivery time rather than after a later tree update.
+    var expandedAtDelivery = null;
+
+    function pressDidSucceedDeliveries() {
+        if (!pressListener) {
+            pressListener = function(element, notification, userInfo) {
+                if (notification != "AXPressDidSucceed")
+                    return;
+                pressDidSucceedCount++;
+                expandedAtDelivery = select.isExpanded;
+            };
+            accessibilityController.addNotificationListener(pressListener);
+        }
+        return pressDidSucceedCount;
+    }
+
+    // Also installs the listener, which must happen before the first press.
+    output += expect("pressDidSucceedDeliveries()", "0");
+
+    setTimeout(async function() {
+        // The first press only sets up the expanded state this test collapses.
+        select.press();
+        output += await expectAsync("pressDidSucceedDeliveries()", "1");
+
+        select.press();
+        output += await expectAsync("pressDidSucceedDeliveries()", "2");
+        output += expect("expandedAtDelivery", "false");
+
+        accessibilityController.removeNotificationListener(pressListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/press-did-succeed-notification-expected.txt
+++ b/LayoutTests/accessibility/mac/press-did-succeed-notification-expected.txt
@@ -1,0 +1,10 @@
+This tests that pressing a collapsed select posts AXPressDidSucceed, and that it already reports itself expanded when the notification arrives.
+
+PASS: pressDidSucceedDeliveries() === 0
+PASS: pressDidSucceedDeliveries() === 1
+PASS: expandedAtDelivery === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/press-did-succeed-notification.html
+++ b/LayoutTests/accessibility/mac/press-did-succeed-notification.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This tests that pressing a collapsed select posts AXPressDidSucceed, and that it already reports itself expanded when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+    var pressDidSucceedCount = 0;
+    var pressListener = null;
+    // Sampled inside the listener, so this reports what an assistive technology would read
+    // at delivery time rather than after a later tree update.
+    var expandedAtDelivery = null;
+
+    function pressDidSucceedDeliveries() {
+        if (!pressListener) {
+            pressListener = function(element, notification, userInfo) {
+                if (notification != "AXPressDidSucceed")
+                    return;
+                pressDidSucceedCount++;
+                expandedAtDelivery = select.isExpanded;
+            };
+            accessibilityController.addNotificationListener(pressListener);
+        }
+        return pressDidSucceedCount;
+    }
+
+    // Also installs the listener, which must happen before the press.
+    output += expect("pressDidSucceedDeliveries()", "0");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("pressDidSucceedDeliveries()", "1");
+        output += expect("expandedAtDelivery", "true");
+
+        // The picker is still open, so hide it to keep its option text out of the dump.
+        document.getElementById("select").style.display = "none";
+        accessibilityController.removeNotificationListener(pressListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6171,6 +6171,12 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::PopoverTargetChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::SupportsExpanded, AXProperty::IsExpanded } });
             break;
+        case AXNotification::PressDidSucceed:
+            // The only presses that post this toggle a select's picker, so the expanded state
+            // has just changed. Refresh it in the same batch that posts the notification so
+            // an AT that queries in response gets the right value.
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsExpanded });
+            break;
         case AXNotification::SelectedTextChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SelectedTextRange });
             break;


### PR DESCRIPTION
#### a01fa7d4f4fec6d8b5842ccfcb18d1a72a031e70
<pre>
AX: Add layout tests for the AXPressDidSucceed, AXTitleChanged, and AXAutocorrectionOccurred notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=323128">https://bugs.webkit.org/show_bug.cgi?id=323128</a>
<a href="https://rdar.apple.com/186390534">rdar://186390534</a>

Reviewed by Dominic Mazzoni.

Three AXNotification kinds are observable from the platform but had no test
waiting for them. Each new test asserts two things:

  1. That the notification fires,
  2. The state an assistive technology would query in response is already
     correct at the moment of delivery.

* LayoutTests/accessibility/mac/press-did-succeed-notification.html: Added.
* LayoutTests/accessibility/mac/press-did-succeed-notification-expected.txt: Added.
  - First test to wait for AXPressDidSucceed. Pressing a collapsed
    base-appearance select reports itself expanded at delivery.

* LayoutTests/accessibility/mac/press-did-succeed-notification-collapse.html: Added.
* LayoutTests/accessibility/mac/press-did-succeed-notification-collapse-expected.txt: Added.
  - The collapsing direction of the same invariant. Split from the test above so
    that only the direction that fails with the isolated tree is gardened (yes, this exposed a bug).

* LayoutTests/accessibility/mac/label-changed-notification.html: Added.
* LayoutTests/accessibility/mac/label-changed-notification-expected.txt: Added.
  - First test to wait for AXTitleChanged, which AXNotification::LabelChanged is
    the sole source of.

* LayoutTests/accessibility/mac/autocorrection-occurred-notification.html: Added.
* LayoutTests/accessibility/mac/autocorrection-occurred-notification-expected.txt: Added.
  - First test to wait for AXAutocorrectionOccurred.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
  - Garden press-did-succeed-notification-collapse.html. AXPressDidSucceed is
    posted synchronously by AccessibilityRenderObject::press(), but the isolated
    tree only learns the collapsed state from the IsExpanded update that
    ExpandedChanged queues, which lands after the notification.

Canonical link: <a href="https://commits.webkit.org/320306@main">https://commits.webkit.org/320306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db035dfaf4c4a8a7aaf52e6942d4137a50055393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148641 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66bfa66c-b066-41bb-bf90-beff6a94cb7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143902 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100023 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47689 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164666 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55ddb8ce-b5c6-4708-bc84-911a0cd26c9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44594 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44189 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5731 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58628 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153144 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47671 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130927 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127354 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57135 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19205 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56503 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->