### PR TITLE
Refactor CachedCSSStyleSheet::sheetText to return std::expected

### DIFF
--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -401,16 +401,18 @@ bool StyleSheetContents::parseAuthorStyleSheet(const CachedCSSStyleSheet* cached
 {
     bool isSameOriginRequest = securityOrigin && securityOrigin->canRequest(baseURL(), OriginAccessPatternsForWebProcess::singleton());
     CachedCSSStyleSheet::MIMETypeCheckHint mimeTypeCheckHint = isStrictParserMode(m_parserContext.mode) || !isSameOriginRequest ? CachedCSSStyleSheet::MIMETypeCheckHint::Strict : CachedCSSStyleSheet::MIMETypeCheckHint::Lax;
-    bool hasValidMIMEType = true;
-    bool hasHTTPStatusOK = true;
-    String sheetText = cachedStyleSheet->sheetText(mimeTypeCheckHint, &hasValidMIMEType, &hasHTTPStatusOK);
+    auto sheetTextOrError = cachedStyleSheet->sheetText(mimeTypeCheckHint);
 
-    if (!hasHTTPStatusOK) {
-        ASSERT(sheetText.isNull());
-        return false;
+    if (sheetTextOrError) {
+        CSSParser::parseStyleSheet(*sheetTextOrError, parserContext(), *this);
+        return true;
     }
-    if (!hasValidMIMEType) {
-        ASSERT(sheetText.isNull());
+
+    switch (sheetTextOrError.error()) {
+    case CachedCSSStyleSheet::Error::UnsuccessfulRequest:
+        break;
+
+    case CachedCSSStyleSheet::Error::InvalidMIMEType:
         if (RefPtr document = singleOwnerDocument()) {
             if (RefPtr frame = document->frame()) {
                 if (isStrictParserMode(m_parserContext.mode))
@@ -421,11 +423,9 @@ bool StyleSheetContents::parseAuthorStyleSheet(const CachedCSSStyleSheet* cached
                     frame->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '"_s, cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed for cross-origin stylesheets."_s));
             }
         }
-        return false;
     }
 
-    CSSParser::parseStyleSheet(sheetText, parserContext(), *this);
-    return true;
+    return false;
 }
 
 bool StyleSheetContents::parseString(const String& sheetText)

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -225,7 +225,7 @@ void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& base
     // We don't need the cross-origin security check here because we are
     // getting the sheet text in "strict" mode. This enforces a valid CSS MIME
     // type.
-    parseStyleSheet(sheet->sheetText());
+    parseStyleSheet(sheet->sheetText().value_or(nullString()));
 }
 
 #if ENABLE(XSLT)

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -404,9 +404,14 @@ bool cachedResourceContent(CachedResource& resource, String* result, bool* base6
     switch (resource.type()) {
     case CachedResource::Type::CSSStyleSheet:
         *base64Encoded = false;
-        *result = downcast<CachedCSSStyleSheet>(resource).sheetText();
-        // The above can return a null String if the MIME type is invalid.
-        return !result->isNull();
+
+        if (auto sheetText = downcast<CachedCSSStyleSheet>(resource).sheetText()) {
+            *result = WTF::move(*sheetText);
+            return true;
+        }
+
+        *result = nullString();
+        return false;
     case CachedResource::Type::JSON:
     case CachedResource::Type::Text:
     case CachedResource::Type::Script:

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -77,13 +77,14 @@ ASCIILiteral CachedCSSStyleSheet::encoding() const
     return m_decoder->encoding().name();
 }
 
-const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
+std::expected<String, CachedCSSStyleSheet::Error> CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint) const
 {
     // Ensure hasValidMIMEType and hasHTTPStatusOK always get set (even if m_data is null or empty) — which in turn
     // ensures that if the MIME type isn't text/css or the HTTP status isn't an OK status, we never load the resource.
     // https://html.spec.whatwg.org/#link-type-stylesheet:process-the-linked-resource
-    if (!canUseSheet(mimeTypeCheckHint, hasValidMIMEType, hasHTTPStatusOK))
-        return String();
+    if (auto err = canUseSheet(mimeTypeCheckHint))
+        return std::unexpected(*err);
+
     RefPtr data = m_data;
     if (!data || data->isEmpty())
         return String();
@@ -146,10 +147,10 @@ bool CachedCSSStyleSheet::mimeTypeAllowedByNosniff() const
     return parseContentTypeOptionsHeader(response().httpHeaderField(HTTPHeaderName::XContentTypeOptions)) != ContentTypeOptionsDisposition::Nosniff || equalLettersIgnoringASCIICase(responseMIMEType(), "text/css"_s);
 }
 
-bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
+std::optional<CachedCSSStyleSheet::Error> CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint) const
 {
     if (errorOccurred())
-        return false;
+        return CachedCSSStyleSheet::Error::UnsuccessfulRequest;
 
     // https://html.spec.whatwg.org/#fetching-and-processing-a-resource-from-a-link-element:processresponseconsumebody
     auto shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest = [&] {
@@ -160,20 +161,14 @@ bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool*
         return response().url().protocolIsInHTTPFamily() && !response().isSuccessful();
     }();
 
-    if (shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest) {
-        if (hasHTTPStatusOK)
-            *hasHTTPStatusOK = false;
-        return false;
-    }
+    if (shouldAvoidUsingStyleSheetDueToUnsuccessfulRequest)
+        return CachedCSSStyleSheet::Error::UnsuccessfulRequest;
 
-    if (!mimeTypeAllowedByNosniff()) {
-        if (hasValidMIMEType)
-            *hasValidMIMEType = false;
-        return false;
-    }
+    if (!mimeTypeAllowedByNosniff())
+        return CachedCSSStyleSheet::Error::InvalidMIMEType;
 
     if (mimeTypeCheckHint == MIMETypeCheckHint::Lax)
-        return true;
+        return std::nullopt;
 
     // This check exactly matches Firefox.  Note that we grab the Content-Type
     // header directly because we want to see what the value is BEFORE content
@@ -184,9 +179,10 @@ bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool*
     // folks can use standards mode for local HTML documents.
     String mimeType = responseMIMEType();
     bool typeOK = mimeType.isEmpty() || equalLettersIgnoringASCIICase(mimeType, "text/css"_s) || equalLettersIgnoringASCIICase(mimeType, "application/x-unknown-content-type"_s) || !isValidContentType(mimeType);
-    if (hasValidMIMEType)
-        *hasValidMIMEType = typeOK;
-    return typeOK;
+    if (!typeOK)
+        return Error::InvalidMIMEType;
+
+    return { };
 }
 
 void CachedCSSStyleSheet::destroyDecodedData()

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -39,7 +39,8 @@ public:
     virtual ~CachedCSSStyleSheet();
 
     enum class MIMETypeCheckHint { Strict, Lax };
-    const String sheetText(MIMETypeCheckHint = MIMETypeCheckHint::Strict, bool* hasValidMIMEType = nullptr, bool* hasHTTPStatusOK = nullptr) const;
+    enum class Error : bool { UnsuccessfulRequest, InvalidMIMEType };
+    std::expected<String, Error> sheetText(MIMETypeCheckHint = MIMETypeCheckHint::Strict) const;
 
     RefPtr<StyleSheetContents> restoreParsedStyleSheet(const CSSParserContext&, CachePolicy, FrameLoader&);
     void saveParsedStyleSheet(Ref<StyleSheetContents>&&);
@@ -48,7 +49,7 @@ public:
 
 private:
     String responseMIMEType() const;
-    bool canUseSheet(MIMETypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const;
+    std::optional<Error> canUseSheet(MIMETypeCheckHint) const;
     bool mayTryReplaceEncodedData() const final { return true; }
 
     void didAddClient(CachedResourceClient&) final;


### PR DESCRIPTION
#### b7794d481cec9bcf56e76492f68d4d44e0686cfd
<pre>
Refactor CachedCSSStyleSheet::sheetText to return std::expected
<a href="https://rdar.apple.com/186388202">rdar://186388202</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323125">https://bugs.webkit.org/show_bug.cgi?id=323125</a>

Reviewed by Alex Christensen.

CachedCSSStyleSheet::sheetText signals error by setting the passed in
boolean pointers, if they&apos;re set. This is inelegant, and particularly
there&apos;s a bug where the booleans only get set when an error occur.

Take this opportunity to refactor CachedCSSStyleSheet::sheetText to
return std::expected. If an error occurs, then it returns an Error
enum, otherwise it returns the CSS text.

Refactoring, tested by existing test suite.

* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parseAuthorStyleSheet):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::setCSSStyleSheet):
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::cachedResourceContent):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::sheetText const):
(WebCore::CachedCSSStyleSheet::canUseSheet const):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:

Canonical link: <a href="https://commits.webkit.org/320483@main">https://commits.webkit.org/320483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc5d1a84bb277eedeeb1715da51cb2eeef6f326

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195193 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc3bea0a-f9cf-4eac-8162-5a36bd0321eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21b0642e-693c-4f38-a544-58852613ce75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165055 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124745 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/4294967297444MallocReadOnly (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/382bf6dd-1490-4fcf-a207-54741a33e600) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46850 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44617 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6248 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197142 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58447 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41225 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59152 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153593 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48106 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131440 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128014 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57649 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57008 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->