### PR TITLE
Trusted Types enforcement in Document.execCommand should be case-insensitive

### DIFF
--- a/LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive-expected.txt
+++ b/LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive-expected.txt
@@ -1,0 +1,12 @@
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+editable target
+PASS: insertHTML threw TypeError
+PASS: InsertHTML threw TypeError
+PASS: inserthtml threw TypeError
+PASS: INSERTHTML threw TypeError
+PASS: iNsErThTmL threw TypeError
+

--- a/LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive.html
+++ b/LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="trusted-types 'none'; require-trusted-types-for 'script'">
+<body>
+<div id="ed" contenteditable="true">editable target</div>
+<pre id="log"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const ed = document.getElementById("ed");
+const logNode = document.getElementById("log");
+
+function log(s) {
+    logNode.textContent += s + "\n";
+}
+
+function tryInsert(commandName) {
+    ed.focus();
+    const range = document.createRange();
+    range.selectNodeContents(ed);
+    range.collapse(false);
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    try {
+        document.execCommand(commandName, false, "<b>test</b>");
+        log(`FAIL: ${commandName} did not throw`);
+    } catch (e) {
+        log(`PASS: ${commandName} threw ${e.name}`);
+    }
+}
+
+tryInsert("insertHTML");
+tryInsert("InsertHTML");
+tryInsert("inserthtml");
+tryInsert("INSERTHTML");
+tryInsert("iNsErThTmL");
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7903,7 +7903,7 @@ ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInte
 
     auto stringValueHolder = WTF::switchOn(value,
         [&commandName, this](const String& str) -> ExceptionOr<String> {
-            if (commandName != "insertHTML"_s)
+            if (!equalIgnoringASCIICase(commandName, "insertHTML"_s))
                 return String(str);
             return trustedTypeCompliantString(TrustedType::TrustedHTML, protect(contextDocument()), str, "Document execCommand"_s);
         },


### PR DESCRIPTION
#### 49cbb806d160d35aba07f40706abab4fd25bfffa
<pre>
Trusted Types enforcement in Document.execCommand should be case-insensitive
<a href="https://bugs.webkit.org/show_bug.cgi?id=314183">https://bugs.webkit.org/show_bug.cgi?id=314183</a>
<a href="https://rdar.apple.com/175852496">rdar://175852496</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

The Trusted Types check in Document::execCommand() was using a case-sensitive
comparison (commandName != &quot;insertHTML&quot;_s) to decide whether to enforce
TrustedHTML. Since execCommand command names are case-insensitive per spec,
passing a differently-cased variant like &quot;InsertHTML&quot; or &quot;inserthtml&quot; would
bypass the Trusted Types enforcement entirely.

Fix by using equalIgnoringASCIICase() for the comparison.

Test: fast/dom/trusted-types-execCommand-insertHTML-case-insensitive.html

* LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive-expected.txt: Added.
* LayoutTests/fast/dom/trusted-types-execCommand-insertHTML-case-insensitive.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::execCommand):

Originally-landed-as: 305413.846@safari-7624-branch (0e4f1956aff4). <a href="https://rdar.apple.com/184744820">rdar://184744820</a>
Canonical link: <a href="https://commits.webkit.org/320372@main">https://commits.webkit.org/320372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ecd9e2c98568a059d40617881424a80a3cedf05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143881 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100006 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46376 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44574 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156777 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44161 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5693 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153112 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47641 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130891 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127330 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57097 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19176 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->