### PR TITLE
[JSC] Object.freeze should bump megamorphic IC epoch

### DIFF
--- a/JSTests/stress/megamorphic-store-frozen-prototype.js
+++ b/JSTests/stress/megamorphic-store-frozen-prototype.js
@@ -1,0 +1,92 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+const shapeCount = 64;
+
+function makeShape(proto, i) {
+    const object = Object.create(proto);
+    for (let j = 0; j <= (i % 8); ++j)
+        object["k" + ((i * 5 + j * 3) % 13)] = j;
+    object["tag" + i] = i;
+    return object;
+}
+
+// Object.create reuses one Structure per prototype object, so the objects built after the freeze
+// carry the same StructureIDs that warmed the store cache and can still hit its entries. Freezing
+// the receiver instead would hand it a fresh StructureID and prove nothing.
+function warmUp(put, proto) {
+    for (let i = 0; i < testLoopCount; ++i)
+        put(makeShape(proto, i % shapeCount), i);
+    Object.freeze(proto);
+}
+
+{
+    const proto = { x: "protoValue" };
+    function put(object, value) { "use strict"; object.x = value; }
+    noInline(put);
+    warmUp(put, proto);
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(proto, i);
+        shouldThrow(() => put(object, -1), `TypeError: Attempted to assign to readonly property.`);
+        shouldBe(object.x, "protoValue");
+        shouldBe(Object.getOwnPropertyDescriptor(object, "x"), undefined);
+    }
+}
+
+{
+    const proto = { get other() { return 1; }, x: "protoValue" };
+    function put(object, value) { "use strict"; object.x = value; }
+    noInline(put);
+    warmUp(put, proto);
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(proto, i);
+        shouldThrow(() => put(object, -1), `TypeError: Attempted to assign to readonly property.`);
+        shouldBe(object.x, "protoValue");
+        shouldBe(Object.getOwnPropertyDescriptor(object, "x"), undefined);
+    }
+}
+
+{
+    const proto = { get other() { return 1; }, x: "protoValue" };
+    function put(object, value) { object.x = value; }
+    noInline(put);
+    warmUp(put, proto);
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(proto, i);
+        put(object, -1);
+        shouldBe(object.x, "protoValue");
+        shouldBe(Object.getOwnPropertyDescriptor(object, "x"), undefined);
+    }
+}
+
+{
+    const proto = { get other() { return 1; }, x: "protoValue" };
+    function put(object, key, value) { "use strict"; object[key] = value; }
+    noInline(put);
+    for (let i = 0; i < testLoopCount; ++i)
+        put(makeShape(proto, i % shapeCount), "x", i);
+    Object.freeze(proto);
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(proto, i);
+        shouldThrow(() => put(object, "x", -1), `TypeError: Attempted to assign to readonly property.`);
+        shouldBe(object.x, "protoValue");
+        shouldBe(Object.getOwnPropertyDescriptor(object, "x"), undefined);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2897,6 +2897,8 @@ void JSObject::freeze(VM& vm)
         Structure* oldStructure = structure();
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::freezeTransition(vm, oldStructure, &deferred));
+        if (mayBePrototype()) [[unlikely]]
+            vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
     }
 }
 


### PR DESCRIPTION
#### 74d9ff91dbb7cac871307142a032f8cbefa72046
<pre>
[JSC] Object.freeze should bump megamorphic IC epoch
<a href="https://bugs.webkit.org/show_bug.cgi?id=323131">https://bugs.webkit.org/show_bug.cgi?id=323131</a>
<a href="https://rdar.apple.com/186393610">rdar://186393610</a>

Reviewed by Keith Miller.

320236@main allows having accessors in [[Prototype]] chain. But
Object.freeze is not invalidating megamorphic IC when it is
mayBePrototype(). It needs to bump the epoch since it is changing
non read-only properties to read-only, which changes [[Put]] operation
results (setting successfully or throwing an error).

Test: JSTests/stress/megamorphic-store-frozen-prototype.js

* JSTests/stress/megamorphic-store-frozen-prototype.js: Added.
(shouldBe):
(makeShape):
(warmUp):
(Object.freeze.put):
(Object.freeze):
(shouldBe.const.proto.get other):
(shouldBe.put):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::freeze):

Canonical link: <a href="https://commits.webkit.org/320276@main">https://commits.webkit.org/320276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85c3e2a4187ce7e1f013b936404e65d57f0e1c2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194520 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124294 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46377 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6270 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13101 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44162 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5695 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45574 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57888 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58592 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153115 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47642 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130893 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57099 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->