### PR TITLE
[JSC] Adopt the instance-scoped qWasmGlobal packet form

### DIFF
--- a/JSTests/wasm/debugger/lib/environment.py
+++ b/JSTests/wasm/debugger/lib/environment.py
@@ -11,7 +11,7 @@ from .utils import log_info, log_warning, log_error, log_success, log_verbose
 class WebKitEnvironment:
     """Detects JSC and LLDB paths and sets up DYLD_FRAMEWORK_PATH."""
 
-    def __init__(self, script_path: Path, build_config: str = None):
+    def __init__(self, script_path: Path, build_config: str = None, lldb_path: str = None):
         # script_path is test-wasm-debugger.py
         # debugger/ -> wasm/ -> JSTests/ -> OpenSource/ (webkit_root)
         self.webkit_root = script_path.resolve().parent.parent.parent.parent
@@ -23,7 +23,9 @@ class WebKitEnvironment:
         self.env["VM"] = str(self.vm_path)
         self.env["DYLD_FRAMEWORK_PATH"] = str(self.vm_path)
 
-        self.lldb_path = self._find_lldb_path()
+        self.lldb_path = lldb_path or self._find_lldb_path()
+        if lldb_path:
+            log_info(f"Using LLDB at: {lldb_path}")
 
     def _find_jsc_path(self):
         if self.build_config:

--- a/JSTests/wasm/debugger/lib/session.py
+++ b/JSTests/wasm/debugger/lib/session.py
@@ -30,6 +30,30 @@ from pathlib import Path
 # Root directory of the debugger test suite (contains test-wasm-debugger.py)
 _TESTS_ROOT = Path(__file__).parent.parent
 
+# This checkout, and the path fragment that locates the suite inside any checkout.
+_CHECKOUT_ROOT = _TESTS_ROOT.parents[2]
+_SUITE_FRAGMENT = b"/JSTests/wasm/debugger/"
+
+
+def _source_map_command(resource_dir):
+    """LLDB command remapping a .wasm's build-time checkout onto this one.
+
+    The .wasm resources are checked in prebuilt, so their DWARF records absolute
+    source paths from whichever checkout produced them. Without the remap LLDB
+    resolves line numbers but prints no source.
+    """
+    for wasm in sorted(Path(resource_dir).glob("*.wasm")):
+        data = wasm.read_bytes()
+        end = data.find(_SUITE_FRAGMENT)
+        if end == -1:
+            continue
+        # DWARF strings are NUL-terminated and NUL-separated.
+        build_root = data[data.rfind(b"\0", 0, end) + 1:end].decode()
+        if build_root != str(_CHECKOUT_ROOT):
+            return f"settings set target.source-map {build_root} {_CHECKOUT_ROOT}"
+    return None
+
+
 # Default wait patterns for commands that change process state.
 # Tests that need different patterns pass them explicitly.
 _DEFAULT_PATTERNS = {
@@ -109,8 +133,13 @@ class DebugSession:
             # Step 3 — all modules are loaded; connect LLDB now. Any module-load
             # notifications that fired before this point are irrelevant to LLDB.
             connect_cmd = f"process connect --plugin wasm connect://localhost:{port}"
+            lldb_cmd = [str(lldb_path)]
+            source_map_cmd = _source_map_command(cwd)
+            if source_map_cmd:
+                lldb_cmd += ["-o", source_map_cmd]
+            lldb_cmd += ["-o", connect_cmd]
             self._lldb = subprocess.Popen(
-                [str(lldb_path), "-o", connect_cmd],
+                lldb_cmd,
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, bufsize=1,
             )

--- a/JSTests/wasm/debugger/test-wasm-debugger.py
+++ b/JSTests/wasm/debugger/test-wasm-debugger.py
@@ -83,6 +83,8 @@ def main():
                         help="List available test cases and exit")
     parser.add_argument("--parallel", "-p", type=int, nargs="?", const=-1, metavar="N",
                         help="Parallel workers (omit N for auto-detect)")
+    parser.add_argument("--lldb", metavar="PATH",
+                        help="LLDB to test against (default: xcrun --find lldb)")
 
     build_group = parser.add_mutually_exclusive_group()
     build_group.add_argument("--debug",   action="store_true", help="Use Debug build")
@@ -95,7 +97,7 @@ def main():
     set_verbose(verbose)
 
     build_config = "Debug" if args.debug else "Release" if args.release else None
-    env = WebKitEnvironment(Path(__file__), build_config)
+    env = WebKitEnvironment(Path(__file__), build_config, args.lldb)
 
     all_tests = list(ALL_TESTS) + [JavaScriptCoreTestCase]
 

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -94,7 +94,7 @@ public:
     std::unique_ptr<MergedProfile> createMergedProfile(const IPIntCallee&);
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-    uint32_t NODELETE debugId() const;
+    JS_EXPORT_PRIVATE uint32_t NODELETE debugId() const;
     void NODELETE setDebugId(uint32_t);
 #endif
 

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -88,7 +88,7 @@ The debugger uses a sophisticated virtual address encoding system to present Web
 ```txt
 Address Format (64-bit):
 - Bits 63-62: Address Type (2 bits)
-- Bits 61-32: ID (30 bits) - ModuleID for code, InstanceID for memory  
+- Bits 61-32: ID (30 bits) - ModuleID for code, InstanceID for memory
 - Bits 31-0:  Offset (32 bits)
 
 Address Types:
@@ -99,7 +99,7 @@ Address Types:
 
 Virtual Memory Layout:
 - 0x0000000000000000 - 0x3FFFFFFFFFFFFFFF: Memory regions
-- 0x4000000000000000 - 0x7FFFFFFFFFFFFFFF: Module regions  
+- 0x4000000000000000 - 0x7FFFFFFFFFFFFFFF: Module regions
 - 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF: Invalid regions
 ```
 
@@ -213,20 +213,29 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 
 The following references correspond to the numbered citations used throughout the WebAssembly debugger implementation:
 
-- [1] [Interrupts](https://sourceware.org/gdb/onlinedocs/gdb/Interrupts.html)  
-- [2] [Packet Acknowledgment](https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html)  
-- [3] [Packets](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html)  
+- [1] [Interrupts](https://sourceware.org/gdb/onlinedocs/gdb/Interrupts.html)
+- [2] [Packet Acknowledgment](https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html)
+- [3] [Packets](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html)
 - [4] [General Query Packets](https://sourceware.org/gdb/current/onlinedocs/gdb.html/General-Query-Packets.html)
 - [5] [Standard Replies](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Standard-Replies.html#Standard-Replies)
-- [6] [Packet Acknowledgment](https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html)  
-- [7] [qSupported](https://sourceware.org/gdb/current/onlinedocs/gdb.html/General-Query-Packets.html#qSupported)  
-- [8] [qProcessInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qprocessinfo)  
-- [9] [qHostInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qhostinfo)  
-- [10] [qRegisterInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qregisterinfo-hex-reg-id)  
-- [11] [qListThreadsInStopReply](https://lldb.llvm.org/resources/lldbgdbremote.html#qlistthreadsinstopreply)  
-- [12] [qEnableErrorStrings](https://lldb.llvm.org/resources/lldbgdbremote.html#qenableerrorstrings)  
-- [13] [qThreadStopInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qthreadstopinfo-tid)  
-- [14] [qXfer:library-list:read](https://sourceware.org/gdb/onlinedocs/gdb/General-Query-Packets.html#qXfer-library-list-read)  
-- [15] [qWasmCallStack](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmcallstack)  
-- [16] [qWasmLocal](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmlocal)  
+- [6] [Packet Acknowledgment](https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html)
+- [7] [qSupported](https://sourceware.org/gdb/current/onlinedocs/gdb.html/General-Query-Packets.html#qSupported)
+- [8] [qProcessInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qprocessinfo)
+- [9] [qHostInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qhostinfo)
+- [10] [qRegisterInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qregisterinfo-hex-reg-id)
+- [11] [qListThreadsInStopReply](https://lldb.llvm.org/resources/lldbgdbremote.html#qlistthreadsinstopreply)
+- [12] [qEnableErrorStrings](https://lldb.llvm.org/resources/lldbgdbremote.html#qenableerrorstrings)
+- [13] [qThreadStopInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qthreadstopinfo-tid)
+- [14] [qXfer:library-list:read](https://sourceware.org/gdb/onlinedocs/gdb/General-Query-Packets.html#qXfer-library-list-read)
+- [15] [qWasmCallStack](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmcallstack)
+- [16] [qWasmLocal](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmlocal)
 - [17] [qMemoryRegionInfo](https://lldb.llvm.org/resources/lldbgdbremote.html#qmemoryregioninfo-addr)
+- [18] [qWasmGlobal](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmglobal)
+- [19] [qWasmInstance](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasminstance-qsupported-feature) —
+  advertised in the `qSupported` reply to opt into naming a module instance in a Wasm query. It
+  adds the form `qWasmGlobal:<global-index>;instance:<instance-id>;`, which reads a global from a
+  named instance rather than from the instance a stack frame is executing. The instance id is the
+  id a Wasm virtual address carries in bits 61:32, which is a module id. Added to LLDB by
+  [llvm/llvm-project#213176](https://github.com/llvm/llvm-project/pull/213176), resolving
+  [llvm/llvm-project#212833](https://github.com/llvm/llvm-project/issues/212833). A module with no
+  live instance, or with more than one, has no single value to report and answers with an error.

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -165,6 +165,39 @@ JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
     return instance;
 }
 
+// Null when a module has no live instance, or more than one: globals are per-instance, so an
+// ambiguous module has no single value to report.
+// FIXME: Workaround until we hand out module instance IDs instead of module IDs.
+JSWebAssemblyInstance* ModuleManager::soleInstanceOfModule(uint32_t moduleId)
+{
+    Locker locker { m_lock };
+    amortizedCleanupIfNeeded();
+
+    JSWebAssemblyInstance* found = nullptr;
+    for (const auto& pair : m_instanceIdToInstance) {
+        RefPtr<InstanceAnchor> anchor = pair.value.get();
+        if (!anchor)
+            continue;
+
+        Locker anchorLocker { anchor->m_lock };
+        JSWebAssemblyInstance* instance = anchor->instance();
+        if (!instance || instance->module().debugId() != moduleId)
+            continue;
+
+        if (found) {
+            dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][soleInstanceOfModule] - more than one live instance for module ID: ", moduleId);
+            return nullptr;
+        }
+
+        RELEASE_ASSERT(instance->vm().debugState()->isStopped, "Instance exists but VM is not stopped");
+        found = instance;
+    }
+
+    if (!found)
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][soleInstanceOfModule] - no live instance for module ID: ", moduleId);
+    return found;
+}
+
 String ModuleManager::generateLibrariesXML() const
 {
     Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
@@ -62,6 +62,7 @@ public:
 
     uint32_t registerInstance(JSWebAssemblyInstance*);
     JSWebAssemblyInstance* jsInstance(uint32_t instanceId);
+    JSWebAssemblyInstance* soleInstanceOfModule(uint32_t moduleId);
     uint32_t nextInstanceId() const;
 
     String generateLibrariesXML() const;

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -52,6 +52,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
@@ -229,6 +230,7 @@ void QueryHandler::handleSupported()
     // This allows LLDB to see loaded WebAssembly modules as "libraries" for debugging
     String supportedFeatures = makeString(
         "qXfer:libraries:read+;"_s, // Support library list transfer for WASM modules
+        "qWasmInstance+;"_s, // A Wasm query may name the module instance it is about (see [19])
         "PacketSize=1000;"_s // Maximum packet size for data transfer
     );
     m_debugServer.sendReply(supportedFeatures);
@@ -352,8 +354,15 @@ void QueryHandler::handleWasmLocal(StringView packet)
         return;
     }
 
-    uint32_t frameIndex = parseDecimal(parts[1]);
-    uint32_t localIndex = parseDecimal(parts[2]);
+    // Reject a non-numeric field rather than defaulting it to 0, which would answer for frame 0.
+    auto parsedFrameIndex = parseInteger<uint32_t>(parts[1]);
+    auto parsedLocalIndex = parseInteger<uint32_t>(parts[2]);
+    if (!parsedFrameIndex || !parsedLocalIndex) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+    uint32_t frameIndex = *parsedFrameIndex;
+    uint32_t localIndex = *parsedLocalIndex;
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmLocal frame=", frameIndex, ", variable=", localIndex);
 
@@ -421,64 +430,96 @@ void QueryHandler::handleWasmLocal(StringView packet)
     m_debugServer.sendReply(response);
 }
 
+// LLDB identifies an instance by the module id encoded in bits 61:32 of a Wasm address, so an
+// `instance:<id>` field names a module here.
+// FIXME: A module with several live instances has several sets of globals. Only a module the
+// debuggee is stopped in, or one with a single live instance, resolves to one of them.
+JSWebAssemblyInstance* QueryHandler::instanceForModule(uint32_t moduleId)
+{
+    auto& stopData = m_debugServer.execution().debuggeeStateForTest()->stopData;
+    if (stopData && stopData->instance->module().debugId() == moduleId)
+        return stopData->instance;
+
+    return m_debugServer.moduleManager().soleInstanceOfModule(moduleId);
+}
+
+JSWebAssemblyInstance* QueryHandler::instanceForFrame(uint32_t frameIndex)
+{
+    auto* state = m_debugServer.execution().debuggeeStateForTest();
+    if (state->isStoppedAtSystemCall())
+        return nullptr;
+
+    auto& stopData = *state->stopData;
+    if (!frameIndex)
+        return stopData.instance;
+
+    auto frames = collectCallStack(stopData.address, stopData.callFrame, stopData.instance->vm());
+    if (frameIndex >= frames.size() || !frames[frameIndex].isWasmFrame())
+        return nullptr;
+    return frames[frameIndex].wasmCallFrame->wasmInstance();
+}
+
 void QueryHandler::handleWasmGlobal(StringView packet)
 {
-    // Format: qWasmGlobal:<frame-index>;<variable-index>
-    // LLDB: Get value of WebAssembly global variable for a given frame's instance
-    // Reference: https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmglobal
+    // Format: qWasmGlobal:<global-index>;instance:<instance-id>;
+    //     or: qWasmGlobal:<frame-index>;<global-index>
+    // LLDB: Get value of a WebAssembly global variable
+    // Reference: [18] and [19] in wasm/debugger/README.md
 
-    // WebAssembly Context: Globals are per-instance; the frame index identifies which
-    // WASM instance to read from, and variable-index is the global index within that instance.
+    // WebAssembly Context: A global index only names a global together with an instance to read
+    // it from. The instance form names one directly, the frame form names the frame's instance.
     auto parts = splitWithDelimiters(packet, ":;"_s);
     if (parts.size() != 3) {
         m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
         return;
     }
 
-    uint32_t frameIndex = parseDecimal(parts[1]);
-    uint32_t globalIndex = parseDecimal(parts[2]);
+    static constexpr auto instanceKey = "instance:"_s;
+    bool namesInstance = parts[2].startsWith(instanceKey);
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal frame=", frameIndex, ", global=", globalIndex);
-
-    auto* state = m_debugServer.execution().debuggeeStateForTest();
-    if (state->isStoppedAtSystemCall()) {
-        m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
-        return;
-    }
-
-    auto& stopData = *state->stopData;
-    JSWebAssemblyInstance* instance = nullptr;
-
-    if (!frameIndex)
-        instance = stopData.instance;
-    else {
-        auto frames = collectCallStack(stopData.address, stopData.callFrame, stopData.instance->vm());
-        if (frameIndex >= frames.size() || !frames[frameIndex].isWasmFrame()) {
-            m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
+    StringView instanceOrFrameField = parts[1];
+    if (namesInstance) {
+        if (!parts[2].endsWith(';')) {
+            m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
             return;
         }
-        instance = frames[frameIndex].wasmCallFrame->wasmInstance();
+        instanceOrFrameField = parts[2].left(parts[2].length() - 1).substring(instanceKey.length());
     }
 
-    const auto& moduleInfo = instance->module().moduleInformation();
-    if (globalIndex >= moduleInfo.globalCount()) {
+    auto globalIndex = parseInteger<uint32_t>(namesInstance ? parts[1] : parts[2]);
+    auto instanceOrFrameIndex = parseInteger<uint32_t>(instanceOrFrameField);
+    if (!globalIndex || !instanceOrFrameIndex) {
         m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
         return;
     }
 
-    Type globalType = moduleInfo.global(globalIndex).type;
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal ", namesInstance ? "instance="_s : "frame="_s, *instanceOrFrameIndex, ", global=", *globalIndex);
+
+    auto* instance = namesInstance ? instanceForModule(*instanceOrFrameIndex) : instanceForFrame(*instanceOrFrameIndex);
+    if (!instance) {
+        m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
+        return;
+    }
+
+    const auto& moduleInfo = instance->module().moduleInformation();
+    if (*globalIndex >= moduleInfo.globalCount()) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    Type globalType = moduleInfo.global(*globalIndex).type;
     uint32_t width = typeKindToWidth(globalType.kind());
 
     String response;
     switch (width) {
     case 32:
-        response = toNativeEndianHex(static_cast<uint32_t>(instance->loadI32Global(globalIndex)));
+        response = toNativeEndianHex(static_cast<uint32_t>(instance->loadI32Global(*globalIndex)));
         break;
     case 64:
-        response = toNativeEndianHex(static_cast<uint64_t>(instance->loadI64Global(globalIndex)));
+        response = toNativeEndianHex(static_cast<uint64_t>(instance->loadI64Global(*globalIndex)));
         break;
     case 128:
-        response = toNativeEndianHex(instance->loadV128Global(globalIndex));
+        response = toNativeEndianHex(instance->loadV128Global(*globalIndex));
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
@@ -29,6 +29,9 @@
 #include "WasmVirtualAddress.h"
 
 namespace JSC {
+
+class JSWebAssemblyInstance;
+
 namespace Wasm {
 
 class DebugServer;
@@ -63,6 +66,8 @@ private:
 
     bool parseLibrariesReadPacket(StringView packet, size_t& offset, size_t& maxSize);
     bool handleChunkedLibrariesResponse(size_t offset, size_t maxSize, String& response);
+    JSWebAssemblyInstance* instanceForModule(uint32_t moduleId);
+    JSWebAssemblyInstance* instanceForFrame(uint32_t frameIndex);
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -43,6 +43,8 @@
 #include "WasmModule.h"
 #include "WasmModuleInformation.h"
 #include "WasmModuleManager.h"
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
 #include <wtf/Threading.h>
@@ -147,12 +149,18 @@ static void setBreakpointsAtAllFunctionEntries(Breakpoint::Type type)
     ModuleManager& moduleManager = debugServer->moduleManager();
     uint32_t maxInstanceId = moduleManager.nextInstanceId();
 
+    // Breakpoints patch module bytecode, which all instances of a module share, so visit each once.
+    UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> patchedModuleIds;
+
     for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
         JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
         if (!instance)
             continue;
 
         auto& module = instance->module();
+        if (!patchedModuleIds.add(module.debugId()).isNewEntry)
+            continue;
+
         auto& moduleInfo = module.moduleInformation();
         uint32_t internalCount = moduleInfo.internalFunctionCount();
 
@@ -312,8 +320,56 @@ static void testBreakpointSingleStepping()
     TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
 }
 
-// ========== TEST ORCHESTRATION HELPERS ==========
+static void testSoleInstanceOfModule()
+{
+    TEST_LOG("\n=== Sole Instance Of Module Lookup ===");
 
+    interrupt();
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    uint32_t maxInstanceId = moduleManager.nextInstanceId();
+
+    // Derive the expectation from what is registered, so this holds for every test script.
+    using ModuleIdToCount = UncheckedKeyHashMap<uint32_t, unsigned, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using ModuleIdToInstance = UncheckedKeyHashMap<uint32_t, JSWebAssemblyInstance*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    ModuleIdToCount liveInstanceCount;
+    ModuleIdToInstance firstLiveInstance;
+    uint32_t highestModuleId = 0;
+
+    for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
+        JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
+        if (!instance)
+            continue;
+
+        uint32_t moduleId = instance->module().debugId();
+        liveInstanceCount.add(moduleId, 0).iterator->value++;
+        firstLiveInstance.add(moduleId, instance);
+        highestModuleId = std::max(highestModuleId, moduleId);
+    }
+
+    CHECK(!liveInstanceCount.isEmpty(), "Expected at least one live instance while stopped");
+
+    unsigned soleModules = 0;
+    unsigned ambiguousModules = 0;
+    for (const auto& pair : liveInstanceCount) {
+        JSWebAssemblyInstance* resolved = moduleManager.soleInstanceOfModule(pair.key);
+        if (pair.value == 1) {
+            soleModules++;
+            CHECK(resolved == firstLiveInstance.get(pair.key), "Module ", pair.key, " has one live instance and should resolve to it");
+        } else {
+            ambiguousModules++;
+            CHECK(!resolved, "Module ", pair.key, " has ", pair.value, " live instances and should not resolve");
+        }
+    }
+
+    CHECK(!moduleManager.soleInstanceOfModule(highestModuleId + 1), "An unregistered module ID should not resolve");
+
+    resume();
+
+    TEST_LOG("PASS (", soleModules, " module(s) with one live instance, ", ambiguousModules, " with several)");
+}
+
+// ========== TEST ORCHESTRATION HELPERS ==========
 static void waitForVMCleanupFromPreviousTest()
 {
     TEST_LOG("Waiting for VMs from previous test to be destroyed...");
@@ -331,7 +387,7 @@ static bool setupScriptAndWaitForVMs(const TestScript& script, RefPtr<Thread>& o
 {
     ModuleManager& moduleManager = debugServer->moduleManager();
     unsigned initialInstanceId = moduleManager.nextInstanceId();
-    unsigned expectedInstanceId = initialInstanceId + script.expectedVMs;
+    unsigned expectedInstanceId = initialInstanceId + script.expectedInstances;
 
     TEST_LOG("\nStarting worker thread with ", script.name, "...");
     outWorkerThread = Thread::create(WORKER_THREAD_NAME, [&script] {
@@ -416,6 +472,7 @@ UNUSED_FUNCTION static int runTests()
         testVMContextSwitching();
         testBreakpointContinueCycles();
         testBreakpointSingleStepping();
+        testSoleInstanceOfModule();
 
         cleanupAfterScript(script, workerThread);
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
@@ -236,6 +236,53 @@ String multiVMSameModuleSameFunction()
     return *cachedScript;
 }
 
+// Multi-VM test script: creates 5 VMs (main + 4 workers) all running WASM in infinite loops
+// Each worker holds two live instances of its module, so a module lookup can be ambiguous.
+String multiVMMultipleInstancesPerModule()
+{
+    static String* cachedScript = nullptr;
+    static std::once_flag once;
+
+    std::call_once(once, [] {
+        cachedScript = new String(makeString(R"script(
+            const wasm = new Uint8Array([)script"_s,
+                wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+            R"script(]);
+
+            const module = new WebAssembly.Module(wasm);
+            const instance = new WebAssembly.Instance(module, { });
+
+            const NUM_WORKERS = 4;
+
+            // Worker script - two live instances of one module, only the first runs
+            const workerScript = `
+                const wasm = new Uint8Array([)script"_s,
+                    wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+                    R"script(]);
+                const module = new WebAssembly.Module(wasm);
+                const instance = new WebAssembly.Instance(module, { });
+                const idleInstance = new WebAssembly.Instance(module, { });
+
+                while (!$.shouldExit())
+                    instance.exports.func1();
+
+                // Keep the second instance alive for the whole run
+                idleInstance.exports.func1();
+            `;
+
+            // Start worker threads via $.agent.start()
+            for (let i = 0; i < NUM_WORKERS; i++)
+                $.agent.start(workerScript);
+
+            // Main thread also runs func1 in loop until $.shouldExit() returns true
+            while (!$.shouldExit())
+                instance.exports.func1();
+        )script"_s));
+    });
+
+    return *cachedScript;
+}
+
 // ========== Test Script Registry ==========
 
 static const TestScript allScripts[] = {
@@ -244,13 +291,21 @@ static const TestScript allScripts[] = {
         .description = "5 VMs (1 main + 4 workers) running different WASM functions from same module"_s,
         .scriptGenerator = multiVMSameModuleDifferentFunction,
         .expectedVMs = 5,
+        .expectedInstances = 5,
         .expectedFunctions = 5
-    },
-    {
+    }, {
         .name = "MultiVMSameModuleSameFunction"_s,
         .description = "5 VMs (1 main + 4 workers) all running same WASM function"_s,
         .scriptGenerator = multiVMSameModuleSameFunction,
         .expectedVMs = 5,
+        .expectedInstances = 5,
+        .expectedFunctions = 5
+    }, {
+        .name = "MultiVMMultipleInstancesPerModule"_s,
+        .description = "5 VMs (1 main + 4 workers), each worker holding two live instances of its module"_s,
+        .scriptGenerator = multiVMMultipleInstancesPerModule,
+        .expectedVMs = 5,
+        .expectedInstances = 9,
         .expectedFunctions = 5
     },
 };

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
@@ -40,12 +40,14 @@ struct TestScript {
     ASCIILiteral description;
     String (*scriptGenerator)(); // Function pointer to generate script
     unsigned expectedVMs;
+    unsigned expectedInstances; // Exceeds expectedVMs when a VM instantiates a module twice
     unsigned expectedFunctions; // For breakpoint tests
 };
 
 // Script generators
 String multiVMSameModuleDifferentFunction();
 String multiVMSameModuleSameFunction();
+String multiVMMultipleInstancesPerModule();
 
 // Get all registered test scripts
 std::span<const TestScript> NODELETE getTestScripts();


### PR DESCRIPTION
#### ca158eb19b753004c61c9405265669ccfdd8557a
<pre>
[JSC] Adopt the instance-scoped qWasmGlobal packet form
<a href="https://bugs.webkit.org/show_bug.cgi?id=323123">https://bugs.webkit.org/show_bug.cgi?id=323123</a>

Reviewed by Yijia Huang.

A Wasm global belongs to a module instance, not to a frame. The global
index space is per instance, and DW_OP_WASM_location&apos;s global operand
indexes the index space of the instance whose code is being evaluated.
qWasmGlobal took a frame index and used it as a proxy for that instance,
which left the globals of an instance with no active frame out of reach:
a page loading several modules could only inspect whichever one it
happened to be stopped inside.

LLDB has since landed a form that names the instance directly:

    qWasmGlobal:&lt;global-index&gt;;instance:&lt;instance-id&gt;

    <a href="https://github.com/llvm/llvm-project/pull/213176">https://github.com/llvm/llvm-project/pull/213176</a>
    resolving <a href="https://github.com/llvm/llvm-project/issues/212833">https://github.com/llvm/llvm-project/issues/212833</a>

This PR adds support for the new packet variant. The id is the module id
already carried in bits 61:32 of a Wasm virtual address. A stub opts in
by advertising qWasmInstance+ in its qSupported reply, which covers any
Wasm query whose scope is an instance rather than a frame. A client that
does not opt in keeps getting the frame form, and the two are told apart
by the presence of the instance: key.

Besides that, I had to make the following changes:

- Because the id is a module id it cannot distinguish two instances of
  one module, which have separate globals.
  ModuleManager::soleInstanceOfModule() answers only when the module has
  exactly one live instance, and QueryHandler::instanceForModule()
  additionally accepts a module the debuggee is stopped in, where the
  stop itself picks the instance. Anything else replies with an error
  rather than guessing, since a wrong value is indistinguishable from a
  right one on the wire.

- Also stop qWasmLocal from defaulting an unparsable field to zero.
  parseDecimal() returns 0 for a field that is not a number, so a client
  sending a field this packet does not have read local 0 of frame 0 and
  got a plausible wrong answer instead of an error. This matters more
  now that a second packet shape exists.

- Module::debugId() becomes JS_EXPORT_PRIVATE so the new test can link
  against it.

- On the test side, setBreakpointsAtAllFunctionEntries() now visits each
  module once rather than once per instance. Breakpoints patch module
  bytecode, which every instance of a module shares, and patching twice
  records the breakpoint opcode itself as the original bytecode. That
  was unreachable until a script held two instances of one module.

Test: MultiVMMultipleInstancesPerModule exercises both the sole-instance

and ambiguous paths; testSoleInstanceOfModule derives its expectation
from the instances actually registered, so it holds for every script.

* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/JavaScriptCore/wasm/debugger/README.md:
* Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp:
(JSC::Wasm::ModuleManager::soleInstanceOfModule):
* Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h:
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp:
(JSC::Wasm::QueryHandler::handleSupported):
(JSC::Wasm::QueryHandler::handleWasmLocal):
(JSC::Wasm::QueryHandler::instanceForModule):
(JSC::Wasm::QueryHandler::instanceForFrame):
(JSC::Wasm::QueryHandler::handleWasmGlobal):
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h:
* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp:
(ExecutionHandlerTest::setBreakpointsAtAllFunctionEntries):
(ExecutionHandlerTest::testSoleInstanceOfModule):
(ExecutionHandlerTest::setupScriptAndWaitForVMs):
(ExecutionHandlerTest::runTests):
* Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp:
* Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h:
* JSTests/wasm/debugger/lib/environment.py:
(WebKitEnvironment.__init__):
* JSTests/wasm/debugger/lib/session.py:
(_source_map_command):
(DebugSession.__init__):
* JSTests/wasm/debugger/test-wasm-debugger.py:
(main):

Canonical link: <a href="https://commits.webkit.org/320536@main">https://commits.webkit.org/320536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bec3b1bc0edbe2d6dffb5cd9a41426e5d46f291

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195333 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46970 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13664 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44732 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46267 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58585 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154051 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41271 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59295 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48220 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131585 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128221 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57787 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19751 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->