### PR TITLE
WKWebView.magnification reports the pre-gesture scale while a committed transient zoom animates

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -73,6 +73,9 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 - (void)_setPageScale:(CGFloat)scale withOrigin:(CGPoint)origin;
 - (CGFloat)_pageScale;
 
+- (CGFloat)_minMagnification;
+- (CGFloat)_maxMagnification;
+
 - (void)_setContinuousSpellCheckingEnabledForTesting:(BOOL)enabled;
 - (void)_setGrammarCheckingEnabledForTesting:(BOOL)enabled;
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -263,6 +263,16 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return _page->pageScaleFactor();
 }
 
+- (CGFloat)_minMagnification
+{
+    return _page->minPageZoomFactor();
+}
+
+- (CGFloat)_maxMagnification
+{
+    return _page->maxPageZoomFactor();
+}
+
 - (void)_setContinuousSpellCheckingEnabledForTesting:(BOOL)enabled
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -102,6 +102,7 @@ public:
 
     virtual void adjustTransientZoom(double, WebCore::FloatPoint /* originInLayerForPageScale */, WebCore::FloatPoint /* originInVisibleRect */) { }
     virtual void commitTransientZoom(double, WebCore::FloatPoint /* originInLayerForPageScale */) { }
+    virtual std::optional<double> committedTransientZoomScale() const { return std::nullopt; }
 
     virtual void viewIsBecomingVisible() { }
     virtual void viewIsBecomingInvisible() { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -75,6 +75,7 @@ private:
 
     void adjustTransientZoom(double, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
     void commitTransientZoom(double, WebCore::FloatPoint) override;
+    std::optional<double> committedTransientZoomScale() const override { return m_committedTransientZoomScale; }
 
     void sendCommitTransientZoom(double, WebCore::FloatPoint, std::optional<WebCore::ScrollingNodeID>);
 
@@ -121,6 +122,7 @@ private:
 
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
     std::optional<double> m_transientZoomScale;
+    std::optional<double> m_committedTransientZoomScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOriginInLayerForPageScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOriginInVisibleRect;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -419,6 +419,10 @@ void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, Float
     auto transientZoomOrigin = std::exchange(m_transientZoomOriginInLayerForPageScale, { });
     m_transientZoomOriginInVisibleRect = { };
 
+    // From now until sendCommitTransientZoom() applies it, the page scale factor still describes
+    // the scale from before the gesture, so we account for it and report this instead.
+    m_committedTransientZoomScale = scale;
+
     auto rootScrollingNodeID = scrollingCoordinatorProxy->rootScrollingNodeID();
     if (rootScrollingNodeID)
         scrollingCoordinatorProxy->deferWheelEventTestCompletionForReason(rootScrollingNodeID, WheelEventTestMonitorDeferReason::CommittingTransientZoom);
@@ -490,6 +494,8 @@ void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, Float
 void RemoteLayerTreeDrawingAreaProxyMac::sendCommitTransientZoom(double scale, FloatPoint origin, std::optional<WebCore::ScrollingNodeID> rootNodeID)
 {
     updateZoomTransactionID();
+
+    m_committedTransientZoomScale = std::nullopt;
 
     RefPtr webPageProxy = page();
     if (!webPageProxy)

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -826,7 +826,7 @@ void ViewGestureController::prepareMagnificationGesture(FloatPoint origin)
     if (!page)
         return;
 
-    m_magnification = page->pageScaleFactor();
+    m_magnification = magnification();
     protect(page->legacyMainFrameProcess())->send(Messages::ViewGestureGeometryCollector::CollectGeometryForMagnificationGesture(), page->webPageIDInMainFrameProcess());
 
     m_initialMagnification = m_magnification;
@@ -882,8 +882,16 @@ double ViewGestureController::magnification() const
     if (m_activeGestureType == ViewGestureType::Magnification)
         return m_magnification;
 
-    auto* page = m_webPageProxy.get();
-    return page ? page->pageScaleFactor() : 1;
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return 1;
+
+    if (RefPtr drawingArea = page->drawingArea()) {
+        if (auto committedTransientZoomScale = drawingArea->committedTransientZoomScale())
+            return *committedTransientZoomScale;
+    }
+
+    return page->pageScaleFactor();
 }
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -159,7 +159,7 @@ public:
 
     bool isPhysicallySwipingLeft(SwipeDirection) const;
 
-    double NODELETE magnification() const;
+    double magnification() const;
 
     void prepareMagnificationGesture(WebCore::FloatPoint);
     void applyMagnification();

--- a/Tools/TestWebKitAPI/Configurations/Base.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/Base.xcconfig
@@ -41,7 +41,7 @@ CLANG_WARN_CXX0X_EXTENSIONS = NO;
 ALTERNATE_HEADER_SEARCH_PATHS = $(ALTERNATE_HEADER_SEARCH_PATHS_$(SDK_VARIANT));
 ALTERNATE_HEADER_SEARCH_PATHS_iosmac = $(BUILT_PRODUCTS_DIR)$(WK_ALTERNATE_FRAMEWORKS_DIR)/usr/local/include
 
-PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform/cocoa $(PROJECT_HEADER_SEARCH_PATHS_$(WK_COCOA_TOUCH)) $(SRCROOT)/../TestRunnerShared/spi $(SRCROOT)/../TestRunnerShared/cocoa $(SRCROOT)/../../Source/WebKit/Platform/spi/Cocoa;
+PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform/cocoa $(PROJECT_HEADER_SEARCH_PATHS_$(WK_COCOA_TOUCH)) $(SRCROOT)/../TestRunnerShared/spi $(SRCROOT)/../TestRunnerShared/cocoa $(SRCROOT)/../TestRunnerShared/mac $(SRCROOT)/../../Source/WebKit/Platform/spi/Cocoa;
 PROJECT_HEADER_SEARCH_PATHS_cocoatouch = $(inherited) $(SRCROOT)/../../Source/WebKit/Platform/spi/ios $(SRCROOT)/../../Source/WebKit/UIProcess/ios $(SRCROOT)/../../Source/WebKit/Shared/ios;
 
 // Needed to resolve the SPI modules WebKit's Swift interface publicly imports on public SDKs.

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -145,6 +145,8 @@ set(TestWebKit_UNIFIED_SOURCE_EXCLUDES
 
 # Files compiled outside unified sources (Xcode membershipExceptions).
 list(APPEND TestWebKit_SOURCES
+    ${TOOLS_DIR}/TestRunnerShared/mac/SyntheticNSEvent.mm
+
     Helpers/Counters.cpp
     Helpers/DeprecatedGlobalValues.cpp
     Helpers/GraphicsTestUtilities.cpp
@@ -202,6 +204,7 @@ list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
     ${WebKit_FRAMEWORK_HEADERS_DIR}
     ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}
     ${TOOLS_DIR}/TestRunnerShared/cocoa
+    ${TOOLS_DIR}/TestRunnerShared/mac
     ${TOOLS_DIR}/TestRunnerShared/spi
     ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCoreTestSupport
     ${TESTWEBKITAPI_DIR}/Helpers

--- a/Tools/TestWebKitAPI/SourcesMac.txt
+++ b/Tools/TestWebKitAPI/SourcesMac.txt
@@ -114,4 +114,5 @@ Tests/WebKit/WKWebView/mac/WillSendSubmitEvent.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/WindowlessWebViewWithMedia.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/WKWebViewCoders.mm @nonARC
 Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WKWebViewMagnification.mm @nonARC
 Tests/WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		DDFBE4AC2A90556700CA7023 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */; };
 		F5971BD071D50EA78EF87EE5 /* UnifiedSource53-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC072EC3DC8EA98F7B7BEE /* UnifiedSource53-nonARC.mm */; };
 		FE9CD7E42D10CE7500266FDD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
+		2B7E14D63A5F60718293C1A3 /* SyntheticNSEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B7E14D63A5F60718293C1A2 /* SyntheticNSEvent.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -541,6 +542,8 @@
 		DDB3724528ECE32F00A2F32D /* libbmalloc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbmalloc.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF3A82928930475005920CF /* gtest.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = gtest.xcodeproj; path = ../../Source/ThirdParty/gtest/xcode/gtest.xcodeproj; sourceTree = SOURCE_ROOT; };
 		F3FC3EE213678B7300126A65 /* libgtest.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgtest.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B7E14D63A5F60718293C1A1 /* SyntheticNSEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyntheticNSEvent.h; path = ../TestRunnerShared/mac/SyntheticNSEvent.h; sourceTree = "<group>"; };
+		2B7E14D63A5F60718293C1A2 /* SyntheticNSEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SyntheticNSEvent.mm; path = ../TestRunnerShared/mac/SyntheticNSEvent.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -1123,6 +1126,7 @@
 				WebKit/WKWebView/mac/WindowlessWebViewWithMedia.mm,
 				WebKit/WKWebView/mac/WKWebViewCoders.mm,
 				WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm,
+				WebKit/WKWebView/mac/WKWebViewMagnification.mm,
 				WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm,
 				WebKit/WKWebView/mac/WordBoundaryTypingAttributes.mm,
 				WebKit/WKWebView/MediaLoading.mm,
@@ -1998,6 +2002,8 @@
 		DD7024AE302CE42A009B6CC0 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				2B7E14D63A5F60718293C1A1 /* SyntheticNSEvent.h */,
+				2B7E14D63A5F60718293C1A2 /* SyntheticNSEvent.mm */,
 				CC1FEED000000000000FF001 /* WebFoundTextRange.cpp */,
 			);
 			name = Shared;
@@ -2495,6 +2501,7 @@
 		7CCE7E881A41144E00447C4C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
+				2B7E14D63A5F60718293C1A3 /* SyntheticNSEvent.mm in Sources */,
 				5C9D922C22D7DE12008E9266 /* UnifiedSource1-nonARC.mm in Sources */,
 				5C9D922E22D7DE1C008E9266 /* UnifiedSource1.cpp in Sources */,
 				5C9D922D22D7DE19008E9266 /* UnifiedSource2-nonARC.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMagnification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMagnification.mm
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/TestNSBundleExtras.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "SyntheticNSEvent.h"
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static void magnify(TestWKWebView *webView, NSEventPhase phase, CGFloat delta)
+{
+    static NSInteger eventNumber = 0;
+
+    NSPoint locationInWindow = NSMakePoint(NSMidX(webView.frame), NSMidY(webView.frame));
+    RetainPtr<NSWindow> window = webView.hostWindow;
+    NSPoint globalLocation = [window convertRectToScreen:NSMakeRect(locationInWindow.x, locationInWindow.y, 1, 1)].origin;
+
+    RetainPtr event = adoptNS([[SyntheticNSEvent alloc] initMagnifyEventAtLocation:locationInWindow
+        globalLocation:globalLocation
+        magnification:delta
+        phase:phase
+        time:NSProcessInfo.processInfo.systemUptime
+        eventNumber:++eventNumber
+        window:window]);
+
+    dispatchSyntheticEvent(event, webView, @"magnify", ^(NSView *targetView, NSEvent *syntheticEvent) {
+        [targetView magnifyWithEvent:syntheticEvent];
+    });
+
+    [webView waitForNextPresentationUpdate];
+}
+
+static double magnifyPastMaximum(TestWKWebView *webView)
+{
+    double maximum = [webView _maxMagnification];
+
+    magnify(webView, NSEventPhaseBegan, 0);
+
+    for (auto i = 0; i < 60 && [webView magnification] <= maximum; ++i)
+        magnify(webView, NSEventPhaseChanged, 0.2);
+
+    return [webView magnification];
+}
+
+static double lowestMagnificationReportedAfterGesture(TestWKWebView *webView)
+{
+    double lowest = [webView magnification];
+
+    // Some presentation updates to outlast the transient zoom snap-back.
+    for (unsigned i = 0; i < 30; ++i) {
+        [webView waitForNextPresentationUpdate];
+        double reported = [webView magnification];
+        if (reported < lowest)
+            lowest = reported;
+    }
+
+    return lowest;
+}
+
+static RetainPtr<TestWKWebView> webViewWithMagnificationAllowed()
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    [webView setAllowsMagnification:YES];
+    return webView;
+}
+
+static void runAccurateAtGestureEndTest(TestWKWebView *webView)
+{
+    double maximum = [webView _maxMagnification];
+    EXPECT_GT(magnifyPastMaximum(webView), maximum);
+
+    // We intentionally want to end magnification _past_ the maximum, since
+    // that forces the commit to animate.
+    magnify(webView, NSEventPhaseEnded, 0);
+
+    EXPECT_NEAR(maximum, lowestMagnificationReportedAfterGesture(webView), 0.01);
+    EXPECT_NEAR(maximum, [webView _pageScale], 0.01);
+}
+
+TEST(WKWebViewMagnification, AccurateAtGestureEnd)
+{
+    RetainPtr webView = webViewWithMagnificationAllowed();
+    [webView synchronouslyLoadHTMLString:@"<body style='margin:0;height:3000px'>magnification</body>"];
+    [webView waitForNextPresentationUpdate];
+    runAccurateAtGestureEndTest(webView);
+}
+
+TEST(WKWebViewMagnification, AccurateAtGestureEndPDF)
+{
+    RetainPtr webView = webViewWithMagnificationAllowed();
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-pages" withExtension:@"pdf"]]);
+    [webView synchronouslyLoadRequest:request];
+    [webView waitForNextPresentationUpdate];
+    runAccurateAtGestureEndTest(webView);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### d732d3bb86897cc43697d418eb589d29081ed549
<pre>
WKWebView.magnification reports the pre-gesture scale while a committed transient zoom animates
<a href="https://bugs.webkit.org/show_bug.cgi?id=323127">https://bugs.webkit.org/show_bug.cgi?id=323127</a>
<a href="https://rdar.apple.com/185381317">rdar://185381317</a>

Reviewed by Richard Robinson.

WKWebView.magnification reports the live scale during an ongoing gesture
and otherwise falls back to the page scale factor. However, at the end
of a gesture, we clear the active gesture type synchronously, while the
committed transient zoom is not written to the page scale factor until
sendCommitTransientZoom() runs (asynchronously) after the gesture
animation is complete (and CATransaction.completionBlock runs). In this
period, we report the scale from before the gesture started, which is
wrong.

We account for the committed-but-not-reflected phase by plumbing a
committedTransientZoomScale value, set in commitTransientZoom(), which
we promptly unset in sendCommitTransientZoom() when the page scale
factor is actually written.

Test: TestWebKitAPI.WKWebViewMagnification

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _minMagnification]):
(-[WKWebView _maxMagnification]):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::committedTransientZoomScale const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::sendCommitTransientZoom):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::prepareMagnificationGesture):
(WebKit::ViewGestureController::magnification const):
* Tools/TestWebKitAPI/Configurations/Base.xcconfig:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/SourcesMac.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMagnification.mm: Added.
(TestWebKitAPI::magnify):
(TestWebKitAPI::magnifyPastMaximum):
(TestWebKitAPI::lowestMagnificationReportedAfterGesture):
(TestWebKitAPI::webViewWithMagnificationAllowed):
(TestWebKitAPI::runAccurateAtGestureEndTest):
(TestWebKitAPI::TEST(WKWebViewMagnification, AccurateAtGestureEnd)):
(TestWebKitAPI::TEST(WKWebViewMagnification, AccurateAtGestureEndPDF)):
  Separate PDF case since the plugin handles its own scale, and also
  has separate magnification limits from regular web content.

Canonical link: <a href="https://commits.webkit.org/320341@main">https://commits.webkit.org/320341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8dc8bf901ba6a48cdc9026b90c0af4d082310b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148654 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18d19214-ccb0-472c-a500-d6de1aa00a59) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100033 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0ced05f-4e58-4f74-8115-8c3b35687d26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44609 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44201 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196619 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57944 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153491 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58648 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153158 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47687 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130943 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57155 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19216 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->