### PR TITLE
AX: In isolated tree mode, AXStringForTextMarkerRange reports an unexpected extra newline for a br element

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated-expected.txt
@@ -1,0 +1,16 @@
+This test ensures a br element ends the line it breaks rather than adding a line of its own.
+
+PASS: lineText(1) === 'Alpha'
+PASS: lineText(2) === 'Bravo'
+PASS: webArea.textMarkerRangeLength(lineRange(1)) === 5
+PASS: lineText(3) === 'Charlie'
+PASS: lineText(4) === 'Delta'
+PASS: lineText(5) === 'Echo'
+PASS: lineText(6) === ''
+PASS: webArea.lineIndexForTextMarker(markerInLine3) === 2
+PASS: lineText(webArea.lineIndexForTextMarker(markerInLine3) + 1) === 'Charlie'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="oneBreak">Alpha<br>Bravo</p>
+<p id="twoBreaks">Charlie<br>Delta<br>Echo</p>
+
+<script>
+var output = "This test ensures a br element ends the line it breaks rather than adding a line of its own.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    function lineRange(oneBasedLine)
+    {
+        return webArea.textMarkerRangeForLine(oneBasedLine);
+    }
+
+    function lineText(oneBasedLine)
+    {
+        return webArea.stringForTextMarkerRange(lineRange(oneBasedLine));
+    }
+
+    output += expect("lineText(1)", "'Alpha'");
+    output += expect("lineText(2)", "'Bravo'");
+    // The range ends before the break, so its length matches the text it yields.
+    output += expect("webArea.textMarkerRangeLength(lineRange(1))", "5");
+
+    // Each break ends a line, so these three lines follow the two above rather than being
+    // shifted by a line per break.
+    output += expect("lineText(3)", "'Charlie'");
+    output += expect("lineText(4)", "'Delta'");
+    output += expect("lineText(5)", "'Echo'");
+
+    // Nothing follows the last line.
+    output += expect("lineText(6)", "''");
+
+    // AXLineForTextMarker counts the same lines, so a marker taken out of line three's range reports
+    // the index that maps back to line three. This walks across the br-ended lines of the first
+    // paragraph, which must each be counted exactly once.
+    var markerInLine3 = webArea.nextTextMarker(webArea.startTextMarkerForTextMarkerRange(lineRange(3)));
+
+    output += expect("webArea.lineIndexForTextMarker(markerInLine3)", "2");
+    output += expect("lineText(webArea.lineIndexForTextMarker(markerInLine3) + 1)", "'Charlie'");
+
+    for (var paragraph of document.querySelectorAll("p"))
+        paragraph.style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated-expected.txt
+++ b/LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated-expected.txt
@@ -1,0 +1,16 @@
+This test ensures a br element ends the line it breaks rather than adding a line of its own.
+
+PASS: lineText(1) === 'Alpha'
+PASS: lineText(2) === 'Bravo'
+PASS: webArea.textMarkerRangeLength(lineRange(1)) === 5
+PASS: lineText(3) === 'Charlie'
+PASS: lineText(4) === 'Delta'
+PASS: lineText(5) === 'Echo'
+PASS: lineText(6) === ''
+PASS: webArea.lineIndexForTextMarker(markerInLine3) === 2
+PASS: lineText(webArea.lineIndexForTextMarker(markerInLine3) + 1) === 'Charlie'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated.html
+++ b/LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="oneBreak">Alpha<br>Bravo</p>
+<p id="twoBreaks">Charlie<br>Delta<br>Echo</p>
+
+<script>
+var output = "This test ensures a br element ends the line it breaks rather than adding a line of its own.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    function lineRange(oneBasedLine)
+    {
+        return webArea.textMarkerRangeForLine(oneBasedLine);
+    }
+
+    function lineText(oneBasedLine)
+    {
+        return webArea.stringForTextMarkerRange(lineRange(oneBasedLine));
+    }
+
+    output += expect("lineText(1)", "'Alpha'");
+    output += expect("lineText(2)", "'Bravo'");
+    // The range ends before the break, so its length matches the text it yields.
+    output += expect("webArea.textMarkerRangeLength(lineRange(1))", "5");
+
+    // Each break ends a line, so these three lines follow the two above rather than being
+    // shifted by a line per break.
+    output += expect("lineText(3)", "'Charlie'");
+    output += expect("lineText(4)", "'Delta'");
+    output += expect("lineText(5)", "'Echo'");
+
+    // Nothing follows the last line.
+    output += expect("lineText(6)", "''");
+
+    // AXLineForTextMarker counts the same lines, so a marker taken out of line three's range reports
+    // the index that maps back to line three. This walks across the br-ended lines of the first
+    // paragraph, which must each be counted exactly once.
+    var markerInLine3 = webArea.nextTextMarker(webArea.startTextMarkerForTextMarkerRange(lineRange(3)));
+
+    output += expect("webArea.lineIndexForTextMarker(markerInLine3)", "2");
+    output += expect("lineText(webArea.lineIndexForTextMarker(markerInLine3) + 1)", "'Charlie'");
+
+    for (var paragraph of document.querySelectorAll("p"))
+        paragraph.style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -796,9 +796,15 @@ int AXTextMarker::lineIndex() const
     while (currentLineID && currentLineID != targetLineID) {
         auto newMarker = currentMarker.nextLineEnd();
         auto newLineID = newMarker.lineID();
-        ++index;
+        // nextLineEnd can advance without reaching a new line, specifically when a <br> sits on the
+        // line it breaks and so carries that line's ID, making the position just past its newline
+        // another end of the line we came from. Count only a line we actually left, or every line
+        // after a <br> would report one too high, disagreeing with markerRangeForLineIndex.
+        bool reachedNewLine = currentLineID != newLineID;
+        if (reachedNewLine)
+            ++index;
 
-        if (currentLineID == newLineID && currentMarker == newMarker) {
+        if (!reachedNewLine && currentMarker.hasSameObjectAndOffset(newMarker)) {
             // nextLineEnd() returned its input, so break. The line walk would loop
             // forever otherwise, causing a hang. This indicates a bug elsewhere
             // (e.g. a sibling lineID collision the caller couldn't disambiguate).
@@ -879,7 +885,7 @@ static AXTextMarkerRange lineRangeWithout(const AXTextMarkerRange& lineRange, Op
 }
 
 // Advances |lineRange| to the following line: the range from the start of the next line through
-// its end. Returns an invalid range when there is no next line (nextLineEnd does not advance),
+// its end. Returns an invalid range when there is no next line (nextLineEnd reaches no new line),
 // which ends the line walks in characterRangeForLine, markerRangeForLineIndex, and
 // lineNumberForIndex. |includeTrailingLineBreak| and |stopAtID| select the caller's line semantics.
 static AXTextMarkerRange nextLineRange(const AXTextMarkerRange& lineRange, IncludeTrailingLineBreak includeTrailingLineBreak, std::optional<AXID> stopAtID)
@@ -888,6 +894,20 @@ static AXTextMarkerRange nextLineRange(const AXTextMarkerRange& lineRange, Inclu
     auto nextLineEndMarker = lineEnd.nextLineEnd(includeTrailingLineBreak, stopAtID);
     if (nextLineEndMarker == lineEnd)
         return { };
+
+    // A <br> carries the line ID of the line it breaks, so the position just past its newline is
+    // another end of the line we came from. That's what nextLineEnd returns here, matching the live
+    // tree. Keep going, or a <br>-ended line gets reported once without its trailing break, then again with it.
+    auto currentLineID = lineEnd.lineID();
+    while (currentLineID && currentLineID == nextLineEndMarker.lineID()) {
+        auto followingLineEndMarker = nextLineEndMarker.nextLineEnd(includeTrailingLineBreak, stopAtID);
+        if (followingLineEndMarker.hasSameObjectAndOffset(nextLineEndMarker)) {
+            // The walk can't leave this line, so there is no next line.
+            return { };
+        }
+        nextLineEndMarker = WTF::move(followingLineEndMarker);
+    }
+
     return { nextLineEndMarker.previousLineStart(stopAtID), WTF::move(nextLineEndMarker) };
 }
 


### PR DESCRIPTION
#### 61bc74179682cf9d197ea60c474513550869b52a
<pre>
AX: In isolated tree mode, AXStringForTextMarkerRange reports an unexpected extra newline for a br element
<a href="https://bugs.webkit.org/show_bug.cgi?id=322443">https://bugs.webkit.org/show_bug.cgi?id=322443</a>
<a href="https://rdar.apple.com/185725696">rdar://185725696</a>

Reviewed by Dominic Mazzoni.

AccessibilityRenderObject::textRuns gives a RenderLineBreak a &quot;\n&quot; run whose lineID is
(containingBlock, box-&gt;lineIndex()). This is the same lineID as the text before it, because a br
sits on the line it breaks. The position just past that newline is therefore another end of
the line the br ended, not the end of the line after it.

The line walk backing AXTextMarkerRangeForLine advanced with nextLineEnd and stopped only
once the marker didn&apos;t move at all, so it reported such a line twice: once without its
trailing break, then again with it. For &lt;p&gt;Alpha&lt;br&gt;Bravo&lt;/p&gt; that exposed three lines —
&quot;Alpha&quot;, &quot;Alpha\n&quot;, &quot;Bravo&quot; — where the live tree exposes two, shifting every later line
index by one.

Landing past the &lt;br&gt;&apos;s newline is nextLineEnd&apos;s correct, live-matching behavior, specified
by accessibility/mac/line-boundary-at-br.html, so this fixes the line enumeration built on
top of it rather than nextLineEnd itself. nextLineRange now keeps advancing while the line
end it finds still carries the line ID it started from.

AXLineForTextMarker counts lines with its own walk and had the same off-by-one, which would
have left the two attributes disagreeing about a &lt;br&gt;. Its fast path (same containing block,
subtract line indices) was already correct, so only a marker in a later block was affected.
It now counts a line only when the line ID changes.

* LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/line-ranges-at-br-not-duplicated.html: Added.
* LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated-expected.txt: Added.
* LayoutTests/accessibility/mac/line-ranges-at-br-not-duplicated.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
(WebCore::nextLineRange):

Canonical link: <a href="https://commits.webkit.org/320305@main">https://commits.webkit.org/320305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bfccbf05c173f96a9c62e208c476a0df3df0ce3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148622 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57958 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143880 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100009 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124292 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46375 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44580 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44164 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5700 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196461 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58597 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153118 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47645 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130898 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127335 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57104 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19179 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->