### PR TITLE
Revised Mixed Content rules to match LNA spec

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -763,7 +763,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         if (!parentFrame)
             return completionHandler(WTF::move(newRequest));
 
-        if (MixedContentChecker::shouldBlockRequest(*parentFrame, newRequest.url())) {
+        if (MixedContentChecker::shouldBlockRequest(*parentFrame, newRequest.url(), MixedContentChecker::IsUpgradable::No, newRequest.targetAddressSpace())) {
             cancelMainResourceLoad(protect(frameLoader())->cancelledError(newRequest));
             return completionHandler(WTF::move(newRequest));
         }

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -643,7 +643,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (!frame)
         return;
 
-    if (MixedContentChecker::shouldBlockRequest(*frame, requestURL))
+    if (MixedContentChecker::shouldBlockRequest(*frame, requestURL, MixedContentChecker::IsUpgradable::No, request.targetAddressSpace()))
         return;
 
     RefPtr<SharedBuffer> data;

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -33,10 +33,12 @@
 #include "ContentFilter.h"
 #include "DocumentQuirks.h"
 #include "FrameLoader.h"
+#include "IPAddressSpace.h"
 #include "LegacySchemeRegistry.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameLoaderClient.h"
 #include "SecurityOrigin.h"
+#include "Settings.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -92,7 +94,20 @@ static bool NODELETE destinationIsImageAndInitiatorIsImageset(FetchOptions::Dest
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }
 
-bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator)
+// Only fetch() stamps a declared target address space onto its request, so every other load type needs
+// one derived here.
+static IPAddressSpace effectiveTargetAddressSpace(const Frame& frame, const URL& url, IPAddressSpace declaredTargetAddressSpace)
+{
+    if (declaredTargetAddressSpace != IPAddressSpace::Public)
+        return declaredTargetAddressSpace;
+
+    if (!frame.settings().localNetworkAccessEnabled())
+        return declaredTargetAddressSpace;
+
+    return determineIPAddressSpace(url);
+}
+
+bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator, IPAddressSpace targetAddressSpace)
 {
     RefPtr document = frame.document();
     if (!document || isUpgradable != IsUpgradable::Yes)
@@ -105,15 +120,18 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
         return false;
 
     // 4.1 The request's URL is not upgraded in the following cases.
-    if (!canModifyRequest(url, destination, initiator))
+    if (!canModifyRequest(url, destination, initiator, effectiveTargetAddressSpace(frame, url, targetAddressSpace)))
         return false;
 
     frame.reportMixedContentViolation(false, url);
     return true;
 }
 
-bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator, IPAddressSpace targetAddressSpace)
 {
+    // Deliberately `!= Public` rather than `== Local`, since Loopback is strictly more private than Local.
+    if (targetAddressSpace != IPAddressSpace::Public)
+        return false;
     // 4.1.1 request’s URL is a potentially trustworthy URL.
     if (url.protocolIs("https"_s))
         return false;
@@ -137,7 +155,7 @@ static bool shouldAllowConnectionWithPotentiallyInsecureProtocol(Frame& frame, c
     return (LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == MixedContentChecker::IsUpgradable::Yes;
 }
 
-bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpgradable isUpgradable)
+bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpgradable isUpgradable, IPAddressSpace targetAddressSpace)
 {
 #if ENABLE(CONTENT_FILTERING) && HAVE(WEBCONTENTRESTRICTIONS)
     if (url == ContentFilter::blockedPageURL())
@@ -147,6 +165,8 @@ bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpg
     if (!isMixedContent(frame, url))
         return false;
     if (shouldAllowConnectionWithPotentiallyInsecureProtocol(frame, url, isUpgradable))
+        return false;
+    if (effectiveTargetAddressSpace(frame, url, targetAddressSpace) != IPAddressSpace::Public)
         return false;
     frame.reportMixedContentViolation(true, url);
     return true;

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <WebCore/FetchOptions.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/ResourceLoaderOptions.h>
 
 namespace WTF {
@@ -47,11 +48,11 @@ namespace MixedContentChecker {
 
 enum class IsUpgradable : bool { No, Yes, };
 
-bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator);
+bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator, IPAddressSpace targetAddressSpace = IPAddressSpace::Public);
 
-bool shouldBlockRequest(Frame&, const URL&, IsUpgradable = IsUpgradable::No);
+bool shouldBlockRequest(Frame&, const URL&, IsUpgradable = IsUpgradable::No, IPAddressSpace targetAddressSpace = IPAddressSpace::Public);
 
-WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator);
+WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator, IPAddressSpace targetAddressSpace = IPAddressSpace::Public);
 
 WEBCORE_EXPORT String mixedContentViolationMessage(bool shouldUpgradeLocalhostAndIPAddressInMixedContent, bool blocked, const URL& current, const URL& target);
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -276,11 +276,11 @@ ResourceErrorOr<RefPtr<CachedImage>> CachedResourceLoader::requestImage(CachedRe
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             bool isRequestUpgradable { false };
             if (RefPtr document = frame->document()) {
-                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator);
+                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator, request.resourceRequest().targetAddressSpace());
                 request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
             }
             URL requestURL = request.resourceRequest().url();
-            if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload()))
+            if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload(), request.resourceRequest().targetAddressSpace()))
                 PingLoader::loadImage(*frame, WTF::move(requestURL));
             return { nullptr };
         }
@@ -462,7 +462,7 @@ static MixedContentChecker::IsUpgradable NODELETE isUpgradableTypeFromResourceTy
     return MixedContentChecker::IsUpgradable::No;
 }
 
-bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const URL& url, MixedContentChecker::IsUpgradable isRequestUpgradable) const
+bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const URL& url, MixedContentChecker::IsUpgradable isRequestUpgradable, IPAddressSpace targetAddressSpace) const
 {
     if (!canRequestInContentDispositionAttachmentSandbox(type, url))
         return false;
@@ -492,7 +492,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
     case CachedResource::Type::Ping:
     case CachedResource::Type::FontResource: {
         if (RefPtr frame = this->frame()) {
-            if (MixedContentChecker::shouldBlockRequest(*frame, url, isRequestUpgradable))
+            if (MixedContentChecker::shouldBlockRequest(*frame, url, isRequestUpgradable, targetAddressSpace))
                 return false;
         }
         break;
@@ -606,7 +606,7 @@ static inline bool isSameOriginDataURL(const URL& url, const ResourceLoaderOptio
 }
 
 // Security checks defined in https://fetch.spec.whatwg.org/#main-fetch.
-bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, ForPreload forPreload, MixedContentChecker::IsUpgradable isRequestUpgradable, bool isLinkPreload)
+bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, ForPreload forPreload, MixedContentChecker::IsUpgradable isRequestUpgradable, bool isLinkPreload, IPAddressSpace targetAddressSpace)
 {
     if (RefPtr document = m_document) {
         if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
@@ -656,14 +656,14 @@ bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url,
     // They'll still get a warning in the console about CSP blocking the load.
 
     // FIXME: Should we consider whether the request is for preload here?
-    if (!checkInsecureContent(type, url, isRequestUpgradable))
+    if (!checkInsecureContent(type, url, isRequestUpgradable, targetAddressSpace))
         return false;
 
     return true;
 }
 
 // FIXME: Should we find a way to know whether the redirection is for a preload request like we do for CachedResourceLoader::canRequest?
-bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, const URL& preRedirectURL) const
+bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, const URL& preRedirectURL, IPAddressSpace targetAddressSpace) const
 {
     if (RefPtr document = m_document) {
         if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
@@ -696,7 +696,7 @@ bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type,
 
     // Last of all, check for insecure content. We do this last so that when folks block insecure content with a CSP policy, they don't get a warning.
     // They'll still get a warning in the console about CSP blocking the load.
-    if (!checkInsecureContent(type, url, MixedContentChecker::IsUpgradable::No)) {
+    if (!checkInsecureContent(type, url, MixedContentChecker::IsUpgradable::No, targetAddressSpace)) {
         CACHEDRESOURCELOADER_RELEASE_LOG("canRequestAfterRedirection: URL was not allowed because content is insecure");
         return false;
     }
@@ -825,7 +825,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         return true;
 
     if (RefPtr document = m_documentLoader->cachedResourceLoader().document()) {
-        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(Ref { *document->frame() }, isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator) : false;
+        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(Ref { *document->frame() }, isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator, request.targetAddressSpace()) : false;
         upgradeInsecureResourceRequestIfNeeded(request, *document, alwaysUpgradeMixedContent ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     }
 
@@ -864,7 +864,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         }
     }
 
-    return canRequestAfterRedirection(type, request.url(), options, preRedirectURL);
+    return canRequestAfterRedirection(type, request.url(), options, preRedirectURL, request.targetAddressSpace());
 }
 
 bool CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox(CachedResource::Type type, const URL& url) const
@@ -1237,7 +1237,7 @@ ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(Cache
     bool isRequestUpgradable { false };
     RefPtr document = m_document;
     if (document) {
-        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
+        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator, request.resourceRequest().targetAddressSpace());
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
         url = request.resourceRequest().url();
     }
@@ -1253,7 +1253,7 @@ ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(Cache
     }
 
     // We are passing url as well as request, as request url may contain a fragment identifier.
-    if (!canRequest(type, url, request.options(), forPreload, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload())) {
+    if (!canRequest(type, url, request.options(), forPreload, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload(), request.resourceRequest().targetAddressSpace())) {
         CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Not allowed to request resource", frame.get());
         return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Not allowed to request resource"_s, ResourceError::Type::AccessControl });
     }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -194,7 +194,7 @@ private:
     void prepareFetch(CachedResource::Type, CachedResourceRequest&);
     void updateHTTPRequestHeaders(FrameLoader&, CachedResource::Type, CachedResourceRequest&);
 
-    bool canRequest(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ForPreload, MixedContentChecker::IsUpgradable, bool isLinkPreload);
+    bool canRequest(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ForPreload, MixedContentChecker::IsUpgradable, bool isLinkPreload, IPAddressSpace targetAddressSpace);
 
     enum RevalidationPolicy { Use, Revalidate, Reload, Load };
     RevalidationPolicy determineRevalidationPolicy(CachedResource::Type, CachedResourceRequest&, CachedResource* existingResource, ForPreload, ImageLoading) const;
@@ -203,14 +203,14 @@ private:
     Ref<CachedResource> updateCachedResourceWithCurrentRequest(const CachedResource&, CachedResourceRequest&&, PAL::SessionID, const CookieJar&, const Settings&);
 
     bool shouldContinueAfterNotifyingLoadedFromMemoryCache(const CachedResourceRequest&, CachedResource&, ResourceError&);
-    bool checkInsecureContent(CachedResource::Type, const URL&, MixedContentChecker::IsUpgradable) const;
+    bool checkInsecureContent(CachedResource::Type, const URL&, MixedContentChecker::IsUpgradable, IPAddressSpace targetAddressSpace) const;
 
     void performPostLoadActions();
 
     ImageLoading NODELETE clientDefersImage(const URL&) const;
     void reloadImagesIfNotDeferred();
 
-    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;
+    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL, IPAddressSpace targetAddressSpace) const;
     bool canRequestInContentDispositionAttachmentSandbox(CachedResource::Type, const URL&) const;
     bool isNoCorsCrossOriginRequestToURLSchemeHandler(CachedResource::Type, const URL&, const ResourceLoaderOptions&) const;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/MixedContentChecker.h>
 
@@ -115,6 +116,78 @@ TEST(MixedContentChecker, CanModifyRequest)
         URL { "custom2://example.com/cat.jpg"_s },
         destination,
         Initiator::Imageset
+    ));
+}
+
+TEST(MixedContentChecker, CanModifyRequestLocalNetworkAccessExemption)
+{
+    URL url { "http://example.com/cat.jpg"_s };
+    FetchOptions::Destination destination = FetchOptions::Destination::Image;
+    Initiator initiator = Initiator::EmptyString;
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        initiator,
+        IPAddressSpace::Local
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        initiator,
+        IPAddressSpace::Loopback
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "http://192.0.1.36"_s },
+        destination,
+        initiator,
+        IPAddressSpace::Local
+    ));
+
+    // Explicit IPAddressSpace::Public should behave identically to omitting the parameter.
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        initiator,
+        IPAddressSpace::Public
+    ));
+
+    // 4.1.2's IP-address rule carries an exception for potentially trustworthy hosts, so a loopback URL
+    // is the one local address that is modifiable while its declared space still reads as public. Naming
+    // the space it is really in is what makes Local Network Access exempt it, and this pair is the whole
+    // behaviour change: same URL, opposite answer.
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        URL { "http://127.0.0.1"_s },
+        destination,
+        initiator,
+        IPAddressSpace::Public
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "http://127.0.0.1"_s },
+        destination,
+        initiator,
+        IPAddressSpace::Loopback
+    ));
+
+    // The case the exemption exists for. 4.1.2 only rejects IP *literals*, so a name that resolves into
+    // the local network reaches the end of the checks and gets upgraded, unlike 192.0.1.36 above. A
+    // ".local" name is Local per determineIPAddressSpace, so declaring it is the only thing that stops
+    // the upgrade -- nothing else in mixed content would have.
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        URL { "http://printer.local/cat.jpg"_s },
+        destination,
+        initiator,
+        IPAddressSpace::Public
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "http://printer.local/cat.jpg"_s },
+        destination,
+        initiator,
+        IPAddressSpace::Local
     ));
 }
 


### PR DESCRIPTION
#### 66d43bea8153d9b8fd36876a06fcf2bd15e6f902
<pre>
Revised Mixed Content rules to match LNA spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=297739">https://bugs.webkit.org/show_bug.cgi?id=297739</a>
<a href="https://rdar.apple.com/154439054">rdar://154439054</a>

Reviewed by Brent Fulgham.

Feature work for Local Network Access (<a href="https://wicg.github.io/local-network-access/).">https://wicg.github.io/local-network-access/).</a>
Section 3.2 (<a href="https://wicg.github.io/local-network-access/#integration-with-mixed-content)">https://wicg.github.io/local-network-access/#integration-with-mixed-content)</a>
amends both mixed-content algorithms so a request whose target IP address space is local is
neither upgraded nor blocked. Without it an https page can never reach a local device over
http, and the Local Network Access permission never gets the chance to decide.

Only fetch() sets a target address space on its request, so MixedContentChecker derives one
from the URL for every other load, and CachedResourceLoader and DocumentThreadableLoader thread
the request&apos;s declared value through to it. Deriving from the URL covers IP literals and .local
names; a hostname that resolves to a private address still reads as public and stays blocked,
since no peer address exists this early in the load. The derivation is gated on the
LocalNetworkAccess setting, so with the feature off nothing escapes an upgrade or block that did
not already.

This exempts loopback as well as local, where the spec exempts only local. Section 3.1.1
leaves loopback out on the grounds that a loopback URL is already potentially trustworthy and
so never reaches these checks; exempting it explicitly means the rule does not depend on that
holding.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::effectiveTargetAddressSpace):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
(WebCore::MixedContentChecker::shouldBlockRequest):
* Source/WebCore/loader/MixedContentChecker.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestImage):
(WebCore::CachedResourceLoader::checkInsecureContent const):
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp:

Canonical link: <a href="https://commits.webkit.org/320538@main">https://commits.webkit.org/320538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a860bd35db3f1d5f94a923a4523096980989320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195365 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58676 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48269 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46996 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44757 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6417 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58616 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41270 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59326 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153740 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48248 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131616 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128258 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57816 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->