### PR TITLE
Seed a document's own IP address space

### DIFF
--- a/LayoutTests/http/wpt/fetch/local-network-access/document-address-space-expected.txt
+++ b/LayoutTests/http/wpt/fetch/local-network-access/document-address-space-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS a document served over loopback knows it is loopback
+PASS an about:blank document inherits its initiator address space
+PASS a blob: document inherits the address space of the environment that created it
+PASS a srcdoc document inherits its parent address space
+

--- a/LayoutTests/http/wpt/fetch/local-network-access/document-address-space.html
+++ b/LayoutTests/http/wpt/fetch/local-network-access/document-address-space.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+test(() => {
+    assert_true(!!window.internals, 'test requires internals');
+    assert_equals(internals.documentIPAddressSpace(), 'loopback');
+}, 'a document served over loopback knows it is loopback');
+
+test(() => {
+    assert_true(!!window.internals, 'test requires internals');
+    const frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+
+    assert_equals(frame.contentWindow.internals.documentIPAddressSpace(), 'loopback');
+}, 'an about:blank document inherits its initiator address space');
+
+promise_test(async (t) => {
+    assert_true(!!window.internals, 'test requires internals');
+    const reported = new Promise((resolve) => {
+        window.addEventListener('message', (event) => resolve(event.data), { once: true });
+        t.step_timeout(() => resolve('no reply'), 4000);
+    });
+
+    const blobURL = URL.createObjectURL(new Blob(
+        ['<script>parent.postMessage(internals.documentIPAddressSpace(), "*")<\/script>'],
+        { type: 'text/html' }));
+    t.add_cleanup(() => URL.revokeObjectURL(blobURL));
+
+    const frame = document.createElement('iframe');
+    frame.src = blobURL;
+    document.body.appendChild(frame);
+
+    assert_equals(await reported, 'loopback');
+}, 'a blob: document inherits the address space of the environment that created it');
+
+promise_test(async (t) => {
+    assert_true(!!window.internals, 'test requires internals');
+    const reported = new Promise((resolve) => {
+        window.addEventListener('message', (event) => resolve(event.data), { once: true });
+        t.step_timeout(() => resolve('no reply'), 4000);
+    });
+
+    const frame = document.createElement('iframe');
+    frame.srcdoc = '<script>parent.postMessage(internals.documentIPAddressSpace(), "*")<\/script>';
+    document.body.appendChild(frame);
+
+    assert_equals(await reported, 'loopback');
+}, 'a srcdoc document inherits its parent address space');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1025,6 +1025,13 @@ void DocumentLoader::responseReceived(ResourceResponse&& response, CompletionHan
 
     m_response = WTF::move(response);
 
+    // blob: is a local scheme, so HTML's "determine navigation params policy container" takes the
+    // initiator's address space for it rather than the response's.
+    if (m_response.url().protocolIsBlob()) {
+        if (auto& requester = triggeringAction().requester())
+            m_response.setIPAddressSpace(requester->policyContainer.ipAddressSpace);
+    }
+
     if (m_identifierForLoadWithoutResourceLoader) {
         RefPtr frameLoader = this->frameLoader();
         if (m_mainResource && m_mainResource->wasRedirected()) {

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -215,6 +215,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         document->setCookieURL(ownerDocument->cookieURL());
         document->setSecurityOriginPolicy(ownerDocument->securityOriginPolicy());
         document->setCrossOriginEmbedderPolicy(ownerDocument->crossOriginEmbedderPolicy());
+        document->setIPAddressSpace(ownerDocument->ipAddressSpace());
 
         document->setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { url }, document));
         CheckedRef contentSecurityPolicy = *document->contentSecurityPolicy();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -885,6 +885,9 @@ void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow
         if (document->url().protocolIsInHTTPFamily() || document->url().protocolIsBlob()) {
             document->setCrossOriginEmbedderPolicy(obtainCrossOriginEmbedderPolicy(documentLoader->response(), document.ptr()));
 
+            if (auto ipAddressSpace = documentLoader->response().ipAddressSpace(); ipAddressSpace != IPAddressSpace::Unknown)
+                document->setIPAddressSpace(ipAddressSpace);
+
             if (frame->settings().originAgentClusterEnabled() && !m_stateMachine.creatingInitialEmptyDocument())
                 document->setIsOriginKeyed(documentLoader->isOriginKeyedFromUIProcess());
         }

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -24,9 +24,11 @@
 
 #include "ResourceResponse.h"
 
+#include "DNS.h"
 #include "GUniquePtrSoup.h"
 #include "HTTPHeaderNames.h"
 #include "HTTPParsers.h"
+#include "IPAddressSpace.h"
 #include "MIMETypeRegistry.h"
 #include "URLSoup.h"
 #include <unicode/uset.h>
@@ -34,6 +36,20 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+static IPAddressSpace resolvedIPAddressSpace(SoupMessage* soupMessage)
+{
+    auto* address = soup_message_get_remote_address(soupMessage);
+    if (!G_IS_INET_SOCKET_ADDRESS(address))
+        return IPAddressSpace::Unknown;
+
+    GUniquePtr<char> ipAddress(g_inet_address_to_string(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(address))));
+    auto resolvedIPAddress = IPAddress::fromString(String::fromUTF8(ipAddress.get()));
+    if (!resolvedIPAddress)
+        return IPAddressSpace::Unknown;
+
+    return classifyIPAddressSpace(*resolvedIPAddress);
+}
 
 ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& sniffedContentType)
 {
@@ -72,6 +88,8 @@ ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& snif
     setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
 
     setExpectedContentLength(soup_message_headers_get_content_length(responseHeaders));
+
+    setIPAddressSpace(resolvedIPAddressSpace(soupMessage));
 }
 
 void ResourceResponse::updateSoupMessageHeaders(SoupMessageHeaders* soupHeaders) const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -132,6 +132,7 @@
 #include "HitTestResult.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "IPAddressSpace.h"
 #include "ImageData.h"
 #include "ImageOverlay.h"
 #include "ImageOverlayController.h"
@@ -6353,6 +6354,26 @@ String Internals::createTemporaryFile(const String& name, const String& contents
 
     file.write(byteCast<uint8_t>(contents.utf8().span()));
     return path;
+}
+
+String Internals::documentIPAddressSpace() const
+{
+    RefPtr document = contextDocument();
+    if (!document)
+        return "unknown"_s;
+
+    switch (document->ipAddressSpace()) {
+    case IPAddressSpace::Public:
+        return "public"_s;
+    case IPAddressSpace::Local:
+        return "local"_s;
+    case IPAddressSpace::Loopback:
+        return "loopback"_s;
+    case IPAddressSpace::Unknown:
+        return "unknown"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return "unknown"_s;
 }
 
 void Internals::queueMicroTask(int testNumber)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -156,6 +156,7 @@ class XMLHttpRequest;
 struct VideoConfiguration;
 
 enum class DocumentMarkerType : uint32_t;
+enum class IPAddressSpace : uint8_t;
 
 #if ENABLE(ENCRYPTED_MEDIA)
 class MediaKeys;
@@ -1005,6 +1006,8 @@ public:
     RefPtr<File> createFile(const String&);
     void asyncCreateFile(const String&, DOMPromiseDeferred<IDLInterface<File>>&&);
     String createTemporaryFile(const String& name, const String& contents);
+
+    String documentIPAddressSpace() const;
 
     void queueMicroTask(int);
     bool testPreloaderSettingViewport();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1189,6 +1189,8 @@ enum ContentsFormat {
     Promise<File> asyncCreateFile(DOMString url);
     DOMString createTemporaryFile(DOMString name, DOMString contents);
 
+    DOMString documentIPAddressSpace();
+
     undefined queueMicroTask(long testNumber);
     boolean testPreloaderSettingViewport();
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3536,6 +3536,7 @@ struct WebCore::PolicyContainer {
     WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     WebCore::CrossOriginOpenerPolicy crossOriginOpenerPolicy;
     WebCore::ReferrerPolicy referrerPolicy;
+    WebCore::IPAddressSpace ipAddressSpace;
 };
 
 [Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool


### PR DESCRIPTION
#### 1b00bc4536dcc4869b04349e2aff2bd77d28041a
<pre>
Seed a document&apos;s own IP address space
<a href="https://bugs.webkit.org/show_bug.cgi?id=323138">https://bugs.webkit.org/show_bug.cgi?id=323138</a>
<a href="https://rdar.apple.com/186398120">rdar://186398120</a>

Reviewed by Youenn Fablet.

Feature work for Local Network Access (<a href="https://wicg.github.io/local-network-access/).">https://wicg.github.io/local-network-access/).</a>

Every publicness comparison the feature makes is against the requesting document&apos;s own address
space, and nothing set it: PolicyContainer::ipAddressSpace existed but was never assigned, so every
document read the default of Public. This seeds it from the response in
FrameLoader::didBeginDocument and copies it on the javascript:/about: path in
DocumentWriter::begin. It was also missing from the struct&apos;s serialization entry, so it never
crossed IPC and subframes read Public whatever the parent had; padding absorbed the field, so the
generated size assertion could not catch that.

A blob: URL is a local scheme, so HTML&apos;s &quot;determine navigation params policy container&quot; takes the
initiator&apos;s policy container for it rather than building one from the response. That is applied in
DocumentLoader::responseReceived, where the response is committed, so
documentLoader-&gt;response().ipAddressSpace() answers correctly for every reader instead of each one
needing to special-case blob. With no initiator the response keeps its undetermined space and the
document keeps the Public default.

NetworkDataTaskSoup had no address space at all, so a GTK or WPE document had nothing to be seeded
from. It is derived in the ResourceResponse constructor that already takes the SoupMessage, next to
the TLS certificate and status it reads from the same message, so it is set once for every soup
response rather than by the caller. The curl ports still have no classifier, so on Windows the space
stays undetermined exactly as it does today.

internals.documentIPAddressSpace() is added because the value is otherwise invisible from a page.
It returns a string so that &quot;unknown&quot; is expressible, which the IDL enum has no member for.

* LayoutTests/http/wpt/fetch/local-network-access/document-address-space-expected.txt: Added.
* LayoutTests/http/wpt/fetch/local-network-access/document-address-space.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::resolvedIPAddressSpace):
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::documentIPAddressSpace const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/320955@main">https://commits.webkit.org/320955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509485adaafc77b55c5d42068a63c78572e02edb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60292 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196688 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49324 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125992 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/48052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7763 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59946 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60658 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154861 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49282 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59079 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58485 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->