### PR TITLE
git-webkit conflict fails to derive the correct conflict PR branch wh…

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
@@ -20,11 +20,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import re
 import sys
 
 from webkitbugspy import Tracker, radar
 from .command import Command
-from .. import local
+from .review import Review
+from .. import local, log, remote
 from ..commit import Commit
 
 
@@ -32,6 +34,11 @@ class Conflict(Command):
     name = 'conflict'
     help = "Given the representative Radar ID of a conflicting merge, checkout the branch with conflict markers in place."
     INTEGRATION_BRANCH_PREFIX = 'integration'
+    PR_URL_KV_KEY = 'scm-integrate:pr_url'
+    COMMENT_PR_URL_RES = [
+        re.compile(r'(?P<url>https?://\S+/projects/\S+/repos/\S+)/pull-requests/(?P<number>\d+)'),
+        re.compile(r'(?P<url>https?://github\.\S+/\S+)/pull/(?P<number>\d+)'),
+    ]
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -42,38 +49,119 @@ class Conflict(Command):
         )
 
     @classmethod
-    def find_conflict_pr(cls, remote, radar_id):
+    def find_conflict_pr_via_kv(cls, radar_obj):
         """
-        Because we don't know what the target branch was just given the radar id,
-        we need to search for PRs with branches that start with the integration prefix
-        and have the first and last sha.
-        """
-        radar_obj = Tracker.from_string(f'rdar://{radar_id}')
-        assert radar_obj, 'Could not fetch radar object for id {}'.format(radar_id)
-        shas = []
+        The merge automation writes the conflict PR's URL directly onto the radar's key-value
+        store (the 'scm-integrate:pr_url' key) when it opens a conflict PR. Read that instead of
+        guessing the PR's branch name from source-change shas, since branch names can't be
+        prefix-searched through the GitHub or Bitbucket APIs.
 
-        repo_name = remote.name if '/' not in remote.name else remote.name.split('/', 1)[-1]
+        Returns the matching PullRequest, or None if no key-value/link was found.
+        """
+        library = getattr(radar_obj.tracker, 'library', None)
+        client = getattr(radar_obj.tracker, 'client', None)
+        if not library or not client:
+            log.debug('{}: tracker has no Radar client available, skipping key-value lookup'.format(radar_obj))
+            return None
+
+        try:
+            pair = client.key_values_for_radar_id(radar_obj.id).key_value_pair_for_key(cls.PR_URL_KV_KEY)
+        except library.exceptions.KeyValuePairNotFoundException:
+            log.debug('{}: no {} key-value set'.format(radar_obj, cls.PR_URL_KV_KEY))
+            return None
+
+        if not pair or not pair.value:
+            log.debug('{}: {} key-value is empty'.format(radar_obj, cls.PR_URL_KV_KEY))
+            return None
+
+        number, rmt = Review.args_for_url(pair.value)
+        if not number or not rmt:
+            log.debug("{}: {} value '{}' isn't a recognized pull-request URL".format(radar_obj, cls.PR_URL_KV_KEY, pair.value))
+            return None
+
+        pr = rmt.pull_requests.get(number)
+        if not pr:
+            log.debug("{}: PR #{} not found on {}".format(radar_obj, number, rmt))
+        return pr
+
+    @classmethod
+    def find_conflict_pr_via_comments(cls, radar_obj):
+        """
+        Fallback used when the key-value lookup doesn't resolve a PR (e.g. the key-value was
+        never written, or points at a since-deleted/invalid PR). Scans the radar's own comments,
+        most recent first, for a pull-request link. A link is only trusted if the PR it points to
+        actually references this radar (by rdar:// in its title or body) -- a PR link mentioned in
+        an unrelated comment shouldn't be picked up.
+
+        Returns the matching PullRequest, or None if nothing was found.
+        """
+        radar_ref = re.compile(r'rdar://(?:problem/)?{}\b'.format(re.escape(str(radar_obj.id))))
+        comments = sorted(radar_obj.comments or [], key=lambda comment: comment.timestamp or 0, reverse=True)
+
+        for comment in comments:
+            for candidate in cls.COMMENT_PR_URL_RES:
+                match = candidate.search(comment.content or '')
+                if not match:
+                    continue
+                try:
+                    rmt = remote.Scm.from_url(match.group('url'))
+                except OSError as e:
+                    log.debug("{}: couldn't resolve '{}' to a known SCM server: {}".format(radar_obj, match.group('url'), e))
+                    continue
+                pr = rmt.pull_requests.get(match.group('number'))
+                if not pr:
+                    log.debug("{}: PR #{} not found on {}".format(radar_obj, match.group('number'), match.group('url')))
+                    continue
+                if not radar_ref.search('{} {}'.format(pr.title or '', pr.body or '')):
+                    log.debug("{}: {} doesn't reference this radar, skipping".format(radar_obj, pr))
+                    continue
+                return pr
+
+        log.debug('{}: no comment referenced a pull-request that references this radar'.format(radar_obj))
+        return None
+
+    @classmethod
+    def find_conflict_pr_via_branch_guess(cls, remote_obj, radar_obj):
+        """
+        Fallback used when the key-value lookup doesn't resolve a PR (e.g. an older radar
+        the automation never wrote a key-value on). Guesses the conflict/CI branch name from
+        the radar's source-change shas and searches the given remote for a matching open PR.
+
+        Automation applies source changes in order and stops at the first one that conflicts,
+        so with changes [1, 2, 3] where 2 conflicts, the real branch spans {1}_{2}, not {1}_{3}.
+        Try every {shas[0]}_{sha} prefix rather than just {shas[0]}_{shas[-1]}.
+
+        Returns the matching PullRequest, or None if nothing was found.
+        """
+        shas = []
+        repo_name = remote_obj.name if '/' not in remote_obj.name else remote_obj.name.split('/', 1)[-1]
         for entry in radar_obj.source_changes:
             repo, action, sha = entry.split(', ')
             if repo.lower() == repo_name.lower():
                 shas.append(sha)
 
         if not shas:
-            print(f'No source changes for {repo_name} found in {radar_obj}', file=sys.stderr)
+            log.debug('{}: no source changes for {} found in {}'.format(radar_obj, repo_name, remote_obj))
             return None
 
-        integration_branches = []
-        for prefix in ('ci', 'conflict'):
-            integration_branches.append("{}/{}/{}_{}".format(cls.INTEGRATION_BRANCH_PREFIX, prefix, shas[0][:Commit.HASH_LABEL_SIZE], shas[-1][:Commit.HASH_LABEL_SIZE]))
+        integration_branches = [
+            '{}/{}/{}_{}'.format(cls.INTEGRATION_BRANCH_PREFIX, prefix, shas[0][:Commit.HASH_LABEL_SIZE], sha[:Commit.HASH_LABEL_SIZE])
+            for prefix in ('ci', 'conflict')
+            for sha in shas
+        ]
+        log.debug('{}: searching {} for branches matching {}'.format(radar_obj, remote_obj, integration_branches))
 
-        for pr in cls.get_open_integration_prs(remote):
+        found_any_open_pr = False
+        for pr in remote_obj.pull_requests.find(head=cls.INTEGRATION_BRANCH_PREFIX, opened=True):
+            found_any_open_pr = True
             for branch in integration_branches:
                 if pr.head.startswith(branch):
                     return pr
-
-    @classmethod
-    def get_open_integration_prs(cls, remote):
-        return remote.pull_requests.find(head=cls.INTEGRATION_BRANCH_PREFIX, opened=True)
+        if not found_any_open_pr:
+            log.debug('{}: no open integration PRs found on {}'.format(radar_obj, remote_obj))
+        else:
+            log.debug('{}: open integration PRs on {} did not match {}'.format(radar_obj, remote_obj, integration_branches))
+        return None
 
     @classmethod
     def main(cls, args, repository, **kwargs):
@@ -87,23 +175,28 @@ class Conflict(Command):
         # This is to remove any extra inputs like rdar://problem/
         radar_id = ''.join(i for i in args.radar if i.isdigit())
         radar_obj = Tracker.from_string(f'rdar://{radar_id}')
-        expected_branch = 'integration/conflict/{}'.format(radar_obj.id)
-        conflict_pr = None
-        source_remote = None
-        for source_remote in repository.source_remotes():
-            rmt = repository.remote(name=source_remote)
-            conflict_pr = cls.find_conflict_pr(rmt, radar_obj.id)
-            if conflict_pr:
-                break
+        conflict_pr = cls.find_conflict_pr_via_kv(radar_obj)
 
         if not conflict_pr:
-            sys.stderr.write('No conflict pull request found with branch {}\n'.format(expected_branch))
+            log.debug('rdar://{}: key-value lookup found nothing, checking comments for a pull-request link'.format(radar_id))
+            conflict_pr = cls.find_conflict_pr_via_comments(radar_obj)
+
+        if not conflict_pr:
+            log.debug('rdar://{}: no pull-request link in comments, falling back to branch-guessing per local remote'.format(radar_id))
+            for source_remote in repository.source_remotes():
+                conflict_pr = cls.find_conflict_pr_via_branch_guess(repository.remote(name=source_remote), radar_obj)
+                if conflict_pr:
+                    break
+
+        if not conflict_pr:
+            sys.stderr.write('No conflict pull request found via the {} key-value, radar comments, or branch-guessing on rdar://{}\n'.format(cls.PR_URL_KV_KEY, radar_id))
             return 1
 
         full_branch = '{}:{}'.format(conflict_pr._metadata['full_name'], conflict_pr.head)
         print('Found conflict branch {}'.format(full_branch))
         checkout_response = repository.checkout(full_branch)
 
+        source_remote = repository.remote_for(conflict_pr.base) or repository.default_remote
         msg = "\n\n-------------------------------------------------------"
         msg += "\nYou are now checked out into the conflict branch.\n"
         msg += "Conflict markers are present in files.\n"

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
@@ -24,11 +24,16 @@ import os
 import time
 from unittest.mock import Mock, patch
 
-from webkitbugspy import mocks as bmocks
+from webkitbugspy import Issue, mocks as bmocks
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
 
 from webkitscmpy import Commit, Contributor, local, mocks, program
+from webkitscmpy.program.conflict import Conflict
+
+
+class KeyValuePairNotFoundException(Exception):
+    pass
 
 
 class TestConflict(testing.PathTestCase):
@@ -48,26 +53,84 @@ class TestConflict(testing.PathTestCase):
 
         self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
 
-    def _mock_radar_response(self, *args, **kwargs):
-        rdar = bmocks.Radar()
-        rdar.sourceChanges = 'WebKit, merge, sha123'
-        rdar.source_changes = rdar.sourceChanges.splitlines()
-        rdar.id = 1234
-        return rdar
+    @staticmethod
+    def _mock_radar_response(pr_url=None, comments=None):
+        def callback(*args, **kwargs):
+            rdar = bmocks.Radar()
+            rdar.sourceChanges = 'WebKit, merge, sha123'
+            rdar.source_changes = rdar.sourceChanges.splitlines()
+            rdar.id = 1234
+            rdar.comments = comments or []
+
+            library = Mock()
+            library.exceptions.KeyValuePairNotFoundException = KeyValuePairNotFoundException
+
+            client = Mock()
+            if pr_url:
+                client.key_values_for_radar_id.return_value.key_value_pair_for_key.return_value = Mock(value=pr_url)
+            else:
+                client.key_values_for_radar_id.return_value.key_value_pair_for_key.side_effect = KeyValuePairNotFoundException()
+
+            rdar.tracker = Mock(library=library, client=client)
+            return rdar
+        return callback
 
     def test_conflict_not_found(self):
         with (
             OutputCapture() as captured,
             mocks.remote.GitHub() as remote,
             mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)),
-            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response)
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response())
         ):
             self.assertEqual(1, program.main(
                 args=('conflict', '1234'),
                 path=self.path,
             ))
 
-            self.assertEqual(captured.stderr.getvalue(), 'No conflict pull request found with branch integration/conflict/1234\n')
+            self.assertEqual(captured.stderr.getvalue(), 'No conflict pull request found via the scm-integrate:pr_url key-value, radar comments, or branch-guessing on rdar://1234\n')
+
+    def test_conflict_via_comments_validates_radar_reference(self):
+        radar_obj = Mock(id=1234)
+        with mocks.remote.GitHub() as remote:
+            remote.pull_requests = [
+                dict(
+                    number=1, state='open', title='Unrelated change', user=dict(login='tcontributor'),
+                    body='No radar reference here.',
+                    head=dict(ref='eng/unrelated', repo=dict(full_name='tcontributor')),
+                    base=dict(ref='main'), requested_reviews=[], reviews=[], draft=False,
+                ),
+                dict(
+                    number=2, state='open', title='Cherry-pick(s)', user=dict(login='tcontributor'),
+                    body='Cherry-pick(s). rdar://1234',
+                    head=dict(ref='integration/conflict/sha_sha', repo=dict(full_name='tcontributor')),
+                    base=dict(ref='main'), requested_reviews=[], reviews=[], draft=False,
+                ),
+            ]
+            radar_obj.comments = [
+                # Most recent comment links an unrelated PR - should be checked first and rejected.
+                Issue.Comment(user=None, timestamp=200, content='See also https://{}/pull/1'.format(remote.remote)),
+                # Older comment links the real conflict PR, which references this radar.
+                Issue.Comment(user=None, timestamp=100, content='Conflict PR: https://{}/pull/2'.format(remote.remote)),
+            ]
+
+            pr = Conflict.find_conflict_pr_via_comments(radar_obj)
+            self.assertIsNotNone(pr)
+            self.assertEqual(pr.number, 2)
+
+    def test_conflict_via_comments_no_matching_pr(self):
+        radar_obj = Mock(id=1234)
+        with mocks.remote.GitHub() as remote:
+            remote.pull_requests = [dict(
+                number=1, state='open', title='Unrelated change', user=dict(login='tcontributor'),
+                body='No radar reference here.',
+                head=dict(ref='eng/unrelated', repo=dict(full_name='tcontributor')),
+                base=dict(ref='main'), requested_reviews=[], reviews=[], draft=False,
+            )]
+            radar_obj.comments = [
+                Issue.Comment(user=None, timestamp=100, content='See also https://{}/pull/1'.format(remote.remote)),
+            ]
+
+            self.assertIsNone(Conflict.find_conflict_pr_via_comments(radar_obj))
 
     def test_conflict_found(self):
         with (
@@ -75,8 +138,7 @@ class TestConflict(testing.PathTestCase):
             mocks.remote.GitHub() as remote,
             mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo,
             mocks.local.Svn(),
-            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response),
-            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda x: [Mock(head='integration/conflict/sha123_sha123/target_branch', _metadata={'full_name': 'tcontributor'})])
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response(pr_url='https://{}/pull/1'.format(remote.remote))),
         ):
             remote.users = dict(
                 rreviewer=Contributor('Ricky Reviewer', ['rreviewer@webkit.org'], github='rreviewer'),
@@ -100,7 +162,7 @@ class TestConflict(testing.PathTestCase):
             Reviewed by NOBODY (OOPS!).
             </pre>
             ''',
-                head=dict(ref='tcontributor:integration/conflict/sha123_sha123/target_branch'),
+                head=dict(ref='integration/conflict/sha123_sha123/target_branch', repo=dict(full_name='tcontributor')),
                 base=dict(ref='main'),
                 requested_reviews=[dict(login='rreviewer')],
                 reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=323129
<rdar://186372021>

Reviewed by NOBODY (OOPS!).


* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py: (Conflict.find_conflict_pr):
(Conflict.get_open_integration_prs):
(Conflict.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py: (TestConflict.test_conflict_not_found):

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a9136486365a728276808b17a52267009cc70b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148797 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3fd5940-3567-4d38-a6e0-58a605a881ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144050 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100091 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01f44191-c901-4f72-88f3-c0878d288243) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124466 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3652b337-3eb0-4307-9cc5-d1a832102918) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183840 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46555 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44722 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44338 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5912 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196784 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183915 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58106 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153636 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58811 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153296 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47822 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127563 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57314 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19352 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56678 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->