### PR TITLE
Stop double applying transfer function when uploading video frames to sRGB textures on the fast path

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5166,7 +5166,6 @@ webkit.org/b/292182 webgl/1.0.x/conformance/textures/misc/texture-srgb-upload.ht
 webkit.org/b/292182 webgl/1.0.x/conformance/textures/misc/texture-video-transparent.html [ Failure Pass ]
 webkit.org/b/292182 webgl/1.0.x/conformance/textures/video/tex-2d-rgba-rgba-unsigned_byte.html [ Failure Pass ]
 webkit.org/b/292182 webgl/2.0.y/conformance/textures/misc/copytexsubimage2d-large-partial-copy-corruption.html [ Failure Pass ]
-webkit.org/b/292182 webgl/2.0.y/conformance/textures/misc/texture-srgb-upload.html [ Failure Pass Timeout ]
 webkit.org/b/292182 webgl/2.0.y/conformance/textures/misc/texture-video-transparent.html [ Failure Pass ]
 webkit.org/b/292182 webgl/2.0.y/conformance2/rendering/clipping-wide-points.html [ Failure Pass ]
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -1330,6 +1330,8 @@ angle::Result ContextMtl::syncState(const gl::Context *context,
                 // NOTE(hqle): MSAA feature.
                 break;
             case gl::state::DIRTY_BIT_FRAMEBUFFER_SRGB_WRITE_CONTROL_MODE:
+                // gl::State also marks the draw framebuffer dirty, and FramebufferMtl::syncState()
+                // rebuilds the render pass from the new mode. Nothing to do at the context level.
                 break;
             case gl::state::DIRTY_BIT_CURRENT_VALUES:
             {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -945,6 +945,7 @@ void DisplayMtl::initializeExtensions() const
     mNativeExtensions.textureMirrorClampToEdgeEXT   = true;
     mNativeExtensions.depthClampEXT                 = true;
     mNativeExtensions.rgbxInternalFormatANGLE       = mFeatures.hasTextureSwizzle.enabled;
+    mNativeExtensions.sRGBWriteControlEXT           = true;
 
     // EXT_debug_marker is not implemented yet, but the entry points must be exposed for the
     // Metal backend to be used in Chrome (http://anglebug.com/42263519)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -776,6 +776,11 @@ angle::Result FramebufferMtl::syncState(const gl::Context *context,
             case gl::Framebuffer::DIRTY_BIT_DEFAULT_SAMPLES:
             case gl::Framebuffer::DIRTY_BIT_DEFAULT_FIXED_SAMPLE_LOCATIONS:
                 break;
+            case gl::Framebuffer::DIRTY_BIT_FRAMEBUFFER_SRGB_WRITE_CONTROL_MODE:
+                // prepareRenderPass() below reads the mode and swaps in linear views of any
+                // sRGB color attachments, which changes the render pass descriptor and so
+                // restarts the render pass by itself.
+                break;
             default:
             {
                 static_assert(gl::Framebuffer::DIRTY_BIT_COLOR_ATTACHMENT_0 == 0, "FB dirty bits");
@@ -1129,6 +1134,7 @@ angle::Result FramebufferMtl::prepareRenderPass(const gl::Context *context,
                                        : gl::DrawBufferMask();
     const gl::DrawBufferMask enabledDrawBuffers =
         getState().getEnabledDrawBuffers() & ~incompatibleAttachments;
+    const gl::SrgbWriteControlMode srgbWriteControlMode = mState.getWriteControlMode();
 
     mtl::RenderPassDesc &desc = *pDescOut;
 
@@ -1152,11 +1158,12 @@ angle::Result FramebufferMtl::prepareRenderPass(const gl::Context *context,
         // enabled attachments.
         if (colorRenderTarget && enabledDrawBuffers.test(colorIndexGL))
         {
-            colorRenderTarget->toRenderPassAttachmentDesc(&colorAttachment);
+            colorRenderTarget->toRenderPassAttachmentDesc(&colorAttachment, srgbWriteControlMode);
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
             if (colorResolveRenderTarget)
             {
-                colorResolveRenderTarget->toRenderPassResolveAttachmentDesc(&colorAttachment);
+                colorResolveRenderTarget->toRenderPassResolveAttachmentDesc(&colorAttachment,
+                                                                           srgbWriteControlMode);
             }
 #endif
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.h
@@ -50,9 +50,13 @@ class RenderTargetMtl final : public FramebufferAttachmentRenderTarget
     uint32_t getRenderSamples() const;
     const mtl::Format &getFormat() const { return mFormat; }
 
-    void toRenderPassAttachmentDesc(mtl::RenderPassAttachmentDesc *rpaDescOut) const;
+    void toRenderPassAttachmentDesc(mtl::RenderPassAttachmentDesc *rpaDescOut,
+                                    gl::SrgbWriteControlMode srgbWriteControlMode =
+                                        gl::SrgbWriteControlMode::Default) const;
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
-    void toRenderPassResolveAttachmentDesc(mtl::RenderPassAttachmentDesc *rpaDescOut) const;
+    void toRenderPassResolveAttachmentDesc(mtl::RenderPassAttachmentDesc *rpaDescOut,
+                                           gl::SrgbWriteControlMode srgbWriteControlMode =
+                                               gl::SrgbWriteControlMode::Default) const;
 #endif
 
   private:

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.mm
@@ -11,6 +11,20 @@
 
 namespace rx
 {
+namespace
+{
+mtl::TextureRef LinearColorViewIfNeeded(const mtl::TextureRef &texture,
+                                        gl::SrgbWriteControlMode srgbWriteControlMode)
+{
+    if (srgbWriteControlMode != gl::SrgbWriteControlMode::Linear || !texture ||
+        !texture->hasLinearColorView())
+    {
+        return texture;
+    }
+    return texture->getLinearColorView();
+}
+}  // namespace
+
 RenderTargetMtl::RenderTargetMtl() {}
 
 RenderTargetMtl::~RenderTargetMtl()
@@ -71,20 +85,22 @@ uint32_t RenderTargetMtl::getRenderSamples() const
     return implicitMSTex ? implicitMSTex->samples() : (tex ? tex->samples() : 1);
 }
 
-void RenderTargetMtl::toRenderPassAttachmentDesc(mtl::RenderPassAttachmentDesc *rpaDescOut) const
+void RenderTargetMtl::toRenderPassAttachmentDesc(
+    mtl::RenderPassAttachmentDesc *rpaDescOut,
+    gl::SrgbWriteControlMode srgbWriteControlMode) const
 {
     mtl::TextureRef implicitMSTex = getImplicitMSTexture();
     mtl::TextureRef tex           = getTexture();
     if (implicitMSTex)
     {
-        rpaDescOut->texture             = implicitMSTex;
-        rpaDescOut->resolveTexture      = tex;
-        rpaDescOut->resolveLevel        = mLevelIndex;
+        rpaDescOut->texture        = LinearColorViewIfNeeded(implicitMSTex, srgbWriteControlMode);
+        rpaDescOut->resolveTexture = LinearColorViewIfNeeded(tex, srgbWriteControlMode);
+        rpaDescOut->resolveLevel   = mLevelIndex;
         rpaDescOut->resolveSliceOrDepth = mLayerIndex;
     }
     else
     {
-        rpaDescOut->texture      = tex;
+        rpaDescOut->texture      = LinearColorViewIfNeeded(tex, srgbWriteControlMode);
         rpaDescOut->level        = mLevelIndex;
         rpaDescOut->sliceOrDepth = mLayerIndex;
     }
@@ -93,11 +109,12 @@ void RenderTargetMtl::toRenderPassAttachmentDesc(mtl::RenderPassAttachmentDesc *
 
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
 void RenderTargetMtl::toRenderPassResolveAttachmentDesc(
-    mtl::RenderPassAttachmentDesc *rpaDescOut) const
+    mtl::RenderPassAttachmentDesc *rpaDescOut,
+    gl::SrgbWriteControlMode srgbWriteControlMode) const
 {
     ASSERT(!getImplicitMSTexture());
     ASSERT(getRenderSamples() == 1);
-    rpaDescOut->resolveTexture      = getTexture();
+    rpaDescOut->resolveTexture      = LinearColorViewIfNeeded(getTexture(), srgbWriteControlMode);
     rpaDescOut->resolveLevel        = mLevelIndex;
     rpaDescOut->resolveSliceOrDepth = mLayerIndex;
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
@@ -330,6 +330,7 @@ class Texture final : public Resource,
     // Get stencil view
     TextureRef getStencilView();
     // Get linear color
+    bool hasLinearColorView() const;
     TextureRef getLinearColorView();
 
     TextureRef parentTexture();

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm
@@ -65,6 +65,22 @@ void EnsureCPUMemWillBeSynced(ContextMtl *context, T *resource)
     resource->resetCPUReadMemNeedSync();
 }
 
+// Returns the linear counterpart of an sRGB color pixel format, or MTLPixelFormatInvalid if the
+// format is not an sRGB color format.
+// NOTE(hqle): Not all sRGB formats are supported yet.
+MTLPixelFormat GetLinearColorPixelFormat(MTLPixelFormat pixelFormat)
+{
+    switch (pixelFormat)
+    {
+        case MTLPixelFormatRGBA8Unorm_sRGB:
+            return MTLPixelFormatRGBA8Unorm;
+        case MTLPixelFormatBGRA8Unorm_sRGB:
+            return MTLPixelFormatBGRA8Unorm;
+        default:
+            return MTLPixelFormatInvalid;
+    }
+}
+
 MTLResourceOptions resourceOptionsForStorageMode(MTLStorageMode storageMode)
 {
     switch (storageMode)
@@ -186,8 +202,28 @@ angle::Result Texture::MakeMemoryLess2DMSTexture(ContextMtl *context,
         desc.textureType = MTLTextureType2DMultisample;
         desc.sampleCount = samples;
 
-        return MakeTexture(context, format, desc, 1, /*renderTargetOnly=*/true,
-                           /*allowFormatView=*/false, /*memoryLess=*/true, refOut);
+        ANGLE_TRY(MakeTexture(context, format, desc, 1, /*renderTargetOnly=*/true,
+                              /*allowFormatView=*/false, /*memoryLess=*/true, refOut));
+
+        if ((*refOut)->get().storageMode == MTLStorageModeMemoryless &&
+            (*refOut)->hasLinearColorView())
+        {
+            const Format &linearFormat =
+                context->getPixelFormat(ConvertToLinear(format.actualFormatId));
+            MTLTextureDescriptor *linearDesc =
+                [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:linearFormat.metalFormat
+                                                                   width:width
+                                                                  height:height
+                                                               mipmapped:NO];
+            linearDesc.textureType = MTLTextureType2DMultisample;
+            linearDesc.sampleCount = samples;
+
+            ANGLE_TRY(MakeTexture(context, linearFormat, linearDesc, 1, /*renderTargetOnly=*/true,
+                                  /*allowFormatView=*/false, /*memoryLess=*/true,
+                                  &(*refOut)->mLinearColorView));
+        }
+
+        return angle::Result::Continue;
     }  // ANGLE_MTL_OBJC_SCOPE
 }
 /** static */
@@ -524,6 +560,8 @@ Texture::Texture(Texture *original, MTLPixelFormat pixelFormat)
     ANGLE_MTL_OBJC_SCOPE
     {
         set(angle::adoptObjCPtr([original->get() newTextureViewWithPixelFormat:pixelFormat]));
+        // A view of a texture that must not be loaded or stored must not be either.
+        mShouldNotLoadStore = original->mShouldNotLoadStore;
         // Texture views consume no additional memory
         mEstimatedByteSize = 0;
     }
@@ -907,24 +945,18 @@ angle::Result Texture::resize(ContextMtl *context, uint32_t width, uint32_t heig
     return angle::Result::Continue;
 }
 
+bool Texture::hasLinearColorView() const
+{
+    return GetLinearColorPixelFormat(pixelFormat()) != MTLPixelFormatInvalid;
+}
+
 TextureRef Texture::getLinearColorView()
 {
-    if (mLinearColorView)
+    if (!mLinearColorView)
     {
-        return mLinearColorView;
-    }
-
-    switch (pixelFormat())
-    {
-        case MTLPixelFormatRGBA8Unorm_sRGB:
-            mLinearColorView = createViewWithCompatibleFormat(MTLPixelFormatRGBA8Unorm);
-            break;
-        case MTLPixelFormatBGRA8Unorm_sRGB:
-            mLinearColorView = createViewWithCompatibleFormat(MTLPixelFormatBGRA8Unorm);
-            break;
-        default:
-            // NOTE(hqle): Not all sRGB formats are supported yet.
-            UNREACHABLE();
+        MTLPixelFormat linearPixelFormat = GetLinearColorPixelFormat(pixelFormat());
+        ASSERT(linearPixelFormat != MTLPixelFormatInvalid);
+        mLinearColorView = createViewWithCompatibleFormat(linearPixelFormat);
     }
 
     return mLinearColorView;

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
@@ -695,8 +695,11 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     auto colorMatrix = YCbCrToRGBMatrixForRangeAndTransferFunction(range, transferFunction);
     GL_UniformMatrix4fv(m_colorMatrixUniformLocation, 1, GL_FALSE, colorMatrix);
 
-    // Do the actual drawing.
+    if (internalFormat == GL_SRGB8_ALPHA8)
+        GL_Disable(GL_FRAMEBUFFER_SRGB_EXT);
     GL_DrawArrays(GL_TRIANGLES, 0, 6);
+    if (internalFormat == GL_SRGB8_ALPHA8)
+        GL_Enable(GL_FRAMEBUFFER_SRGB_EXT);
 
     m_knownContent.set(outputTexture, content);
     autoClearTextureOnError.release();


### PR DESCRIPTION
#### f69c13d5f9a90599067a31d75578fc3b4ffa2e35
<pre>
Stop double applying transfer function when uploading video frames to sRGB textures on the fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=323134">https://bugs.webkit.org/show_bug.cgi?id=323134</a>
<a href="https://rdar.apple.com/problem/186394572">rdar://problem/186394572</a>

Reviewed by NOBODY (OOPS!).

texImage2D with an sRGB internal format must store the source bytes as the
texture&apos;s sRGB-encoded texels. The accelerated video upload path renders the
frame into the destination through a framebuffer, and in ES3 writing to an
sRGB-encoded color attachment always applies the linear-to-sRGB transfer
function.

Implement Metal backend support for EXT_sRGB_write_control and use it to
disable GL_FRAMEBUFFER_SRGB_EXT for sRGB destinations during video frame
uploads.

This is not a problem for SRGB8 textures because they are not color-
renderable, so we fall back to the software path for this.

EXT_multisampled_render_to_texture needs the linear view of both the implicit
multisample texture and the resolve target, because Metal requires the two to
have the same pixel format and the resolve otherwise applies the encode. The
implicit multisample texture is memoryless and Metal cannot create a view of
such textures, so give it a second memoryless texture with the linear format
instead.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::syncState):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm:
(rx::DisplayMtl::initializeExtensions const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::syncState):
(rx::FramebufferMtl::prepareRenderPass):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/RenderTargetMtl.mm:
(rx::LinearColorViewIfNeeded):
(rx::RenderTargetMtl::toRenderPassAttachmentDesc const):
(rx::RenderTargetMtl::toRenderPassResolveAttachmentDesc const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm:
(rx::mtl::GetLinearColorPixelFormat):
(rx::mtl::Texture::MakeMemoryLess2DMSTexture):
(rx::mtl::Texture::Texture):
(rx::mtl::Texture::hasLinearColorView const):
(rx::mtl::Texture::getLinearColorView):
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm:
(WebCore::GraphicsContextGLCVCocoa::copyVideoSampleToTexture):
* LayoutTests/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f69c13d5f9a90599067a31d75578fc3b4ffa2e35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184666 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58583 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194998 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148931 "Failed to checkout and rebase branch from PR 72978") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186528 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59939 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58316 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/194998 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148931 "Failed to checkout and rebase branch from PR 72978") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187621 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/59939 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/194998 "Failed to checkout and rebase branch from PR 72978") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/59939 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/58316 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/194998 "Failed to checkout and rebase branch from PR 72978") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/59939 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6054 "Failed to checkout and rebase branch from PR 72978") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51247 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/58316 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196945 "Failed to checkout and rebase branch from PR 72978") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58256 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/196945 "Failed to checkout and rebase branch from PR 72978") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58958 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/196945 "Failed to checkout and rebase branch from PR 72978") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/58958 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131246 "Failed to checkout and rebase branch from PR 72978") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127766 "Failed to checkout and rebase branch from PR 72978") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57459 "Failed to checkout and rebase branch from PR 72978") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/52408 "Failed to checkout and rebase branch from PR 72978") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56820 "Failed to checkout and rebase branch from PR 72978") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57068 "Failed to checkout and rebase branch from PR 72978") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56895 "Failed to checkout and rebase branch from PR 72978") | | | | 
<!--EWS-Status-Bubble-End-->