### PR TITLE
[CMake] Non-unified builds don't apply -fobjc-arc to ARC sources.

### DIFF
--- a/Source/WTF/Scripts/generate-unified-source-bundles.py
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.py
@@ -243,6 +243,9 @@ def parse_args():
                         help='Path of the generated input .xcfilelist file.')
     parser.add_argument('--output-xcfilelist-path', type=Path,
                         help='Path of the generated output .xcfilelist file.')
+    parser.add_argument('--print-arc-sources', type=Path, metavar='PATH',
+                        help='While printing all sources, also write the .mm sources that were '
+                             'not annotated @nonARC (one per line) to PATH.')
     parser.add_argument('--max-cpp-bundle-count', type=int, default=None,
                         help='Use global sequential numbers for cpp bundle filenames and set the limit on the number.')
     parser.add_argument('--max-c-bundle-count', type=int, default=None,
@@ -304,6 +307,7 @@ def main() -> None:
     input_sources: list[str] = []
     output_sources: list[str] = []
     bundled_members: list[str] = []
+    arc_members: list[str] = []
 
     bundle_managers = {
         '.cpp': BundleManager('cpp', '.cpp', args.max_cpp_bundle_count, args, generated_sources, output_sources),
@@ -363,6 +367,8 @@ def main() -> None:
                 bundled_members.append(source_file.bundled_source_form())
         elif args.mode == 'PrintAllSources':
             generated_sources.append(str(source_file))
+            if source_file.bundle_manager_key == '.mm':
+                arc_members.append(str(source_file))
 
     if args.mode != 'PrintAllSources':
         for manager in bundle_managers.values():
@@ -394,6 +400,12 @@ def main() -> None:
         with open(args.print_bundled_sources, 'w') as f:
             f.write("\n".join(bundled_members))
             if bundled_members:
+                f.write("\n")
+
+    if args.mode == 'PrintAllSources' and args.print_arc_sources:
+        with open(args.print_arc_sources, 'w') as f:
+            f.write("\n".join(arc_members))
+            if arc_members:
                 f.write("\n")
 
     # We use stdout to report our unified source list to CMake.

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -198,9 +198,11 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
         unset(_resultTmp)
         unset(_outputTmp)
     else ()
+        set(_arcSourcesFile "${CMAKE_CURRENT_BINARY_DIR}/${_framework}ARCSources.txt")
         execute_process(COMMAND ${Python_EXECUTABLE} ${WTF_SCRIPTS_DIR}/generate-unified-source-bundles.py
             ${gusb_args}
             "--print-all-sources"
+            --print-arc-sources "${_arcSourcesFile}"
             ${_sourceListFileTruePaths}
             RESULT_VARIABLE _resultTmp
             OUTPUT_VARIABLE _outputTmp)
@@ -209,7 +211,17 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
              message(FATAL_ERROR "generate-unified-source-bundles.py exited with non-zero status, exiting")
         endif ()
 
-        list(APPEND ${_framework}_SOURCES ${_outputTmp})
+        # Without bundles there is no *-ARC.mm to key off, so take the @nonARC
+        # annotations straight from the source lists to keep the ARC sources in the
+        # OBJECT library whose OBJCXX precompiled header agrees on -fobjc-arc.
+        file(STRINGS "${_arcSourcesFile}" _arcSources)
+        foreach (_file IN LISTS _outputTmp)
+            if (_file IN_LIST _arcSources)
+                list(APPEND ${_framework}_ARC_SOURCES ${_file})
+            else ()
+                list(APPEND ${_framework}_SOURCES ${_file})
+            endif ()
+        endforeach ()
         unset(_resultTmp)
         unset(_outputTmp)
     endif ()


### PR DESCRIPTION
#### 72ec90eba3416f058590d510153a1a6395e404e0
<pre>
[CMake] Non-unified builds don&apos;t apply -fobjc-arc to ARC sources.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323139">https://bugs.webkit.org/show_bug.cgi?id=323139</a>
<a href="https://rdar.apple.com/186400332">rdar://186400332</a>

Reviewed by Pascoe.

Building with -DENABLE_UNIFIED_BUILDS=OFF on Cocoa fails: 97 .mm files in Source/WebKit error out with

    error: This file requires ARC. Add the &quot;-fobjc-arc&quot; compiler flag for this file.

A .mm entry in Sources*.txt compiles with ARC unless it is annotated @nonARC, but WEBKIT_COMPUTE_SOURCES
only ever learns that from bundle filenames. The bundler emits *-ARC.mm and *-nonARC.mm, and the unified
branch matches on -ARC\.mm$ to route sources into ${_framework}_ARC_SOURCES -- the OBJECT library that
carries -fobjc-arc.

The non-unified branch instead calls generate-unified-source-bundles.py with --print-all-sources, which
prints real source paths. There are no bundle filenames to match on, so every source landed in
${_framework}_SOURCES and nothing ever reached the ARC target.

Add a --print-arc-sources option to generate-unified-source-bundles.py that writes out the .mm sources
not annotated @nonARC, and use it in the non-unified branch to route those into ${_framework}_ARC_SOURCES.

Only Source/WebKit and Source/WebGPU have ARC .mm sources today; WebCore and WebKitLegacy are entirely
@nonARC. Note that a framework acquiring ARC sources must also consume ${_framework}_ARC_SOURCES in its
CMakeLists.txt, or those files will silently drop out of the non-unified build.

* Source/WTF/Scripts/generate-unified-source-bundles.py:
(parse_args):
(main):
* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/320759@main">https://commits.webkit.org/320759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a4ad5d9b3f6bf9bb27998a6b23d6671bd5ad32c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148631 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143894 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100016 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eea386df-34fe-4aed-8f6e-18523004ca6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65f764f1-f3ed-4d67-b94c-b1364cfe0f3b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44589 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6282 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13120 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44181 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45596 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196478 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57910 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58614 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153135 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47661 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130915 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57121 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19196 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56556 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->