### PR TITLE
Rotating device to landscape exits full screen

### DIFF
--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -60,6 +60,7 @@
 #include "SourceBuffer.h"
 #include "TextTrack.h"
 #include "TextTrackList.h"
+#include "UserGestureIndicator.h"
 #include "VideoTrack.h"
 #include "VideoTrackConfiguration.h"
 #include "VideoTrackList.h"
@@ -522,6 +523,15 @@ std::expected<void, MediaPlaybackDenialExplanation> MediaElementSession::playbac
         && !element->paused() && state == MediaPlaybackState::Paused
         && !document->processingUserGestureForMedia())
         return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "Quirk requires user gesture to pause in Picture-in-Picture"_s);
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (document->quirks().requiresUserGestureToPauseInFullscreenAfterOrientationChange()
+        && element->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModeStandard
+        && !element->paused() && state == MediaPlaybackState::Paused
+        && !UserGestureIndicator::processingUserGestureForMedia()
+        && (MonotonicTime::now() - page->lastOrientationChangeTime()) < 500_ms)
+        return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "Quirk requires user gesture to pause in fullscreen after an orientation change"_s);
+#endif
 
 #if ENABLE(FULLSCREEN_API)
     if (mainFrameDocument && mainFrameDocument->quirks().requiresUserGestureToPlayInFullscreen() && document->fullscreen().fullscreenElement() && state == MediaPlaybackState::Playing && element->paused()) {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4702,6 +4702,11 @@ void Page::clearDeviceOrientationAndMotionPermissions()
 }
 #endif
 
+void Page::orientationDidChange()
+{
+    m_lastOrientationChangeTime = MonotonicTime::now();
+}
+
 bool Page::findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>& functor) const
 {
     for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1188,6 +1188,9 @@ public:
     WEBCORE_EXPORT void clearDeviceOrientationAndMotionPermissions();
 #endif
 
+    MonotonicTime lastOrientationChangeTime() const { return m_lastOrientationChangeTime; }
+    WEBCORE_EXPORT void orientationDidChange();
+
     WEBCORE_EXPORT void forEachDocument(NOESCAPE const Function<void(Document&)>&) const;
     bool findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>&) const;
     void forEachRenderableDocument(NOESCAPE const Function<void(Document&)>&) const;
@@ -1898,6 +1901,7 @@ private:
     bool m_shouldDeferScrollEvents { false };
     bool m_shouldDeferIntersectionObservations { false };
     MonotonicTime m_lastResizeTimeForIOQuirk;
+    MonotonicTime m_lastOrientationChangeTime;
 
     Ref<DocumentSyncData> m_topDocumentSyncData;
 

--- a/Source/WebCore/page/QuirkNames.h
+++ b/Source/WebCore/page/QuirkNames.h
@@ -158,6 +158,7 @@ enum class SiteSpecificQuirk {
 #endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RequiresUserGestureToLoadInPictureInPictureQuirk,
+    RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk,
     RequiresUserGestureToPauseInPictureInPictureQuirk,
 #endif
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -890,6 +890,12 @@ static constexpr Quirk table[] = {
 #endif
         } },
 
+#if ENABLE(VIDEO_PRESENTATION_MODE) && PLATFORM(IOS)
+    // yahoo.com: rdar://148284059
+    { .match = QuirkURLMatch::embeddedDocumentInTopMatch(URLMatch::anyTopLevelDomain("yahoo"_s), URLMatch::domain("yimg.com"_s)),
+        .behaviors = { RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk } },
+#endif
+
 #if ENABLE(TEXT_AUTOSIZING)
     // news.ycombinator.com: rdar://127246368
     { .match = URLMatch::host("news.ycombinator.com"_s),

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1550,6 +1550,18 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 #endif
 }
 
+// sports.yahoo.com: rdar://148284059
+bool Quirks::requiresUserGestureToPauseInFullscreenAfterOrientationChange() const
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(SiteSpecificQuirk::RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk);
+#else
+    return false;
+#endif
+}
+
 // youtube.com: rdar://178769976
 bool Quirks::requiresUserGestureToPlayInFullscreen() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -208,6 +208,7 @@ public:
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
     bool requiresUserGestureToPlayInFullscreen() const;
+    bool requiresUserGestureToPauseInFullscreenAfterOrientationChange() const;
 
     WEBCORE_EXPORT bool blocksReturnToFullscreenFromPictureInPictureQuirk() const;
     WEBCORE_EXPORT bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2920,6 +2920,7 @@ void WebPage::setDeviceOrientation(IntDegrees deviceOrientation)
     if (deviceOrientation == m_deviceOrientation)
         return;
     m_deviceOrientation = deviceOrientation;
+    protect(m_page)->orientationDidChange();
 #if ENABLE(ORIENTATION_EVENTS)
     if (RefPtr localMainFrame = protect(m_page)->localMainFrame())
         localMainFrame->orientationChanged();


### PR DESCRIPTION
#### e75adef42393a3c8ddbc4ef10757d06a9feec890
<pre>
Rotating device to landscape exits full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=323142">https://bugs.webkit.org/show_bug.cgi?id=323142</a>
<a href="https://rdar.apple.com/148284059">rdar://148284059</a>

Reviewed by Jer Noble.

sports.yahoo.com posts a PAUSE message to its cross-origin s.yimg.com player frame on rotation,
which pauses the &lt;video&gt; even while it is in fullscreen.

Add RequiresUserGestureToPauseInFullscreenAfterOrientationChangeQuirk, denying a programmatic pause
of a video in standard fullscreen within 500ms of an orientation change. Scoped to the s.yimg.com
player document embedded in yahoo.com.

Record the orientation change time on Page rather than Document, and look the quirk up on the player
document rather than the main frame document, so both still work when the player runs in its own
process under site isolation.

Use UserGestureIndicator::processingUserGestureForMedia() rather than the Document accessor, which
reports true for the whole 5 second transient activation window after the fullscreen tap.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::orientationChanged):
* Source/WebCore/dom/Document.h:
(WebCore::Document::lastOrientationChangeTime const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::playbackStateChangePermitted const):
* Source/WebCore/page/QuirkNames.h:
* Source/WebCore/page/QuirkTable.cpp:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/320318@main">https://commits.webkit.org/320318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88454ac81a7a3f97305662dd9bbb55efe38f062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148637 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100024 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124323 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f36b624-0c42-492b-8a37-43616f080b9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46401 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44596 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44188 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5727 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196488 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57920 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153480 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41115 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58624 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153148 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47672 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130923 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57131 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19204 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56566 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->