### PR TITLE
Cherry-pick 305413.1123@safari-7624.5.1.10-branch (039ba968916b). https://bugs.webkit.org/show_bug.cgi?id=319704

### DIFF
--- a/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt
+++ b/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html
+++ b/LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#outer { width: 200px; font-family: Ahem; font-size: 10px; }
+</style>
+<div id=outer><span>aa bb cc<div id=inner>xx<br id=br>yy zz ww vv</div>dd ee ff</span></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// Initial layout: outer IFC contains a block-in-inline (#inner) that establishes its own IFC.
+document.body.offsetHeight;
+
+// Remove a leaf from the inner IFC via a partial-invalidation-eligible mutation. The removed
+// renderer's Layout::Box is retained by InlineDamage while the previous inline display content
+// (which still holds a CheckedPtr to it) is kept for partial layout.
+br.remove();
+document.body.offsetHeight;
+
+// Force another full layout of the outer IFC so that inner's LineLayout::layout() runs
+// clearInlineContent() again on the previous display boxes.
+outer.style.width = '190px';
+document.body.offsetHeight;
+
+document.body.textContent = 'PASS if no crash.';
+</script>

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+
+    const audioData = new AudioData({
+      format: "f32",
+      sampleRate: 48000,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+      timestamp: 0,
+      data: new Float32Array([0.125, -0.125])
+    });
+    const copyDestination = new Int16Array(16);
+
+    let threw = false;
+    try {
+      audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameOffset: 1 });
+    } catch (e) {
+      threw = e instanceof RangeError;
+    }
+
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameCount: 0 });
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 1, frameCount: 0 });
+
+    document.body.innerHTML = threw ? "PASS if no crash." : "FAIL: frameOffset == numberOfFrames did not throw RangeError.";
+  });
+</script>
+<body></body>

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
@@ -2,4 +2,5 @@
 PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+PASS AudioData.copyTo throws RangeError when frameOffset >= frameCount
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
@@ -88,3 +88,25 @@ test(() => {
     0, 0,
   ], 'only 3 middle elements are copied');
 }, 'Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset');
+
+// Per the "Compute Copy Element Count" algorithm step 7
+// (https://www.w3.org/TR/webcodecs/#compute-copy-element-count):
+// "If options.frameOffset is greater than or equal to frameCount, throw a RangeError."
+test(() => {
+  const data = new AudioData({
+    format: 'f32',
+    sampleRate: 48000,
+    numberOfChannels: 1,
+    numberOfFrames: 5,
+    data: new Float32Array([1, 2, 3, 4, 5]),
+    timestamp: 0,
+  });
+  const output = new Float32Array(5);
+  assert_throws_js(RangeError, () => {
+    data.copyTo(output, { planeIndex: 0, frameOffset: 5 });
+  }, 'frameOffset == numberOfFrames must throw RangeError');
+  assert_throws_js(RangeError, () => {
+    data.copyTo(output, { planeIndex: 0, frameOffset: 6 });
+  }, 'frameOffset > numberOfFrames must throw RangeError');
+  data.close();
+}, 'AudioData.copyTo throws RangeError when frameOffset >= frameCount');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
@@ -2,4 +2,5 @@
 PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+PASS AudioData.copyTo throws RangeError when frameOffset >= frameCount
 

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() { window.testRunner?.notifyDone(); }
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const pageID = IPC.pageID;
+
+    const state = {
+        pageIdentifier: pageID,
+        sessionIdentifier: 1234,
+        logIdentifier: 0,
+        mediaType: 0,
+        presentationType: 0,
+        displayType: 0,
+        state: 0,
+        stateToRestore: 0,
+        interruptionType: 0,
+        duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { },
+        nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false,
+        isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false,
+        hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false,
+        isNowPlayingEligible: false,
+        canProduceAudio: false,
+        isSuspended: false,
+        isPlaying: false,
+        isAudible: false,
+        isEnded: false,
+        canReceiveRemoteControlCommands: false,
+        supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false,
+        isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false,
+        activeAudioSessionRequired: false,
+        preparingToPlay: false,
+        isActiveNowPlayingSession: false,
+    };
+
+    // AddMediaSession creates the AudioHardwareListener; RemoveMediaSession (last
+    // session) clears MediaSessionManagerCocoa::m_audioHardwareListener while
+    // RemoteMediaSessionManagerProxy used to retain a stale listener proxy whose
+    // raw Client& dispatched into a manager with a null m_audioHardwareListener.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageID, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageID, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageID, { });
+
+    // Let the async IPC drain before finishing.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    done();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    done();
+else
+    run().catch(done);
+</script>

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+let finished = false;
+function finish() {
+    if (finished)
+        return;
+    finished = true;
+    window.testRunner?.notifyDone();
+}
+
+function makeState(pageID) {
+    return {
+        pageIdentifier: pageID, sessionIdentifier: 1234, logIdentifier: 0,
+        mediaType: 0, presentationType: 0, displayType: 0, state: 0, stateToRestore: 0,
+        interruptionType: 0, duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { }, nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false, isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false, hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false, isNowPlayingEligible: false,
+        canProduceAudio: false, isSuspended: false, isPlaying: false, isAudible: false,
+        isEnded: false, canReceiveRemoteControlCommands: false, supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false, isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false, activeAudioSessionRequired: false,
+        preparingToPlay: false, isActiveNowPlayingSession: false,
+    };
+}
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    // With RemoteMediaSessionManagerEnabled=true each WebPageProxy creates its
+    // RemoteMediaSessionManagerProxy eagerly, so the last-opened page (B) owns
+    // the process-global AudioHardwareListener factory.
+    const winA = window.open("about:blank", "A");
+    const winB = window.open("about:blank", "B");
+    await wait(0);
+
+    if (!winA?.IPC || !winB?.IPC) {
+        finish();
+        return;
+    }
+    const pageA = winA.IPC.pageID;
+    const pageB = winB.IPC.pageID;
+
+    // A.AddMediaSession -> AudioHardwareListener::create(*A) -> B's factory ->
+    // B caches a listener whose raw Client& was A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageA, { session: makeState(pageA) });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageA, { session: makeState(pageA) });
+
+    // Destroy A's WebPageProxy; B's listener used to keep a dangling Client& to A.
+    winA.close();
+    for (let i = 0; i < 8; ++i)
+        await wait(50);
+    if (window.GCController)
+        GCController.collect();
+    await wait(100);
+
+    // RemoteAudioOutputDeviceChanged on B used to dispatch on freed A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageB, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageB, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageB, { });
+
+    await wait(100);
+    finish();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+// The watchdog also finishes the test if an opened window never populates window.IPC.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    finish();
+else {
+    setTimeout(finish, 8000);
+    run().catch(finish);
+}
+</script>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -120,7 +120,7 @@ ExceptionOr<size_t> computeCopyElementCount(const WebCodecsAudioData& data, cons
     // All planes have the same number of frames, always
     auto frameCount = data.numberOfFrames();
     // 7. If options.frameOffset is greater than or equal to frameCount, throw a RangeError.
-    if (options.frameOffset && *options.frameOffset > frameCount)
+    if (options.frameOffset && *options.frameOffset >= frameCount)
         return Exception { ExceptionCode::RangeError, "frameOffset is too large"_s };
 
     // 8. Let copyFrameCount be the difference of subtracting options.frameOffset from frameCount.

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -337,15 +337,22 @@ FloatRect InlineContentBuilder::handlePartialDisplayContentUpdate(Layout::Inline
         return { boxCount };
     }();
 
+    auto damagedRect = FloatRect { };
+
     if (!firstDamagedLineIndex || !numberOfDamagedLines || !firstDamagedBoxIndex || !numberOfDamagedBoxes) {
         ASSERT_NOT_REACHED();
-        return { };
+        // We failed to compute the damaged range. The existing display content may still hold references to
+        // layout boxes that were detached (see InlineDamage::m_detachedLayoutBoxes) and will be destroyed as
+        // soon as line damage is released. Do not leave those stale display boxes in place.
+        for (auto& line : inlineContent.displayContent().lines)
+            damagedRect.unite(line.inkOverflow());
+        inlineContent.displayContent().clear();
+        return damagedRect;
     }
 
     auto numberOfNewLines = layoutResult.displayContent.lines.size();
     auto numberOfNewBoxes = layoutResult.displayContent.boxes.size();
 
-    auto damagedRect = FloatRect { };
     auto adjustDamagedRectWithLineRange = [&](size_t firstLineIndex, size_t lineCount) {
         auto& lines = inlineContent.displayContent().lines;
         ASSERT(firstLineIndex + lineCount <= lines.size());

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -25,11 +25,12 @@
 
 #pragma once
 
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-    
+
 enum class AudioHardwareActivityType {
     Unknown,
     IsActive,
@@ -38,7 +39,7 @@ enum class AudioHardwareActivityType {
 
 class AudioHardwareListener : public AbstractRefCounted {
 public:
-    class Client {
+    class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:
         virtual ~Client() = default;
         virtual void audioHardwareDidBecomeActive() = 0;
@@ -66,10 +67,12 @@ public:
 protected:
     WEBCORE_EXPORT AudioHardwareListener(Client&);
 
+    Client* client() const { return m_client.get(); }
     void setHardwareActivity(AudioHardwareActivityType activity) { m_activity = activity; }
     void setSupportedBufferSizes(BufferSizeRange sizes) { m_supportedBufferSizes = sizes; }
 
-    Client& m_client;
+private:
+    WeakPtr<Client> m_client;
     AudioHardwareActivityType m_activity { AudioHardwareActivityType::Unknown };
     BufferSizeRange m_supportedBufferSizes;
 };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -669,8 +669,10 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
 void MediaSessionManagerCocoa::audioOutputDeviceChanged()
 {
-    ASSERT(m_audioHardwareListener);
-    m_supportedAudioHardwareBufferSizes = m_audioHardwareListener->supportedBufferSizes();
+    RefPtr audioHardwareListener = m_audioHardwareListener;
+    if (!audioHardwareListener)
+        return;
+    m_supportedAudioHardwareBufferSizes = audioHardwareListener->supportedBufferSizes();
     m_defaultBufferSize = AudioSession::singleton().preferredBufferSize();
     AudioSession::singleton().audioOutputDeviceChanged();
     updateSessionState();

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -244,6 +244,9 @@ static Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<st
 
 void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFormat destinationFormat, size_t planeIndex, std::optional<size_t> frameOffset, std::optional<size_t>, unsigned long copyElementCount)
 {
+    if (!copyElementCount)
+        return;
+
     // WebCodecsAudioDataAlgorithms's computeCopyElementCount ensures that all parameters are correct.
     auto& audioData = downcast<PlatformRawAudioDataCocoa>(*this);
 

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -157,17 +157,21 @@ void AudioHardwareListenerMac::processIsRunningChanged()
     if (activity == hardwareActivity())
         return;
     setHardwareActivity(activity);
-    
+
+    RefPtr client = this->client();
+    if (!client)
+        return;
     if (hardwareActivity() == AudioHardwareActivityType::IsActive)
-        m_client.audioHardwareDidBecomeActive();
+        client->audioHardwareDidBecomeActive();
     else if (hardwareActivity() == AudioHardwareActivityType::IsInactive)
-        m_client.audioHardwareDidBecomeInactive();
+        client->audioHardwareDidBecomeInactive();
 }
 
 void AudioHardwareListenerMac::outputDeviceChanged()
 {
     setSupportedBufferSizes(currentDeviceSupportedBufferSizes());
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -956,7 +956,7 @@ Ref<RemoteMediaEngineConfigurationFactoryProxy> GPUConnectionToWebProcess::prote
 void GPUConnectionToWebProcess::createAudioHardwareListener(RemoteAudioHardwareListenerIdentifier identifier)
 {
     auto addResult = m_remoteAudioHardwareListenerMap.ensure(identifier, [&]() {
-        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTF::move(identifier));
+        return RemoteAudioHardwareListenerProxy::create(*this, WTF::move(identifier));
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -453,7 +453,7 @@ private:
     HashMap<std::pair<WebPageProxyIdentifier, WebCore::PageIdentifier>, std::unique_ptr<LayerHostingContext>> m_visibilityPropagationContexts;
 #endif
 
-    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, std::unique_ptr<RemoteAudioHardwareListenerProxy>>;
+    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, Ref<RemoteAudioHardwareListenerProxy>>;
     RemoteAudioHardwareListenerMap m_remoteAudioHardwareListenerMap;
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
@@ -43,13 +44,21 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 
-class RemoteAudioHardwareListenerProxy final : private WebCore::AudioHardwareListener::Client {
+class RemoteAudioHardwareListenerProxy final : public RefCounted<RemoteAudioHardwareListenerProxy>, private WebCore::AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioHardwareListenerProxy);
 public:
-    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+    static Ref<RemoteAudioHardwareListenerProxy> create(GPUConnectionToWebProcess& connection, RemoteAudioHardwareListenerIdentifier&& identifier)
+    {
+        return adoptRef(*new RemoteAudioHardwareListenerProxy(connection, WTF::move(identifier)));
+    }
     virtual ~RemoteAudioHardwareListenerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+
     // AudioHardwareListener::Client
     void audioHardwareDidBecomeActive() final;
     void audioHardwareDidBecomeInactive() final;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -66,19 +66,22 @@ public:
     void audioHardwareDidBecomeActive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsActive);
-        m_client.audioHardwareDidBecomeActive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeActive();
     }
 
     void audioHardwareDidBecomeInactive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsInactive);
-        m_client.audioHardwareDidBecomeInactive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeInactive();
     }
 
     void audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
     {
         setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-        m_client.audioOutputDeviceChanged();
+        if (RefPtr client = this->client())
+            client->audioOutputDeviceChanged();
     }
 };
 #endif
@@ -102,8 +105,10 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy(WebCore::PageIden
 #endif
 
 #if PLATFORM(COCOA)
-    WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
-        return protectedThis->ensureAudioHardwareListenerProxy(client);
+    WebCore::AudioHardwareListener::setCreationFunction([weakThis = ThreadSafeWeakPtr { *this }] (WebCore::AudioHardwareListener::Client& client) -> Ref<WebCore::AudioHardwareListener> {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->ensureAudioHardwareListenerProxy(client);
+        return RemoteMediaSessionManagerAudioHardwareListener::create(client);
     });
 #endif
 
@@ -273,27 +278,33 @@ void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)
 #if PLATFORM(COCOA)
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeActive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeActive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeInactive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeInactive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
 }
 
 Ref<RemoteMediaSessionManagerAudioHardwareListener> RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy(WebCore::AudioHardwareListener::Client& client)
 {
-    if (!m_audioHardwareListenerProxy)
-        m_audioHardwareListenerProxy = RemoteMediaSessionManagerAudioHardwareListener::create(client);
-    return *m_audioHardwareListenerProxy;
+    if (&client == static_cast<WebCore::AudioHardwareListener::Client*>(this)) {
+        if (RefPtr existing = m_audioHardwareListenerProxy.get())
+            return existing.releaseNonNull();
+        auto listener = RemoteMediaSessionManagerAudioHardwareListener::create(client);
+        m_audioHardwareListenerProxy = listener.get();
+        return listener;
+    }
+
+    return RemoteMediaSessionManagerAudioHardwareListener::create(client);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -37,6 +37,8 @@
 #include <WebCore/PageIdentifier.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WeakPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/MediaSessionManagerIOS.h>
@@ -160,7 +162,7 @@ private:
     HashSet<WebCore::PageIdentifier> m_remoteSessionManagerPages;
 
 #if PLATFORM(COCOA)
-    RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
+    ThreadSafeWeakPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
 #endif
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -77,19 +77,22 @@ void RemoteAudioHardwareListener::gpuProcessConnectionDidClose(GPUProcessConnect
 void RemoteAudioHardwareListener::audioHardwareDidBecomeActive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsActive);
-    m_client.audioHardwareDidBecomeActive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeActive();
 }
 
 void RemoteAudioHardwareListener::audioHardwareDidBecomeInactive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsInactive);
-    m_client.audioHardwareDidBecomeInactive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeInactive();
 }
 
 void RemoteAudioHardwareListener::audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
     setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }


### PR DESCRIPTION
#### 9e2b19d8e67b855ca789e9b2b3f6797ad5e2b73d
<pre>
Cherry-pick 305413.1123@safari-7624.5.1.10-branch (039ba968916b). <a href="https://bugs.webkit.org/show_bug.cgi?id=319704">https://bugs.webkit.org/show_bug.cgi?id=319704</a>

    [IFC] Do not leave stale display content when partial merge fails in InlineContentBuilder
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319704">https://bugs.webkit.org/show_bug.cgi?id=319704</a>&gt;
    &lt;<a href="https://rdar.apple.com/177161065">rdar://177161065</a>&gt;

    Reviewed by Alan Baradlay.

    Field MTE reports show a use-after-free destroying InlineDisplay::Content during
    LineLayout::layout()&apos;s clearInlineContent(): a display box&apos;s CheckedPtr&lt;Layout::Box&gt;
    still references a Layout::Box that was already freed.

    Partial inline layout keeps the previous display content alive so the newly-built
    lines can be spliced into it, relying on InlineDamage::m_detachedLayoutBoxes to keep
    removed layout boxes alive across the merge. When handlePartialDisplayContentUpdate
    cannot compute a valid damaged range, it returned early through ASSERT_NOT_REACHED()
    and left the previous display content untouched. The caller then destroys the
    InlineDamage (m_lineDamage = { }), freeing the detached layout boxes while the display
    boxes still reference them; the next clearInlineContent() touches freed memory.

    Drop the previous display content on that fallback path (after collecting its ink
    overflow for repaint) so we never carry stale CheckedPtr&lt;Layout::Box&gt; references past
    the point their target is released. This hardens an ASSERT_NOT_REACHED() branch and
    does not change behavior on the fast path.

    * Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
    (WebCore::LayoutIntegration::InlineContentBuilder::handlePartialDisplayContentUpdate const):
    * LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash.html: Added.
    * LayoutTests/fast/block/inside-inlines/block-in-inline-partial-relayout-crash-expected.txt: Added.

    Identifier: 305413.1123@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1135@webkitglib/2.52">https://commits.webkit.org/305877.1135@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a80092a6bded04704466c14a9136eb065a2dcd91
<pre>
Cherry-pick 305413.1119@safari-7624.5.1.10-branch (6b8717a224a0). <a href="https://bugs.webkit.org/show_bug.cgi?id=318500">https://bugs.webkit.org/show_bug.cgi?id=318500</a>

    [WebCore] Memory underflow in PlatformRawAudioData::copyTo()
    <a href="https://rdar.apple.com/176473804">rdar://176473804</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318500">https://bugs.webkit.org/show_bug.cgi?id=318500</a>

    Reviewed by Jean-Yves Avenard

    When PlatformRawAudioData::copyTo() is told to copy zero samples, just bail out early. This
    avoids a calculation where the number of samples has 1 subtracted from it, causing a math
    underflow.

    Cherry-pick <a href="https://commits.webkit.org/314451@main">https://commits.webkit.org/314451@main</a> for test to pass.

    Test: fast/webcodecs/audio-data-copy-to-zero-frames-crash.html

    * LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt: Added.
    * LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js:
    (test):
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt:
    * Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp:
    (WebCore::computeCopyElementCount):
    * Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
    (WebCore::PlatformRawAudioData::copyTo):

    Identifier: 305413.1119@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1134@webkitglib/2.52">https://commits.webkit.org/305877.1134@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b5dfc709ba57e67d3efa64f74c581c0db9df5b4a
<pre>
Cherry-pick 305413.1115@safari-7624.5.1.10-branch (ddf732bdf8b3). <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>

    Hold AudioHardwareListener client weakly and stop caching listener proxies across clients
    <a href="https://rdar.apple.com/177436036">rdar://177436036</a>

    Reviewed by Jean-Yves Avenard.

    AudioHardwareListener stored its Client as a raw reference, while
    RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy()
    cached the first listener it created and reused it (with the original
    client) for every subsequent caller, in addition to holding it
    strongly via m_audioHardwareListenerProxy. Because each
    RemoteMediaSessionManagerProxy also overwrites the process-global
    AudioHardwareListener factory with a lambda capturing Ref{*this}, two
    WebPageProxy instances could end up with B&apos;s cached listener bound to
    A; closing A&apos;s page then made B&apos;s RemoteAudioOutputDeviceChanged
    dispatch a virtual call on a freed proxy (UI-process heap-use-after-
    free). Within a single page, removing the last media session cleared
    MediaSessionManagerCocoa::m_audioHardwareListener but left the
    strongly-held m_audioHardwareListenerProxy, so the same IPC message
    null-dereferenced m_audioHardwareListener in audioOutputDeviceChanged.

    Make AudioHardwareListener::Client an AbstractRefCountedAndCanMakeWeakPtr
    (matching NowPlayingManagerClient), store m_client as a WeakPtr, and
    upgrade to a protecting RefPtr before dispatching in every listener
    subclass. In RemoteMediaSessionManagerProxy, capture *this weakly in
    the creation lambda (also removing a leak of the last-constructed
    proxy), always create a fresh listener per call, only stash a
    ThreadSafeWeakPtr to it when the client is *this*, and dispatch IPC
    through that weak pointer so the listener&apos;s lifetime is governed
    solely by MediaSessionManagerCocoa::m_audioHardwareListener. Also
    guard MediaSessionManagerCocoa::audioOutputDeviceChanged() against a
    null m_audioHardwareListener for defense in depth, and make
    RemoteAudioHardwareListenerProxy ref-counted to satisfy the new Client
    contract.

    Tests: ipc/remote-media-session-manager-audio-hardware-listener-crash.html
           ipc/remote-media-session-manager-audio-hardware-listener-uaf.html

    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html: Added.
    * Source/WebCore/platform/audio/AudioHardwareListener.h:
    (WebCore::AudioHardwareListener::client const):
    * Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
    (WebCore::MediaSessionManagerCocoa::audioOutputDeviceChanged):
    * Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
    (WebCore::AudioHardwareListenerMac::processIsRunningChanged):
    (WebCore::AudioHardwareListenerMac::outputDeviceChanged):
    * Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
    (WebKit::GPUConnectionToWebProcess::createAudioHardwareListener):
    * Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
    * Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h:
    * Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
    (WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged):
    (WebKit::RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy):
    * Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
    * Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
    (WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeActive):
    (WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeInactive):
    (WebKit::RemoteAudioHardwareListener::audioOutputDeviceChanged):

    Identifier: 305413.1115@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1133@webkitglib/2.52">https://commits.webkit.org/305877.1133@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ffb1c6ad26fae4bb1cabd2bfeb8e1d0fdd04f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184599 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58518 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148873 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186461 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59872 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58251 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144247 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148873 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187554 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59872 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124530 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59872 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58251 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59872 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5988 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51182 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58251 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196876 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58190 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153713 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58893 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153366 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28046 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58893 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131182 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127677 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57394 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52341 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56756 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57005 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56830 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->