### PR TITLE
[Site Isolation] New pages added to BrowsingContextGroup are not registered with shared process

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -191,6 +191,11 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     auto createRemotePageIfNeeded = [&](WebPageProxy& page, const Site& site) {
         if (!functor(page))
             return;
+
+        // The process is hosting main frame so it does not need remote page.
+        if (page.legacyMainFrameProcess().coreProcessIdentifier() == processProxy->coreProcessIdentifier())
+            return;
+
         auto& set = m_remotePages.ensure(page, [] {
             return HashSet<Ref<RemotePageProxy>> { };
         }).iterator->value;
@@ -201,6 +206,7 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
             ASSERT(existingPage->page() == newRemotePage->page());
         }
 #endif
+
         // Register before injecting, so creation parameters can resolve this page's identifier in the
         // new process via webPageIDInProcess().
         set.add(newRemotePage.copyRef());
@@ -208,12 +214,14 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     };
 
     if (process.isSharedProcess()) {
-        Ref processProxy = process.process();
+        // RemotePageProxy currently requires a site, but it has no meaning under shared process mode since
+        // one process/RemotePageProxy can represent multiple sites, so we just pick the first site as a
+        // placeholder value.
+        auto& representativeSite = *m_sharedProcessSites.begin();
         for (Ref page : m_pages) {
             if (!m_pagesInSharedProcess.add(page).isNewEntry)
                 continue;
-            for (auto site : m_sharedProcessSites)
-                createRemotePageIfNeeded(page, site);
+            createRemotePageIfNeeded(page, representativeSite);
         }
         return;
     }
@@ -222,13 +230,10 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     auto& site = *process.site();
     for (Ref page : m_pages) {
         // Under site isolation, a same-site page should be hosted in the same process and
-        // shouldn't need a remote page. Empty sites are the exception as they can span
-        // multiple processes but they appear as same-site.
-        // So for an empty site, only skip when the page really is in this process.
+        // shouldn't need a remote page. Empty sites are the exception, as they can compare equal
+        // for pages that are not actually co-located in the same process.
         bool sameSite = site == Site(URL(page->currentURL()));
-        RefPtr mainFrame = page->mainFrame();
-        bool pageIsInThisProcess = mainFrame && mainFrame->process().coreProcessIdentifier() == process.process().coreProcessIdentifier();
-        if (sameSite && (!site.isEmpty() || pageIsInThisProcess))
+        if (sameSite && !site.isEmpty())
             continue;
         createRemotePageIfNeeded(page, site);
     }
@@ -296,17 +301,12 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
     auto& set = m_remotePages.ensure(page, [] {
         return HashSet<Ref<RemotePageProxy>> { };
     }).iterator->value;
-    m_processMap.removeIf([&] (auto& pair) {
-        auto& site = pair.key;
-        auto& process = pair.value;
-        if (!process) {
-            ASSERT_NOT_REACHED_WITH_MESSAGE("FrameProcess should remove itself in the destructor so we should never find a null WeakPtr");
-            return true;
-        }
 
-        if (process->process().coreProcessIdentifier() == page.legacyMainFrameProcess().coreProcessIdentifier())
-            return false;
-        Ref processProxy = process->process();
+    auto createRemotePageIfNeeded = [&, page = Ref { page }](WebProcessProxy& processProxy, const Site& site) {
+        // A page whose main frame is already hosted directly by this process doesn't need a
+        // RemotePageProxy to reach itself.
+        if (page->legacyMainFrameProcess().coreProcessIdentifier() == processProxy.coreProcessIdentifier())
+            return;
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
 #if ASSERT_ENABLED
         for (auto& existingPage : set) {
@@ -316,6 +316,20 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
 #endif
         set.add(newRemotePage.copyRef());
         newRemotePage->injectPageIntoNewProcess();
+    };
+
+    if (RefPtr sharedProcess = m_sharedProcess.get(); sharedProcess && m_pagesInSharedProcess.add(page).isNewEntry)
+        createRemotePageIfNeeded(sharedProcess->process(), *m_sharedProcessSites.begin());
+
+    m_processMap.removeIf([&] (auto& pair) {
+        auto& site = pair.key;
+        auto& process = pair.value;
+        if (!process) {
+            ASSERT_NOT_REACHED_WITH_MESSAGE("FrameProcess should remove itself in the destructor so we should never find a null WeakPtr");
+            return true;
+        }
+
+        createRemotePageIfNeeded(process->process(), site);
         return false;
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -3147,7 +3147,48 @@ TEST(SiteIsolation, OpenerProcessSharing)
         { "/opened_iframe"_s, { "<script>alert('done')</script>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto [webView, delegate] = siteIsolatedViewAndDelegate(server);
+    auto [webView, delegate] = siteIsolatedViewAndDelegateWithoutSharedProcess(server);
+
+    __block RetainPtr<TestWKWebView> openedWebView;
+    __block RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    webView.get().UIDelegate = uiDelegate.get();
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        static RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [openedNavigationDelegate allowAnyTLSCertificate];
+        openedWebView.get().navigationDelegate = openedNavigationDelegate.get();
+        openedWebView.get().UIDelegate = uiDelegate.get();
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [delegate waitForDidFinishNavigation];
+    [webView evaluateJavaScript:@"w = window.open('/opened')" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "done");
+
+    auto openerMainFrame = [webView mainFrame];
+    auto openedMainFrame = [openedWebView mainFrame];
+    pid_t openerMainFramePid = openerMainFrame.info._processIdentifier;
+    pid_t openedMainFramePid = openedMainFrame.info._processIdentifier;
+    pid_t openerIframePid = openerMainFrame.childFrames.firstObject.info._processIdentifier;
+    pid_t openedIframePid = openedMainFrame.childFrames.firstObject.info._processIdentifier;
+
+    EXPECT_EQ(openerMainFramePid, openedMainFramePid);
+    EXPECT_NE(openerMainFramePid, 0);
+    EXPECT_EQ(openerIframePid, openedIframePid);
+    EXPECT_NE(openerIframePid, 0);
+}
+
+TEST(SiteIsolation, OpenerProcessSharingWithSharedProcess)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/opener_iframe'></iframe>"_s } },
+        { "/opened"_s, { "<iframe src='https://webkit.org/opened_iframe'></iframe>"_s } },
+        { "/opener_iframe"_s, { "hello"_s } },
+        { "/opened_iframe"_s, { "<script>alert('done')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, delegate] = siteIsolatedViewWithSharedProcess(server);
 
     __block RetainPtr<TestWKWebView> openedWebView;
     __block RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);


### PR DESCRIPTION
#### b8e586fe8c3068f916f90de3e2ccd5e305af81fe
<pre>
[Site Isolation] New pages added to BrowsingContextGroup are not registered with shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=323149">https://bugs.webkit.org/show_bug.cgi?id=323149</a>
<a href="https://rdar.apple.com/186407140">rdar://186407140</a>

Reviewed by Per Arne Vollan.

When SiteIsolationSharedProcessEnabled is on, BrowsingContextGroup::addPage() only creates RemotePageProxys for pages
joining per-site FrameProcesses in m_processMap, not for m_sharedProcess. A page that joins a group which already has a
shared process (e.g. a same-site window.open() popup) never gets registered there, so a later WebPage::LoadRequest to a
site already hosted in the shared process targets a PageIdentifier with no registered receiver, and
WebProcess::filterUnhandledMessage() silently drops it, hanging the page. Fixed addPage() to create a RemotePageProxy in
the shared process when a page joins.

Also, since RemotePageDrawingAreaProxy keys its message receiver by (page, process) rather than by site, only one
RemotePageProxy can be created per (page, process); the existing code loops over every m_sharedProcessSites entry per
page and creates duplicates, which would lead to crashes in MessageReceiverMap::addMessageReceiver. Fixed this by
ensuring to create one RemotePageProxy per (page, process). For RemotePageProxy in shared process, we use an arbitrary
site as a placeholder since RemotePageProxy::site() is meaningless under shared process mode (as multiple sites will be
put in the same process and share the same remote page).

This patch also consolidated the pre-existing &quot;this process is the main frame process so don&apos;t need a remote page&quot; check
into createRemotePageIfNeeded() functions, so new call sites won&apos;t omit the check by mistake.

Tests: SiteIsolation.OpenerProcessSharing
       SiteIsolation.OpenerProcessSharingWithSharedProcess
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::addPage):
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, OpenerProcessSharing)):
(TestWebKitAPI::TEST(SiteIsolation, OpenerProcessSharingWithSharedProcess)):

Canonical link: <a href="https://commits.webkit.org/320434@main">https://commits.webkit.org/320434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d00d2e3cb272c6b9a8b75bd903bdf1ad33508e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194846 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148803 "Hash 7d00d2e3 for PR 72988 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cec5b8b-169c-4644-9a81-9b5c26e11b29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144057 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148803 "Hash 7d00d2e3 for PR 72988 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/304350a1-dd6e-457d-a5f5-730dbd7130d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a9c876b-130e-4c26-8f29-f926db970431) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46561 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44727 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44344 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5918 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196790 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58112 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153642 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58817 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153303 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131108 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57320 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19358 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56684 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->