### PR TITLE
[GTK] Remove unnecessary webkitWebViewBaseLeave

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1753,51 +1753,6 @@ static gboolean webkitWebViewBaseMotion(WebKitWebViewBase* webViewBase, double x
 
     return GDK_EVENT_PROPAGATE;
 }
-
-static void webkitWebViewBaseLeave(WebKitWebViewBase* webViewBase, GtkEventController*)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    if (priv->dialog)
-        return;
-
-#if ENABLE(DEVELOPER_MODE)
-    // Do not send mouse move events to the WebProcess for crossing events during testing.
-    // WTR never generates crossing events and they can confuse tests.
-    // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()) [[unlikely]]
-        return;
-#endif
-
-    if (!priv->lastMotionEvent)
-        return;
-
-    // We need to synthesize a fake mouse event here to let WebCore know that the mouse has left the
-    // web view. Let's compute a point outside the web view that is close to the previous
-    // coordinates of the pointer before it left the web view. First we'll figure out which
-    // coordinate is closest to an edge of the web view, then we'll adjust the coordinate to be one
-    // pixel outside the view. This is not necessarily the closest point outside the web view, but
-    // it's simple to calculate and surely good enough.
-
-    int previousX = std::round(priv->lastMotionEvent->position.x());
-    int previousY = std::round(priv->lastMotionEvent->position.y());
-    int width = gtk_widget_get_width(GTK_WIDGET(webViewBase));
-    int height = gtk_widget_get_height(GTK_WIDGET(webViewBase));
-    int xDistanceFromRightEdge = width - previousX;
-    int yDistanceFromBottomEdge = height - previousY;
-
-    if (previousX <= xDistanceFromRightEdge && previousX <= previousY && previousX <= yDistanceFromBottomEdge)
-        priv->pageProxy->handleMouseEvent(NativeWebMouseEvent::create(DoublePoint(-1, previousY)));
-    else if (xDistanceFromRightEdge <= previousX && xDistanceFromRightEdge <= previousY && xDistanceFromRightEdge <= yDistanceFromBottomEdge)
-        priv->pageProxy->handleMouseEvent(NativeWebMouseEvent::create(DoublePoint(width, previousY)));
-    else if (previousY <= previousX && previousY <= xDistanceFromRightEdge && previousY <= yDistanceFromBottomEdge)
-        priv->pageProxy->handleMouseEvent(NativeWebMouseEvent::create(DoublePoint(previousX, -1)));
-    else {
-        ASSERT(yDistanceFromBottomEdge <= previousX);
-        ASSERT(yDistanceFromBottomEdge <= previousY);
-        ASSERT(yDistanceFromBottomEdge <= xDistanceFromRightEdge);
-        priv->pageProxy->handleMouseEvent(NativeWebMouseEvent::create(DoublePoint(previousX, height)));
-    }
-}
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
@@ -2335,7 +2290,6 @@ static void webkitWebViewBaseConstructed(GObject* object)
     controller = gtk_event_controller_motion_new();
     g_signal_connect_object(controller, "enter", G_CALLBACK(webkitWebViewBaseEnter), viewWidget, G_CONNECT_SWAPPED);
     g_signal_connect_object(controller, "motion", G_CALLBACK(webkitWebViewBaseMotion), viewWidget, G_CONNECT_SWAPPED);
-    g_signal_connect_object(controller, "leave", G_CALLBACK(webkitWebViewBaseLeave), viewWidget, G_CONNECT_SWAPPED);
     gtk_widget_add_controller(viewWidget, controller);
 
     controller = gtk_event_controller_focus_new();


### PR DESCRIPTION
#### c0b26d84d7632090939aa298e0a87150e9506c1f
<pre>
[GTK] Remove unnecessary webkitWebViewBaseLeave
<a href="https://bugs.webkit.org/show_bug.cgi?id=323153">https://bugs.webkit.org/show_bug.cgi?id=323153</a>

Reviewed by NOBODY (OOPS!).

webkitWebViewBaseLeave sent a fake mousemove event for leave event. This is not
needed. No mousemove events have to be sent for leave event.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseMotion):
(webkitWebViewBaseConstructed):
(webkitWebViewBaseLeave): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b26d84d7632090939aa298e0a87150e9506c1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143914 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100029 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44603 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44196 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5744 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57938 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58642 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153156 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47683 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130938 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127364 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57149 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19211 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->