### PR TITLE
[EWS] A clean-tree flake conviction can rest on a single observation from the same author

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -29,7 +29,9 @@ import sys
 import time
 import urllib.parse
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Optional
 
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
@@ -87,6 +89,7 @@ class ResultsDatabase(object):
 
     PRS_FOR_DIRTY_TREE_FLAKE = 2
     AUTHORS_FOR_DIRTY_TREE_FLAKE = 2
+    BUILDS_FOR_CLEAN_TREE_FLAKE = 2
     PRS_FOR_BETWEEN_BUILD_FLAKE = 3
     AUTHORS_FOR_BETWEEN_BUILD_FLAKE = 2
 
@@ -95,10 +98,11 @@ class ResultsDatabase(object):
     FLAKY_QUERY_TIMEOUT_SECONDS = 30
     FLAKY_WINDOW_SECONDS = 3 * 24 * 60 * 60
 
-    # What EWS records in the flaky_type column, which the reporting side writes.
     WITHIN_STEP_CLEAN_TREE = 'WithinStepCleanTree'
     WITHIN_STEP_DIRTY_TREE = 'WithinStepDirtyTree'
     BETWEEN_STEPS_DIRTY_TREE = 'BetweenStepsDirtyTree'
+    FAILED_ROWS = 'Failed'
+    WITHIN_BUILD_ROWS = (WITHIN_STEP_CLEAN_TREE, WITHIN_STEP_DIRTY_TREE, BETWEEN_STEPS_DIRTY_TREE)
 
     # What the read path concludes, which is what a caller decides to act on.
     CLEAN_TREE_VERDICT = 'CleanTree'
@@ -295,32 +299,72 @@ class ResultsDatabase(object):
         return evidence
 
     @classmethod
-    def _convict(cls, evidence, flaky_type, prs_needed, authors_needed):
-        if len(evidence.pr_numbers) >= prs_needed and len(evidence.authors) >= authors_needed:
+    def _convict(
+        cls, evidence: FlakyVerdict, flaky_type: str,
+        prs_needed: int = 0, authors_needed: int = 0, builds_needed: int = 0,
+    ) -> Optional[FlakyVerdict]:
+        if (
+            len(evidence.pr_numbers) >= prs_needed
+            and len(evidence.authors) >= authors_needed
+            and len(evidence.build_urls) >= builds_needed
+        ):
             evidence.flaky_type = flaky_type
             return evidence
 
     @classmethod
-    def _rows_by_flaky_type(cls, entries):
-        rows = {}
+    def _rows_by_type(
+        cls, entries: list[dict], curr_authors: Optional[Iterable[str]], curr_pr: Optional[int], logger: Callable[[str], None],
+    ) -> dict[str, list[dict]]:
+        """Rows grouped by `flaky_type`, dropping those attributable to the change being judged."""
+        curr = {author for author in (curr_authors or []) if author}
+
+        def independent_of_this_pull_request(row: dict) -> bool:
+            return not curr_pr or (row.get('details') or {}).get('pr_number') != curr_pr
+
+        def independent_of_this_changes_authors(row: dict) -> bool:
+            recorded = {a for a in ((row.get('details') or {}).get('authors') or []) if a}
+            return not recorded or bool(recorded - curr)
+
+        by_type = {}
+        same_pull_request = {}
+        same_authors = {}
         for entry in entries:
             for row in entry.get('results', []):
-                rows.setdefault(row.get('flaky_type'), []).append(row)
-        return rows
+                flaky_type = row.get('flaky_type') or cls.FAILED_ROWS
+                # A clean-tree row is recorded with the change reverted; its pr_number and authors name the build.
+                if flaky_type == cls.WITHIN_STEP_CLEAN_TREE:
+                    bucket = by_type
+                elif not independent_of_this_pull_request(row):
+                    bucket = same_pull_request
+                elif not independent_of_this_changes_authors(row):
+                    bucket = same_authors
+                else:
+                    bucket = by_type
+                bucket.setdefault(flaky_type, []).append(row)
+
+        for flaky_type, dropped in sorted(same_pull_request.items()):
+            logger(f"Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own pull request (#{curr_pr})\n")
+        for flaky_type, dropped in sorted(same_authors.items()):
+            logger(f"Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own author(s)\n")
+        return by_type
 
     @classmethod
-    def _is_intra_build_flake(cls, entries, logger):
-        rows = cls._rows_by_flaky_type(entries)
-        recognized = (cls.WITHIN_STEP_CLEAN_TREE, cls.WITHIN_STEP_DIRTY_TREE, cls.BETWEEN_STEPS_DIRTY_TREE)
-
-        if unrecognized := {name for name in rows if name and name not in recognized}:
+    def _is_intra_build_flake(cls, rows: dict[str, list[dict]], logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
+        if failed_with_no_flaky_type := rows.get(cls.FAILED_ROWS, []):
+            logger(f'Ignored {len(failed_with_no_flaky_type)} flake row(s) that carried no flaky_type\n')
+        if unrecognized := {name for name in rows if name and name not in cls.WITHIN_BUILD_ROWS and name != cls.FAILED_ROWS}:
             logger(f"Ignored flakiness recorded as {', '.join(sorted(unrecognized))}\n")
 
-        if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE):
+        if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE, []):
             evidence = cls._evidence_in(clean_tree)
-            evidence.flaky_type = cls.CLEAN_TREE_VERDICT
-            return evidence
+            if verdict := cls._convict(evidence, cls.CLEAN_TREE_VERDICT, builds_needed=cls.BUILDS_FOR_CLEAN_TREE_FLAKE):
+                return verdict
+            logger(
+                f'{len(clean_tree)} clean-tree row(s) come from {len(evidence.build_urls)} build(s), '
+                f'fewer than the {cls.BUILDS_FOR_CLEAN_TREE_FLAKE} the clean-tree rule needs\n'
+            )
 
+        # Folding a below-threshold clean-tree row here would let the change's own rows fill these quotas.
         with_change = rows.get(cls.WITHIN_STEP_DIRTY_TREE, []) + rows.get(cls.BETWEEN_STEPS_DIRTY_TREE, [])
         return cls._convict(
             cls._evidence_in(with_change), cls.DIRTY_TREE_VERDICT,
@@ -328,9 +372,9 @@ class ResultsDatabase(object):
         )
 
     @classmethod
-    def _is_inter_build_flake(cls, entries, logger):
-        rows = [row for entry in entries for row in entry.get('results', [])]
-        evidence = cls._evidence_in(rows)
+    def _is_inter_build_flake(cls, rows: dict[str, list[dict]], logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
+        failed = rows.get(cls.FAILED_ROWS, [])
+        evidence = cls._evidence_in(failed)
 
         if verdict := cls._convict(
             evidence, cls.BETWEEN_BUILDS_VERDICT,
@@ -339,7 +383,7 @@ class ResultsDatabase(object):
             return verdict
 
         rows_without_an_author = sum(
-            1 for row in rows if not {a for a in ((row.get('details') or {}).get('authors') or []) if a}
+            1 for row in failed if not {a for a in ((row.get('details') or {}).get('authors') or []) if a}
         )
         if rows_without_an_author and len(evidence.authors) < cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE:
             logger(
@@ -406,7 +450,10 @@ class ResultsDatabase(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def flaky_verdicts_for(cls, tests, configuration=None, suite=None):
+    def flaky_verdicts_for(
+        cls, tests: Iterable[str], configuration: Optional[dict] = None, suite: Optional[str] = None,
+        authors: Optional[Iterable] = None, pr_number: Optional[int] = None,
+    ) -> defer.Deferred:
         logs = []
 
         def logger(log):
@@ -424,13 +471,16 @@ class ResultsDatabase(object):
                 for test in remaining:
                     verdicts[test] = FlakyVerdict(request_failed=True)
                 return verdicts, ''.join(logs)
-            if flaky:
-                intra_build_rows = result
 
             still_unexplained = []
             for test in remaining:
-                if found := classify(result.get(test, []), logger):
-                    found.intra_build_evidence = bool(intra_build_rows.get(test))
+                rows = cls._rows_by_type(result.get(test, []), authors, pr_number, logger)
+                if flaky:
+                    intra_build_rows[test] = rows
+                if found := classify(rows, logger):
+                    found.intra_build_evidence = any(
+                        intra_build_rows.get(test, {}).get(name) for name in cls.WITHIN_BUILD_ROWS
+                    )
                     verdicts[test] = found
                 else:
                     still_unexplained.append(test)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4211,7 +4211,11 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             )
 
         unexplained = [test for test in tests if not pre_existing[test]['is_existing_failure']]
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(unexplained, configuration=configuration, suite=self.suite)
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
+            unexplained, configuration=configuration, suite=self.suite,
+            authors=self.getProperty('owners', []),
+            pr_number=self.getProperty('github.number', None),
+        )
         if flake_logs:
             yield self._addToLog(self.results_db_log_name, flake_logs)
 
@@ -6183,7 +6187,11 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
         configuration = self.results_db_query_configuration()
         yield self._addToLog(self.results_db_log_name, f'Checking Results database for flakiness of {len(tests)} new failure(s). Configuration: {configuration}\n')
 
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(tests, configuration=configuration, suite=self.suite)
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
+            tests, configuration=configuration, suite=self.suite,
+            authors=self.getProperty('owners', []),
+            pr_number=self.getProperty('github.number', None),
+        )
         if flake_logs:
             yield self._addToLog(self.results_db_log_name, flake_logs)
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Generator, Optional
+from typing import Any, Generator, Iterable, Optional
 from unittest import skip as skipTest
 from unittest.mock import call, create_autospec, patch
 
@@ -4287,9 +4287,12 @@ class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.T
 
     @staticmethod
     def fake_verdicts(verdicts: dict, queried: Optional[list] = None) -> classmethod:
-        def flaky_verdicts_for(cls, tests: list, configuration: Optional[dict] = None, suite: Optional[str] = None) -> defer.Deferred:
+        def flaky_verdicts_for(
+            cls, tests: list, configuration: Optional[dict] = None, suite: Optional[str] = None,
+            authors: Optional[Iterable] = None, pr_number: Optional[int] = None,
+        ) -> defer.Deferred:
             if queried is not None:
-                queried.append((sorted(tests), configuration, suite))
+                queried.append((sorted(tests), configuration, suite, authors, pr_number))
             return defer.succeed(({test: verdicts.get(test, FlakyVerdict()) for test in tests}, ''))
         return classmethod(flaky_verdicts_for)
 
@@ -4352,7 +4355,7 @@ class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.T
 
         yield step.run()
 
-        self.assertEqual(queried, [(['suite.new'], {'platform': 'mac', 'style': 'release'}, 'api-tests')])
+        self.assertEqual(queried, [(['suite.new'], {'platform': 'mac', 'style': 'release'}, 'api-tests', [], None)])
 
     @defer.inlineCallbacks
     def test_a_test_flaky_only_between_builds_without_intra_build_evidence_is_unsupported(self) -> Generator[Any, Any, None]:
@@ -4390,7 +4393,19 @@ class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.T
 
         yield step.run()
 
-        self.assertEqual([len(tests) for tests, _, _ in queried], [cap])
+        self.assertEqual([len(tests) for tests, _, _, _, _ in queried], [cap])
+
+    @defer.inlineCallbacks
+    def test_the_api_read_forwards_the_change_identity(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(['suite.new'], ['suite.new'], [])
+        self.setProperty('owners', ['jappleseed'])
+        self.setProperty('github.number', 42)
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts({}, queried))
+
+        yield step.run()
+
+        self.assertEqual([(authors, pr_number) for _, _, _, authors, pr_number in queried], [(['jappleseed'], 42)])
 
 
 class TestAPITestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):
@@ -13246,6 +13261,9 @@ if __name__ == '__main__':
 
 
 class TestIsTestFlakyClassifier(unittest.TestCase):
+    SUBMITTER = 'issacroy'
+    TEST = 'layout/test.html'
+
     def _response(self, rows=None):
         # rows=None simulates the find endpoint's 404 (no results for this test in that table).
         if rows is None:
@@ -13253,13 +13271,22 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         payload = [{'test': 'layout/test.html', 'configuration': {}, 'results': rows}]
         return TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
 
-    def _flaky_row(self, flaky_type, build_url=None, pr_number=None, authors=None):
+    def _flaky_row(
+        self, flaky_type: Optional[str], build: Optional[int] = None,
+        pr_number: Optional[int] = None, authors: Optional[list] = None,
+    ) -> dict:
         return {'flaky_type': flaky_type, 'details': {
-            'build_url': build_url, 'pr_number': pr_number, 'authors': authors or [],
+            'build_url': self._builder_url(build) if build is not None else None,
+            'pr_number': pr_number, 'authors': authors or [],
         }}
 
-    def _failed_row(self, pr_number=None, authors=None, build_url=None):
-        return {'details': {'pr_number': pr_number, 'authors': authors or [], 'build_url': build_url}}
+    def _failed_row(
+        self, build: Optional[int] = None, pr_number: Optional[int] = None, authors: Optional[list] = None,
+    ) -> dict:
+        return {'details': {
+            'build_url': self._builder_url(build) if build is not None else None,
+            'pr_number': pr_number, 'authors': authors or [],
+        }}
 
     def _mock(self, flaky_response, failed_response):
         # The flaky table is asked first, then the failed one; route on which table was requested.
@@ -13268,124 +13295,247 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
             return defer.succeed(flaky_response if params.get('flaky') == 'true' else failed_response)
         return patch('ews-build.results_db.TwistedAdditions.request', fake_request)
 
+    def _builder_url(self, build: int) -> str:
+        return f'https://ews-build.webkit.org/#/builders/72/builds/{build}'
+
+    @defer.inlineCallbacks
+    def _verdicts_for(
+        self, flaky_rows: Optional[list] = None, failed_rows: Optional[list] = None,
+        authors: tuple = (SUBMITTER,), pr_number: Optional[int] = None,
+    ) -> Generator[Any, Any, tuple]:
+        with self._mock(self._response(rows=flaky_rows), self._response(rows=failed_rows)):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(
+                [self.TEST], suite='layout-tests', authors=list(authors), pr_number=pr_number,
+            )
+        return (verdicts, logs)
+
     @defer.inlineCallbacks
     def test_a_clean_tree_flake_is_flaky(self):
-        flaky = self._response(rows=[self._flaky_row('WithinStepCleanTree', build_url='https://build/1/builds/7')])
-        with self._mock(flaky, self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertEqual(result.flaky_type, 'CleanTree')
-            self.assertEqual(result.build_urls, {'https://build/1/builds/7'})
+        rows = [self._flaky_row('WithinStepCleanTree', 7), self._flaky_row('WithinStepCleanTree', 8)]
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'CleanTree')
+        self.assertEqual(result.build_urls, {self._builder_url(7), self._builder_url(8)})
+
+    @defer.inlineCallbacks
+    def test_a_single_build_of_clean_tree_evidence_does_not_convict(self) -> Generator[Any, Any, None]:
+        # GTK-WK2-Tests-EWS build 153043 excused a crash on evidence from build 153004, the same pull
+        # request by the same author, and the test then failed 9 of 14 runs on main after it landed.
+        rows = [self._flaky_row('WithinStepCleanTree', 153004, 72787, [self.SUBMITTER])]
+        verdicts, logs = yield self._verdicts_for(rows)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn('1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+        self.assertNotIn("recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_clean_tree_own_pull_request_and_author_row_still_counts_toward_the_threshold(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepCleanTree', 153004, 72787, [self.SUBMITTER]),
+            self._flaky_row('WithinStepCleanTree', 152980, 72701, ['aperturedev']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows, pr_number=72787)
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'CleanTree')
+        self.assertEqual(result.authors, {self.SUBMITTER, 'aperturedev'})
+        self.assertEqual(result.pr_numbers, {72787, 72701})
+        self.assertEqual(result.build_urls, {self._builder_url(153004), self._builder_url(152980)})
+        self.assertNotIn("recorded by this change's own pull request", logs)
+        self.assertNotIn("recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_a_clean_tree_row_the_change_wrote_itself_is_within_build_evidence(self) -> Generator[Any, Any, None]:
+        failed = [self._failed_row(pr_number=n, authors=[author]) for n, author in enumerate(['alice', 'bob', 'alice'], start=1)]
+        own = [self._flaky_row('WithinStepCleanTree', 153004, 72787, ['webkit-commit-queue'])]
+        verdicts, logs = yield self._verdicts_for(own, failed, pr_number=72787)
+        self.assertEqual(verdicts[self.TEST].flaky_type, 'BetweenBuilds')
+        self.assertTrue(verdicts[self.TEST].intra_build_evidence)
+        self.assertNotIn('BetweenBuilds with no within-build flakiness recorded', logs)
+
+    @defer.inlineCallbacks
+    def test_clean_tree_rows_sharing_one_build_do_not_convict(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepCleanTree', 153004, 72787, ['aperturedev']),
+            self._flaky_row('WithinStepCleanTree', 153004, 72701, ['jsmith-webkit']),
+            self._flaky_row('WithinStepCleanTree', 153004, 72650, ['dpettifer']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn('3 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+
+    @defer.inlineCallbacks
+    def test_a_single_build_of_clean_tree_evidence_falls_through_to_the_dirty_tree_rule(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepCleanTree', 153004, 72787, [self.SUBMITTER]),
+            self._flaky_row('WithinStepDirtyTree', 152980, 72701, ['aperturedev']),
+            self._flaky_row('WithinStepDirtyTree', 152950, 72650, ['jsmith-webkit']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows)
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'DirtyTree')
+        self.assertEqual(result.pr_numbers, {72701, 72650})
+        self.assertIn('1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+
+    @defer.inlineCallbacks
+    def test_clean_tree_evidence_below_its_threshold_does_not_fill_the_dirty_tree_quota(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepCleanTree', 1, 101, ['alice']),
+            self._flaky_row('WithinStepDirtyTree', 2, 102, ['bob']),
+        ]
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_the_dirty_tree_rule_does_not_count_the_change_s_own_author(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', 153004, 72787, [self.SUBMITTER]),
+            self._flaky_row('WithinStepDirtyTree', 152980, 72701, ['aperturedev']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn("Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_the_dirty_tree_rule_does_not_count_the_change_s_own_pull_request(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', 153004, 72787, ['webkit-commit-queue']),
+            self._flaky_row('BetweenStepsDirtyTree', 152980, 72701, ['aperturedev', 'jsmith-webkit']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows, pr_number=72787)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn("Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own pull request (#72787)", logs)
+
+    @defer.inlineCallbacks
+    def test_the_dirty_tree_rule_convicts_when_the_submitter_wrote_none_of_the_rows(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', 152980, 72701, ['aperturedev']),
+            self._flaky_row('BetweenStepsDirtyTree', 152950, 72650, ['jsmith-webkit']),
+        ]
+        verdicts, logs = yield self._verdicts_for(rows)
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'DirtyTree')
+        self.assertEqual(result.pr_numbers, {72701, 72650})
+        self.assertEqual(result.authors, {'aperturedev', 'jsmith-webkit'})
+        self.assertNotIn("recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_the_dirty_tree_rule_with_every_row_written_by_the_submitter(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build, 72787, [self.SUBMITTER])
+            for build in (153004, 153043)
+        ]
+        verdicts, logs = yield self._verdicts_for(rows)
+        self.assertEqual(verdicts[self.TEST], FlakyVerdict())
+        self.assertIsNone(verdicts[self.TEST].flaky_type)
+        self.assertIn("Ignored 2 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_two_dirty_tree_pull_requests_is_flaky(self):
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n, authors=[author])
+            self._flaky_row('WithinStepDirtyTree', n, n, [author])
             for n, author in enumerate(['alice', 'bob'], start=1)
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertEqual(result.flaky_type, 'DirtyTree')
-            self.assertEqual(result.pr_numbers, {1, 2})
-            self.assertEqual(result.authors, {'alice', 'bob'})
-            self.assertEqual(result.build_urls, {'https://build/1/builds/1', 'https://build/1/builds/2'})
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'DirtyTree')
+        self.assertEqual(result.pr_numbers, {1, 2})
+        self.assertEqual(result.authors, {'alice', 'bob'})
+        self.assertEqual(result.build_urls, {self._builder_url(1), self._builder_url(2)})
 
     @defer.inlineCallbacks
     def test_retrying_one_pull_request_does_not_excuse_its_own_failure(self):
         # build_url carries the build number, so an EWS retry is a distinct build.
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=99, authors=['alice'])
+            self._flaky_row('WithinStepDirtyTree', n, 99, ['alice'])
             for n in range(1, 6)
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
 
     @defer.inlineCallbacks
     def test_a_missing_pull_request_is_not_a_second_pull_request(self):
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=1, authors=['alice']),
-            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/2', authors=['bob']),
+            self._flaky_row('WithinStepDirtyTree', 1, 1, ['alice']),
+            self._flaky_row('WithinStepDirtyTree', 2, authors=['bob']),
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
 
     @defer.inlineCallbacks
     def test_a_single_author_across_two_pull_requests_is_not_flaky(self) -> Generator[Any, Any, None]:
         # A stack of pull requests is one author's work, so the parent commit's own regression must
         # not excuse itself: a build's first run writes rows its own re-run then reads.
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n, authors=['alice'])
+            self._flaky_row('WithinStepDirtyTree', n, n, ['alice'])
             for n in range(1, 4)
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
 
     @defer.inlineCallbacks
     def test_dirty_tree_pull_requests_with_no_author_not_flaky(self):
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n)
+            self._flaky_row('WithinStepDirtyTree', n, n)
             for n in range(1, 4)
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        self.assertFalse(verdicts[self.TEST].is_flaky)
 
     @defer.inlineCallbacks
     def test_a_row_recording_no_flakiness_at_all_is_ignored(self):
         # flaky_type is required in the flaky table, so a null means malformed data.
         rows = [
-            self._flaky_row(None, build_url='https://build/1/builds/1'),
-            self._flaky_row('SomethingNewerReports', build_url='https://build/1/builds/2'),
+            self._flaky_row(None, 1),
+            self._flaky_row('SomethingNewerReports', 2),
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        verdicts, logs = yield self._verdicts_for(rows, authors=())
 
-        self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
         self.assertIn('SomethingNewerReports', logs)
 
     @defer.inlineCallbacks
     def test_flakiness_recorded_under_an_unknown_name_is_reported(self):
         # A results database holding a value this EWS does not know counts the row for nothing, which
         # is what deploying the two halves out of order looks like.
-        rows = [self._flaky_row('SomethingNewerReports', build_url='https://build/1/builds/7')]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        rows = [self._flaky_row('SomethingNewerReports', 7)]
+        verdicts, logs = yield self._verdicts_for(rows, authors=())
 
-        self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
         self.assertIn('SomethingNewerReports', logs)
+
+    @defer.inlineCallbacks
+    def test_a_flake_row_with_no_flaky_type_logs_its_own_line(self) -> Generator[Any, Any, None]:
+        rows = [self._flaky_row(None, 1)]
+        verdicts, logs = yield self._verdicts_for(rows, authors=())
+
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn('Ignored 1 flake row(s) that carried no flaky_type', logs)
+        self.assertNotIn('Ignored flakiness recorded as Failed', logs)
 
     @defer.inlineCallbacks
     def test_dirty_tree_same_build_deduped_not_flaky(self):
         rows = [
-            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/42', pr_number=7, authors=['alice'])
+            self._flaky_row('WithinStepDirtyTree', 42, 7, ['alice'])
             for _ in range(3)
         ]
-        with self._mock(self._response(rows=rows), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertFalse(result.is_flaky)
+        verdicts, _ = yield self._verdicts_for(rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertFalse(result.is_flaky)
 
     @defer.inlineCallbacks
     def test_a_verdict_records_whether_any_build_saw_the_flakiness(self):
         failed = [self._failed_row(pr_number=n, authors=[a]) for n, a in enumerate(['alice', 'bob', 'alice'], start=1)]
-        with self._mock(self._response(), self._response(rows=failed)):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-        self.assertFalse(verdicts['layout/test.html'].intra_build_evidence)
+        verdicts, _ = yield self._verdicts_for(failed_rows=failed, authors=())
+        self.assertFalse(verdicts[self.TEST].intra_build_evidence)
 
-        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=9)]
-        with self._mock(self._response(rows=short_of_a_verdict), self._response(rows=failed)):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-        self.assertTrue(verdicts['layout/test.html'].intra_build_evidence)
+        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', 1, 9)]
+        verdicts, _ = yield self._verdicts_for(short_of_a_verdict, failed, authors=())
+        self.assertTrue(verdicts[self.TEST].intra_build_evidence)
 
     @defer.inlineCallbacks
     def test_a_conviction_keeps_its_evidence_when_a_later_query_fails(self):
         convicted = [{'test': 'a.html', 'configuration': {}, 'results': [
-            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=1, authors=['alice']),
-            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/2', pr_number=2, authors=['bob']),
+            self._flaky_row('WithinStepDirtyTree', 1, 1, ['alice']),
+            self._flaky_row('WithinStepDirtyTree', 2, 2, ['bob']),
         ]}]
         flaky = TwistedAdditions.Response(status_code=200, content=json.dumps(convicted).encode('utf-8'))
 
@@ -13408,35 +13558,48 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
             for n, author in enumerate(['alice', 'bob', 'alice'], start=1)
         ]
 
-        with self._mock(self._response(), self._response(rows=failed)):
-            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-        self.assertEqual(verdicts['layout/test.html'].flaky_type, 'BetweenBuilds')
+        verdicts, logs = yield self._verdicts_for(failed_rows=failed, authors=())
+        self.assertEqual(verdicts[self.TEST].flaky_type, 'BetweenBuilds')
         self.assertIn('BetweenBuilds with no within-build flakiness recorded', logs)
-        self.assertIn('layout/test.html', logs)
+        self.assertIn(self.TEST, logs)
 
         # One dirty-tree row is short of a verdict on its own, but it is still an inconsistency
         # some build observed, so this conviction is not the between-builds rule acting alone.
-        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=9)]
-        with self._mock(self._response(rows=short_of_a_verdict), self._response(rows=failed)):
-            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-        self.assertEqual(verdicts['layout/test.html'].flaky_type, 'BetweenBuilds')
+        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', 1, 9)]
+        verdicts, logs = yield self._verdicts_for(short_of_a_verdict, failed, authors=())
+        self.assertEqual(verdicts[self.TEST].flaky_type, 'BetweenBuilds')
+        self.assertNotIn('BetweenBuilds with no within-build flakiness recorded', logs)
+
+    @defer.inlineCallbacks
+    def test_a_within_build_row_the_change_wrote_itself_is_not_within_build_evidence(self) -> Generator[Any, Any, None]:
+        failed = [self._failed_row(pr_number=n, authors=[author]) for n, author in enumerate(['alice', 'bob', 'alice'], start=1)]
+        own = [self._flaky_row('WithinStepDirtyTree', 153004, 72787, ['webkit-commit-queue'])]
+        verdicts, logs = yield self._verdicts_for(own, failed, pr_number=72787)
+        self.assertEqual(verdicts[self.TEST].flaky_type, 'BetweenBuilds')
+        self.assertFalse(verdicts[self.TEST].intra_build_evidence)
+        self.assertIn('BetweenBuilds with no within-build flakiness recorded', logs)
+
+    @defer.inlineCallbacks
+    def test_a_within_build_row_from_another_pull_request_is_within_build_evidence(self) -> Generator[Any, Any, None]:
+        failed = [self._failed_row(pr_number=n, authors=[author]) for n, author in enumerate(['alice', 'bob', 'alice'], start=1)]
+        elsewhere = [self._flaky_row('WithinStepDirtyTree', 152980, 72701, ['aperturedev'])]
+        verdicts, logs = yield self._verdicts_for(elsewhere, failed, pr_number=72787)
+        self.assertEqual(verdicts[self.TEST].flaky_type, 'BetweenBuilds')
+        self.assertTrue(verdicts[self.TEST].intra_build_evidence)
         self.assertNotIn('BetweenBuilds with no within-build flakiness recorded', logs)
 
     @defer.inlineCallbacks
     def test_between_builds_three_prs_two_authors_is_flaky(self):
         rows = [
-            self._failed_row(pr_number=1, authors=['alice'], build_url='https://build/1/builds/1'),
-            self._failed_row(pr_number=2, authors=['bob'], build_url='https://build/1/builds/2'),
-            self._failed_row(pr_number=3, authors=['alice'], build_url='https://build/1/builds/3'),
+            self._failed_row(1, 1, ['alice']),
+            self._failed_row(2, 2, ['bob']),
+            self._failed_row(3, 3, ['alice']),
         ]
-        with self._mock(self._response(), self._response(rows=rows)):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertEqual(result.flaky_type, 'BetweenBuilds')
-            self.assertEqual(result.pr_numbers, {1, 2, 3})
-            self.assertEqual(result.build_urls, {
-                'https://build/1/builds/1', 'https://build/1/builds/2', 'https://build/1/builds/3',
-            })
+        verdicts, _ = yield self._verdicts_for(failed_rows=rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'BetweenBuilds')
+        self.assertEqual(result.pr_numbers, {1, 2, 3})
+        self.assertEqual(result.build_urls, {self._builder_url(1), self._builder_url(2), self._builder_url(3)})
 
     @defer.inlineCallbacks
     def test_between_builds_too_few_prs_not_flaky(self):
@@ -13444,26 +13607,123 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
             self._failed_row(pr_number=1, authors=['alice']),
             self._failed_row(pr_number=2, authors=['bob']),
         ]
-        with self._mock(self._response(), self._response(rows=rows)):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertFalse(result.is_flaky)
+        verdicts, _ = yield self._verdicts_for(failed_rows=rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertFalse(result.is_flaky)
 
     @defer.inlineCallbacks
     def test_between_builds_single_author_not_flaky(self):
         # 3 PRs but all from one author-set -> fails the >=2 distinct author-sets floor.
         rows = [self._failed_row(pr_number=n, authors=['alice']) for n in range(1, 4)]
-        with self._mock(self._response(), self._response(rows=rows)):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertFalse(result.is_flaky)
+        verdicts, _ = yield self._verdicts_for(failed_rows=rows, authors=())
+        result = verdicts[self.TEST]
+        self.assertFalse(result.is_flaky)
+
+    @defer.inlineCallbacks
+    def test_between_builds_does_not_count_the_change_s_own_pull_request(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(153004, 72787, ['webkit-commit-queue']),
+            self._failed_row(152980, 72701, ['aperturedev']),
+            self._failed_row(152950, 72650, ['jsmith-webkit']),
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+
+    @defer.inlineCallbacks
+    def test_the_change_s_own_pull_request_does_not_fill_the_between_builds_quota(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(153004, 72787, ['webkit-commit-queue']),
+            self._failed_row(153043, 72787, ['webkit-commit-queue']),
+            self._failed_row(152980, 72701, ['aperturedev']),
+            self._failed_row(152950, 72650, ['jsmith-webkit']),
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
+        result = verdicts[self.TEST]
+        self.assertFalse(result.is_flaky)
+        self.assertIn("Ignored 2 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+
+    @defer.inlineCallbacks
+    def test_the_two_rejection_reasons_are_reported_separately(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(153004, 72787, ['webkit-commit-queue']),
+            self._failed_row(152901, 72602, [self.SUBMITTER]),
+            self._failed_row(152980, 72701, ['aperturedev']),
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_does_not_count_the_change_s_own_author(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(153004, 72787, [self.SUBMITTER]),
+        ] + [
+            self._failed_row(build, pr, ['aperturedev'])
+            for pr, build in ((72701, 152980), (72650, 152950), (72602, 152901))
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_convicts_when_the_submitter_wrote_none_of_the_rows(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(152980, 72701, ['aperturedev']),
+            self._failed_row(152950, 72650, ['jsmith-webkit']),
+            self._failed_row(152901, 72602, ['aperturedev']),
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows)
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'BetweenBuilds')
+        self.assertEqual(result.pr_numbers, {72701, 72650, 72602})
+        self.assertEqual(result.authors, {'aperturedev', 'jsmith-webkit'})
+        self.assertNotIn("recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_still_reports_rows_recording_no_author(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(build, pr)
+            for pr, build in ((72701, 152980), (72650, 152950), (72602, 152901))
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows)
+        self.assertFalse(verdicts[self.TEST].is_flaky)
+        self.assertIn('3 row(s) record no author, so the between-builds rule saw 0 of the 2 it needs', logs)
+        self.assertIn('across 3 pull request(s)', logs)
+        self.assertNotIn("recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_with_every_row_written_by_the_submitter(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(build, 72787, [self.SUBMITTER])
+            for build in (153004, 153043)
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows)
+        self.assertEqual(verdicts[self.TEST], FlakyVerdict())
+        self.assertIsNone(verdicts[self.TEST].flaky_type)
+        self.assertIn("Ignored 2 Failed row(s) recorded by this change's own author(s)", logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_counts_a_row_the_submitter_co_authored(self) -> Generator[Any, Any, None]:
+        rows = [
+            self._failed_row(153004, 72787, ['aperturedev', self.SUBMITTER]),
+            self._failed_row(152980, 72701, ['jsmith-webkit']),
+            self._failed_row(152950, 72650, ['dpettifer']),
+            self._failed_row(152870, 72590, [self.SUBMITTER]),
+        ]
+        verdicts, logs = yield self._verdicts_for(failed_rows=rows)
+        result = verdicts[self.TEST]
+        self.assertEqual(result.flaky_type, 'BetweenBuilds')
+        self.assertEqual(result.pr_numbers, {72787, 72701, 72650})
+        self.assertEqual(result.authors, {'aperturedev', 'issacroy', 'jsmith-webkit', 'dpettifer'})
+        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_no_history_not_flaky(self):
-        with self._mock(self._response(), self._response()):
-            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
-            result = verdicts['layout/test.html']
-            self.assertFalse(result.is_flaky)
+        verdicts, _ = yield self._verdicts_for(authors=())
+        result = verdicts[self.TEST]
+        self.assertFalse(result.is_flaky)
 
     @defer.inlineCallbacks
     def test_a_body_that_is_not_a_list_of_entries_is_a_failed_query(self):
@@ -13497,7 +13757,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
     def test_an_entry_naming_no_test_is_a_failed_query(self):
         # A results database predating the batched endpoint answers without naming the test. Matching
         # nothing, those entries would otherwise be dropped and every test would read as not flaky.
-        payload = [{'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]}]
+        payload = [{'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', 1)]}]
         nameless = TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
         with self._mock(nameless, self._response()):
             verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['a.html'], suite='layout-tests')
@@ -13511,8 +13771,12 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         # Two of the three are convicted by the first table. Dropping them from the list while
         # iterating it would skip the one in between, which would then read as not flaky.
         rows = [
-            {'test': 'a.html', 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]},
-            {'test': 'b.html', 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/2')]},
+            {'test': 'a.html', 'configuration': {}, 'results': [
+                self._flaky_row('WithinStepCleanTree', 1), self._flaky_row('WithinStepCleanTree', 2),
+            ]},
+            {'test': 'b.html', 'configuration': {}, 'results': [
+                self._flaky_row('WithinStepCleanTree', 3), self._flaky_row('WithinStepCleanTree', 4),
+            ]},
         ]
         flaky = TwistedAdditions.Response(status_code=200, content=json.dumps(rows).encode('utf-8'))
         with self._mock(flaky, self._response()):
@@ -13534,8 +13798,10 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
             captured.append(params)
             asked = params['tests']
             rows = [
-                {'test': test, 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url=f'build/{test}')]}
-                for test in asked
+                {'test': test, 'configuration': {}, 'results': [
+                    self._flaky_row('WithinStepCleanTree', n), self._flaky_row('WithinStepCleanTree', n + 1000),
+                ]}
+                for n, test in enumerate(asked, start=1)
             ] if params.get('flaky') == 'true' else []
             if not rows:
                 return defer.succeed(TwistedAdditions.Response(status_code=404))
@@ -13564,7 +13830,9 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
             if params.get('flaky') != 'true' or len(answered) == 1:
                 return defer.succeed(TwistedAdditions.Response(status_code=404))
             rows = [
-                {'test': test, 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]}
+                {'test': test, 'configuration': {}, 'results': [
+                    self._flaky_row('WithinStepCleanTree', 1), self._flaky_row('WithinStepCleanTree', 2),
+                ]}
                 for test in params['tests']
             ]
             return defer.succeed(TwistedAdditions.Response(status_code=200, content=json.dumps(rows).encode('utf-8')))


### PR DESCRIPTION
#### 118e5ea7dccdc5c700252646be5951025c4e5306
<pre>
[EWS] A clean-tree flake conviction can rest on a single observation from the same author
<a href="https://bugs.webkit.org/show_bug.cgi?id=323115">https://bugs.webkit.org/show_bug.cgi?id=323115</a>
<a href="https://rdar.apple.com/186374059">rdar://186374059</a>

Reviewed by Aakash Jain.

EWS excuses a failing test when the results database already calls it flaky. A
`WithinStepCleanTree` row convicts on its own, with no threshold, while a
dirty-tree verdict demands two pull requests and two authors and a
between-builds verdict three and two. Nothing compared that evidence against the
change being judged, so a pull request&apos;s own earlier build could excuse its own
failure and the test was dropped before it ever ran against a clean tree.
GTK-WK2-Tests-EWS build 153043 excused a crash recorded by build 153004, the
same pull request by the same author; the test then failed 9 of 14 runs on main
after it landed, and 0 of 35 before.

`_rows_by_type` buckets the rows by `flaky_type` in one pass and drops those
that are not independent evidence: a row goes when its `pr_number` is the pull
request being judged, or when every author it records is one of the change&apos;s
own.

Both axes are needed: the merge queue records the login of whoever applied the
label rather than the submitter, so the author check alone lets a PR&apos;s own row
through. `authors` comes from the `owners` property that `results_db_details`
already writes into each row&apos;s `details`, so there is no new source of truth. A
build where neither GitHub step ran leaves `owners` holding buildbot&apos;s blamelist
of commit authors rather than GitHub logins; the comparison then matches nothing
and conviction proceeds as it does today.

A `WithinStepCleanTree` row is exempt from that filtering. It is recorded after
the change is reverted and recompiled, so the pull request and authors on it
name the build that ran rather than a party with a stake in the verdict, and
dropping it for naming the change under test would discard the one observation
that already excludes the change as the cause. Independence there is a matter of
how many builds saw it, not who owned them: `_convict` takes a `builds_needed`
counted through `evidence.build_urls`, and `BUILDS_FOR_CLEAN_TREE_FLAKE` is 2.
All three thresholds default to 0, so the two existing call sites are unchanged.

Below that threshold the rule logs what it saw and falls through to the
dirty-tree rule instead of returning, so a test with one clean-tree row and
enough dirty-tree evidence is still convicted. The two rules read disjoint
buckets, so no row counts toward both, and `INCLUDED_FLAKY_VERDICTS` already
carries either verdict.

`intra_build_evidence` is now taken from the rows that survived that filtering
rather than the raw query, since a between-builds verdict whose only
within-build rows came from the change itself is exactly what the warning it
feeds exists to report. A clean-tree row the change wrote itself does count as
within-build evidence, so a `BetweenBuilds` verdict recorded alongside one is no
longer reported as `results-db_flaky_unsupported`.

`AnalyzeAPITestsResults` reads the database for the same reason and drops a
failure on the same verdicts, so it passes the same identity. `APITestsFactory`
derives from `TestFactory`, whose base adds `ValidateChange`, so `owners` and
`github.number` reach an API build by the same route as a layout build, and the
blamelist fallback above applies unchanged.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase):
(ResultsDatabase._convict):
(ResultsDatabase._rows_by_type):
(ResultsDatabase._rows_by_type.written_by_another_pull_request):
(ResultsDatabase._rows_by_type.written_by_others):
(ResultsDatabase._is_intra_build_flake):
(ResultsDatabase._is_inter_build_flake):
(ResultsDatabase.flaky_verdicts_for):
(ResultsDatabase._rows_by_flaky_type): Deleted.
(ResultsDatabase.flaky_verdicts_for.logger): Deleted.
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.filter_failures_using_results_db):
(AnalyzeAPITestsResults.flaky_new_failures_using_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/320410@main">https://commits.webkit.org/320410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5b7de6e6fe624dca4cd0f511b3017b83590f28e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144271 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100162 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44791 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44422 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6018 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196908 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184033 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58220 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58922 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153392 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47909 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57423 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->