### PR TITLE
[list-marker] RenderListItem should answer for its marker instead of its callers consulting RenderListMarker

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2194,23 +2194,23 @@ static RenderListItem* NODELETE renderListItemContainer(Node* node)
 }
 
 // Returns the text representing a list marker taking into account the position of the text in the line of text.
-static StringView lineStartListMarkerText(const RenderListItem* listItem, const VisiblePosition& startVisiblePosition, std::optional<StringView> markerText = std::nullopt)
+static String lineStartListMarkerText(const RenderListItem* listItem, const VisiblePosition& startVisiblePosition, String markerText = { })
 {
     if (!listItem)
         return { };
 
-    if (!markerText)
+    if (markerText.isNull())
         markerText = listItem->markerText();
-    if (markerText->isEmpty())
+    if (markerText.isEmpty())
         return { };
 
     // Only include the list marker if the range includes the line start (where the marker would be), and is in the same line as the marker.
     if (!isStartOfLine(startVisiblePosition) || !inSameLine(startVisiblePosition, firstPositionInNode(protect(*listItem->element()))))
         return { };
-    return *markerText;
+    return markerText;
 }
 
-StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Position&& startPosition)
+String AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Position&& startPosition)
 {
     CheckedPtr listItem = renderListItemContainer(node);
     if (!listItem)
@@ -2220,7 +2220,7 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
     auto markerText = listItem->markerText();
     if (markerText.isEmpty())
         return { };
-    return lineStartListMarkerText(listItem.get(), startPosition, markerText);
+    return lineStartListMarkerText(listItem.get(), startPosition, WTF::move(markerText));
 }
 
 String AccessibilityObject::textContentPrefixFromListMarker() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -709,7 +709,7 @@ public:
     String doAXStringForRange(const CharacterRange&) const override { return { }; }
     IntRect doAXBoundsForRange(const CharacterRange&) const override { return { }; }
     IntRect doAXBoundsForRangeUsingCharacterOffset(const CharacterRange&) const override { return { }; }
-    static StringView listMarkerTextForNodeAndPosition(Node*, Position&&);
+    static String listMarkerTextForNodeAndPosition(Node*, Position&&);
 
     unsigned doAXLineForIndex(unsigned) final;
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -387,13 +387,18 @@ void RenderListItem::updateValue()
     }
 }
 
+void RenderListItem::updateMarkerContent()
+{
+    if (CheckedPtr marker = m_marker.get())
+        marker->updateInlineMarginsAndContent();
+}
+
 void RenderListItem::updateValueAndMarkerContent()
 {
     updateValue();
     // Nothing is changing the render tree here, so there is nothing to wait for: fill the marker's text in right away
     // rather than leave it to layout (see RenderTreeBuilder::updateListMarkerContents()).
-    if (m_marker)
-        m_marker->updateInlineMarginsAndContent();
+    updateMarkerContent();
 }
 
 void RenderListItem::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
@@ -455,19 +460,23 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
 void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    // The marker box paints before our content, so content overlapping it (a negative margin pulling the first line
-    // over the marker) covers it rather than the other way around.
     if (CheckedPtr excludedMarker = this->excludedMarker(); excludedMarker && !excludedMarker->hasSelfPaintingLayer())
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
 
     RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
-String RenderListItem::markerText(RenderListMarker::IncludeSuffix includeSuffix) const
+String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
 {
-    if (!m_marker)
+    CheckedPtr marker = m_marker.get();
+    if (!marker)
         return { };
-    return m_marker->textContent(includeSuffix);
+
+    if (marker->style().content().isData())
+        return { };
+
+    auto textContent = listMarkerTextContent(marker->style(), const_cast<RenderListItem&>(*this));
+    return includeSuffix == ListMarkerIncludeSuffix::Yes ? textContent.textWithSuffix : textContent.textWithoutSuffix().toString();
 }
 
 void RenderListItem::usedCounterDirectivesChanged()
@@ -484,7 +493,7 @@ void RenderListItem::usedCounterDirectivesChanged()
         item->updateValueAndMarkerContent();
 }
 
-Vector<CheckedRef<RenderListMarker>> RenderListItem::updateListMarkerNumbers()
+Vector<CheckedRef<RenderListItem>> RenderListItem::updateListMarkerNumbers()
 {
     RefPtr list = enclosingList(*this);
     if (!list)
@@ -498,15 +507,14 @@ Vector<CheckedRef<RenderListMarker>> RenderListItem::updateListMarkerNumbers()
 
     // If an item has been marked for update before, we know that all following items have, too.
     // This gives us the opportunity to stop and avoid marking the same nodes again.
-    Vector<CheckedRef<RenderListMarker>> markersNeedingContentUpdate;
+    Vector<CheckedRef<RenderListItem>> itemsNeedingMarkerUpdate;
     auto* item = this;
     auto subsequentListItem = isInReversedOrderedList ? previousListItem : nextListItem;
     while ((item = subsequentListItem(*list, *item)) && item->m_value) {
         item->updateValue();
-        if (CheckedPtr marker = item->m_marker.get())
-            markersNeedingContentUpdate.append(*marker);
+        itemsNeedingMarkerUpdate.append(*item);
     }
-    return markersNeedingContentUpdate;
+    return itemsNeedingMarkerUpdate;
 }
 
 bool RenderListItem::isInReversedOrderedList() const

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -39,11 +39,9 @@ public:
     int value() const;
     void updateValue();
 
-    WEBCORE_EXPORT String markerText(RenderListMarker::IncludeSuffix = RenderListMarker::IncludeSuffix::Yes) const;
+    WEBCORE_EXPORT String markerText(ListMarkerIncludeSuffix = ListMarkerIncludeSuffix::Yes) const;
 
-    // Returns the markers whose text the renumbering invalidated, for the caller to fill in once it is done changing
-    // the tree (RenderTreeBuilder::addListMarkerNeedingContentUpdate).
-    Vector<CheckedRef<RenderListMarker>> updateListMarkerNumbers();
+    Vector<CheckedRef<RenderListItem>> updateListMarkerNumbers();
 
     static void updateItemValuesForOrderedList(const HTMLOListElement&);
     static unsigned itemCountForOrderedList(const HTMLOListElement&);
@@ -53,6 +51,8 @@ public:
 
     RenderListMarker* markerRenderer() const { return m_marker.get(); }
     void setMarkerRenderer(RenderListMarker& marker) { m_marker = marker; }
+
+    void updateMarkerContent();
 
     bool isInReversedOrderedList() const;
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -483,30 +483,7 @@ void RenderListMarker::updateContent()
         return;
     }
 
-    WTF::switchOn(style().listStyleType(),
-        [&](const CSS::Keyword::None&) {
-            m_textContent = {
-                .textWithSuffix = " "_s,
-                .textWithoutSuffixLength = 0,
-            };
-        },
-        [&](const Style::String& identifier) {
-            m_textContent = {
-                .textWithSuffix = identifier.value,
-                .textWithoutSuffixLength = identifier.value.length(),
-            };
-        },
-        [&](const Style::CounterStyle&) {
-            auto counter = counterStyle();
-            ASSERT(counter);
-
-            auto text = makeString(counter->prefix().text, counter->text(m_listItem->value(), writingMode()));
-            m_textContent = {
-                .textWithSuffix = makeString(text, counter->suffix().text),
-                .textWithoutSuffixLength = text.length(),
-            };
-        }
-    );
+    m_textContent = listMarkerTextContent(style(), *m_listItem);
 
     // The marker text is only known here (counter values resolve at layout), while the renderers
     // holding it were created from style. Push the text down so the inline formatting context has something to lay out.
@@ -584,7 +561,7 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
 
 void RenderListMarker::updateInlineMargins()
 {
-    constexpr int markerPadding = 7;
+    constexpr int markerPadding = listMarkerImagePadding;
     const FontMetrics& fontMetrics = style().metricsOfPrimaryFont();
 
     auto marginsForInsideMarker = [&]() -> std::pair<LayoutUnit, LayoutUnit> {
@@ -612,25 +589,23 @@ void RenderListMarker::updateInlineMargins()
     };
 
     auto [marginStart, marginEnd] = isInside() ? marginsForInsideMarker() : marginsForOutsideMarker();
-    auto zoom = style().usedZoomForLength().value;
+    setListMarkerInlineMargins(mutableStyle(), m_listItem->writingMode(), marginStart, marginEnd);
+}
 
-    // Which side of the list item these hang the marker off follows the list item's directionality
-    // rather than the marker's own: with marker-side: match-self (its initial value) css-lists-3
-    // positions the marker box using the directionality of the ::marker's originating element.
-    // Write the edges of the parent's inline axis, which is where
-    // BoxGeometryUpdater::horizontalLogicalMargin reads them back from.
-    auto listItemWritingMode = m_listItem->writingMode();
+void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode listItemWritingMode, LayoutUnit marginStart, LayoutUnit marginEnd)
+{
+    auto zoom = markerStyle.usedZoomForLength().value;
     auto startEdge = Style::MarginEdge::Fixed { marginStart / zoom };
     auto endEdge = Style::MarginEdge::Fixed { marginEnd / zoom };
     if (listItemWritingMode.isHorizontal()) {
         auto startIsLeft = listItemWritingMode.isInlineLeftToRight();
-        mutableStyle().setMarginLeft(startIsLeft ? startEdge : endEdge);
-        mutableStyle().setMarginRight(startIsLeft ? endEdge : startEdge);
+        markerStyle.setMarginLeft(startIsLeft ? startEdge : endEdge);
+        markerStyle.setMarginRight(startIsLeft ? endEdge : startEdge);
         return;
     }
     auto startIsTop = listItemWritingMode.isInlineTopToBottom();
-    mutableStyle().setMarginTop(startIsTop ? startEdge : endEdge);
-    mutableStyle().setMarginBottom(startIsTop ? endEdge : startEdge);
+    markerStyle.setMarginTop(startIsTop ? startEdge : endEdge);
+    markerStyle.setMarginBottom(startIsTop ? endEdge : startEdge);
 }
 
 bool RenderListMarker::isInside() const
@@ -640,12 +615,7 @@ bool RenderListMarker::isInside() const
 
 bool RenderListMarker::isDisclosureMarker() const
 {
-    auto counter = counterStyle();
-    if (!counter)
-        return false;
-    auto system = counter->system();
-    return system == CSSCounterStyleDescriptors::System::DisclosureClosed
-        || system == CSSCounterStyleDescriptors::System::DisclosureOpen;
+    return listMarkerIsDisclosure(style(), protect(document()));
 }
 
 RenderListItem* RenderListMarker::listItem() const
@@ -718,12 +688,61 @@ LayoutRect RenderListMarker::selectionRectForRepaint(const RenderLayerModelObjec
     return { };
 }
 
-RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
+static RefPtr<CSSRegisteredCounterStyle> counterStyleFor(const Style::ComputedStyle& markerStyle, Document& document)
 {
-    auto counterStyle = style().listStyleType().tryCounterStyle();
+    auto counterStyle = markerStyle.listStyleType().tryCounterStyle();
     if (!counterStyle)
         return nullptr;
-    return document().counterStyleRegistry().resolvedCounterStyle(*counterStyle);
+    return document.counterStyleRegistry().resolvedCounterStyle(*counterStyle);
+}
+
+RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
+{
+    return counterStyleFor(style(), protect(document()));
+}
+
+bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document& document)
+{
+    RefPtr counterStyle = counterStyleFor(markerStyle, document);
+    if (!counterStyle)
+        return false;
+    auto system = counterStyle->system();
+    return system == CSSCounterStyleDescriptors::System::DisclosureClosed || system == CSSCounterStyleDescriptors::System::DisclosureOpen;
+}
+
+bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)
+{
+    // css-lists-3 §3.3: a non-normal `content` supersedes list-style-type, and a list-style-image draws in place of
+    // the glyph unless it failed to load, so neither leaves us a glyph to draw.
+    if (markerStyle.content().isData())
+        return false;
+    if (RefPtr image = markerStyle.listStyleImage().tryStyleImage(); image && !image->errorOccurred())
+        return false;
+
+    auto& listType = markerStyle.listStyleType();
+    return listType.isCircle() || listType.isDisc() || listType.isSquare();
+}
+
+ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem& listItem)
+{
+    ListMarkerTextContent textContent;
+    WTF::switchOn(markerStyle.listStyleType(),
+        [&](const CSS::Keyword::None&) {
+            textContent = { .textWithSuffix = " "_s, .textWithoutSuffixLength = 0 };
+        },
+        [&](const Style::String& identifier) {
+            textContent = { .textWithSuffix = identifier.value, .textWithoutSuffixLength = identifier.value.length() };
+        },
+        [&](const Style::CounterStyle&) {
+            auto counter = counterStyleFor(markerStyle, protect(listItem.document()));
+            ASSERT(counter);
+            if (!counter)
+                return;
+            auto text = makeString(counter->prefix().text, counter->text(listItem.value(), markerStyle.writingMode()));
+            textContent = { .textWithSuffix = makeString(text, counter->suffix().text), .textWithoutSuffixLength = text.length() };
+        }
+    );
+    return textContent;
 }
 
 bool RenderListMarker::synthesizesGlyph() const

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -31,6 +31,8 @@ class RenderBlockFlow;
 class RenderListItem;
 class StyleRuleCounterStyle;
 
+enum class ListMarkerIncludeSuffix : bool { No, Yes };
+
 struct ListMarkerTextContent {
     String textWithSuffix;
     uint32_t textWithoutSuffixLength { 0 };
@@ -54,7 +56,7 @@ public:
     RenderListMarker(RenderListItem&, Style::ComputedStyle&&);
     virtual ~RenderListMarker();
 
-    enum class IncludeSuffix : bool { No, Yes };
+    using IncludeSuffix = ListMarkerIncludeSuffix;
     String textContent(IncludeSuffix includeSuffix = IncludeSuffix::Yes) const
     {
         return includeSuffix == IncludeSuffix::Yes ? m_textContent.textWithSuffix : m_textContent.textWithoutSuffix().toString();
@@ -145,6 +147,13 @@ private:
     std::optional<ExcludedPosition> m_excludedPosition;
     bool m_shouldCollapseAnonymousBlockParent { false };
 };
+
+// The room an image marker keeps between itself and the content it labels.
+constexpr int listMarkerImagePadding = 7;
+ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem&);
+bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle);
+bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document&);
+void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode listItemWritingMode, LayoutUnit marginStart, LayoutUnit marginEnd);
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -201,18 +201,18 @@ RenderTreeBuilder::~RenderTreeBuilder()
     s_current = m_previous;
 }
 
-void RenderTreeBuilder::addListMarkerNeedingContentUpdate(RenderListMarker& marker)
+void RenderTreeBuilder::addListItemNeedingMarkerUpdate(RenderListItem& listItem)
 {
-    m_listMarkersNeedingContentUpdate.add(marker);
+    m_listItemsNeedingMarkerUpdate.add(listItem);
 }
 
 void RenderTreeBuilder::updateListMarkerContents()
 {
     // A marker's text is made of its list item's list-item counter value, which is only settled once the tree is done
     // changing: inserting or removing a list item renumbers every item after it.
-    while (!m_listMarkersNeedingContentUpdate.isEmptyIgnoringNullReferences()) {
-        for (auto& marker : std::exchange(m_listMarkersNeedingContentUpdate, { }))
-            marker.updateInlineMarginsAndContent();
+    while (!m_listItemsNeedingMarkerUpdate.isEmptyIgnoringNullReferences()) {
+        for (auto& listItem : std::exchange(m_listItemsNeedingMarkerUpdate, { }))
+            listItem.updateMarkerContent();
     }
 }
 
@@ -506,8 +506,8 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
         if (CheckedPtr fragmentedFlow = dynamicDowncast<RenderMultiColumnFlow>(newChild->enclosingFragmentedFlow()))
             multiColumnBuilder().multiColumnDescendantInserted(*fragmentedFlow, *newChild);
         if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(*newChild)) {
-            for (auto& marker : listItemRenderer->updateListMarkerNumbers())
-                addListMarkerNeedingContentUpdate(marker);
+            for (auto& listItem : listItemRenderer->updateListMarkerNumbers())
+                addListItemNeedingMarkerUpdate(listItem);
         }
     }
 
@@ -1062,8 +1062,8 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
         resetRendererStateOnDetach(parent, child, willBeDestroyed);
 
     if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(child); listItemRenderer && child.everHadLayout() && m_internalMovesType == IsInternalMove::No) {
-        for (auto& marker : listItemRenderer->updateListMarkerNumbers())
-            addListMarkerNeedingContentUpdate(marker);
+        for (auto& listItem : listItemRenderer->updateListMarkerNumbers())
+            addListItemNeedingMarkerUpdate(listItem);
     }
 
     if (m_tearDownType == RenderTreeBuilder::TearDownType::Root || is<RenderInline>(m_subtreeDestroyRoot)) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class RenderGrid;
+class RenderListItem;
 class RenderListMarker;
 class RenderTreeUpdater;
 
@@ -76,7 +77,7 @@ public:
 private:
     // Collected while the tree is being built: a marker's text is made of its list item's list-item counter value,
     // which is only settled once the tree is done changing.
-    void addListMarkerNeedingContentUpdate(RenderListMarker&);
+    void addListItemNeedingMarkerUpdate(RenderListItem&);
 
     static void markBoxForRelayoutAfterSplit(RenderBoxModelObject&);
 
@@ -140,7 +141,7 @@ private:
 
     WidgetHierarchyUpdatesSuspensionScope m_widgetHierarchyUpdatesSuspensionScope;
     RenderView& m_view;
-    SingleThreadWeakHashSet<RenderListMarker> m_listMarkersNeedingContentUpdate;
+    SingleThreadWeakHashSet<RenderListItem> m_listItemsNeedingMarkerUpdate;
     RenderTreeBuilder* m_previous { nullptr };
     static RenderTreeBuilder* s_current;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -141,7 +141,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         auto contentChanged = markerRenderer->style().content() != newStyle.content() || markerRenderer->style().unicodeBidi() != newStyle.unicodeBidi() || markerRenderer->style().listStyleType() != newStyle.listStyleType();
         markerRenderer->setStyle(WTF::move(newStyle));
         // list-style-type, the counter style it resolves to and the writing mode all decide the marker's text.
-        m_builder.addListMarkerNeedingContentUpdate(*markerRenderer);
+        m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
 
         // Recomputing this here rather than diffing the style properties it is made of also picks up
         // what is not the marker's own style: its direction, and what the document's counter style
@@ -195,7 +195,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
 
     RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
-    m_builder.addListMarkerNeedingContentUpdate(*newMarkerRenderer);
+    m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
     auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
     auto shouldCollapseAnonymousBlockParent = !searchResult.parent && !newMarkerRenderer->isInside() && searchResult.shouldCollapseAnonymousBlockParent;


### PR DESCRIPTION
#### f15a2f2705c4d3c658bdc35936b8834eaf4da056
<pre>
[list-marker] RenderListItem should answer for its marker instead of its callers consulting RenderListMarker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323151">https://bugs.webkit.org/show_bug.cgi?id=323151</a>
<a href="https://rdar.apple.com/problem/186407352">rdar://problem/186407352</a>

Reviewed by Antti Koivisto.

Preparation for making an inside marker an inline content: an anonymous inline box holding the marker&apos;s renderers.
There is no RenderListMarker in that setup (only an anon RenderInline), so every question that is asked of the renderer on trunk by reaching for RenderListMarker has to be answerable without one.

No change in behavior.

* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::updateMarkerContent):
(WebCore::RenderListItem::updateValueAndMarkerContent):
(WebCore::RenderListItem::markerText const):
(WebCore::RenderListItem::updateListMarkerNumbers):
(WebCore::RenderListItem::paintObject):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::counterStyleFor):
(WebCore::RenderListMarker::counterStyle const):
(WebCore::listMarkerIsDisclosure):
(WebCore::listMarkerSynthesizesGlyph):
(WebCore::listMarkerTextContent):
(WebCore::setListMarkerInlineMargins):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::updateInlineMargins):
(WebCore::RenderListMarker::isDisclosureMarker const):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::addListItemNeedingMarkerUpdate):
(WebCore::RenderTreeBuilder::updateListMarkerContents):
(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
(WebCore::RenderTreeBuilder::detachFromRenderElement):
(WebCore::RenderTreeBuilder::addListMarkerNeedingContentUpdate): Deleted.
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::RenderTreeBuilder::List::updateItemMarker):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::lineStartListMarkerText):
(WebCore::AccessibilityObject::listMarkerTextForNodeAndPosition):
* Source/WebCore/accessibility/AccessibilityObject.h:

Canonical link: <a href="https://commits.webkit.org/320447@main">https://commits.webkit.org/320447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8464b25a2d182eeec3a05e5635aba04870996f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194806 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148761 "Hash d8464b25 for PR 72995 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ab1c700-1dbb-4920-b901-7568d1cbea86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144021 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148761 "Hash d8464b25 for PR 72995 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c1ab7f3-38f5-4a0a-b268-07e40d68c369) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124437 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d99a3681-70e8-4dc3-bd62-68a818d3f0c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44701 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44309 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5878 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196749 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58071 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41196 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153266 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47794 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131068 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127516 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19323 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->