### PR TITLE
Harden `PlatformXR::Device` by making `TrackingAndRenderingClient` ref-countable

### DIFF
--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -26,6 +26,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/TransformationMatrix.h>
 #include <memory>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Platform.h>
@@ -56,15 +57,6 @@
 #if ENABLE(WEBXR_LAYERS)
 #include <WebCore/FloatSize.h>
 #endif
-
-namespace PlatformXR {
-class TrackingAndRenderingClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<PlatformXR::TrackingAndRenderingClient> : std::true_type { };
-}
 
 namespace WebCore {
 enum class XRHitTestTrackableType : uint8_t;
@@ -630,7 +622,7 @@ protected:
 
 using DeviceList = Vector<Ref<Device>>;
 
-class TrackingAndRenderingClient : public CanMakeWeakPtr<TrackingAndRenderingClient> {
+class TrackingAndRenderingClient : public AbstractRefCountedAndCanMakeWeakPtr<TrackingAndRenderingClient> {
 public:
     virtual ~TrackingAndRenderingClient() = default;
 

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -104,14 +104,14 @@ void SimulatedXRDevice::setViewerOrigin(const std::optional<PlatformXR::FrameDat
 
 void SimulatedXRDevice::setVisibilityState(XRVisibilityState visibilityState)
 {
-    if (m_trackingAndRenderingClient)
-        m_trackingAndRenderingClient->updateSessionVisibilityState(visibilityState);
+    if (RefPtr client = m_trackingAndRenderingClient)
+        client->updateSessionVisibilityState(visibilityState);
 }
 
 void SimulatedXRDevice::simulateShutdownCompleted()
 {
-    if (m_trackingAndRenderingClient)
-        m_trackingAndRenderingClient->sessionDidEnd();
+    if (RefPtr client = m_trackingAndRenderingClient)
+        client->sessionDidEnd();
 }
 
 WebCore::IntSize SimulatedXRDevice::recommendedResolution(PlatformXR::SessionMode)
@@ -131,8 +131,8 @@ void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOr
             auto protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            if (m_trackingAndRenderingClient)
-                m_trackingAndRenderingClient->sessionDidInitializeInputSources({ });
+            if (RefPtr client = m_trackingAndRenderingClient)
+                client->sessionDidInitializeInputSources({ });
         });
     }
     m_frameData.environmentBlendMode = (sessionMode == PlatformXR::SessionMode::ImmersiveAr) ? PlatformXR::XREnvironmentBlendMode::AlphaBlend : PlatformXR::XREnvironmentBlendMode::Opaque;

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -71,20 +71,20 @@ XRDeviceProxy::XRDeviceProxy(XRDeviceInfo&& deviceInfo, PlatformXRSystemProxy& x
 
 void XRDeviceProxy::sessionDidEnd()
 {
-    if (trackingAndRenderingClient())
-        trackingAndRenderingClient()->sessionDidEnd();
+    if (RefPtr client = trackingAndRenderingClient())
+        client->sessionDidEnd();
 }
 
 void XRDeviceProxy::updateSessionVisibilityState(PlatformXR::VisibilityState visibilityState)
 {
-    if (trackingAndRenderingClient())
-        trackingAndRenderingClient()->updateSessionVisibilityState(visibilityState);
+    if (RefPtr client = trackingAndRenderingClient())
+        client->updateSessionVisibilityState(visibilityState);
 }
 
 void XRDeviceProxy::sessionDidInitializeRendering(uint32_t width, uint32_t height, uint32_t arrayLength)
 {
-    if (trackingAndRenderingClient())
-        trackingAndRenderingClient()->sessionDidInitializeRendering(width, height, arrayLength);
+    if (RefPtr client = trackingAndRenderingClient())
+        client->sessionDidInitializeRendering(width, height, arrayLength);
 }
 
 void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList& requestedFeatures, std::optional<WebCore::XRCanvasConfiguration>&& init)
@@ -106,8 +106,8 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
         if (!protectedThis)
             return;
 
-        if (trackingAndRenderingClient())
-            trackingAndRenderingClient()->sessionDidInitializeInputSources({ });
+        if (RefPtr client = trackingAndRenderingClient())
+            client->sessionDidInitializeInputSources({ });
     });
 }
 


### PR DESCRIPTION
#### d3e5e156482fdbdd56bbb62c9f47f20291265818
<pre>
Harden `PlatformXR::Device` by making `TrackingAndRenderingClient` ref-countable
<a href="https://bugs.webkit.org/show_bug.cgi?id=323161">https://bugs.webkit.org/show_bug.cgi?id=323161</a>
<a href="https://rdar.apple.com/186410747">rdar://186410747</a>

Reviewed by Dan Glastonbury and Chris Dumez.

This makes `TrackingAndRenderingClient` ref-countable since nothing enforces
that the client stays alive across its virtual functions.

No new tests, no behavior change.

* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::setVisibilityState):
(WebCore::SimulatedXRDevice::simulateShutdownCompleted):
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::sessionDidEnd):
(WebKit::XRDeviceProxy::updateSessionVisibilityState):
(WebKit::XRDeviceProxy::sessionDidInitializeRendering):
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):

Canonical link: <a href="https://commits.webkit.org/320347@main">https://commits.webkit.org/320347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/904716f25cc804282f36fa6082a347666c9f3f87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144051 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100103 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46556 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44340 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5913 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58107 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153638 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41139 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58812 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153298 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47825 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131103 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57315 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19354 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->