### PR TITLE
bankofamerica.com: cannot complete a wire transfer because the window load event is never dispatched

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The window load event is dispatched when a readystatechange handler starts a new load
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>The window load event is dispatched when a readystatechange handler starts a new load</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/parsing.html#the-end">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#resource-metadata-management">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+// The readystatechange event for "complete" is dispatched synchronously while the document
+// is being marked as completely loaded, so a handler for it runs before the load event.
+// Starting a new load from that handler must not stop the load event from being dispatched.
+//
+// Engines differ on whether the new load delays the load event, so no ordering between the
+// two is asserted here.
+var loadEventTest = async_test("The window load event is dispatched when a readystatechange handler starts a new load");
+
+function startLoadFromReadyStateChangeHandler() {
+    // A dynamically inserted script with a src is async. Its contents are irrelevant; what
+    // matters is that appending it starts a load.
+    var scriptURL = URL.createObjectURL(new Blob([], { type: "text/javascript" }));
+
+    var script = document.createElement("script");
+    script.src = scriptURL;
+    script.onload = function() { URL.revokeObjectURL(scriptURL); };
+    script.onerror = loadEventTest.unreached_func("the script started from readystatechange failed to load");
+    document.body.appendChild(script);
+}
+
+document.addEventListener("readystatechange", function() {
+    if (document.readyState === "complete")
+        startLoadFromReadyStateChangeHandler();
+});
+
+// If the load event is never dispatched, this test times out and fails.
+window.addEventListener("load", loadEventTest.step_func_done(function() {
+    assert_equals(document.readyState, "complete");
+}));
+</script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1006,30 +1006,42 @@ void FrameLoader::checkCompleted()
         return;
     }
 
-    // Are we still parsing?
-    if (document->parsing())
-        return;
-
     // Still waiting for images/scripts?
     if (document->cachedResourceLoader().requestCount())
         return;
 
-    // Still waiting for elements that don't go through a FrameLoader?
-    if (document->isDelayingLoadEvent())
-        return;
+    auto isBlockedFromCompleting = [&] {
+        if (document->parsing())
+            return true;
 
-    RefPtr scriptableParser = document->scriptableDocumentParser();
-    if (scriptableParser && scriptableParser->hasScriptsWaitingForStylesheets())
-        return;
+        // Still waiting for elements that don't go through a FrameLoader?
+        if (document->isDelayingLoadEvent())
+            return true;
 
-    // Any frame that hasn't completed yet?
-    if (!allChildrenAreComplete())
+        RefPtr scriptableParser = document->scriptableDocumentParser();
+        if (scriptableParser && scriptableParser->hasScriptsWaitingForStylesheets())
+            return true;
+
+        // Any frame that hasn't completed yet?
+        return !allChildrenAreComplete();
+    };
+
+    if (isBlockedFromCompleting())
         return;
 
     // OK, completed.
-    m_isComplete = true;
     m_requestedHistoryItem = nullptr;
     document->setReadyState(Document::ReadyState::Complete);
+
+    // The readystatechange dispatch above ran author script, so both of these can have changed
+    // underneath us.
+    if (m_isComplete)
+        return;
+
+    if (isBlockedFromCompleting())
+        return;
+
+    m_isComplete = true;
 
     checkCallImplicitClose(); // if we didn't do it before
 


### PR DESCRIPTION
#### a4d8f6d0f464caa32a3970a23e2f9dd5475e8b21
<pre>
bankofamerica.com: cannot complete a wire transfer because the window load event is never dispatched
<a href="https://bugs.webkit.org/show_bug.cgi?id=323179">https://bugs.webkit.org/show_bug.cgi?id=323179</a>
<a href="https://rdar.apple.com/186373617">rdar://186373617</a>

Reviewed by Chris Dumez.

On bankofamerica.com&apos;s wire transfer page the &quot;Continue Transfer&quot; button stays
disabled because the 2FA step-up modal never appears. The site&apos;s
sparta-stepup-loader-util.js creates the step-up widget&apos;s container element from a
window.onload handler, so when the load event is not dispatched the container is missing
and sparta-widget-loader-util.js throws on document.getElementById(params.containerId).style.

FrameLoader::checkCompleted() checked its completion conditions, set m_isComplete,
and only then called setReadyState(Complete), which dispatches readystatechange
synchronously which can as a result start new loads. In some cases, like
in bankofamerica.com and the test case, we may end up incrementing the load
event delay count. This can then result in us bailing out early in
checkCallImplicitClose(). Later on we will enter checkCompleted again but
bail out really early since we set m_isComplete.

Here we slightly modify the logic so that we check the completion
conditions (e.g. document-&gt;isDelayingLoadEvent()) after the call to setReadyState()
before setting m_isComplete in case anything changed as a result of
setReadyState(). Both checks now share one lambda so the two condition lists cannot
drift apart. An outstanding subresource request is deliberately left out of the second
check, since it never gated the load event before this change.

Author script running from readystatechange can also re-enter checkCompleted() and
complete the frame before we get back here. In that case the rest of the function has
already run, so we return early on m_isComplete rather than dispatching the load event
from inside the readystatechange dispatch and running the tail a second time.

Tests: imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load.html

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkCompleted): Set m_isComplete after setReadyState(Complete)
rather than before it, and re-check the completion conditions once the readystatechange
handlers have run.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/resource-metadata-management/load-event-after-readystatechange-starts-load-expected.txt: Added.
Starts an async script from a readystatechange handler and checks that the window load
event is still dispatched rather than being dropped. Whether that new load delays the
load event is not interoperable, so the test asserts no ordering between the two.

Canonical link: <a href="https://commits.webkit.org/320331@main">https://commits.webkit.org/320331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a9cdee527c574b60595657769f7bb0d91e81599

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9a0648e-d82f-4fb6-8689-d1207817e4f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143952 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100044 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f46d51b-1b63-4d2c-88a5-900b685b170c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124370 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86d5b86f-6806-475c-8c9c-79d1149982fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44640 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44243 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5795 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164188 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153532 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41127 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58694 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153198 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47728 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130983 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127405 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57199 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19258 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56565 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->