### PR TITLE
[CFNetwork] document.cookie exposes a phantom cookie after a script write the network process rejected

### DIFF
--- a/LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https-expected.txt
@@ -1,0 +1,22 @@
+Tests that the Cookie Store API set() rejects, and does not leave a phantom entry visible to document.cookie, when an HttpOnly cookie of the same name already exists. RFC 6265bis section 5.6 requires a cookie received from a non-HTTP API to be ignored entirely in that case.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+An HttpOnly cookie of the same name already exists:
+PASS cookieStore.set() rejected.
+PASS The existing HttpOnly cookie is unchanged in the cookie store.
+PASS document.cookie does not expose a phantom entry.
+No cookie of that name exists:
+PASS cookieStore.set() resolved.
+PASS The cookie is in the cookie store.
+A cookie of the same name exists and is not HttpOnly:
+PASS cookieStore.set() resolved.
+PASS The cookie was overwritten in the cookie store.
+A set() whose expiry is already in the past is a deletion:
+PASS cookieStore.set() resolved.
+PASS The cookie was removed from the cookie store.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html
+++ b/LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='resources/cookies-test-pre.js'></script>
+</head>
+<body>
+<script>
+description('Tests that the Cookie Store API set() rejects, and does not leave a phantom entry visible to document.cookie, when an HttpOnly cookie of the same name already exists. RFC 6265bis section 5.6 requires a cookie received from a non-HTTP API to be ignored entirely in that case.');
+jsTestIsAsync = true;
+
+// internals.getCookies() observes the cookie store directly, including HttpOnly cookies.
+// document.cookie goes through the web process cookie cache, which is where a phantom entry
+// would show up.
+function storeValueOf(name)
+{
+    for (let cookie of internals.getCookies()) {
+        if (cookie.name === name)
+            return cookie.value;
+    }
+    return null;
+}
+
+function documentCookieValueOf(name)
+{
+    for (let pair of document.cookie.split('; ')) {
+        let index = pair.indexOf('=');
+        if (index !== -1 && pair.substring(0, index) === name)
+            return pair.substring(index + 1);
+    }
+    return null;
+}
+
+function setViaHTTP(cookie)
+{
+    if (!setCookies(cookie))
+        testFailed(`Could not set cookie via HTTP: ${cookie}`);
+}
+
+function deleteViaHTTP(name)
+{
+    // An HTTP-originated Set-Cookie may delete an HttpOnly cookie; a script write may not.
+    setCookies(`${name}=; path=/; Max-Age=0`);
+}
+
+async function trySet(options)
+{
+    try {
+        await cookieStore.set(options);
+        return 'resolved';
+    } catch (e) {
+        return 'rejected';
+    }
+}
+
+async function testRejectsWhenHTTPOnlyCookieExists()
+{
+    debug('An HttpOnly cookie of the same name already exists:');
+    let name = 'httponly-shadowed';
+    setViaHTTP(`${name}=fromHTTP; path=/; HttpOnly`);
+
+    let result = await trySet({ name: name, value: 'fromScript', path: '/' });
+    if (result === 'rejected')
+        testPassed('cookieStore.set() rejected.');
+    else
+        testFailed('cookieStore.set() resolved, but the write cannot succeed.');
+
+    if (storeValueOf(name) === 'fromHTTP')
+        testPassed('The existing HttpOnly cookie is unchanged in the cookie store.');
+    else
+        testFailed(`The HttpOnly cookie was modified; store value is ${storeValueOf(name)}.`);
+
+    if (documentCookieValueOf(name) === null)
+        testPassed('document.cookie does not expose a phantom entry.');
+    else
+        testFailed(`document.cookie exposes '${documentCookieValueOf(name)}', which is not in the cookie store.`);
+
+    deleteViaHTTP(name);
+}
+
+async function testSetsWhenNoCookieExists()
+{
+    debug('No cookie of that name exists:');
+    let name = 'httponly-fresh';
+
+    let result = await trySet({ name: name, value: 'fromScript', path: '/' });
+    if (result === 'resolved')
+        testPassed('cookieStore.set() resolved.');
+    else
+        testFailed('cookieStore.set() rejected, but the write should have succeeded.');
+
+    if (storeValueOf(name) === 'fromScript')
+        testPassed('The cookie is in the cookie store.');
+    else
+        testFailed(`The cookie is missing from the store; store value is ${storeValueOf(name)}.`);
+
+    deleteViaHTTP(name);
+}
+
+async function testOverwritesNonHTTPOnlyCookie()
+{
+    debug('A cookie of the same name exists and is not HttpOnly:');
+    let name = 'httponly-absent';
+    setViaHTTP(`${name}=fromHTTP; path=/`);
+
+    let result = await trySet({ name: name, value: 'fromScript', path: '/' });
+    if (result === 'resolved')
+        testPassed('cookieStore.set() resolved.');
+    else
+        testFailed('cookieStore.set() rejected, but overwriting a non-HttpOnly cookie is allowed.');
+
+    if (storeValueOf(name) === 'fromScript')
+        testPassed('The cookie was overwritten in the cookie store.');
+    else
+        testFailed(`The cookie was not overwritten; store value is ${storeValueOf(name)}.`);
+
+    deleteViaHTTP(name);
+}
+
+async function testExpiredSetDeletesCookie()
+{
+    debug('A set() whose expiry is already in the past is a deletion:');
+    let name = 'httponly-expired';
+    setViaHTTP(`${name}=fromHTTP; path=/`);
+
+    let result = await trySet({ name: name, value: 'fromScript', path: '/', expires: Date.now() - 86400000 });
+    if (result === 'resolved')
+        testPassed('cookieStore.set() resolved.');
+    else
+        testFailed('cookieStore.set() rejected, but the deletion should have succeeded.');
+
+    if (storeValueOf(name) === null)
+        testPassed('The cookie was removed from the cookie store.');
+    else
+        testFailed(`The cookie is still in the store with value ${storeValueOf(name)}.`);
+
+    deleteViaHTTP(name);
+}
+
+onload = async () => {
+    await testRejectsWhenHTTPOnlyCookieExists();
+    await testSetsWhenNoCookieExists();
+    await testOverwritesNonHTTPOnlyCookie();
+    await testExpiredSetDeletesCookie();
+    finishJSTest();
+};
+</script>
+<script src='resources/cookies-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1969,6 +1969,7 @@ streams/readable-stream-byob-request-worker.html [ Skip ]
 imported/w3c/web-platform-tests/cookiestore [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
+http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html [ Skip ] # NetworkStorageSession::setCookieFromDOM is a stub that always returns false for curl.
 cookies/cookie-store-start-listening-for-change-with-null-url-crash.html [ Skip ] # crash
 http/tests/navigation/ping-attribute/anchor-cookie.html [ Skip ]
 http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html [ Skip ]

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -531,6 +531,20 @@ static RetainPtr<NSHTTPCookie> parseDOMCookie(String cookieString, NSURL* cookie
     return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:nsStringNilIfEmpty(partition).get()], cappedLifetime);
 }
 
+// The (name, domain, path) triple identifies a cookie. Name and path are case-sensitive, domain is
+// not.
+static bool isSameCookieIdentity(NSHTTPCookie *a, NSHTTPCookie *b)
+{
+    return [a.name isEqualToString:b.name]
+        && [a.path isEqualToString:b.path]
+        && [a.domain caseInsensitiveCompare:b.domain] == NSOrderedSame;
+}
+
+static bool cookieIsAlreadyExpired(NSHTTPCookie *cookie)
+{
+    return cookie.expiresDate && cookie.expiresDate.timeIntervalSinceNow <= 0;
+}
+
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, RequiresScriptTrackingPrivacy requiresScriptTrackingPrivacy, const String& cookieString, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker) const
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
@@ -582,7 +596,25 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
 #endif
 
     setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty.createNSURL().get(), partition.get(), sameSiteInfo, thirdPartyCookieBlockingDecision);
-    return true;
+
+    // setHTTPCookiesForURL() is void, and CFNetwork silently ignores writes it declines -- notably a
+    // script-originated write over an existing HttpOnly cookie (RFC 6265bis section 5.6). Read the
+    // store back so the result reflects what was actually stored rather than what we asked for.
+    RetainPtr storedCookies = httpCookiesForURL(cookieStorage().get(), firstParty.createNSURL().get(), sameSiteInfo, url.createNSURL().get(), thirdPartyCookieBlockingDecision);
+    bool identityIsPresent = false;
+    bool valueMatches = false;
+    for (NSHTTPCookie *storedCookie in storedCookies.get()) {
+        if (!isSameCookieIdentity(storedCookie, nshttpCookie.get()))
+            continue;
+        identityIsPresent = true;
+        valueMatches = [storedCookie.value isEqualToString:[nshttpCookie value]];
+        break;
+    }
+
+    // A write whose expiry is already in the past is a deletion, so success means it is gone.
+    if (cookieIsAlreadyExpired(nshttpCookie.get()))
+        return !identityIsPresent;
+    return valueMatches;
 
     END_BLOCK_OBJC_EXCEPTIONS
     return false;


### PR DESCRIPTION
#### c640f74f4d5f9547d71dc7652a5728e8d78bea26
<pre>
[CFNetwork] document.cookie exposes a phantom cookie after a script write the network process rejected
<a href="https://bugs.webkit.org/show_bug.cgi?id=323164">https://bugs.webkit.org/show_bug.cgi?id=323164</a>
&lt;<a href="https://rdar.apple.com/186411739">rdar://186411739</a>&gt;

Reviewed by NOBODY (OOPS!).

NetworkStorageSession::setCookieFromDOM returned true unconditionally once it had handed&apos;
the cookie to setHTTPCookiesForURL(). CFNetwork silently ignores writes it declines (e.g.,
HttpOnly cookies). In effect, the promise was only asserting that the cookie had been handed
to CFNetwork, not that it had actually been set.

The false success had a second effect: WebCookieJar::setCookieAsync commits
WebCookieCache::didSetCookieFromDOM() only when success is true, so a bogus true also left
a phantom entry in the web process cookie cache and document.cookie reported a value that
did not actually exist in the cookie store.

To avoid this, we check with the store after writing and report whether the intended cookie
is actually present. That also covers every other decline class (accept policy, prefix rules,
jar eviction, a cookie stored already-expired), and handles deletions: a write whose expiry
is already in the past succeeds when the cookie is gone.

Unfortunately this change does not fix the document.cookie setting path, which commits to
WebCookieCache unconditionally and sends SetCookiesFromDOM with no reply. That remains open
separately.

Test: http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html

* LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https-expected.txt: Added.
* LayoutTests/http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::isSameCookieIdentity):
(WebCore::cookieIsAlreadyExpired):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c640f74f4d5f9547d71dc7652a5728e8d78bea26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148662 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143922 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100036 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187314 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47717 "Found 1 new test failure: http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124338 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46427 "Found 2 new test failures: imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44615 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156817 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44211 "Found 3 new test failures: http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5761 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50946 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48907 "Found 3 new test failures: http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196629 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57954 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164158 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153501 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58659 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40834 "Found 3 new test failures: http/tests/cookies/cookie-store-set-rejects-when-httponly-cookie-exists.https.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153166 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47698 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130953 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127377 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57165 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19226 "Found 2 new test failures: imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56533 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->