### PR TITLE
[WebDriver] deleteAllCookies implementation ignores completion handler and always returns success

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -831,7 +831,8 @@
             "description": "Delete all cookies that are visible to the specified browsing context.",
             "parameters": [
                 { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context." }
-            ]
+            ],
+            "async": true
         },
         {
             "name": "getSessionPermissions",

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2118,20 +2118,23 @@ void WebAutomationSession::addSingleCookie(const Inspector::Protocol::Automation
     });
 }
 
-CommandResult<void> WebAutomationSession::deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+void WebAutomationSession::deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, CommandCallback<void>&& callback)
 {
     RefPtr page = webPageProxyForHandle(browsingContextHandle);
-    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
 
     auto& activeURL = activeOrInitialURL(*page);
 
     String host = activeURL.host().toString();
-    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(host.isNull(), WindowNotFound);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(host.isNull(), WindowNotFound);
 
+    // Wait for the cookies to actually be deleted before replying. Returning early
+    // lets a client proceed while the deletion is still in flight, so cookies can
+    // survive into whatever the client does next.
     Ref cookieStore = protect(page->websiteDataStore())->cookieStore();
-    cookieStore->deleteCookiesForHostnames({ host, domainByAddingDotPrefixIfNeeded(host) }, [] { });
-
-    return { };
+    cookieStore->deleteCookiesForHostnames({ host, domainByAddingDotPrefixIfNeeded(host) }, [callback = WTF::move(callback)]() {
+        callback({ });
+    });
 }
 
 CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> WebAutomationSession::getSessionPermissions()

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -287,7 +287,7 @@ public:
     void getAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::Cookie>>>&&) override;
     void deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& cookieName, Inspector::CommandCallback<void>&&) override;
     void addSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Object>&& cookie, Inspector::CommandCallback<void>&&) override;
-    Inspector::CommandResult<void> deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    void deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<void>&&) override;
     Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> getSessionPermissions() override;
     Inspector::CommandResult<void> setSessionPermissions(Ref<JSON::Array>&&) override;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -35,6 +35,9 @@
 #import <WebKit/WKHTTPCookieStorePrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKAutomationSession.h>
+#import <WebKit/_WKAutomationSessionConfiguration.h>
+#import <WebKit/_WKAutomationSessionPrivateForTesting.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/BlockPtr.h>
@@ -1202,6 +1205,79 @@ TEST(WKHTTPCookieStore, SetCookies)
     TestWebKitAPI::Util::run(&done);
     done = false;
 }
+
+#if ENABLE(REMOTE_INSPECTOR)
+
+// A driver that reads cookies back after a successful deleteAllCookies must not see any.
+TEST(WKHTTPCookieStore, AutomationDeleteAllCookiesWaitsForDeletion)
+{
+    RetainPtr dataStore = [WKWebsiteDataStore nonPersistentDataStore];
+
+    RetainPtr sessionConfiguration = adoptNS([_WKAutomationSessionConfiguration new]);
+    RetainPtr session = adoptNS([[_WKAutomationSession alloc] initWithConfiguration:sessionConfiguration.get()]);
+    [session setSessionIdentifier:@"DeleteAllCookiesTest"];
+
+    RetainPtr processPool = adoptNS([WKProcessPool new]);
+    [processPool _setAutomationSession:session.get()];
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    [configuration setProcessPool:processPool.get()];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"start network process" baseURL:[NSURL URLWithString:@"http://example.com/"]];
+
+    // One cookie can be removed too quickly to catch a reply that did not wait.
+    constexpr NSUInteger cookieCount = 200;
+    RetainPtr cookies = adoptNS([[NSMutableArray alloc] initWithCapacity:cookieCount]);
+    for (NSUInteger i = 0; i < cookieCount; ++i) {
+        [cookies addObject:[NSHTTPCookie cookieWithProperties:@{
+            NSHTTPCookiePath: @"/",
+            NSHTTPCookieName: [NSString stringWithFormat:@"cookie%lu", static_cast<unsigned long>(i)],
+            NSHTTPCookieValue: @"value",
+            NSHTTPCookieDomain: @"example.com",
+        }]];
+    }
+
+    __block bool done = false;
+    [[dataStore httpCookieStore] setCookies:cookies.get() completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
+        EXPECT_EQ([allCookies count], cookieCount);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr handle = [session _registerWebViewForTesting:webView.get()];
+    EXPECT_NOT_NULL(handle.get());
+
+    // The store must already be empty by the time the reply arrives.
+    __block bool gotReply = false;
+    __block NSUInteger cookiesRemainingAtReply = NSNotFound;
+    [session _setMessageToFrontendHandlerForTesting:^(NSString *message) {
+        if (![message containsString:@"\"id\":1"])
+            return;
+        [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
+            cookiesRemainingAtReply = [allCookies count];
+            gotReply = true;
+        }];
+    }];
+
+    [session _dispatchMessageFromRemoteForTesting:[NSString stringWithFormat:
+        @"{\"id\":1,\"method\":\"Automation.deleteAllCookies\",\"params\":{\"browsingContextHandle\":\"%@\"}}", handle.get()]];
+
+    TestWebKitAPI::Util::run(&gotReply);
+    EXPECT_EQ(cookiesRemainingAtReply, static_cast<NSUInteger>(0));
+
+    [session _setMessageToFrontendHandlerForTesting:nil];
+    [processPool _setAutomationSession:nil];
+}
+
+#endif // ENABLE(REMOTE_INSPECTOR)
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
 TEST(WKHTTPCookieStore, PartitionedCookieShouldHavePartitionProperty)


### PR DESCRIPTION
#### 99bcbf16626d2c7ca9707ef1d499fa02327f441b
<pre>
[WebDriver] deleteAllCookies implementation ignores completion handler and always returns success
<a href="https://bugs.webkit.org/show_bug.cgi?id=323158">https://bugs.webkit.org/show_bug.cgi?id=323158</a>
<a href="https://rdar.apple.com/186410147">rdar://186410147</a>

Reviewed by BJ Burg.

WebDriver&apos;s implementation of deleteAllCookies discards its completion handler and returns
success before the network process has actually deleted and saved the cookies. Since the
delete process is asynchronous, we create a race condition that can lead to downstream test
failures, implying bugs in WebKit that are not present in real Safari.

Fixing this will avoid bugs in one cookie-based WPT from poisoning other steps.

This patch corrects that problem, and make the command match the behavior of the other
cookie features.

Tested with a new API test.

* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::deleteAllCookies):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, AutomationDeleteAllCookiesWaitsForDeletion)):

Canonical link: <a href="https://commits.webkit.org/320440@main">https://commits.webkit.org/320440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d9523c8451ddbcfed6bda14646d6ff51db1539f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194690 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148664 "Hash 5d9523c8 for PR 73001 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f685d38f-17da-4098-8199-04307b8ddc34) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143925 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148664 "Hash 5d9523c8 for PR 73001 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/870cffee-6c7b-40e5-8973-1417b59eb7f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124341 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e0d6a95-5946-4804-a8c2-829bff4140d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44617 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44214 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5763 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196631 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57956 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153503 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41194 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58661 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153168 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47699 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130955 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127379 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19229 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->