### PR TITLE
[list-marker] Opening a <details> makes its summary one pixel shorter

### DIFF
--- a/LayoutTests/fast/html/details-add-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-child-1-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderInline {B} at (0,0) size 144x18
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: "should have bold test"

--- a/LayoutTests/fast/html/details-add-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-child-2-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderInline {B} at (0,0) size 144x18
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: "should have bold test"

--- a/LayoutTests/fast/html/details-add-details-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-details-child-1-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderInline {B} at (0,0) size 144x18
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: "should have bold test"

--- a/LayoutTests/fast/html/details-add-details-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-details-child-2-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderInline {SPAN} at (0,0) size 144x18
             RenderInline {B} at (0,0) size 144x18
               RenderText {#text} at (0,0) size 144x18

--- a/LayoutTests/fast/html/details-add-summary-10-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-10-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SUMMARY} at (0,0) size 784x18
             RenderText {#text} at (0,0) size 60x18
               text run at (0,0) width 60: "summary"

--- a/LayoutTests/fast/html/details-add-summary-6-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-6-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-add-summary-7-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-7-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SUMMARY} at (0,0) size 784x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 2"

--- a/LayoutTests/fast/html/details-add-summary-8-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-8-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 2"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 2"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SUMMARY} at (0,0) size 784x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/fast/html/details-add-summary-9-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-9-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SUMMARY} at (0,0) size 784x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/fast/html/details-add-summary-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-child-1-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 64x18
-            text run at (16,0) width 64: "summary "
-          RenderInline {B} at (79,0) size 145x18
-            RenderText {#text} at (79,0) size 145x18
-              text run at (79,0) width 145: "should have bold test"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 64x19
+            text run at (16,1) width 64: "summary "
+          RenderInline {B} at (79,1) size 145x19
+            RenderText {#text} at (79,1) size 145x19
+              text run at (79,1) width 145: "should have bold test"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-add-summary-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-child-2-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 64x18
-            text run at (16,0) width 64: "summary "
-          RenderInline {SPAN} at (79,0) size 145x18
-            RenderInline {B} at (79,0) size 145x18
-              RenderText {#text} at (79,0) size 145x18
-                text run at (79,0) width 145: "should have bold test"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 64x19
+            text run at (16,1) width 64: "summary "
+          RenderInline {SPAN} at (79,1) size 145x19
+            RenderInline {B} at (79,1) size 145x19
+              RenderText {#text} at (79,1) size 145x19
+                text run at (79,1) width 145: "should have bold test"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-nested-1-expected.txt
+++ b/LayoutTests/fast/html/details-nested-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x136 [border: (8px solid #555599)]
-        RenderListItem {SUMMARY} at (8,8) size 768x102 [border: (8px solid #9999CC)]
-          RenderBlock (anonymous) at (8,8) size 752x18
-            RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-            RenderText {#text} at (16,0) size 60x18
-              text run at (16,0) width 60: "summary"
-          RenderBlock {DETAILS} at (8,26) size 752x68 [border: (8px solid #995555)]
-            RenderListItem {SUMMARY} at (8,8) size 736x34 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,8) size 17x18: "\x{25BC}"
-              RenderText {#text} at (24,8) size 287x18
-                text run at (24,8) width 287: "nested summary (summary-deails-summary)"
-            RenderBlock {SLOT} at (8,42) size 736x18
+      RenderBlock {DETAILS} at (0,0) size 784x139 [border: (8px solid #555599)]
+        RenderListItem {SUMMARY} at (8,8) size 768x105 [border: (8px solid #9999CC)]
+          RenderBlock (anonymous) at (8,8) size 752x20
+            RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+            RenderText {#text} at (16,1) size 60x19
+              text run at (16,1) width 60: "summary"
+          RenderBlock {DETAILS} at (8,27) size 752x70 [border: (8px solid #995555)]
+            RenderListItem {SUMMARY} at (8,8) size 736x36 [border: (8px solid #CC9999)]
+              RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+              RenderText {#text} at (24,9) size 287x19
+                text run at (24,9) width 287: "nested summary (summary-deails-summary)"
+            RenderBlock {SLOT} at (8,43) size 736x19
               RenderText {#text} at (0,0) size 204x18
                 text run at (0,0) width 204: "nested details (summary-deails)"
-        RenderBlock {SLOT} at (8,110) size 768x18
+        RenderBlock {SLOT} at (8,112) size 768x19
           RenderText {#text} at (0,0) size 42x18
             text run at (0,0) width 42: "details"

--- a/LayoutTests/fast/html/details-nested-2-expected.txt
+++ b/LayoutTests/fast/html/details-nested-2-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x136 [border: (8px solid #555599)]
-        RenderListItem {SUMMARY} at (8,8) size 768x34 [border: (8px solid #9999CC)]
-          RenderListMarker at (8,8) size 17x18: "\x{25BC}"
-          RenderText {#text} at (24,8) size 60x18
-            text run at (24,8) width 60: "summary"
-        RenderBlock {SLOT} at (8,42) size 768x86
-          RenderBlock {DETAILS} at (0,0) size 768x68 [border: (8px solid #995555)]
-            RenderListItem {SUMMARY} at (8,8) size 752x34 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,8) size 17x18: "\x{25BC}"
-              RenderText {#text} at (24,8) size 269x18
-                text run at (24,8) width 269: "nested summary (details-deails-summary)"
-            RenderBlock {SLOT} at (8,42) size 752x18
+      RenderBlock {DETAILS} at (0,0) size 784x139 [border: (8px solid #555599)]
+        RenderListItem {SUMMARY} at (8,8) size 768x36 [border: (8px solid #9999CC)]
+          RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+          RenderText {#text} at (24,9) size 60x19
+            text run at (24,9) width 60: "summary"
+        RenderBlock {SLOT} at (8,43) size 768x88
+          RenderBlock {DETAILS} at (0,0) size 768x70 [border: (8px solid #995555)]
+            RenderListItem {SUMMARY} at (8,8) size 752x36 [border: (8px solid #CC9999)]
+              RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+              RenderText {#text} at (24,9) size 269x19
+                text run at (24,9) width 269: "nested summary (details-deails-summary)"
+            RenderBlock {SLOT} at (8,43) size 752x19
               RenderText {#text} at (0,0) size 186x18
                 text run at (0,0) width 186: "nested details (details-deails)"
-          RenderBlock (anonymous) at (0,68) size 768x18
+          RenderBlock (anonymous) at (0,69) size 768x19
             RenderText {#text} at (0,0) size 42x18
               text run at (0,0) width 42: "details"

--- a/LayoutTests/fast/html/details-no-summary2-expected.txt
+++ b/LayoutTests/fast/html/details-no-summary2-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
-            text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 46x19
+            text run at (16,1) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-open6-expected.txt
+++ b/LayoutTests/fast/html/details-open6-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-remove-child-1-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderText {#text} at (0,0) size 160x18
             text run at (0,0) width 160: "should have no bold test."

--- a/LayoutTests/fast/html/details-remove-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-remove-child-2-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderText {#text} at (0,0) size 160x18
             text run at (0,0) width 160: "should have no bold test."

--- a/LayoutTests/fast/html/details-remove-summary-4-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-4-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
-            text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 46x19
+            text run at (16,1) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-5-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-5-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
-            text run at (16,0) width 72: "summary 2"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 72x19
+            text run at (16,1) width 72: "summary 2"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-6-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-6-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
-            text run at (16,0) width 72: "summary 1"
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 72x19
+            text run at (16,1) width 72: "summary 1"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-child-1-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 64x18
-            text run at (16,0) width 64: "summary "
-          RenderText {#text} at (79,0) size 190x18
-            text run at (79,0) width 190: "shouldn't have only bold text."
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 64x19
+            text run at (16,1) width 64: "summary "
+          RenderText {#text} at (79,1) size 190x19
+            text run at (79,1) width 190: "shouldn't have only bold text."
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-child-2-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 64x18
-            text run at (16,0) width 64: "summary "
-          RenderInline {SPAN} at (79,0) size 185x18
-            RenderText {#text} at (79,0) size 185x18
-              text run at (79,0) width 185: "shouldn't have any bold text."
-        RenderBlock {SLOT} at (0,18) size 784x0
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 64x19
+            text run at (16,1) width 64: "summary "
+          RenderInline {SPAN} at (79,1) size 185x19
+            RenderText {#text} at (79,1) size 185x19
+              text run at (79,1) width 185: "shouldn't have any bold text."
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference: a disclosure marker takes the same line height whichever way it points</title>
+<style>
+  ul { margin: 0; padding: 0; list-style-position: inside; }
+  li { color: transparent; }
+  div { width: 100px; height: 100px; background: green; }
+</style>
+<ul>
+  <li style="list-style-type: disclosure-closed">disclosure
+</ul>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference: a disclosure marker takes the same line height whichever way it points</title>
+<style>
+  ul { margin: 0; padding: 0; list-style-position: inside; }
+  li { color: transparent; }
+  div { width: 100px; height: 100px; background: green; }
+</style>
+<ul>
+  <li style="list-style-type: disclosure-closed">disclosure
+</ul>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Counter Styles Test: a disclosure marker takes the same line height whichever way it points</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#disclosure-open">
+<link rel="match" href="disclosure-line-height-ref.html">
+<meta name="assert" content="A list item with disclosure-open is as tall as one with disclosure-closed, so that toggling a disclosure does not move the content after it.">
+<style>
+  ul { margin: 0; padding: 0; list-style-position: inside; }
+  /* The glyph itself is not what is being tested, only the room the line gives it. */
+  li { color: transparent; }
+  div { width: 100px; height: 100px; background: green; }
+</style>
+<ul>
+  <li style="list-style-type: disclosure-open">disclosure
+</ul>
+<div></div>

--- a/LayoutTests/platform/ios/fast/html/details-add-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-child-1-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderInline {B} at (0,0) size 144x18
+            RenderText {#text} at (0,0) size 144x18
+              text run at (0,0) width 144: "should have bold test"

--- a/LayoutTests/platform/ios/fast/html/details-add-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-child-2-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderInline {B} at (0,0) size 144x18
+            RenderText {#text} at (0,0) size 144x18
+              text run at (0,0) width 144: "should have bold test"
+          RenderText {#text} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/html/details-add-details-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-details-child-1-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderInline {B} at (0,0) size 144x18
+            RenderText {#text} at (0,0) size 144x18
+              text run at (0,0) width 144: "should have bold test"

--- a/LayoutTests/platform/ios/fast/html/details-add-details-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-details-child-2-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderInline {SPAN} at (0,0) size 144x18
+            RenderInline {B} at (0,0) size 144x18
+              RenderText {#text} at (0,0) size 144x18
+                text run at (0,0) width 144: "should have bold test"
+          RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-1-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-1-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-10-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-10-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
+      RenderBlock {DETAILS} at (0,0) size 800x37
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x18
+        RenderBlock {SLOT} at (0,19) size 800x18
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 60x18
               text run at (0,0) width 60: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-10-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-10-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
+            text run at (16,0) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderBlock {SUMMARY} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 60x18
+              text run at (0,0) width 60: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-2-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-2-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-3-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 2"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-3-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 2"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-4-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 61x19
-            text run at (16,5) width 61: "summary"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 61x19
+            text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-4-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-4-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 61x19
-            text run at (16,5) width 61: "summary"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 61x19
+            text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-5-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-5-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 40x19
-            text run at (16,5) width 40: "new 1"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 40x19
+            text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-6-and-click-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x0
+        RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-6-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
+            text run at (16,0) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-7-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-7-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
+      RenderBlock {DETAILS} at (0,0) size 800x37
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x18
+        RenderBlock {SLOT} at (0,19) size 800x18
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-7-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-7-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
+            text run at (16,0) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderBlock {SUMMARY} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 39x18
+              text run at (0,0) width 39: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-8-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-8-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
+      RenderBlock {DETAILS} at (0,0) size 800x37
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 2"
-        RenderBlock {SLOT} at (0,18) size 800x18
+        RenderBlock {SLOT} at (0,19) size 800x18
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-8-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-8-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 39x19
+            text run at (16,0) width 39: "new 2"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderBlock {SUMMARY} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 39x18
+              text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-9-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-9-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
+      RenderBlock {DETAILS} at (0,0) size 800x37
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 800x18
+        RenderBlock {SLOT} at (0,19) size 800x18
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-9-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-9-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderBlock {SUMMARY} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 39x18
+              text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-child-1-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 64x19
+            text run at (16,0) width 64: "summary "
+          RenderInline {B} at (79,0) size 145x19
+            RenderText {#text} at (79,0) size 145x19
+              text run at (79,0) width 145: "should have bold test"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-child-2-expected.txt
@@ -1,0 +1,15 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 64x19
+            text run at (16,0) width 64: "summary "
+          RenderInline {SPAN} at (79,0) size 145x19
+            RenderInline {B} at (79,0) size 145x19
+              RenderText {#text} at (79,0) size 145x19
+                text run at (79,0) width 145: "should have bold test"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-marker-style-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x314
-  RenderBlock {HTML} at (0,0) size 800x315
-    RenderBody {BODY} at (8,8) size 784x299
-      RenderBlock {DIV} at (0,0) size 784x32
-        RenderBlock {DETAILS} at (0,0) size 784x32
-          RenderListItem {SUMMARY} at (0,0) size 784x32
-            RenderListMarker at (0,2) size 25x27: "\x{25B6}"
-            RenderText {#text} at (24,2) size 94x28
-              text run at (24,2) width 94: "Summary"
-      RenderBlock {DIV} at (0,32) size 27x118
-        RenderBlock {DETAILS} at (0,0) size 27x118
-          RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 27x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 27x95
-              text run at (0,23) width 94: "Summary"
-      RenderBlock {DIV} at (0,149) size 784x33
-        RenderBlock {DETAILS} at (0,0) size 784x32
-          RenderListItem {SUMMARY} at (0,0) size 784x32
-            RenderListMarker at (0,2) size 25x27: "\x{25B6}"
-            RenderText {#text} at (24,2) size 94x28
-              text run at (24,2) width 94: "Summary"
-      RenderBlock {DIV} at (0,181) size 27x118
-        RenderBlock {DETAILS} at (0,0) size 27x118
-          RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 27x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 27x95
-              text run at (0,23) width 94: "Summary"
+layer at (0,0) size 800x308
+  RenderBlock {HTML} at (0,0) size 800x309
+    RenderBody {BODY} at (8,8) size 784x293
+      RenderBlock {DIV} at (0,0) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderText {#text} at (24,1) size 94x28
+              text run at (24,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,29) size 29x118
+        RenderBlock {DETAILS} at (0,0) size 29x118
+          RenderListItem {SUMMARY} at (0,0) size 29x118
+            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
+            RenderText {#text} at (1,23) size 28x95
+              text run at (1,23) width 94: "Summary"
+      RenderBlock {DIV} at (0,146) size 784x30
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderText {#text} at (24,1) size 94x28
+              text run at (24,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,175) size 29x118
+        RenderBlock {DETAILS} at (0,0) size 29x118
+          RenderListItem {SUMMARY} at (0,0) size 29x118
+            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
+            RenderText {#text} at (1,23) size 28x95
+              text run at (1,23) width 94: "Summary"

--- a/LayoutTests/platform/ios/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-marker-style-mixed-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x314
-  RenderBlock {HTML} at (0,0) size 800x315
-    RenderBody {BODY} at (8,8) size 784x299
-      RenderBlock {DIV} at (0,0) size 784x32
-        RenderBlock {DETAILS} at (0,0) size 784x32
-          RenderListItem {SUMMARY} at (0,0) size 784x32
-            RenderListMarker at (0,2) size 25x27: "\x{25B6}"
-            RenderText {#text} at (24,2) size 94x28
-              text run at (24,2) width 94: "Summary"
-      RenderBlock {DIV} at (0,32) size 27x118
+layer at (0,0) size 800x308
+  RenderBlock {HTML} at (0,0) size 800x309
+    RenderBody {BODY} at (8,8) size 784x293
+      RenderBlock {DIV} at (0,0) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderText {#text} at (24,1) size 94x28
+              text run at (24,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,29) size 27x118
         RenderBlock {DETAILS} at (0,0) size 27x118
           RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 27x24: "\x{25BC}"
+            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
             RenderText {#text} at (0,23) size 27x95
               text run at (0,23) width 94: "Summary"
-      RenderBlock {DIV} at (0,149) size 784x33
-        RenderBlock {DETAILS} at (0,0) size 784x32
-          RenderListItem {SUMMARY} at (0,0) size 784x32
-            RenderListMarker at (0,2) size 25x27: "\x{25B6}"
-            RenderText {#text} at (24,2) size 94x28
-              text run at (24,2) width 94: "Summary"
-      RenderBlock {DIV} at (0,181) size 27x118
+      RenderBlock {DIV} at (0,146) size 784x30
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderText {#text} at (24,1) size 94x28
+              text run at (24,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,175) size 27x118
         RenderBlock {DETAILS} at (0,0) size 27x118
           RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 27x24: "\x{25BC}"
+            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
             RenderText {#text} at (0,23) size 27x95
               text run at (0,23) width 94: "Summary"

--- a/LayoutTests/platform/ios/fast/html/details-nested-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-nested-1-expected.txt
@@ -1,0 +1,22 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x138 [border: (8px solid #555599)]
+        RenderListItem {SUMMARY} at (8,8) size 768x104 [border: (8px solid #9999CC)]
+          RenderBlock (anonymous) at (8,8) size 752x19
+            RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+            RenderText {#text} at (16,0) size 60x19
+              text run at (16,0) width 60: "summary"
+          RenderBlock {DETAILS} at (8,27) size 752x69 [border: (8px solid #995555)]
+            RenderListItem {SUMMARY} at (8,8) size 736x35 [border: (8px solid #CC9999)]
+              RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+              RenderText {#text} at (24,8) size 287x19
+                text run at (24,8) width 287: "nested summary (summary-deails-summary)"
+            RenderBlock {SLOT} at (8,43) size 736x18
+              RenderText {#text} at (0,0) size 204x18
+                text run at (0,0) width 204: "nested details (summary-deails)"
+        RenderBlock {SLOT} at (8,112) size 768x18
+          RenderText {#text} at (0,0) size 42x18
+            text run at (0,0) width 42: "details"

--- a/LayoutTests/platform/ios/fast/html/details-nested-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-nested-2-expected.txt
@@ -1,0 +1,22 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x138 [border: (8px solid #555599)]
+        RenderListItem {SUMMARY} at (8,8) size 768x35 [border: (8px solid #9999CC)]
+          RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+          RenderText {#text} at (24,8) size 60x19
+            text run at (24,8) width 60: "summary"
+        RenderBlock {SLOT} at (8,43) size 768x87
+          RenderBlock {DETAILS} at (0,0) size 768x69 [border: (8px solid #995555)]
+            RenderListItem {SUMMARY} at (8,8) size 752x35 [border: (8px solid #CC9999)]
+              RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+              RenderText {#text} at (24,8) size 269x19
+                text run at (24,8) width 269: "nested summary (details-deails-summary)"
+            RenderBlock {SLOT} at (8,43) size 752x18
+              RenderText {#text} at (0,0) size 186x18
+                text run at (0,0) width 186: "nested details (details-deails)"
+          RenderBlock (anonymous) at (0,69) size 768x18
+            RenderText {#text} at (0,0) size 42x18
+              text run at (0,0) width 42: "details"

--- a/LayoutTests/platform/ios/fast/html/details-no-summary1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary1-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 47x19
-            text run at (16,5) width 47: "Details"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 47x19
+            text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-no-summary2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary2-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 46x19
+            text run at (16,0) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-no-summary3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary3-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 47x19
-            text run at (16,5) width 47: "Details"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 47x19
+            text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-open1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open1-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 61x19
-            text run at (16,5) width 61: "summary"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 61x19
+            text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open3-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 61x19
-            text run at (16,5) width 61: "summary"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 61x19
+            text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open5-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 61x19
-            text run at (16,5) width 61: "summary"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 61x19
+            text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open6-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-position-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-position-expected.txt
@@ -4,20 +4,20 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x0
-      RenderBlock {DETAILS} at (0,0) size 784x26
-      RenderBlock {DETAILS} at (0,26) size 784x0
-layer at (50,150) size 50x26
-  RenderListItem {SUMMARY} at (50,150) size 50x26
-    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-    RenderText {#text} at (16,5) size 34x19
-      text run at (16,5) width 34: "fixed"
-layer at (158,158) size 784x26
-  RenderListItem {SUMMARY} at (0,0) size 784x26
-    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-    RenderText {#text} at (16,5) size 49x19
-      text run at (16,5) width 49: "relative"
-layer at (250,150) size 70x26
-  RenderListItem {SUMMARY} at (250,150) size 71x26
-    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-    RenderText {#text} at (16,5) size 55x19
-      text run at (16,5) width 55: "absolute"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+      RenderBlock {DETAILS} at (0,19) size 784x0
+layer at (50,150) size 50x19
+  RenderListItem {SUMMARY} at (50,150) size 50x19
+    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderText {#text} at (16,0) size 34x19
+      text run at (16,0) width 34: "fixed"
+layer at (158,158) size 784x19
+  RenderListItem {SUMMARY} at (0,0) size 784x19
+    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderText {#text} at (16,0) size 49x19
+      text run at (16,0) width 49: "relative"
+layer at (250,150) size 70x19
+  RenderListItem {SUMMARY} at (250,150) size 71x19
+    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderText {#text} at (16,0) size 55x19
+      text run at (16,0) width 55: "absolute"

--- a/LayoutTests/platform/ios/fast/html/details-remove-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-child-1-expected.txt
@@ -1,0 +1,13 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderText {#text} at (0,0) size 160x18
+            text run at (0,0) width 160: "should have no bold test."

--- a/LayoutTests/platform/ios/fast/html/details-remove-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-child-2-expected.txt
@@ -1,0 +1,13 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x37
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 60x19
+            text run at (16,0) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x18
+          RenderText {#text} at (0,0) size 160x18
+            text run at (0,0) width 160: "should have no bold test."

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-1-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 47x19
-            text run at (16,5) width 47: "Details"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 47x19
+            text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-1-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 47x19
-            text run at (16,5) width 47: "Details"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 47x19
+            text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-2-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 73x19
-            text run at (16,5) width 73: "summary 2"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 73x19
+            text run at (16,0) width 73: "summary 2"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-2-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 73x19
-            text run at (16,5) width 73: "summary 2"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 73x19
+            text run at (16,0) width 73: "summary 2"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-3-and-click-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x26
-        RenderListItem {SUMMARY} at (0,0) size 800x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 73x19
-            text run at (16,5) width 73: "summary 1"
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 73x19
+            text run at (16,0) width 73: "summary 1"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-3-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x26
-        RenderListItem {SUMMARY} at (0,0) size 784x26
-          RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-          RenderText {#text} at (16,5) size 73x19
-            text run at (16,5) width 73: "summary 1"
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderText {#text} at (16,0) size 73x19
+            text run at (16,0) width 73: "summary 1"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-4-and-click-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 46x19
             text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 800x0
+        RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-4-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-4-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 46x19
+            text run at (16,0) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-5-and-click-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 2"
-        RenderBlock {SLOT} at (0,18) size 800x0
+        RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-5-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 72x19
+            text run at (16,0) width 72: "summary 2"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-6-and-click-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
+      RenderBlock {DETAILS} at (0,0) size 800x19
+        RenderListItem {SUMMARY} at (0,0) size 800x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 1"
-        RenderBlock {SLOT} at (0,18) size 800x0
+        RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-6-expected.txt
@@ -1,0 +1,11 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 72x19
+            text run at (16,0) width 72: "summary 1"
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-child-1-expected.txt
@@ -1,0 +1,13 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 64x19
+            text run at (16,0) width 64: "summary "
+          RenderText {#text} at (79,0) size 190x19
+            text run at (79,0) width 190: "shouldn't have only bold text."
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-child-2-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DETAILS} at (0,0) size 784x19
+        RenderListItem {SUMMARY} at (0,0) size 784x19
+          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderText {#text} at (16,0) size 64x19
+            text run at (16,0) width 64: "summary "
+          RenderInline {SPAN} at (79,0) size 185x19
+            RenderText {#text} at (79,0) size 185x19
+              text run at (79,0) width 185: "shouldn't have any bold text."
+        RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
@@ -38,144 +38,144 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,5) size 61x19
-                      text run at (16,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,3) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,2) size 61x19
-                      text run at (16,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,0) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (2,16) size 19x61
-                      text run at (2,16) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,0) size 20x17: "\x{25B6}"
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,0) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (5,16) size 19x61
-                      text run at (5,16) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,0) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,0) size 20x17: "\x{25C0}"
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,5) size 60x19
-                      text run at (35,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,2) size 60x19
-                      text run at (35,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,95) size 18x25: "\x{25B6}"
-                      RenderBlock (generated) at (8,0) size 27x25
-                        RenderText at (2,0) size 19x25
-                          text run at (2,0) width 5 RTL: " "
-                          text run at (2,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (2,35) size 19x60
-                      text run at (2,35) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,103) size 20x17: "\x{25B6}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,95) size 18x25: "\x{25C0}"
-                      RenderBlock (generated) at (-6,0) size 27x25
-                        RenderText at (5,0) size 19x25
-                          text run at (5,0) width 5 RTL: " "
-                          text run at (5,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (5,35) size 19x60
-                      text run at (5,35) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,103) size 20x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,370) size 614x352 [border: (1px outset #000000)]
@@ -213,144 +213,144 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,5) size 61x19
-                      text run at (16,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,3) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,2) size 61x19
-                      text run at (16,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,0) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (2,16) size 19x61
-                      text run at (2,16) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,0) size 20x17: "\x{25B6}"
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,0) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (5,16) size 19x61
-                      text run at (5,16) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,0) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,0) size 20x17: "\x{25C0}"
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,5) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,5) size 60x19
-                      text run at (0,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,-1) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (0,0) size 60x18
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (0,0) size 60x19
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,3) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,2) size 60x19
-                      text run at (0,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,0) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 60x18
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 60x19
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,59) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 18x60
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 19x60
                       text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,59) size 18x26: "\x{25B6}"
-                      RenderBlock (generated) at (8,0) size 27x25
-                        RenderText at (2,0) size 19x25
-                          text run at (2,0) width 5 RTL: " "
-                          text run at (2,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (2,0) size 19x60
-                      text run at (2,0) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,59) size 20x18: "\x{25B6}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,59) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,59) size 18x26: "\x{25C0}"
-                      RenderBlock (generated) at (-6,0) size 27x25
-                        RenderText at (5,0) size 19x25
-                          text run at (5,0) width 5 RTL: " "
-                          text run at (5,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (5,0) size 19x60
-                      text run at (5,0) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,59) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,722) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,740) size 614x352 [border: (1px outset #000000)]
@@ -388,144 +388,144 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (21,5) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (38,5) size 61x19
-                      text run at (38,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (38,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (21,-1) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (38,0) size 61x19
+                      text run at (38,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (22,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (21,3) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (38,2) size 61x19
-                      text run at (38,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (38,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (21,0) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (38,0) size 61x19
+                      text run at (38,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (22,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,38) size 18x60
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,22) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,38) size 19x60
                       text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,21) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (2,38) size 19x61
-                      text run at (2,38) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,21) size 20x18: "\x{25B6}"
+                    RenderText {#text} at (0,38) size 19x61
+                      text run at (0,38) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,38) size 18x60
-                      text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,21) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (5,38) size 19x61
-                      text run at (5,38) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,22) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,38) size 19x60
+                      text run at (0,38) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,21) size 20x18: "\x{25C0}"
+                    RenderText {#text} at (0,38) size 19x61
+                      text run at (0,38) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (77,5) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (17,5) size 61x19
-                      text run at (17,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,-1) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x19
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (22,0) size 60x19
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (77,3) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (17,2) size 61x19
-                      text run at (17,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,0) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x19
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (22,0) size 60x19
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,81) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,77) size 18x26: "\x{25B6}"
-                      RenderBlock (generated) at (8,0) size 27x25
-                        RenderText at (2,0) size 19x25
-                          text run at (2,0) width 5 RTL: " "
-                          text run at (2,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (2,17) size 19x61
-                      text run at (2,17) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 19x60
+                      text run at (0,22) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,81) size 20x18: "\x{25B6}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 19x61
+                      text run at (0,21) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,81) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,77) size 18x26: "\x{25C0}"
-                      RenderBlock (generated) at (-6,0) size 27x25
-                        RenderText at (5,0) size 19x25
-                          text run at (5,0) width 5 RTL: " "
-                          text run at (5,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (5,17) size 19x61
-                      text run at (5,17) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 19x60
+                      text run at (0,22) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,81) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,21) size 19x61
+                      text run at (0,21) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1110) size 614x352 [border: (1px outset #000000)]
@@ -563,141 +563,141 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (43,5) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (60,5) size 60x19
-                      text run at (60,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (60,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (43,-1) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (44,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (60,0) size 60x19
+                      text run at (60,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (43,3) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (60,2) size 60x19
-                      text run at (60,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (60,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (43,0) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (44,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (60,0) size 60x19
+                      text run at (60,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,60) size 18x60
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,44) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,60) size 19x60
                       text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,43) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (2,60) size 19x60
-                      text run at (2,60) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,43) size 20x18: "\x{25B6}"
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,43) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (5,60) size 19x60
-                      text run at (5,60) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,44) size 20x17: "\x{25BC}"
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,43) size 20x18: "\x{25C0}"
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,5) size 60x19
-                      text run at (35,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,2) size 60x19
-                      text run at (35,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,95) size 18x25: "\x{25B6}"
-                      RenderBlock (generated) at (8,0) size 27x25
-                        RenderText at (2,0) size 19x25
-                          text run at (2,0) width 5 RTL: " "
-                          text run at (2,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (2,35) size 19x60
-                      text run at (2,35) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (0,103) size 20x17: "\x{25B6}"
+                      RenderBlock (generated) at (11,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 26x120
-                  RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,95) size 18x25: "\x{25C0}"
-                      RenderBlock (generated) at (-6,0) size 27x25
-                        RenderText at (5,0) size 19x25
-                          text run at (5,0) width 5 RTL: " "
-                          text run at (5,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (5,35) size 19x60
-                      text run at (5,35) width 61: "summary"
-                  RenderBlock {SLOT} at (26,0) size 0x120
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderListMarker at (-1,103) size 20x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
@@ -38,40 +38,40 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,5) size 61x19
-                      text run at (16,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,3) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,2) size 61x19
-                      text run at (16,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderListMarker at (-2,0) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderListMarker at (-2,0) size 20x17: "\x{25B6}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -79,12 +79,12 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
+                    RenderListMarker at (0,0) size 20x17: "\x{25C0}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -94,87 +94,87 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,5) size 60x19
-                      text run at (35,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,2) size 60x19
-                      text run at (35,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (-2,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,95) size 18x25: "\x{25B6}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,35) size 18x60
-                      text run at (0,35) width 60: "summary"
+                    RenderListMarker at (-2,103) size 20x17: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,95) size 18x25: "\x{25C0}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,35) size 18x60
-                      text run at (0,35) width 60: "summary"
+                    RenderListMarker at (0,103) size 20x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -213,40 +213,40 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,5) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,5) size 61x19
-                      text run at (16,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (0,3) size 17x18: "\x{25B6}"
-                    RenderText {#text} at (16,2) size 61x19
-                      text run at (16,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (16,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderText {#text} at (16,0) size 61x19
+                      text run at (16,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderListMarker at (-2,0) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderListMarker at (-2,0) size 20x17: "\x{25B6}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -254,12 +254,12 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
+                    RenderListMarker at (0,0) size 20x17: "\x{25C0}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -269,64 +269,64 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,5) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,5) size 60x19
-                      text run at (0,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,-1) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (0,0) size 60x18
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (0,0) size 60x19
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,3) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,2) size 60x19
-                      text run at (0,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,0) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 60x18
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (59,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 60x19
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (-2,59) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x26: "\x{25B6}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25B6}"
+                    RenderListMarker at (-2,59) size 20x18: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -334,20 +334,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,59) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x26: "\x{25C0}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25C0}"
+                    RenderListMarker at (0,59) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -388,40 +388,40 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (21,5) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (38,5) size 61x19
-                      text run at (38,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (38,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (21,-1) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (38,0) size 61x19
+                      text run at (38,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (22,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (21,3) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (38,2) size 61x19
-                      text run at (38,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (38,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (21,0) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (38,0) size 61x19
+                      text run at (38,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (22,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
+                    RenderListMarker at (-2,22) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25B6}"
+                    RenderListMarker at (-2,21) size 20x18: "\x{25B6}"
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -429,12 +429,12 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
+                    RenderListMarker at (0,22) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25C0}"
+                    RenderListMarker at (0,21) size 20x18: "\x{25C0}"
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -444,87 +444,87 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (77,5) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (17,5) size 61x19
-                      text run at (17,5) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,-1) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x19
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (22,0) size 60x19
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (77,3) size 26x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (17,2) size 61x19
-                      text run at (17,2) width 61: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,0) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x19
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (81,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (22,0) size 60x19
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (-2,81) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 18x60
+                      text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,77) size 18x26: "\x{25B6}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,17) size 18x61
-                      text run at (0,17) width 60: "summary"
+                    RenderListMarker at (-2,81) size 20x18: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 18x61
+                      text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,81) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 18x60
+                      text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,77) size 18x26: "\x{25C0}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,17) size 18x61
-                      text run at (0,17) width 60: "summary"
+                    RenderListMarker at (0,81) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,21) size 18x61
+                      text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -563,40 +563,40 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "ltr"
             RenderTableCell {TD} at (107,98) size 125x124 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (43,5) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (60,5) size 60x19
-                      text run at (60,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (60,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (43,-1) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (44,-1) size 17x20: "\x{25BC}"
+                    RenderText {#text} at (60,0) size 60x19
+                      text run at (60,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (43,3) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (60,2) size 60x19
-                      text run at (60,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (60,0) size 60x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (43,0) size 18x20: "\x{25B6}"
+                    RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (44,0) size 17x20: "\x{25B2}"
+                    RenderText {#text} at (60,0) size 60x19
+                      text run at (60,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
+                    RenderListMarker at (-2,44) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25B6}"
+                    RenderListMarker at (-2,43) size 20x18: "\x{25B6}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -604,12 +604,12 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
+                    RenderListMarker at (0,44) size 20x17: "\x{25BC}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25C0}"
+                    RenderListMarker at (0,43) size 20x18: "\x{25C0}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -619,85 +619,85 @@ layer at (0,0) size 800x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-6) size 25x27
-                        RenderText at (0,5) size 25x19
-                          text run at (0,5) width 4 RTL: " "
-                          text run at (4,5) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,5) size 60x19
-                      text run at (35,5) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x26
-                  RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,8) size 25x27
-                        RenderText at (0,2) size 25x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 21 RTL: "\x{25C0}"
-                    RenderText {#text} at (35,2) size 60x19
-                      text run at (35,2) width 60: "summary"
-                RenderBlock {DETAILS} at (0,26) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x19
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x19
+                  RenderListItem {SUMMARY} at (0,0) size 120x19
+                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,11) size 17x20
+                        RenderText at (0,-1) size 17x21
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x19
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (-2,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,95) size 18x25: "\x{25B6}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,35) size 18x60
-                      text run at (0,35) width 60: "summary"
+                    RenderListMarker at (-2,103) size 20x17: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
                           text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,95) size 18x25: "\x{25C0}"
-                      RenderBlock (generated) at (-5,0) size 27x25
-                        RenderText at (4,0) size 18x25
-                          text run at (4,0) width 5 RTL: " "
-                          text run at (4,4) width 22 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,35) size 18x60
-                      text run at (0,35) width 60: "summary"
+                    RenderListMarker at (0,103) size 20x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 20x17
+                        RenderText at (-1,0) size 21x17
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-no-summary4-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-no-summary4-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x37
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
-            text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 784x19
+      RenderBlock {DETAILS} at (0,0) size 784x39
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 46x19
+            text run at (16,1) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x20
           RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-layer at (11,29) size 142x13
+layer at (11,30) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open-javascript-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open-javascript-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x37
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 50x18
-            text run at (16,0) width 50: "details1"
-        RenderBlock {SLOT} at (0,18) size 784x19
+      RenderBlock {DETAILS} at (0,0) size 784x39
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 50x19
+            text run at (16,1) width 50: "details1"
+        RenderBlock {SLOT} at (0,19) size 784x20
           RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DETAILS} at (0,37) size 784x20
+      RenderBlock {DETAILS} at (0,38) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 51x19
             text run at (16,1) width 51: "details2"
-layer at (11,29) size 142x13
+layer at (11,30) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open2-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open2-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x37
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x19
+      RenderBlock {DETAILS} at (0,0) size 784x39
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x20
           RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
-layer at (11,29) size 142x13
+layer at (11,30) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open4-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open4-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x37
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x19
+      RenderBlock {DETAILS} at (0,0) size 784x39
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x20
           RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-layer at (11,29) size 142x13
+layer at (11,30) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-summary-child-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderBlock {SPAN} at (16,2) size 63x16
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderBlock {SPAN} at (16,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"
-          RenderText {#text} at (78,0) size 5x18
-            text run at (78,0) width 5: " "
-          RenderBlock {SPAN} at (82,2) size 63x16
+          RenderText {#text} at (78,1) size 5x19
+            text run at (78,1) width 5: " "
+          RenderBlock {SPAN} at (82,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details3"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {SLOT} at (0,18) size 784x0
-      RenderBlock (anonymous) at (0,18) size 784x18
+        RenderBlock {SLOT} at (0,19) size 784x0
+      RenderBlock (anonymous) at (0,19) size 784x19
         RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-text-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 63x18
-            text run at (16,0) width 63: "Summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 63x19
+            text run at (16,1) width 63: "Summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SPAN} at (0,2) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details2"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,36) size 784x18
+      RenderBlock (anonymous) at (0,37) size 784x19
         RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x39
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
-            text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 784x21
+      RenderBlock {DETAILS} at (0,0) size 784x41
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 46x19
+            text run at (16,1) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 784x22
           RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-layer at (15,30) size 142x13
+layer at (15,31) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x39
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 50x18
-            text run at (16,0) width 50: "details1"
-        RenderBlock {SLOT} at (0,18) size 784x21
+      RenderBlock {DETAILS} at (0,0) size 784x41
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 50x19
+            text run at (16,1) width 50: "details1"
+        RenderBlock {SLOT} at (0,19) size 784x22
           RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DETAILS} at (0,39) size 784x20
+      RenderBlock {DETAILS} at (0,40) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 51x19
             text run at (16,1) width 51: "details2"
-layer at (15,30) size 142x13
+layer at (15,31) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x39
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x21
+      RenderBlock {DETAILS} at (0,0) size 784x41
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x22
           RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
-layer at (15,30) size 142x13
+layer at (15,31) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x39
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 784x21
+      RenderBlock {DETAILS} at (0,0) size 784x41
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 784x22
           RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-layer at (15,30) size 142x13
+layer at (15,31) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x18
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderBlock {SPAN} at (16,2) size 63x16
+      RenderBlock {DETAILS} at (0,0) size 784x20
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderBlock {SPAN} at (16,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"
-          RenderText {#text} at (78,0) size 5x18
-            text run at (78,0) width 5: " "
-          RenderBlock {SPAN} at (82,2) size 63x16
+          RenderText {#text} at (78,1) size 5x19
+            text run at (78,1) width 5: " "
+          RenderBlock {SPAN} at (82,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details3"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {SLOT} at (0,18) size 784x0
-      RenderBlock (anonymous) at (0,18) size 784x18
+        RenderBlock {SLOT} at (0,19) size 784x0
+      RenderBlock (anonymous) at (0,19) size 784x19
         RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DETAILS} at (0,0) size 784x36
-        RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 63x18
-            text run at (16,0) width 63: "Summary"
-        RenderBlock {SLOT} at (0,18) size 784x18
+      RenderBlock {DETAILS} at (0,0) size 784x38
+        RenderListItem {SUMMARY} at (0,0) size 784x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 63x19
+            text run at (16,1) width 63: "Summary"
+        RenderBlock {SLOT} at (0,19) size 784x19
           RenderBlock {SPAN} at (0,2) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details2"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,36) size 784x18
+      RenderBlock (anonymous) at (0,37) size 784x19
         RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13

--- a/LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt
@@ -1,32 +1,32 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x130
-  RenderBlock {HTML} at (0,0) size 800x130
-    RenderBody {BODY} at (8,8) size 784x114
-      RenderBlock {DETAILS} at (0,0) size 784x114 [border: (1px solid #000000)]
+layer at (0,0) size 800x131
+  RenderBlock {HTML} at (0,0) size 800x132
+    RenderBody {BODY} at (8,8) size 784x116
+      RenderBlock {DETAILS} at (0,0) size 784x116 [border: (1px solid #000000)]
         RenderBlock (anonymous) at (1,1) size 782x18
           RenderInline (generated) at (0,0) size 41x18
             RenderText at (0,0) size 41x18
               text run at (0,0) width 41: "before"
-        RenderListItem {SUMMARY} at (1,19) size 782x58 [border: (1px solid #000000)]
-          RenderBlock (anonymous) at (1,1) size 780x18
-            RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-            RenderInline (generated) at (16,0) size 42x18
-              RenderText at (16,0) size 42x18
-                text run at (16,0) width 42: "before"
-            RenderText {#text} at (57,0) size 63x18
-              text run at (57,0) width 63: "Summary"
-          RenderBlock {DIV} at (1,19) size 780x20 [border: (1px solid #000000)]
+        RenderListItem {SUMMARY} at (1,19) size 782x60 [border: (1px solid #000000)]
+          RenderBlock (anonymous) at (1,1) size 780x20
+            RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+            RenderInline (generated) at (16,1) size 42x19
+              RenderText at (16,1) size 42x19
+                text run at (16,1) width 42: "before"
+            RenderText {#text} at (57,1) size 63x19
+              text run at (57,1) width 63: "Summary"
+          RenderBlock {DIV} at (1,20) size 780x21 [border: (1px solid #000000)]
             RenderText {#text} at (1,1) size 62x18
               text run at (1,1) width 62: "Inner Div"
-          RenderBlock (anonymous) at (1,39) size 780x18
+          RenderBlock (anonymous) at (1,40) size 780x19
             RenderInline (generated) at (0,0) size 30x18
               RenderText at (0,0) size 30x18
                 text run at (0,0) width 30: "after"
-        RenderBlock {SLOT} at (1,77) size 782x18
+        RenderBlock {SLOT} at (1,78) size 782x19
           RenderText {#text} at (0,0) size 46x18
             text run at (0,0) width 46: "Details"
-        RenderBlock (anonymous) at (1,95) size 782x18
+        RenderBlock (anonymous) at (1,96) size 782x19
           RenderInline (generated) at (0,0) size 30x18
             RenderText at (0,0) size 30x18
               text run at (0,0) width 30: "after"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x0
+      RenderBlock {DETAILS} at (0,0) size 800x20
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 800x0
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x18
+      RenderBlock {DETAILS} at (0,0) size 800x38
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 800x19
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 2"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 2"
-        RenderBlock {SLOT} at (0,18) size 800x18
+      RenderBlock {DETAILS} at (0,0) size 800x38
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 2"
+        RenderBlock {SLOT} at (0,19) size 800x19
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 2"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 60x18
-            text run at (16,0) width 60: "summary"
-        RenderBlock {SLOT} at (0,18) size 800x18
+      RenderBlock {DETAILS} at (0,0) size 800x38
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 60x19
+            text run at (16,1) width 60: "summary"
+        RenderBlock {SLOT} at (0,19) size 800x19
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 39x18
               text run at (0,0) width 39: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x36
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 39x18
-            text run at (16,0) width 39: "new 1"
-        RenderBlock {SLOT} at (0,18) size 800x18
+      RenderBlock {DETAILS} at (0,0) size 800x38
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 39x19
+            text run at (16,1) width 39: "new 1"
+        RenderBlock {SLOT} at (0,19) size 800x19
           RenderBlock {SUMMARY} at (0,0) size 800x18
             RenderText {#text} at (0,0) size 60x18
               text run at (0,0) width 60: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 2"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,1) size 25x29: "\x{25B6}"
+            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,29) size 28x118
-        RenderBlock {DETAILS} at (0,0) size 28x118
-          RenderListItem {SUMMARY} at (0,0) size 28x118
-            RenderListMarker at (0,0) size 28x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 28x95
-              text run at (0,23) width 94: "Summary"
+      RenderBlock {DIV} at (0,29) size 30x118
+        RenderBlock {DETAILS} at (0,0) size 30x118
+          RenderListItem {SUMMARY} at (0,0) size 30x118
+            RenderListMarker at (-1,0) size 29x24: "\x{25BC}"
+            RenderText {#text} at (1,23) size 29x95
+              text run at (1,23) width 94: "Summary"
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,1) size 25x29: "\x{25B6}"
+            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,175) size 28x118
-        RenderBlock {DETAILS} at (0,0) size 28x118
-          RenderListItem {SUMMARY} at (0,0) size 28x118
-            RenderListMarker at (0,0) size 28x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 28x95
-              text run at (0,23) width 94: "Summary"
+      RenderBlock {DIV} at (0,175) size 30x118
+        RenderBlock {DETAILS} at (0,0) size 30x118
+          RenderListItem {SUMMARY} at (0,0) size 30x118
+            RenderListMarker at (-1,0) size 29x24: "\x{25BC}"
+            RenderText {#text} at (1,23) size 29x95
+              text run at (1,23) width 94: "Summary"

--- a/LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,1) size 25x29: "\x{25B6}"
+            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,29) size 28x118
@@ -18,7 +18,7 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,1) size 25x29: "\x{25B6}"
+            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,175) size 28x118

--- a/LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-open1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open1-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-open3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open3-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-open5-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open5-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-position-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-position-expected.txt
@@ -8,16 +8,16 @@ layer at (0,0) size 800x585
       RenderBlock {DETAILS} at (0,19) size 784x0
 layer at (50,150) size 49x19
   RenderListItem {SUMMARY} at (50,150) size 49x20
-    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
     RenderText {#text} at (16,1) size 33x19
       text run at (16,1) width 33: "fixed"
 layer at (158,158) size 784x19
   RenderListItem {SUMMARY} at (0,0) size 784x20
-    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
     RenderText {#text} at (16,1) size 49x19
       text run at (16,1) width 49: "relative"
 layer at (250,150) size 70x19
   RenderListItem {SUMMARY} at (250,150) size 71x20
-    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
     RenderText {#text} at (16,1) size 55x19
       text run at (16,1) width 55: "absolute"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 46x18
-            text run at (16,0) width 46: "Details"
-        RenderBlock {SLOT} at (0,18) size 800x0
+      RenderBlock {DETAILS} at (0,0) size 800x20
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 46x19
+            text run at (16,1) width 46: "Details"
+        RenderBlock {SLOT} at (0,19) size 800x0
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 0 {SLOT} of {#document-fragment} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
-            text run at (16,0) width 72: "summary 2"
-        RenderBlock {SLOT} at (0,18) size 800x0
+      RenderBlock {DETAILS} at (0,0) size 800x20
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 72x19
+            text run at (16,1) width 72: "summary 2"
+        RenderBlock {SLOT} at (0,19) size 800x0
 caret: position 0 of child 0 {#text} of child 2 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 2"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DETAILS} at (0,0) size 800x18
-        RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-          RenderText {#text} at (16,0) size 72x18
-            text run at (16,0) width 72: "summary 1"
-        RenderBlock {SLOT} at (0,18) size 800x0
+      RenderBlock {DETAILS} at (0,0) size 800x20
+        RenderListItem {SUMMARY} at (0,0) size 800x20
+          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderText {#text} at (16,1) size 72x19
+            text run at (16,1) width 72: "summary 1"
+        RenderBlock {SLOT} at (0,19) size 800x0
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 1"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 0 {SLOT} of {#document-fragment} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 2"
 caret: position 0 of child 0 {#text} of child 2 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
@@ -40,142 +40,142 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
-                      text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (16,1) size 60x19
+                      text run at (16,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,0) size 17x18: "\x{25B6}"
+                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,0) size 19x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderListMarker at (1,0) size 19x17: "\x{25B6}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,0) size 19x17: "\x{25BC}"
+                    RenderText {#text} at (1,16) size 19x60
+                      text run at (1,16) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,0) size 19x17: "\x{25C0}"
+                    RenderText {#text} at (1,16) size 19x61
+                      text run at (1,16) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,1) size 61x19
+                      text run at (43,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,1) size 60x19
+                      text run at (44,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x18
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x18
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 20x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (1,103) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,42) size 18x60
-                      text run at (0,42) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,103) size 19x17: "\x{25B6}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 19x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (-4,0) size 25x20
-                        RenderText at (3,0) size 19x20
-                          text run at (3,0) width 5 RTL: " "
-                          text run at (3,4) width 17 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,40) size 18x60
-                      text run at (0,40) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,103) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (1,44) size 19x60
+                      text run at (1,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,103) size 19x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,43) size 19x61
+                      text run at (1,43) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,370) size 614x352 [border: (1px outset #000000)]
@@ -215,142 +215,142 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
-                      text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (16,1) size 60x19
+                      text run at (16,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,0) size 17x18: "\x{25B6}"
+                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,0) size 19x17: "\x{25BC}"
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderListMarker at (1,0) size 19x17: "\x{25B6}"
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,0) size 19x17: "\x{25BC}"
+                    RenderText {#text} at (1,16) size 19x60
+                      text run at (1,16) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,0) size 19x17: "\x{25C0}"
+                    RenderText {#text} at (1,16) size 19x61
+                      text run at (1,16) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,-1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,1) size 60x19
+                      text run at (0,1) width 60: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (0,1) size 60x19
+                      text run at (0,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 60x18
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,59) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,59) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 20x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (1,59) size 19x18: "\x{25B6}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 19x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25C0}"
-                      RenderBlock (generated) at (-4,0) size 25x20
-                        RenderText at (3,0) size 19x20
-                          text run at (3,0) width 5 RTL: " "
-                          text run at (3,4) width 17 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,59) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (1,0) size 19x60
+                      text run at (1,0) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,59) size 19x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,0) size 19x60
+                      text run at (1,0) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,722) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,740) size 614x352 [border: (1px outset #000000)]
@@ -390,142 +390,142 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
+                    RenderListMarker at (21,-1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (38,1) size 61x19
                       text run at (38,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (38,0) size 60x18
-                      text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (22,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (38,1) size 60x19
+                      text run at (38,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,0) size 18x18: "\x{25B6}"
+                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (38,0) size 61x18
                       text run at (38,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (22,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (38,0) size 60x18
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,22) size 19x17: "\x{25BC}"
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25B6}"
+                    RenderListMarker at (1,21) size 19x18: "\x{25B6}"
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,38) size 18x60
-                      text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (0,38) size 18x61
-                      text run at (0,38) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,22) size 19x17: "\x{25BC}"
+                    RenderText {#text} at (1,38) size 19x60
+                      text run at (1,38) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,21) size 19x18: "\x{25C0}"
+                    RenderText {#text} at (1,38) size 19x61
+                      text run at (1,38) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,-1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,1) size 61x19
+                      text run at (21,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (22,1) size 60x19
+                      text run at (22,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x18
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (22,0) size 60x18
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,80) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 20x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (1,81) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x60
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 18x60
+                      text run at (0,22) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,81) size 19x18: "\x{25B6}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 18x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 19x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25C0}"
-                      RenderBlock (generated) at (-4,0) size 25x20
-                        RenderText at (3,0) size 19x20
-                          text run at (3,0) width 5 RTL: " "
-                          text run at (3,4) width 17 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,81) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (1,22) size 19x60
+                      text run at (1,22) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,81) size 19x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,21) size 19x61
+                      text run at (1,21) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1110) size 614x352 [border: (1px outset #000000)]
@@ -565,139 +565,139 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
+                    RenderListMarker at (43,-1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (60,0) size 60x18
-                      text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (44,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (60,1) size 60x19
+                      text run at (60,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,0) size 18x18: "\x{25B6}"
+                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (44,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,44) size 19x17: "\x{25BC}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25B6}"
+                    RenderListMarker at (1,43) size 19x18: "\x{25B6}"
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,44) size 19x17: "\x{25BC}"
+                    RenderText {#text} at (1,60) size 19x60
+                      text run at (1,60) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,43) size 19x18: "\x{25C0}"
+                    RenderText {#text} at (1,60) size 19x60
+                      text run at (1,60) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,1) size 61x19
+                      text run at (43,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,1) size 60x19
+                      text run at (44,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x18
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x18
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 20x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 20x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (1,103) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,42) size 18x60
-                      text run at (0,42) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (1,103) size 19x17: "\x{25B6}"
+                      RenderBlock (generated) at (12,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 19x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (-4,0) size 25x20
-                        RenderText at (3,0) size 19x20
-                          text run at (3,0) width 5 RTL: " "
-                          text run at (3,4) width 17 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,40) size 18x60
-                      text run at (0,40) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,103) size 19x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (1,44) size 19x60
+                      text run at (1,44) width 60: "summary"
+                RenderBlock {DETAILS} at (19,0) size 20x120
+                  RenderListItem {SUMMARY} at (0,0) size 20x120
+                    RenderListMarker at (-1,103) size 19x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,43) size 19x61
+                      text run at (1,43) width 60: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
@@ -40,28 +40,28 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
-                      text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (16,1) size 60x19
+                      text run at (16,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,0) size 17x18: "\x{25B6}"
+                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
@@ -94,87 +94,87 @@ layer at (0,0) size 785x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,1) size 61x19
+                      text run at (43,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,1) size 60x19
+                      text run at (44,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x18
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x18
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 18x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,42) size 18x60
-                      text run at (0,42) width 60: "summary"
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (-3,0) size 24x20
-                        RenderText at (3,0) size 18x20
-                          text run at (3,0) width 4 RTL: " "
-                          text run at (3,4) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,40) size 18x60
-                      text run at (0,40) width 60: "summary"
+                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -215,28 +215,28 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (16,0) size 60x18
-                      text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (16,1) size 60x19
+                      text run at (16,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,0) size 17x18: "\x{25B6}"
+                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
@@ -269,64 +269,64 @@ layer at (0,0) size 785x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,-1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,1) size 60x19
+                      text run at (0,1) width 60: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (0,1) size 60x19
+                      text run at (0,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 60x18
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (59,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 60x18
+                      text run at (0,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 18x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (0,59) size 18x18: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -334,20 +334,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x21: "\x{25C0}"
-                      RenderBlock (generated) at (-3,0) size 24x20
-                        RenderText at (3,0) size 18x20
-                          text run at (3,0) width 4 RTL: " "
-                          text run at (3,4) width 16 RTL: "\x{25C0}"
+                    RenderListMarker at (0,59) size 18x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -390,28 +390,28 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
+                    RenderListMarker at (21,-1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (38,1) size 61x19
                       text run at (38,1) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (38,0) size 60x18
-                      text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (22,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (38,1) size 60x19
+                      text run at (38,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,0) size 18x18: "\x{25B6}"
+                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (38,0) size 61x18
                       text run at (38,0) width 61: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (22,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (22,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (38,0) size 60x18
                       text run at (38,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
@@ -444,87 +444,87 @@ layer at (0,0) size 785x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,-1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,1) size 61x19
+                      text run at (21,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (22,1) size 60x19
+                      text run at (22,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,1) size 18x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (20,0) size 60x18
-                      text run at (20,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (21,0) size 61x18
+                      text run at (21,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (81,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (22,0) size 60x18
+                      text run at (22,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 18x60
+                      text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,80) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 18x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (0,81) size 18x18: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x60
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 18x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 18x60
+                      text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x21: "\x{25C0}"
-                      RenderBlock (generated) at (-3,0) size 24x20
-                        RenderText at (3,0) size 18x20
-                          text run at (3,0) width 4 RTL: " "
-                          text run at (3,4) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,20) size 18x60
-                      text run at (0,20) width 60: "summary"
+                    RenderListMarker at (0,81) size 18x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,21) size 18x61
+                      text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -565,28 +565,28 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
+                    RenderListMarker at (43,-1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (60,0) size 60x18
-                      text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (44,-1) size 17x19: "\x{25BC}"
+                    RenderText {#text} at (60,1) size 60x19
+                      text run at (60,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,98) size 125x124 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,0) size 18x18: "\x{25B6}"
+                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,19) size 120x19
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (44,0) size 17x18: "\x{25B2}"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (44,1) size 17x19: "\x{25B2}"
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
@@ -619,85 +619,85 @@ layer at (0,0) size 785x1478
                 text run at (6,6) width 17: "rtl"
             RenderTableCell {TD} at (107,224) size 125x124 [border: (1px solid #000000)] [r=4 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,-4) size 20x25
-                        RenderText at (0,3) size 20x19
-                          text run at (0,3) width 4 RTL: " "
-                          text run at (4,3) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x19
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,1) size 61x19
+                      text run at (43,1) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
+                      RenderBlock (generated) at (0,0) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderText {#text} at (44,1) size 60x19
+                      text run at (44,1) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,7) size 20x25
-                        RenderText at (0,2) size 20x19
-                          text run at (0,2) width 4 RTL: " "
-                          text run at (4,2) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (40,0) size 60x18
-                      text run at (40,0) width 60: "summary"
-                RenderBlock {DETAILS} at (0,18) size 120x18
-                  RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
+                RenderBlock {DETAILS} at (0,0) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
                           text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (40,0) size 61x18
-                      text run at (40,0) width 61: "summary"
-                  RenderBlock {SLOT} at (0,18) size 120x0
+                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (43,0) size 61x18
+                      text run at (43,0) width 61: "summary"
+                RenderBlock {DETAILS} at (0,19) size 120x20
+                  RenderListItem {SUMMARY} at (0,0) size 120x20
+                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
+                      RenderBlock (generated) at (0,12) size 17x19
+                        RenderText at (0,-1) size 17x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderText {#text} at (44,0) size 60x18
+                      text run at (44,0) width 60: "summary"
+                  RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 18x19
-                        RenderText at (0,0) size 18x19
+                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 15 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,42) size 18x60
-                      text run at (0,42) width 60: "summary"
+                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 18x20
-                        RenderText at (0,0) size 18x20
+                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
                           text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 16 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,40) size 18x61
-                      text run at (0,40) width 60: "summary"
+                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 18x60
+                      text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (-3,0) size 24x20
-                        RenderText at (3,0) size 18x20
-                          text run at (3,0) width 4 RTL: " "
-                          text run at (3,4) width 16 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,40) size 18x60
-                      text run at (0,40) width 60: "summary"
+                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,0) size 19x17
+                        RenderText at (-1,0) size 20x17
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 18x61
+                      text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -26,6 +26,7 @@
 
 #include "ContainerNodeInlines.h"
 #include "CSSFontSelector.h"
+#include "DocumentInlines.h"
 #include "ElementInlines.h"
 #include "ElementTraversal.h"
 #include "HTMLNames.h"
@@ -182,6 +183,15 @@ Style::ComputedStyle RenderListItem::computeMarkerStyle() const
         markerStyle.setTextTransform({ });
         return markerStyle;
     }();
+
+    // A disclosure triangle is drawn from the system font rather than from the one the marker inherited, so that is the
+    // font the marker has: it is what the glyph is measured with too, the way it is for every other marker.
+    if (listMarkerIsDisclosure(markerStyle, protect(document()))) {
+        auto fontDescription = FontCascadeDescription { markerStyle.fontDescription() };
+        fontDescription.setFamilies({ { "system-ui"_s, FontFamilyKind::Generic } });
+        markerStyle.setFontDescription(WTF::move(fontDescription));
+        markerStyle.fontCascade().update(&protect(document())->fontSelector());
+    }
 
     // The marker box is a text-decoration boundary: the originating element's text-decoration must
     // not propagate into the marker's generated contents, matching list-style-type markers which are

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -214,15 +214,6 @@ struct TextRunWithUnderlyingString {
     operator const TextRun&() const { return textRun; }
 };
 
-static FontCascade disclosureMarkerFontCascade(const Style::ComputedStyle& style, Document& document)
-{
-    auto fontDescription = FontCascadeDescription { style.fontDescription() };
-    fontDescription.setFamilies({ { "system-ui"_s, FontFamilyKind::Generic } });
-    auto fontCascade = FontCascade(WTF::move(fontDescription));
-    fontCascade.update(&document.fontSelector());
-    return fontCascade;
-}
-
 static auto textRunForContent(ListMarkerTextContent textContent, const Style::ComputedStyle& style) -> TextRunWithUnderlyingString
 {
     ASSERT(!textContent.isEmpty());
@@ -230,14 +221,6 @@ static auto textRunForContent(ListMarkerTextContent textContent, const Style::Co
     auto textForRun = textContent.textWithSuffix;
     auto textRun = RenderBlock::constructTextRun(textForRun, style);
     return { WTF::move(textRun), WTF::move(textForRun) };
-}
-
-void RenderListMarker::paintDisclosureMarker(GraphicsContext& context, const FloatRect& markerRect)
-{
-    auto systemUIFontCascade = disclosureMarkerFontCascade(style(), protect(document()));
-    auto textOrigin = FloatPoint { markerRect.x(), markerRect.y() + systemUIFontCascade.metricsOfPrimaryFont().ascent() };
-    textOrigin = roundPointToDevicePixels(LayoutPoint(textOrigin), protect(document())->deviceScaleFactor(), writingMode().isLogicalLeftInlineStart());
-    context.drawText(systemUIFontCascade, textRunForContent(m_textContent, style()), textOrigin);
 }
 
 void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -322,11 +305,6 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
         context.translate(markerRect.x(), markerRect.maxY());
         context.rotate(static_cast<float>(deg2rad(90.)));
         context.translate(-markerRect.x(), -markerRect.maxY());
-    }
-
-    if (isDisclosureMarker()) {
-        paintDisclosureMarker(context, markerRect);
-        return;
     }
 
     if (writingMode().isHorizontal()) {
@@ -540,12 +518,7 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
 
     ASSERT(!hasContentProperty());
 
-    std::optional<FontCascade> systemUIFontCascade;
-    // Use system-ui font for disclosure triangles
-    if (isDisclosureMarker())
-        systemUIFontCascade = disclosureMarkerFontCascade(style(), protect(document()));
-
-    auto& font = systemUIFontCascade ? *systemUIFontCascade : style().fontCascade();
+    auto& font = style().fontCascade();
 
     LayoutUnit logicalWidth;
     if (!m_textContent.isEmpty())
@@ -658,21 +631,8 @@ FloatRect RenderListMarker::relativeMarkerRect()
     if (m_textContent.isEmpty())
         return { };
 
-    FloatRect relativeRect;
-    if (isDisclosureMarker()) {
-        // Use system-ui font for disclosure triangles
-        auto systemUIFontCascade = disclosureMarkerFontCascade(style(), protect(document()));
-        auto& fontMetrics = style().metricsOfPrimaryFont();
-        auto& systemUIFontMetrics = systemUIFontCascade.metricsOfPrimaryFont();
-        auto width = systemUIFontCascade.width(textRunForContent(m_textContent, style()));
-        auto height = systemUIFontMetrics.height();
-        // Center vertically within the original font metrics
-        auto yOffset = (fontMetrics.height() - height) / 2.0f;
-        relativeRect = { 0.f, yOffset, width, height };
-    } else {
-        auto& font = style().fontCascade();
-        relativeRect = { 0.f, 0.f, font.width(textRunForContent(m_textContent, style())), font.metricsOfPrimaryFont().height() };
-    }
+    auto& font = style().fontCascade();
+    auto relativeRect = FloatRect { 0.f, 0.f, font.width(textRunForContent(m_textContent, style())), font.metricsOfPrimaryFont().height() };
 
     if (!writingMode().isHorizontal()) {
         relativeRect = relativeRect.transposedRect();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -131,7 +131,6 @@ private:
 
     FloatRect relativeMarkerRect();
     LayoutRect NODELETE localSelectionRect();
-    void paintDisclosureMarker(GraphicsContext&, const FloatRect& markerRect);
 
     RefPtr<CSSRegisteredCounterStyle> counterStyle() const;
     bool textNeedsBidiResolution() const;


### PR DESCRIPTION
#### ffffaa2b2c717ed716eb66afe6b596ace506bfb8
<pre>
[list-marker] Opening a &lt;details&gt; makes its summary one pixel shorter
<a href="https://bugs.webkit.org/show_bug.cgi?id=323168">https://bugs.webkit.org/show_bug.cgi?id=323168</a>
<a href="https://rdar.apple.com/problem/186413478">rdar://problem/186413478</a>

Reviewed by Antti Koivisto.

280433@main renders disclosure triangles with system-ui rather than with the font the marker inherited.
It gave RenderListMarker a font cascade of its own, built at paint time, and used it for painting,
but not for the marker box&apos;s height or its layout bounds, which stayed with the inherited font.

Make the font part of the ::marker style instead, so that the glyph is measured with the font it is drawn with.

Tests: imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-ref.html
       imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height.html: Added.
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::paint):
(WebCore::RenderListMarker::computeIntrinsicLogicalWidthContributions):
(WebCore::RenderListMarker::relativeMarkerRect):
(WebCore::disclosureMarkerFontCascade): Deleted.
(WebCore::RenderListMarker::paintDisclosureMarker): Deleted.
* Source/WebCore/rendering/RenderListMarker.h:
* LayoutTests/fast/html/details-add-child-1-expected.txt:
* LayoutTests/fast/html/details-add-child-2-expected.txt:
* LayoutTests/fast/html/details-add-details-child-1-expected.txt:
* LayoutTests/fast/html/details-add-details-child-2-expected.txt:
* LayoutTests/fast/html/details-add-summary-10-expected.txt:
* LayoutTests/fast/html/details-add-summary-6-expected.txt:
* LayoutTests/fast/html/details-add-summary-7-expected.txt:
* LayoutTests/fast/html/details-add-summary-8-expected.txt:
* LayoutTests/fast/html/details-add-summary-9-expected.txt:
* LayoutTests/fast/html/details-add-summary-child-1-expected.txt:
* LayoutTests/fast/html/details-add-summary-child-2-expected.txt:
* LayoutTests/fast/html/details-nested-1-expected.txt:
* LayoutTests/fast/html/details-nested-2-expected.txt:
* LayoutTests/fast/html/details-no-summary2-expected.txt:
* LayoutTests/fast/html/details-open6-expected.txt:
* LayoutTests/fast/html/details-remove-child-1-expected.txt:
* LayoutTests/fast/html/details-remove-child-2-expected.txt:
* LayoutTests/fast/html/details-remove-summary-4-expected.txt:
* LayoutTests/fast/html/details-remove-summary-5-expected.txt:
* LayoutTests/fast/html/details-remove-summary-6-expected.txt:
* LayoutTests/fast/html/details-remove-summary-child-1-expected.txt:
* LayoutTests/fast/html/details-remove-summary-child-2-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt:
* LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt:
* LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open5-expected.txt:
* LayoutTests/platform/mac/fast/html/details-position-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320461@main">https://commits.webkit.org/320461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9cd6024b74015fadfa5ce05b4b515ec835b6559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195150 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49c386e0-3d6c-4abb-859d-00c7f49e9cab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c646d45c-f150-448d-988e-8d950b92c7bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48090 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124708 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11dcca39-745e-4d7c-97fd-043058b07444) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46814 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44578 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6206 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164517 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41203 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59110 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153554 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48068 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131399 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127959 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57608 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19596 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56966 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->