### PR TITLE
Cherry-pick 305413.975@safari-7624.5-branch (d74d692503fc). https://bugs.webkit.org/show_bug.cgi?id=316723

### DIFF
--- a/JSTests/stress/new-regexp-untyped-soft-invalid-stale-captures.js
+++ b/JSTests/stress/new-regexp-untyped-soft-invalid-stale-captures.js
@@ -1,0 +1,52 @@
+//@ runDefault("--jitPolicyScale=0")
+
+const nesting = 34000;
+const callDepth = 8000;
+const iterations = testLoopCount;
+const stride = 1024;
+const emptyCaptures = 22;
+
+function atDepth(depth, callback) {
+    const keep = depth;
+    if (!depth)
+        return callback() + keep;
+    return atDepth(depth - 1, callback) + Number(keep === -1);
+}
+
+let regexpPayload = "";
+for (let i = 0; i < emptyCaptures; ++i)
+    regexpPayload += "()";
+regexpPayload += "(?=b*(a*))";
+regexpPayload += "(?:stablefinalread)?";
+
+const pattern = "(?:".repeat(nesting) + regexpPayload + ")".repeat(nesting);
+
+const pieces = [];
+for (let offset = 0; offset < pattern.length; offset += 8000)
+    pieces.push(JSON.stringify(pattern.slice(offset, offset + 8000)));
+const make = eval(`(function (run) { if (!run) return 1; return new RegExp(${pieces.join(" + ")}, ""); })`);
+
+try { make(true); } catch (e) { }
+fullGC();
+
+let exposed = null;
+try {
+    atDepth(callDepth, () => {
+        try { new RegExp(pattern, ""); } catch (e) { }
+        for (let i = 0; i < iterations && !exposed; ++i) {
+            make(false);
+            if ((i % stride) === stride - 1)
+                try { exposed = make(true); } catch (e) { }
+        }
+        if (!exposed)
+            try { exposed = make(true); } catch (e) { }
+        return 0;
+    });
+} catch (e) { }
+
+if (exposed) {
+    const subject = "a".repeat(113);
+    for (let i = 0; i < 6; ++i) {
+        try { exposed.test(subject); } catch (e) { }
+    }
+}

--- a/JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rule-promoted-parent.js
+++ b/JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rule-promoted-parent.js
@@ -1,0 +1,26 @@
+function makeInner() {
+    return function inner(q) { return {}; };
+}
+
+function clobber(a,b,c,d,e,f,g,h) { return a; }
+
+let escaped;
+function sink(o) { escaped = o; }
+noInline(sink);
+
+let arr = [1.1,2.2,3.3,4.4,5.5,6.6,7.7,8.8];
+
+function opt(ff) {
+    let p = ff(0);
+    let y = {};
+    p.f = y;
+    p.f = null;
+    clobber(...arr);
+    sink(p);
+}
+noInline(opt);
+
+let inners = [makeInner(), makeInner()];
+for (let i = 0; i < testLoopCount; ++i)
+    opt(inners[i & 1]);
+opt(inners[0]);

--- a/JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rules.js
+++ b/JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rules.js
@@ -1,0 +1,26 @@
+function makeInner() {
+    return function inner(q) { return {}; };
+}
+
+function clobber(a,b,c,d,e,f,g,h) { return a; }
+
+let escaped;
+function sink(o) { escaped = o; }
+noInline(sink);
+
+let arr = [1.1,2.2,3.3,4.4,5.5,6.6,7.7,8.8];
+
+function opt(ff, cond) {
+    let v = {};
+    let c = ff(0);
+    c.x = v;
+    clobber(...arr);
+    if (cond)
+        sink(c);
+}
+noInline(opt);
+
+let inners = [makeInner(), makeInner()];
+for (let i = 0; i < testLoopCount; ++i)
+    opt(inners[i & 1], (i & 1) == 0);
+opt(inners[0], true);

--- a/JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js
+++ b/JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js
@@ -1,0 +1,151 @@
+// The module is hand-assembled as raw bytes rather than written in WAT because
+// the current in-tree WAT assemblers do not support both GC and exceptions.
+
+// --- WebAssembly encoding helpers ------------------------------------------------
+
+// Unsigned LEB128.
+function u32(value)
+{
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        result.push(byte);
+    } while (value);
+    return result;
+}
+
+// A name/vec(byte): length-prefixed UTF-8 bytes.
+function str(value)
+{
+    const result = [];
+    for (let i = 0; i < value.length; ++i)
+        result.push(value.charCodeAt(i));
+    return [...u32(result.length), ...result];
+}
+
+// section(id, payload) = id, size(payload), payload.
+function section(id, payload)
+{
+    return [id, ...u32(payload.length), ...payload];
+}
+
+// A function body: vec(locals), code, 0x0b(end-of-function). `localGroups` is a
+// list of [count, valtype] pairs; `code` is the instruction stream.
+function body(localGroups, code)
+{
+    const payload = [...u32(localGroups.length)];
+    for (const [count, type] of localGroups)
+        payload.push(...u32(count), type);
+    payload.push(...code, 0x0b);                       // 0x0b = end (of function)
+    return [...u32(payload.length), ...payload];
+}
+
+const localGet = (index) => [0x20, ...u32(index)];     // 0x20 = local.get
+const localSet = (index) => [0x21, ...u32(index)];     // 0x21 = local.set
+const bitsCount = 24;
+
+// valtype bytes: 0x7f = i32, 0x7e = i64, 0x6f = externref. Section ids: 1 type,
+// 2 import, 3 function, 7 export, 10 code, 13 tag.
+
+function makeModule()
+{
+    // --- Type section (id 1): four function types ------------------------------
+    const helperParams = [...new Array(bitsCount).fill(0x7e), 0x6f]; // 24 x i64, then externref
+    const typeSection = [
+        ...u32(4),                                     // 4 types
+        0x60, 0x00, 0x01, 0x7f,                        // type 0: () -> i32                      ($thrower)
+        0x60, ...u32(helperParams.length), ...helperParams, 0x01, 0x7f, // type 1: (i64 x24, externref) -> i32  ($helper)
+        0x60, 0x01, 0x7f, 0x01, 0x6f,                  // type 2: (i32) -> externref            ($target)
+        0x60, 0x00, 0x00,                              // type 3: () -> ()                       (tag type)
+    ];
+
+    // --- Import section (id 2): one function + 25 mutable globals ---------------
+    const imports = [
+        [...str("m"), ...str("thrower"), 0x00, ...u32(0)],          // func   "m"."thrower" : type 0
+        [...str("m"), ...str("object"), 0x03, 0x6f, 0x01],          // global "m"."object"  : externref, mutable
+    ];
+    for (let index = 0; index < bitsCount; ++index)
+        imports.push([...str("m"), ...str(`bits${index}`), 0x03, 0x7e, 0x01]); // global "m"."bitsN" : i64, mutable
+    const importSection = [...u32(imports.length), ...imports.flat()];
+
+    // --- Function section (id 3): the two defined functions ---------------------
+    // Imported funcs occupy index 0 ($thrower); defined funcs follow:
+    //   func 1 = $helper (type 1), func 2 = $target (type 2).
+    const functionSection = [...u32(2), ...u32(1), ...u32(2)];
+
+    // --- Tag section (id 13): one exception tag of type 3 -----------------------
+    const tagSection = [...u32(1), 0x00, ...u32(3)];   // 1 tag, attribute 0 (exception), type 3
+
+    // --- Export section (id 7): export $target ----------------------------------
+    const exportSection = [...u32(1), ...str("target"), 0x00, ...u32(2)]; // "target" = func 2
+
+    // --- Code section (id 10): bodies for $helper and $target -------------------
+
+    // $helper: padding nops keep it above the inlining threshold, then it calls the
+    // imported JS thrower (which always throws).
+    const helperBody = body([], [
+        ...new Array(600).fill(0x01),                  // nop x600 (0x01 = nop)
+        0x10, 0x00,                                    // call 0  ($thrower)
+    ]);
+
+    // $target: the trigger. One externref local ($live = local 1; local 0 = param).
+    const targetBody = body([[1, 0x6f]], [
+        0x06, 0x6f,                                                            // try (result externref)
+          ...new Array(bitsCount).fill(0).flatMap((_, index) => [0x23, ...u32(1 + index)]), // global.get $bits0 .. $bits23  (globals 1..24)
+          0xd0, 0x6f,                                                         //   ref.null extern         (0xd0 ref.null, 0x6f extern; constant select arm)
+          0x23, 0x00,                                                         //   global.get 0            ($object, the other select arm)
+          ...localGet(0),                                                     //   local.get 0             ($predicate, the select condition)
+          0x1c, 0x01, 0x6f,                                                   //   select (result externref) (0x1c typed-select, 1 result type, externref)
+          ...localSet(1),                                                     //   local.set 1             ($live = select result)
+          ...localGet(1),                                                     //   local.get 1             ($live, passed as the call's externref arg)
+          0x10, 0x01,                                                         //   call 1                  ($helper; exception-capable call cloned by specializeSelect)
+          0x1a,                                                               //   drop                    (discard $helper's i32 result)
+          ...localGet(1),                                                     //   local.get 1             ($live)
+          0xd4,                                                               //   ref.as_non_null         (0xd4; the Check whose Select specializeSelect rewrites)
+          0x1a,                                                               //   drop
+          0xd0, 0x6f,                                                         //   ref.null extern         (normal-path try result; unreachable, $helper always throws)
+        0x19,                                                                 // catch_all (0x19)
+          ...localGet(1),                                                     //   local.get 1             ($live -> restored externref, the function result)
+        0x0b,                                                                 // end (of try)
+    ]);
+
+    const codeSection = [...u32(2), ...helperBody, ...targetBody]; // 2 function bodies
+
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // "\0asm", version 1
+        ...section(1, typeSection),
+        ...section(2, importSection),
+        ...section(3, functionSection),
+        ...section(13, tagSection),
+        ...section(7, exportSection),
+        ...section(10, codeSection),
+    ]);
+}
+
+// --- Imports: a throwing function, a marker externref, and 24 i64 sentinels ------
+
+const marker = { marker: 0x1227 };
+const raw42 = 0xfffe00000000002an;
+const imports = {
+    thrower() {
+        throw marker;
+    },
+    object: new WebAssembly.Global({ value: "externref", mutable: true }, marker),
+};
+for (let index = 0; index < bitsCount; ++index) {
+    imports[`bits${index}`] = new WebAssembly.Global(
+        { value: "i64", mutable: true },
+        BigInt.asIntN(64, raw42 + BigInt(index) * 0x100n));
+}
+
+const target = new WebAssembly.Instance(
+    new WebAssembly.Module(makeModule()), { m: imports }).exports.target;
+
+for (let iteration = 0; iteration < wasmTestLoopCount; ++iteration) {
+    const result = target(1);
+    if (result !== null)
+        throw new Error(`expected null catch restoration, got ${String(result)} at iteration ${iteration}`);
+}

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3284,7 +3284,23 @@ private:
                         && (value->child(1)->isConstant() || value->child(2)->isConstant());
                 });
             
-            if (select) {
+            if (!select)
+                break;
+
+            // All values between Select and Check must be cloneable.
+            bool canClone = true;
+            for (unsigned i = m_index; ; --i) {
+                Value* value = m_block->at(i);
+                if (value->kind().isCloningForbidden()) {
+                    canClone = false;
+                    break;
+                }
+                if (value == select)
+                    break;
+                RELEASE_ASSERT(i); // Select should be found
+            }
+
+            if (canClone) {
                 specializeSelect(select);
                 m_didSpecializeSelect = true;
                 break;

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1514,7 +1514,9 @@ escapeChildren:
         // 2) If we put a sink candidate into a local allocation, that
         //    allocation becomes a sink candidate as well.
         //
-        // We currently choose to implement closure rule #2.
+        // Typically we implement closure rule #2. However, when a candidate is
+        // excluded due to InlineCallFrame mismatch, we use rule #1 to also exclude
+        // anything that transitively depends on it.
         UncheckedKeyHashMap<Node*, Vector<Node*>> dependencies;
         bool hasUnescapedReads = false;
         for (BasicBlock* block : m_graph.blocksInPreOrder()) {
@@ -1596,32 +1598,17 @@ escapeChildren:
             }
         };
 
-        if (m_sinkCandidates.size()) {
-            // If we're moving an allocation to `where` in the program, we need to ensure
-            // we can still walk the stack at that point in the program for the
-            // InlineCallFrame of the original allocation. Certain InlineCallFrames rely on
-            // data in the stack when taking a stack trace. All allocation sites can do a
-            // stack walk (we do a stack walk when we GC). Conservatively, we say we're
-            // still ok to move this allocation if we are moving within the same InlineCallFrame.
-            // We could be more precise here and do an analysis of stack writes. However,
-            // this scenario is so rare that we just take the conservative-and-straight-forward 
-            // approach of checking that we're in the same InlineCallFrame.
+        auto shouldDemote = [] (Node* candidate, Node* where) {
+            InlineCallFrame* inlineCallFrame = candidate->origin.semantic.inlineCallFrame();
+            if (!inlineCallFrame)
+                return false;
+            if (!inlineCallFrame->isClosureCall && !inlineCallFrame->isVarargs())
+                return false;
+            return inlineCallFrame != where->origin.semantic.inlineCallFrame();
+        };
 
-            forEachEscapee([&] (UncheckedKeyHashMap<Node*, Allocation>& escapees, Node* where) {
-                for (Node* allocation : escapees.keys()) {
-                    InlineCallFrame* inlineCallFrame = allocation->origin.semantic.inlineCallFrame();
-                    if (!inlineCallFrame)
-                        continue;
-                    if ((inlineCallFrame->isClosureCall || inlineCallFrame->isVarargs()) && inlineCallFrame != where->origin.semantic.inlineCallFrame()) {
-                        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Removing candidate because it escapes from a frame that has a closure: ", allocation);
-                        m_sinkCandidates.remove(allocation);
-                    }
-                }
-            });
-        }
-
-        // Ensure that the set of sink candidates is closed for put operations
-        // This is (2) as described above.
+        // Closure rule #2: for each candidate, promote every `dependencies` entry
+        // (i.e. every allocation it was put into).
         Vector<Node*> worklist;
         worklist.appendRange(m_sinkCandidates.begin(), m_sinkCandidates.end());
 
@@ -1632,6 +1619,49 @@ escapeChildren:
             }
         }
 
+        bool hasDemotedAnyCandidate = false;
+        if (m_sinkCandidates.size()) {
+            // If we're moving an allocation to `where` in the program, we need to ensure
+            // we can still walk the stack at that point in the program for the
+            // InlineCallFrame of the original allocation. Certain InlineCallFrames rely on
+            // data in the stack when taking a stack trace. All allocation sites can do a
+            // stack walk (we do a stack walk when we GC). Conservatively, we say we're
+            // still ok to move this allocation if we are moving within the same InlineCallFrame.
+            // We could be more precise here and do an analysis of stack writes. However,
+            // this scenario is so rare that we just take the conservative-and-straight-forward
+            // approach of checking that we're in the same InlineCallFrame.
+            forEachEscapee([&] (UncheckedKeyHashMap<Node*, Allocation>& escapees, Node* where) {
+                for (Node* allocation : escapees.keys()) {
+                    if (shouldDemote(allocation, where)) {
+                        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Removing candidate because it escapes from a frame that has a closure: ", allocation);
+                        m_sinkCandidates.remove(allocation);
+                        hasDemotedAnyCandidate = true;
+                    }
+                }
+            });
+        }
+
+        // Closure rule #1: demote any candidate that was put into a demoted allocation
+        // (i.e. one removed by the InlineCallFrame check above). Iterate to fixpoint;
+        // rule #2's fixpoint is preserved through this loop and doesn't need re-running.
+        if (hasDemotedAnyCandidate) [[unlikely]] {
+            Vector<Node*> toRemove;
+            do {
+                toRemove.shrink(0);
+                for (Node* candidate : m_sinkCandidates) {
+                    for (Node* parent : dependencies.get(candidate)) {
+                        if (!m_sinkCandidates.contains(parent)) {
+                            dataLogLnIf(Options::verboseObjectAllocationSinking(), "Removing candidate ", candidate, " because parent ", parent, " was a demoted candidate");
+                            toRemove.append(candidate);
+                            break;
+                        }
+                    }
+                }
+                for (Node* candidate : toRemove)
+                    m_sinkCandidates.remove(candidate);
+            } while (!toRemove.isEmpty());
+        }
+
         if (m_sinkCandidates.isEmpty())
             return hasUnescapedReads;
 
@@ -1639,6 +1669,10 @@ escapeChildren:
 
         // Create the materialization nodes.
         forEachEscapee([&] (UncheckedKeyHashMap<Node*, Allocation>& escapees, Node* where) {
+#if ASSERT_ENABLED
+            for (Node* allocation : escapees.keys())
+                ASSERT(!shouldDemote(allocation, where));
+#endif
             placeMaterializations(WTF::move(escapees), where);
         });
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -732,6 +732,9 @@ private:
             if (!regExp)
                 break;
 
+            if (!regExp->isValid())
+                break;
+
             m_node->convertToNewRegExp(m_graph.freezeStrong(regExp), m_insertionSet.insertConstantForUse(m_nodeIndex, m_node->origin, jsNumber(0), UntypedUse));
             m_changed = true;
             break;

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -167,6 +167,11 @@ void RegExp::finishCreation(VM& vm)
         return;
     }
 
+    updateMetadataFromPattern(pattern);
+}
+
+void RegExp::updateMetadataFromPattern(Yarr::YarrPattern& pattern)
+{
     m_atom = WTF::move(pattern.m_atom);
     m_specificPattern = pattern.m_specificPattern;
 
@@ -281,10 +286,7 @@ void RegExp::byteCodeCompileIfNecessary(VM* vm)
         m_state = ParseError;
         return;
     }
-    ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
-
-    m_atom = WTF::move(pattern.m_atom);
-    m_specificPattern = pattern.m_specificPattern;
+    updateMetadataFromPattern(pattern);
 
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
     if (!m_regExpBytecode) {
@@ -302,10 +304,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
         m_state = ParseError;
         return;
     }
-    ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
-
-    m_atom = WTF::move(pattern.m_atom);
-    m_specificPattern = pattern.m_specificPattern;
+    updateMetadataFromPattern(pattern);
 
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);
@@ -372,10 +371,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
         m_state = ParseError;
         return;
     }
-    ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
-
-    m_atom = WTF::move(pattern.m_atom);
-    m_specificPattern = pattern.m_specificPattern;
+    updateMetadataFromPattern(pattern);
 
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -35,6 +35,10 @@
 
 namespace JSC {
 
+namespace Yarr {
+struct YarrPattern;
+}
+
 struct RegExpRepresentation;
 class VM;
 
@@ -182,6 +186,8 @@ private:
     friend class RegExpCache;
     RegExp(VM&, const String&, OptionSet<Yarr::Flags>);
     void finishCreation(VM&);
+
+    void updateMetadataFromPattern(Yarr::YarrPattern&);
 
     static RegExp* createWithoutCaching(VM&, const String&, OptionSet<Yarr::Flags>);
 

--- a/Source/JavaScriptCore/runtime/RegExpCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpCache.cpp
@@ -59,6 +59,9 @@ RegExp* RegExpCache::lookupOrCreate(VM& vm, const String& patternString, OptionS
     vm.addRegExpToTrace(regExp);
 #endif
 
+    if (!regExp->isValid())
+        return regExp;
+
     {
         Locker locker { m_lock };
         weakAdd(m_weakCache, key, Weak<RegExp>(regExp, this));

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4749,6 +4749,8 @@ RefPtr<PatchpointExceptionHandle> OMGIRGenerator::preparePatchpointForExceptions
     if (!mustSaveState)
         return nullptr;
 
+    ASSERT(patch->kind().isCloningForbidden());
+
     unsigned firstStackmapChildOffset = patch->numChildren();
     unsigned firstStackmapParamOffset = firstStackmapChildOffset + m_proc.resultCount(patch->type());
 
@@ -5356,7 +5358,10 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const RTT& signatur
     auto constrainedPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfo, tmpArgs);
 
     advanceCallSiteIndex();
-    PatchpointValue* patchpoint = m_proc.add<PatchpointValue>(returnType, origin());
+    // Calls inside a try carry a catch-restoration stackmap keyed by CallSiteIndex, see preparePatchpointForExceptions.
+    // Forbid cloning so a B3 transform won't alias two call sites to one stackmap.
+    auto patchpointKind = m_tryCatchDepth ? cloningForbidden(Patchpoint) : Patchpoint;
+    PatchpointValue* patchpoint = m_proc.add<PatchpointValue>(returnType, origin(), patchpointKind);
     patchpoint->effects.writesPinned = true;
     patchpoint->effects.readsPinned = true;
     patchpoint->clobberEarly(RegisterSet::macroClobberedGPRs());


### PR DESCRIPTION
#### 3dd1d046dd9c37914e7b5e846d2442a1fc34bc01
<pre>
Cherry-pick 305413.975@safari-7624.5-branch (d74d692503fc). <a href="https://bugs.webkit.org/show_bug.cgi?id=316723">https://bugs.webkit.org/show_bug.cgi?id=316723</a>

    [JSC] Validate RegExps in DFG strength reduction phase
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316723">https://bugs.webkit.org/show_bug.cgi?id=316723</a>
    <a href="https://rdar.apple.com/178446883">rdar://178446883</a>

    Reviewed by Yusuke Suzuki.

    This patch prevents conversion to NewRegExpUntyped if the regexp in question is invalid.

    Test: JSTests/stress/new-regexp-untyped-soft-invalid-stale-captures.js

    * JSTests/stress/new-regexp-untyped-soft-invalid-stale-captures.js: Added.
    (atDepth):
    (const.make.eval):
    (catch):
    (try.catch):
    (try.i.catch):
    (exposed.i.catch):
    * Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
    (JSC::DFG::StrengthReductionPhase::handleNode):
    * Source/JavaScriptCore/runtime/RegExp.cpp:
    (JSC::RegExp::finishCreation):
    (JSC::RegExp::updateMetadataFromPattern):
    (JSC::RegExp::byteCodeCompileIfNecessary):
    (JSC::RegExp::compile):
    (JSC::RegExp::compileMatchOnly):
    * Source/JavaScriptCore/runtime/RegExp.h:
    * Source/JavaScriptCore/runtime/RegExpCache.cpp:
    (JSC::RegExpCache::lookupOrCreate):

    Identifier: 305413.975@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.180@webkitglib/2.54">https://commits.webkit.org/317695.180@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 09236187b6514c773084e2d3f962c4b68e8db926
<pre>
Cherry-pick 305413.973@safari-7624.5.1.10-branch (a4e027e916f5). <a href="https://bugs.webkit.org/show_bug.cgi?id=315674">https://bugs.webkit.org/show_bug.cgi?id=315674</a>

    [JSC] Fix Object Allocation Sinking closure rule for allocations within inlined closure-call and varargs frames
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315674">https://bugs.webkit.org/show_bug.cgi?id=315674</a>
    <a href="https://rdar.apple.com/176555185">rdar://176555185</a>

    Reviewed by Yijia Huang.

    208291@main added an InlineCallFrame check that demotes candidate
    allocations whose origin is a closure-call or varargs inline frame and
    whose escape site is in a different frame. The check is necessary
    because such an allocation, if sunk to the escape site, would have its
    Materialize* node emitted where the frame&apos;s closure-call callee
    slot or varargs argc slot has been reused by intervening code, causing
    subsequent stack walks to potentially dereference garbage.

    However, that fix was incomplete in two ways. First, the InlineCallFrame
    check ran before the closure rule&apos;s worklist (&quot;rule #2&quot;), so it only
    inspected the initial candidates. Rule #2 then promoted additional
    dependencies to satisfy the closure invariant (a sink candidate stored
    into a local allocation, that allocation must also be a sink candidate&quot;),
    and any such promoted allocation that would have failed the
    InlineCallFrame check slipped through. Second, even for candidates the
    check correctly removed, rule #2&apos;s worklist re-promoted them in order
    to maintain its invariant, undoing the InlineCallFrame check.

    Fix this with two complementary changes:

    1. Run the closure rule (rule #2) before the InlineCallFrame check, so
       the InlineCallFrame check sees both seeded and rule-#2-promoted
       candidates and is the final determination of which stay sunk.

    2. Add an additional closure rule (which was already documented as a
       potential rule #1): remove candidates that depend on the candidates
       that were demoted (due to the InlineCallFrame mismatch). Like the
       original fix, this happens rarely.

    Add an ASSERT in the materialization-placement loop to verify that no
    allocation reaching it would fail the InlineCallFrame check. This
    catches the bug pattern in debug builds and guards against future
    regressions.

    Test: JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rules.js

    * JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rule-promoted-parent.js: Added.
    (makeInner.return.inner):
    (makeInner):
    (clobber):
    (sink):
    (opt):
    * JSTests/stress/object-allocation-sinking-phase-must-only-move-allocations-if-stack-trace-is-still-valid-closure-rules.js: Added.
    (makeInner.return.inner):
    (makeInner):
    (clobber):
    (sink):
    (opt):
    * Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:

    Identifier: 305413.973@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.179@webkitglib/2.54">https://commits.webkit.org/317695.179@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### bee3709247042124663a14be27e8715957ffbb99
<pre>
Cherry-pick 305413.972@safari-7624.5.1.10-branch (db24355101bd). <a href="https://bugs.webkit.org/show_bug.cgi?id=316791">https://bugs.webkit.org/show_bug.cgi?id=316791</a>

    [JSC] Do not clone patchpoints for Wasm calls within a try block
    <a href="https://rdar.apple.com/178657225">rdar://178657225</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316791">https://bugs.webkit.org/show_bug.cgi?id=316791</a>

    Reviewed by Yijia Huang.

    Similar to throw/rethrow patchpoints, a Wasm OMG call patchpoint inside
    a Try block carries an exception-restoration stackmap keyed by its CallSiteIndex,
    so it should not be cloned. If B3 Select specialization (or B3DuplicateTails)
    duplicates them, that leaves two call sites sharing one stackmap even with
    potentially differing live-value layouts.

    Extend 266643@main to also mark call patchpoints cloningForbidden when
    m_tryCatchDepth != 0, and make specializeSelect() bail when a
    cloning-forbidden value is in the range it would clone.

    Test: JSTests/wasm/stress/omg-reduce-strength-select-exception-stackmap.js
    Identifier: 305413.972@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.178@webkitglib/2.54">https://commits.webkit.org/317695.178@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c1268bb8a452c8bf90a9554f4f7bc9f7cfcb35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184366 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58292 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194695 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148669 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59638 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58026 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143938 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148669 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187321 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59638 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124356 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59638 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58026 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6325 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59638 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5768 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/45645 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50953 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58026 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196636 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/57961 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153513 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58666 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153178 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28005 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58666 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130960 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127384 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57172 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52109 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56540 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56782 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56607 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->