### PR TITLE
Enhance testLibJSCTools to track test suite run time, and fix an intermittent hang.

### DIFF
--- a/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp
@@ -44,7 +44,8 @@ using JSC::Corpse::Address;
 
 void testAddress()
 {
-    if (!beginSuite("Address"))
+    SuiteTracer tracer("Address");
+    if (!tracer.shouldRun())
         return;
 
     {

--- a/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp
@@ -39,7 +39,8 @@ using JSC::Corpse::ByteParser;
 
 void testByteParser()
 {
-    if (!beginSuite("ByteParser"))
+    SuiteTracer tracer("ByteParser");
+    if (!tracer.shouldRun())
         return;
 
     {

--- a/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp
@@ -686,7 +686,8 @@ static void testWalkIsBounded()
 
 void testExportsTrie()
 {
-    if (!beginSuite("ExportsTrie"))
+    SuiteTracer tracer("ExportsTrie");
+    if (!tracer.shouldRun())
         return;
 
     testFoundExports();
@@ -749,7 +750,8 @@ static void* fuzzWatchdog(void*)
 
 void fuzzExportsTrie(uint64_t seed, unsigned iterations)
 {
-    if (!beginSuite("ExportsTrie fuzz"))
+    SuiteTracer tracer("ExportsTrie fuzz");
+    if (!tracer.shouldRun())
         return;
     dataLogLn("    seed ", RawHex(seed), ", ", iterations, " iterations");
 

--- a/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
@@ -31,27 +31,43 @@
 #include "LibJSCToolsTestUtilities.h"
 
 #include <JavaScriptCore/CorpseProcess.h>
+#include <errno.h>
 #include <signal.h>
 #include <spawn.h>
+#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/text/CString.h>
 
 namespace JSCToolsTest {
 
 using JSC::Corpse::Process;
 
-// A pid that is certainly not in use: a child that has been reaped. Returns 0 if
-// no child could be made.
+// A pid that is certainly not in use: a child that has been reaped. Returns 0 if no
+// child could be made, reporting why, since the caller only sees the missing pid.
 static pid_t reapedChildPid()
 {
     pid_t child = fork();
     if (!child)
         _exit(0);
-    if (child < 0)
+    if (child < 0) {
+        dataLogLn("    could not fork: ", safeStrerror(errno));
         return 0;
+    }
+
+    // EINTR leaves the child unreaped, so resume rather than report a failure.
     int status = 0;
-    if (waitpid(child, &status, 0) != child)
+    pid_t waited = 0;
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+
+    if (waited != child) {
+        dataLogLn("    could not reap child ", child, ": waitpid returned ", waited,
+            ", errno ", errno, " (", safeStrerror(errno), ")");
         return 0;
+    }
     return child;
 }
 
@@ -86,7 +102,8 @@ static pid_t spawnTranslatedChild()
 
 void testProcess()
 {
-    if (!beginSuite("Process"))
+    SuiteTracer tracer("Process");
+    if (!tracer.shouldRun())
         return;
 
     {
@@ -186,7 +203,7 @@ void testProcess()
             TEST_ASSERT(process->isTranslated(), "a process running x86_64 code is translated");
             kill(translated, SIGKILL);
             int status = 0;
-            waitpid(translated, &status, 0);
+            while (waitpid(translated, &status, 0) < 0 && errno == EINTR) { }
         }
     }
 #endif // CPU(ARM64)

--- a/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp
@@ -46,7 +46,8 @@ using JSC::Corpse::Region;
 
 void testRegion()
 {
-    if (!beginSuite("Region"))
+    SuiteTracer tracer("Region");
+    if (!tracer.shouldRun())
         return;
 
     size_t pageSize = static_cast<size_t>(getpagesize());

--- a/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
@@ -42,7 +42,8 @@ using JSC::Corpse::Snapshot;
 
 void testSnapshot()
 {
-    if (!beginSuite("Snapshot"))
+    SuiteTracer tracer("Snapshot");
+    if (!tracer.shouldRun())
         return;
 
     RefPtr<Process> process = Process::create(getpid());

--- a/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
@@ -56,7 +56,8 @@ using JSC::Corpse::Symbol;
 // space. That makes every look up below checkable against ground truth.
 void testSymbol()
 {
-    if (!beginSuite("Symbol"))
+    SuiteTracer tracer("Symbol");
+    if (!tracer.shouldRun())
         return;
 
     SelfSnapshot self;

--- a/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp
@@ -42,7 +42,8 @@ using JSC::Corpse::Thread;
 
 void testThreads()
 {
-    if (!beginSuite("Thread"))
+    SuiteTracer tracer("Thread");
+    if (!tracer.shouldRun())
         return;
 
     static constexpr const char* alphaName = "jsctools alpha";

--- a/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp
+++ b/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp
@@ -35,6 +35,7 @@
 #include <pthread.h>
 #include <string>
 #include <unistd.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/StdLibExtras.h>
 
 namespace JSCToolsTest {
@@ -43,13 +44,39 @@ unsigned assertionsRun = 0;
 unsigned assertionsFailed = 0;
 unsigned suitesSkipped = 0;
 const char* suiteFilter = nullptr;
+bool verbose = false;
 
-bool beginSuite(const char* name)
+static Seconds s_totalSuiteTime;
+
+SuiteTracer::SuiteTracer(const char* name)
+    : m_name(name)
+    , m_shouldRun(!suiteFilter || std::string_view(name).contains(std::string_view(suiteFilter)))
 {
-    if (suiteFilter && !std::string_view(name).contains(std::string_view(suiteFilter)))
-        return false;
-    dataLogLn("--- ", name);
-    return true;
+    if (!m_shouldRun)
+        return;
+    dataLogLn("--- ", m_name);
+    m_start = MonotonicTime::now();
+}
+
+SuiteTracer::~SuiteTracer()
+{
+    if (!m_shouldRun)
+        return;
+
+    Seconds elapsed = MonotonicTime::now() - m_start;
+    s_totalSuiteTime += elapsed;
+    if (!verbose)
+        return;
+
+    uint64_t microseconds = static_cast<uint64_t>(elapsed.microseconds());
+    uint64_t fraction = microseconds % 1000;
+    dataLogLn("    ran for ", microseconds / 1000, ".",
+        fraction < 100 ? "0" : "", fraction < 10 ? "0" : "", fraction, " ms");
+}
+
+Seconds totalSuiteTime()
+{
+    return s_totalSuiteTime;
 }
 
 void skipSuite(const char* name, const char* why)

--- a/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h
+++ b/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h
@@ -34,7 +34,9 @@
 #include <string_view>
 #include <wtf/DataLog.h>
 #include <wtf/HexNumber.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RefPtr.h>
+#include <wtf/Seconds.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -54,8 +56,31 @@ extern unsigned suitesSkipped;
 // Only suites whose name contains this substring run. Null runs all of them.
 extern const char* suiteFilter;
 
-bool beginSuite(const char* name);
+extern bool verbose;
+
 void skipSuite(const char* name, const char* why);
+
+// Announces a suite, times it, and reports on the way out. Destroyed on every path out
+// of a suite, including the early returns a suite takes when it cannot set itself up.
+class SuiteTracer {
+public:
+    explicit SuiteTracer(const char* name);
+    ~SuiteTracer();
+
+    SuiteTracer(const SuiteTracer&) = delete;
+    SuiteTracer& operator=(const SuiteTracer&) = delete;
+    SuiteTracer(SuiteTracer&&) = delete;
+    SuiteTracer& operator=(SuiteTracer&&) = delete;
+
+    bool shouldRun() const { return m_shouldRun; }
+
+private:
+    const char* m_name;
+    MonotonicTime m_start;
+    bool m_shouldRun;
+};
+
+Seconds totalSuiteTime();
 
 // Nothing is printed for a passing assertion: a passing run should be quiet, and
 // a failing one should say only what failed.

--- a/Source/JavaScriptCore/corpse/tests/testLibJSCTools.cpp
+++ b/Source/JavaScriptCore/corpse/tests/testLibJSCTools.cpp
@@ -56,7 +56,7 @@ constexpr unsigned defaultFuzzIterations = 20000;
 
 void printUsage()
 {
-    dataLogLn("Usage: testLibJSCTools [<suite filter>]");
+    dataLogLn("Usage: testLibJSCTools [--verbose] [<suite filter>]");
     dataLogLn("       testLibJSCTools --fuzz-trie [<seed> [<iterations>]]");
     dataLogLn("");
     dataLogLn("  Runs the tests for libJavaScriptCoreTools. With a filter, only the");
@@ -90,6 +90,10 @@ int main(int argc, char** argv)
         if (argument == "--help" || argument == "-h") {
             printUsage();
             return 0;
+        }
+        if (argument == "--verbose") {
+            JSCToolsTest::verbose = true;
+            continue;
         }
         if (argument == "--fuzz-trie") {
             fuzzOnly = true;
@@ -126,7 +130,8 @@ int main(int argc, char** argv)
 
     dataLogLn("Ran ", JSCToolsTest::assertionsRun, " assertions, ",
         JSCToolsTest::assertionsFailed, " failed, ",
-        JSCToolsTest::suitesSkipped, " suites skipped");
+        JSCToolsTest::suitesSkipped, " suites skipped, in ",
+        static_cast<uint64_t>(JSCToolsTest::totalSuiteTime().milliseconds()), " ms");
 
     if (JSCToolsTest::assertionsFailed) {
         dataLogLn("Some libJavaScriptCoreTools tests FAILED!");


### PR DESCRIPTION
#### afbe314b93fc84ded1e57c21a32d955cd6197931
<pre>
Enhance testLibJSCTools to track test suite run time, and fix an intermittent hang.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323167">https://bugs.webkit.org/show_bug.cgi?id=323167</a>
<a href="https://rdar.apple.com/186413086">rdar://186413086</a>

Reviewed by Marcus Plutowski and Dan Hecht.

Now introducing and using a SuiteTracer RAII class to track testLibJSCTools&apos; test suite
run times.  We will use this to make sure test suites don&apos;t take too long to run.  To dumpi
run times, run testLibJSCTools with the --verbose option.

The intermittent hang is due to spurious wakes from waits in testProcess() and its utility
function, reapedChildPid().  These functions were not previously accounting for the spurious
wakes.  This is now fixed.

No new tests because this change is for enhancing and fixing an existing test.

* Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp:
(JSCToolsTest::testAddress):
* Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp:
(JSCToolsTest::testByteParser):
* Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp:
(JSCToolsTest::testExportsTrie):
(JSCToolsTest::fuzzExportsTrie):
* Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp:
(JSCToolsTest::reapedChildPid):
(JSCToolsTest::testProcess):
* Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp:
(JSCToolsTest::testRegion):
* Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp:
(JSCToolsTest::testSnapshot):
* Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp:
(JSCToolsTest::testSymbol):
* Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp:
(JSCToolsTest::testThreads):
* Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp:
(JSCToolsTest::SuiteTracer::SuiteTracer):
(JSCToolsTest::SuiteTracer::~SuiteTracer):
(JSCToolsTest::totalSuiteTime):
(JSCToolsTest::beginSuite): Deleted.
* Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h:
(JSCToolsTest::SuiteTracer::shouldRun const):
* Source/JavaScriptCore/corpse/tests/testLibJSCTools.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/320337@main">https://commits.webkit.org/320337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94c2168617e767ebee9afe206bb80073afb4a54e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148800 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20390a04-47de-4b0f-af2c-706ed6936072) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144055 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100092 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cce44748-031e-48bb-a075-c54dac7046c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47847 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcf4ffd5-d17c-4723-8e7c-40568d719e46) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46559 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13279 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44343 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5915 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45792 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196787 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58109 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58814 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153299 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28017 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47826 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131105 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127567 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57317 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19357 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->