### PR TITLE
[JSC] Store DFG OSR entry expected values as a byte stream

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -424,10 +424,8 @@ void JITCode::validateReferences(const TrackedReferences& trackedReferences)
 {
     common.validateReferences(trackedReferences);
     
-    for (OSREntryData& entry : m_osrEntry) {
-        for (unsigned i = entry.m_expectedValues.size(); i--;)
-            entry.m_expectedValues[i].validateReferences(trackedReferences);
-    }
+    for (OSREntryData& entry : m_osrEntry)
+        entry.m_expectedValues.validateReferences(trackedReferences);
     
     minifiedDFG.validateReferences(trackedReferences);
 }

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -470,7 +470,7 @@ void JITCompiler::noticeOSREntry(BasicBlock& basicBlock, JITCompiler::Label bloc
         }
     }
         
-    entry.m_expectedValues = WTF::move(expectedValues);
+    entry.m_expectedValues = OSREntryExpectedValues(expectedValues);
     entry.m_reshufflings = WTF::move(reshufflings);
     m_osrEntry.append(WTF::move(entry));
 }

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -35,20 +35,132 @@
 #include "DFGNode.h"
 #include "JSCJSValueInlines.h"
 #include "RegisterAtOffsetList.h"
+#include "TrackedReferences.h"
 #include "VMInlines.h"
 #include <wtf/CommaPrinter.h>
+#include <wtf/LEBDecoder.h>
+#include <wtf/LEBEncoder.h>
+#include <wtf/UnalignedAccess.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace DFG {
+
+namespace {
+
+constexpr uint8_t explicitValueTag = 0x80;
+constexpr uint8_t constantBit = 1 << 0;
+constexpr uint8_t allArrayModesBit = 1 << 1;
+constexpr uint8_t explicitArrayModesBit = 1 << 2;
+constexpr uint8_t topStructuresBit = 1 << 3;
+constexpr uint8_t structureListBit = 1 << 4;
+
+} // anonymous namespace
+
+OSREntryExpectedValues::OSREntryExpectedValues(const FixedOperands<AbstractValue>& values)
+    : m_numberOfArguments(values.numberOfArguments())
+    , m_numberOfLocals(values.numberOfLocals())
+{
+    unsigned numberOfOperands = m_numberOfArguments + m_numberOfLocals;
+    Vector<uint8_t> bytes;
+    bytes.reserveInitialCapacity(numberOfOperands);
+    for (unsigned index = 0; index < numberOfOperands; ++index) {
+        const AbstractValue& value = values[index];
+        if (value.isBytecodeTop()) {
+            unsigned runLength = 1;
+            while (runLength < explicitValueTag && index + runLength < numberOfOperands && values[index + runLength].isBytecodeTop())
+                ++runLength;
+            bytes.append(static_cast<uint8_t>(runLength - 1));
+            index += runLength - 1;
+            continue;
+        }
+
+        uint8_t tag = explicitValueTag;
+        if (value.m_value)
+            tag |= constantBit;
+        if (value.m_arrayModes == ALL_ARRAY_MODES)
+            tag |= allArrayModesBit;
+        else if (value.m_arrayModes)
+            tag |= explicitArrayModesBit;
+        if (value.m_structure.isInfinite())
+            tag |= topStructuresBit;
+        else if (!value.m_structure.isClear())
+            tag |= structureListBit;
+        bytes.append(tag);
+
+        WTF::LEBEncoder::encodeUInt64(bytes, value.m_type);
+        if (tag & explicitArrayModesBit)
+            WTF::LEBEncoder::encodeUInt32(bytes, value.m_arrayModes);
+        if (tag & structureListBit) {
+            WTF::LEBEncoder::encodeUInt32(bytes, value.m_structure.size());
+            value.m_structure.forEach([&](RegisteredStructure structure) {
+                bytes.append(asByteSpan(structure->id()));
+            });
+        }
+        if (tag & constantBit)
+            bytes.append(asByteSpan(JSValue::encode(value.m_value)));
+    }
+    m_bytes = FixedVector<uint8_t>(WTF::move(bytes));
+}
+
+FixedOperands<AbstractValue> OSREntryExpectedValues::decode() const
+{
+    FixedOperands<AbstractValue> result(m_numberOfArguments, m_numberOfLocals, 0, AbstractValue::bytecodeTop());
+    std::span<const uint8_t> bytes = m_bytes.span();
+    size_t offset = 0;
+    for (unsigned index = 0; index < result.size(); ++index) {
+        uint8_t tag = bytes[offset++];
+        if (!(tag & explicitValueTag)) {
+            index += tag;
+            continue;
+        }
+
+        AbstractValue& value = result[index];
+        value.m_type = WTF::LEBDecoder::decodeUInt64OrCrash(bytes, offset);
+
+        if (tag & explicitArrayModesBit)
+            value.m_arrayModes = WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset);
+        else
+            value.m_arrayModes = (tag & allArrayModesBit) ? ALL_ARRAY_MODES : 0;
+
+        if (tag & structureListBit) {
+            RegisteredStructureSet structures;
+            unsigned count = WTF::LEBDecoder::decodeUInt32OrCrash(bytes, offset);
+            for (unsigned i = 0; i < count; ++i) {
+                structures.add(RegisteredStructure::createPrivate(WTF::unalignedLoad<StructureID>(bytes.subspan(offset, sizeof(StructureID)).data()).decode()));
+                offset += sizeof(StructureID);
+            }
+            value.m_structure = structures;
+        } else if (tag & topStructuresBit)
+            value.m_structure.makeTop();
+        else
+            value.m_structure.clear();
+
+        if (tag & constantBit) {
+            value.m_value = JSValue::decode(WTF::unalignedLoad<EncodedJSValue>(bytes.subspan(offset, sizeof(EncodedJSValue)).data()));
+            offset += sizeof(EncodedJSValue);
+        }
+        value.checkConsistency();
+    }
+    RELEASE_ASSERT(offset == bytes.size());
+    return result;
+}
+
+void OSREntryExpectedValues::validateReferences(const TrackedReferences& trackedReferences) const
+{
+    FixedOperands<AbstractValue> values = decode();
+    for (unsigned index = 0; index < values.size(); ++index)
+        values[index].validateReferences(trackedReferences);
+}
 
 void OSREntryData::dumpInContext(PrintStream& out, DumpContext* context) const
 {
     out.print(m_bytecodeIndex, ", machine code = ", RawPointer(m_machineCode.taggedPtr()));
     out.print(", stack rules = [");
     
+    FixedOperands<AbstractValue> expectedValues = m_expectedValues.decode();
     auto printOperand = [&] (VirtualRegister reg) {
-        out.print(inContext(m_expectedValues.operand(reg), context), " (");
+        out.print(inContext(expectedValues.operand(reg), context), " (");
         VirtualRegister toReg;
         bool overwritten = false;
         for (OSREntryReshuffling reshuffling : m_reshufflings) {
@@ -76,11 +188,11 @@ void OSREntryData::dumpInContext(PrintStream& out, DumpContext* context) const
     };
     
     CommaPrinter comma;
-    for (size_t argumentIndex = m_expectedValues.numberOfArguments(); argumentIndex--;) {
+    for (size_t argumentIndex = expectedValues.numberOfArguments(); argumentIndex--;) {
         out.print(comma, "arg"_s, argumentIndex, ":"_s);
         printOperand(virtualRegisterForArgumentIncludingThis(argumentIndex));
     }
-    for (size_t localIndex = 0; localIndex < m_expectedValues.numberOfLocals(); ++localIndex) {
+    for (size_t localIndex = 0; localIndex < expectedValues.numberOfLocals(); ++localIndex) {
         out.print(comma, "loc"_s, localIndex, ":"_s);
         printOperand(virtualRegisterForLocal(localIndex));
     }
@@ -147,6 +259,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     }
     
     ASSERT(entry->m_bytecodeIndex == bytecodeIndex);
+    FixedOperands<AbstractValue> expectedValues = entry->m_expectedValues.decode();
     
     // The code below checks if it is safe to perform OSR entry. It may find
     // that it is unsafe to do so, for any number of reasons, which are documented
@@ -172,20 +285,20 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     //    into a less-likely path. So, the wisest course of action is to simply not
     //    OSR at this time.
     
-    for (size_t argument = 0; argument < entry->m_expectedValues.numberOfArguments(); ++argument) {
+    for (size_t argument = 0; argument < expectedValues.numberOfArguments(); ++argument) {
         JSValue value = callFrame->r(virtualRegisterForArgumentIncludingThis(argument)).asanUnsafeJSValue();
-        if (!entry->m_expectedValues.argument(argument).validateOSREntryValue(value, FlushedJSValue)) {
+        if (!expectedValues.argument(argument).validateOSREntryValue(value, FlushedJSValue)) {
             dataLogLnIf(Options::verboseOSR(),
                 "    OSR failed because argument ", argument, " is ", value,
-                ", expected ", entry->m_expectedValues.argument(argument));
+                ", expected ", expectedValues.argument(argument));
             return nullptr;
         }
     }
     
-    for (size_t local = 0; local < entry->m_expectedValues.numberOfLocals(); ++local) {
+    for (size_t local = 0; local < expectedValues.numberOfLocals(); ++local) {
         int localOffset = virtualRegisterForLocal(local).offset();
         JSValue value = callFrame->registers()[localOffset].asanUnsafeJSValue();
-        auto& abstractValue = entry->m_expectedValues.local(local);
+        auto& abstractValue = expectedValues.local(local);
         FlushFormat format = FlushedJSValue;
 
         if (entry->m_localsForcedAnyInt.get(local)) {
@@ -214,7 +327,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
 
         if (!abstractValue.validateOSREntryValue(value, format)) {
             dataLogLnIf(Options::verboseOSR(),
-                "    OSR failed because variable ", VirtualRegister(localOffset), " is ", value, ", with format ", format, ", expected ", entry->m_expectedValues.local(local), ".");
+                "    OSR failed because variable ", VirtualRegister(localOffset), " is ", value, ", with format ", format, ", expected ", expectedValues.local(local), ".");
             return nullptr;
         }
     }
@@ -242,7 +355,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     // 3) Set up the data in the scratch buffer and perform data format conversions.
 
     unsigned frameSize = jitCode->common.frameRegisterCount;
-    unsigned baselineFrameSize = entry->m_expectedValues.numberOfLocals();
+    unsigned baselineFrameSize = expectedValues.numberOfLocals();
     unsigned maxFrameSize = std::max(frameSize, baselineFrameSize);
 
     Register* scratch = std::bit_cast<Register*>(vm.scratchBufferForSize(sizeof(Register) * (2 + CallFrame::headerSizeInRegisters + maxFrameSize))->dataBuffer());
@@ -272,7 +385,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
                 continue;
             }
 
-            auto& abstractValue = entry->m_expectedValues.local(reg.toLocal());
+            auto& abstractValue = expectedValues.local(reg.toLocal());
             if (value.isDouble() && abstractValue.isType(SpecInt32Only)) {
                 pivot[index] = jsNumber(value.asInt32AsAnyInt());
                 continue;

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.h
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.h
@@ -31,11 +31,13 @@
 #include "MacroAssemblerCodeRef.h"
 #include "Operands.h"
 #include <wtf/BitVector.h>
+#include <wtf/FixedVector.h>
 
 namespace JSC {
 
 class CallFrame;
 class CodeBlock;
+class TrackedReferences;
 
 namespace DFG {
 
@@ -53,10 +55,34 @@ struct OSREntryReshuffling {
     int toOffset;
 };
 
+// Stores the AbstractValue of every operand of an OSR entry (arguments, then locals) as a
+// byte stream: a tag byte followed by an optional payload.
+//
+//   0x00-0x7F  (tag + 1) consecutive BytecodeTop values
+//   0x80-0xFF  an explicit value: LEB128 SpeculatedType follows, then the payloads the tag bits select
+//     bit 0    a constant: 8-byte EncodedJSValue follows
+//     bit 1    array modes are ALL_ARRAY_MODES (otherwise none)
+//     bit 2    explicit array modes: LEB128 ArrayModes follows, overriding bit 1
+//     bit 3    structures are TOP or clobbered (otherwise none)
+//     bit 4    a structure list: LEB128 count and 4-byte StructureIDs follow, overriding bit 3
+class OSREntryExpectedValues {
+public:
+    OSREntryExpectedValues() = default;
+    explicit OSREntryExpectedValues(const FixedOperands<AbstractValue>&);
+
+    FixedOperands<AbstractValue> decode() const;
+    void validateReferences(const TrackedReferences&) const;
+
+private:
+    FixedVector<uint8_t> m_bytes;
+    unsigned m_numberOfArguments { 0 };
+    unsigned m_numberOfLocals { 0 };
+};
+
 struct OSREntryData {
     BytecodeIndex m_bytecodeIndex;
     CodeLocationLabel<OSREntryPtrTag> m_machineCode;
-    FixedOperands<AbstractValue> m_expectedValues;
+    OSREntryExpectedValues m_expectedValues;
     // Use bitvectors here because they tend to only require one word.
     BitVector m_localsForcedDouble;
     BitVector m_localsForcedAnyInt;

--- a/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
+++ b/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
@@ -51,6 +51,7 @@ public:
 
 private:
     friend class Graph;
+    friend class OSREntryExpectedValues;
 
     RegisteredStructure(Structure* structure)
         : m_structure(structure)


### PR DESCRIPTION
#### 472f03956a363f00072e5f4aaea86e6f6d5c6b3c
<pre>
[JSC] Store DFG OSR entry expected values as a byte stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=323169">https://bugs.webkit.org/show_bug.cgi?id=323169</a>

Reviewed by Yusuke Suzuki.

Every DFG OSR entry point keeps a FixedOperands&lt;AbstractValue&gt; with the
expected value of each argument and local, 32 bytes per operand, for as long
as the DFG code lives, although it is only read when the baseline JIT tries to
enter the loop. On JetStream3 that is 972k AbstractValues over the run, 31 MB,
and 90% of them are BytecodeTop.

This patch stores the expected values of an entry as a byte stream
(OSREntryExpectedValues; the format is in the comment above the class) that
run-length encodes BytecodeTop and writes the array modes, structures and
constant of the other values only when they are not the trivial ones, and
decodes it back into a FixedOperands&lt;AbstractValue&gt; in prepareOSREntry. The
same JetStream3 run goes from 31.1 MB to 0.76 MB (0.8 bytes per operand).

* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITCode::validateReferences):
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::noticeOSREntry):
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::OSREntryExpectedValues::OSREntryExpectedValues):
(JSC::DFG::OSREntryExpectedValues::decode const):
(JSC::DFG::OSREntryExpectedValues::validateReferences const):
(JSC::DFG::OSREntryData::dumpInContext const):
(JSC::DFG::prepareOSREntry):
* Source/JavaScriptCore/dfg/DFGOSREntry.h:
* Source/JavaScriptCore/dfg/DFGRegisteredStructure.h:

Canonical link: <a href="https://commits.webkit.org/320303@main">https://commits.webkit.org/320303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/689d1599aec96e2ca77f7e4659c6e4933f6da25e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194699 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47725 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46435 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6318 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13158 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44220 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5772 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45649 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57965 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153512 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41104 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58670 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153177 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47703 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130964 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57176 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->