### PR TITLE
[AppKit Gestures] wikimedia.org: Cannot press-and-drag over media player controls

### DIFF
--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -115,6 +115,45 @@ static int typeForEvent(NSEvent *event)
     return static_cast<int>([NSMenu menuTypeForEvent:event]);
 }
 
+static unsigned short buttonsMaskForMouseButton(WebCore::MouseButton button)
+{
+    // https://w3c.github.io/pointerevents/#the-buttons-property
+    switch (button) {
+    case WebCore::MouseButton::Left:
+        return 1;
+    case WebCore::MouseButton::Right:
+        return 2;
+    case WebCore::MouseButton::Middle:
+        return 4;
+    case WebCore::MouseButton::Back:
+        return 8;
+    case WebCore::MouseButton::Forward:
+        return 16;
+    case WebCore::MouseButton::None:
+    case WebCore::MouseButton::PointerHasNotChanged:
+    case WebCore::MouseButton::Other:
+        return 0;
+    }
+
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+static unsigned short buttonsForAutomationEvent(NSEvent *event)
+{
+    switch ([event type]) {
+    case NSEventTypeLeftMouseDown:
+    case NSEventTypeLeftMouseDragged:
+    case NSEventTypeRightMouseDown:
+    case NSEventTypeRightMouseDragged:
+    case NSEventTypeOtherMouseDown:
+    case NSEventTypeOtherMouseDragged:
+        return buttonsMaskForMouseButton(WebCore::mouseButtonForEvent(event));
+    default:
+        return 0;
+    }
+}
+
 bool WebEventFactory::shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent& event)
 {
     return (static_cast<NSMenuType>(event.menuTypeForEvent()) == NSMenuTypeContextMenu);
@@ -138,7 +177,7 @@ WebMouseEventInit WebEventFactory::createWebMouseEvent(NSEvent *event, NSEvent *
     }
 
     WebMouseEventButton button = kit(WebCore::mouseButtonForEvent(event));
-    unsigned short buttons = WebCore::currentlyPressedMouseButtons();
+    unsigned short buttons = inputSource == WebEventInputSource::Automation ? buttonsForAutomationEvent(event) : WebCore::currentlyPressedMouseButtons();
     float deltaX = [event deltaX];
     float deltaY = [event deltaY];
     float deltaZ = [event deltaZ];

--- a/Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html
@@ -36,6 +36,10 @@
         "native-slider": new Set(),
     };
 
+    window.buttonsLog = [];
+    for (const type of ["pointerdown", "pointermove", "pointerup"])
+        document.addEventListener(type, e => window.buttonsLog.push(`${e.type}:${e.buttons}`));
+
     function setValue(value) {
         value = Math.max(0, Math.min(maxValue, value));
         customSlider.setAttribute("aria-valuenow", value);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -973,30 +973,7 @@ extension AppKitGesturesTests.Basic {
         let maximumValue = 10
         let initialValue = maximumValue / 2
 
-        let elementID = useNativeWidget ? "native-slider" : "custom-slider"
-
-        let customHTML = try #require(Bundle.testResources.url(forResource: "custom-slider", withExtension: "html"))
-        try await page.load(customHTML).wait()
-
-        await page.waitForNextPresentationUpdate()
-
-        try await page.callJavaScript(
-            arguments: ["elementID": "custom-slider", "interactive": false],
-            script: styleAdjustmentForCustomWidgetScript
-        )
-        await page.waitForNextPresentationUpdate()
-
-        let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
-        let convertedSliderBounds = screenBounds(ofRectInViewportCoordinates: sliderBounds)
-
-        let start = convertedSliderBounds.center
-        let end = CGPoint(x: convertedSliderBounds.maxX, y: convertedSliderBounds.center.y)
-
-        await recap.play { composer in
-            composer._wk_drag(withStart: start, end: end, duration: .seconds(1.5), pressAndWait: .seconds(0.5))
-        }
-
-        await page.waitForNextPresentationUpdate()
+        let elementID = try await dragAcrossSlider(useNativeWidget: useNativeWidget)
 
         let finalSliderValue = try await page.callJavaScript(
             returning: Double.self,
@@ -1020,6 +997,22 @@ extension AppKitGesturesTests.Basic {
         }
 
         #expect(eventLog == (initialValue...maximumValue).map(Double.init))
+    }
+
+    @Test(
+        .bug("https://webkit.org/b/323157", "wikimedia.org: Cannot press-and-drag over media player controls"),
+        arguments: [true, false]
+    )
+    func pressDragOverRangeInputReportsHeldButton(useNativeWidget: Bool) async throws {
+        try await dragAcrossSlider(useNativeWidget: useNativeWidget)
+        let buttonsLog = try await page.callJavaScript(returning: [String].self) {
+            """
+            return window.buttonsLog;
+            """
+        }
+        #expect(buttonsLog.first == "pointerdown:1")
+        #expect(buttonsLog.last == "pointerup:0")
+        #expect(Set(buttonsLog) == ["pointerdown:1", "pointermove:1", "pointerup:0"])
     }
 
     @Test(
@@ -1692,6 +1685,36 @@ extension CGPoint {
 }
 
 extension AppKitGesturesTests.Basic {
+    @discardableResult
+    private func dragAcrossSlider(useNativeWidget: Bool) async throws -> String {
+        let elementID = useNativeWidget ? "native-slider" : "custom-slider"
+
+        let customHTML = try #require(Bundle.testResources.url(forResource: "custom-slider", withExtension: "html"))
+        try await page.load(customHTML).wait()
+
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript(
+            arguments: ["elementID": "custom-slider", "interactive": false],
+            script: styleAdjustmentForCustomWidgetScript
+        )
+        await page.waitForNextPresentationUpdate()
+
+        let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
+        let convertedSliderBounds = screenBounds(ofRectInViewportCoordinates: sliderBounds)
+
+        let start = convertedSliderBounds.center
+        let end = CGPoint(x: convertedSliderBounds.maxX, y: convertedSliderBounds.center.y)
+
+        await recap.play { composer in
+            composer._wk_drag(withStart: start, end: end, duration: .seconds(1.5), pressAndWait: .seconds(0.5))
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        return elementID
+    }
+
     private func loadScrollableText() async throws {
         let lines = (0..<100)
             .reversed()


### PR DESCRIPTION
#### 33f7944ccaed19ca603e650b1aa639f5206e9277
<pre>
[AppKit Gestures] wikimedia.org: Cannot press-and-drag over media player controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=323157">https://bugs.webkit.org/show_bug.cgi?id=323157</a>
<a href="https://rdar.apple.com/186303933">rdar://186303933</a>

Reviewed by Richard Robinson, Aditya Keerthi, and Wenson Hsieh.

createWebMouseEvent read +[NSEvent pressedMouseButtons] to get the
`buttons` field, but this method may not report the right state during
gesture recognizer-driven event synthesis/handling, which produces
pointermoves with .buttons == 0, breaking media controls seeking in
wikimedia.org (which uses Video.js&apos;s components).

To fix this, we stop reading pressedMouseButtons and instead derive
buttons from the recognized event type.

Test: AppKitGesturesTests.Basic.pressDragOverRangeInputReportsHeldButton

* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::buttonsMaskForMouseButton):
(WebKit::buttonsForAutomationEvent):
(WebKit::WebEventFactory::createWebMouseEvent):
* Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/320319@main">https://commits.webkit.org/320319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/178f688ce6a0d27ece18bdddddc2cdc44afcaa5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194707 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143939 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124357 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46441 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44230 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5780 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196648 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57973 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153521 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153187 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47714 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130970 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57184 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19244 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->