### PR TITLE
`run-benchmark` should show per-iteration value after each iteration and in the final output

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py
@@ -53,11 +53,13 @@ class BenchmarkResults(object):
         self._lint_results(results)
         self._results = self._aggregate_results(results)
 
-    def format(self, scale_unit=True, show_iteration_values=False, max_depth=sys.maxsize):
-        return self._format_tests(self._results, scale_unit, show_iteration_values, max_depth)
+    def format(self, scale_unit=True, show_iteration_raw_values=False, max_depth=sys.maxsize, show_iteration_aggregates=None):
+        if show_iteration_aggregates is None:
+            show_iteration_aggregates = not show_iteration_raw_values
+        return self._format_tests(self._results, scale_unit, show_iteration_raw_values, max_depth, show_iteration_aggregates)
 
     @classmethod
-    def _format_tests(cls, tests, scale_unit, show_iteration_values, max_depth, indent=''):
+    def _format_tests(cls, tests, scale_unit, show_iteration_raw_values, max_depth, show_iteration_aggregates=False, indent=''):
         output = ''
         config_name = 'current'
         for test_name in sorted(tests.keys()):
@@ -76,14 +78,24 @@ class BenchmarkResults(object):
                     output += ':' + metric_name + ':'
                     if aggregator_name:
                         output += aggregator_name + ':'
-                    output += ' ' + cls._format_values(metric_name, metric[aggregator_name][config_name], scale_unit, show_iteration_values) + '\n'
+                    output += ' ' + cls._format_values(metric_name, metric[aggregator_name][config_name], scale_unit, show_iteration_raw_values, show_iteration_aggregates) + '\n'
             if 'tests' in test and max_depth > 1:
-                output += cls._format_tests(test['tests'], scale_unit, show_iteration_values, max_depth - 1, indent=(indent + ' ' * len(test_name)))
+                output += cls._format_tests(test['tests'], scale_unit, show_iteration_raw_values, max_depth - 1, show_iteration_aggregates, indent=(indent + ' ' * len(test_name)))
         return output
 
     @classmethod
-    def _format_values(cls, metric_name, values, scale_unit=True, show_iteration_values=False):
+    def _format_values(cls, metric_name, values, scale_unit=True, show_iteration_raw_values=False, show_iteration_aggregates=False):
+        if values and isinstance(values[0], list):
+            iteration_values = [cls._mean(cls._flatten_list(group)) for group in values]
+            values = cls._flatten_list(values)
+        else:
+            iteration_values = list(values)
+        if not show_iteration_aggregates:
+            iteration_values = None
+
         values = list(map(float, values))
+        if iteration_values is not None:
+            iteration_values = list(map(float, iteration_values))
         total = sum(values)
         mean = total / len(values)
         square_sum = sum([x * x for x in values])
@@ -104,14 +116,18 @@ class BenchmarkResults(object):
             if mean:
                 delta = sample_stdev / mean
             formatted_value = '{mean:.3f}{unit} stdev={delta:.1%}'.format(mean=mean, delta=delta, unit=unit)
-            if show_iteration_values:
-                formatted_value += ' [' + ', '.join(['{value:.3f}'.format(value=value) for value in values]) + ']'
+            if show_iteration_raw_values:
+                formatted_value += ' raw=[' + ', '.join(['{value:.3f}'.format(value=value) for value in values]) + ']'
+            if iteration_values is not None:
+                formatted_value += ' per-iteration=[' + ', '.join(['{value:.3f}'.format(value=value) for value in iteration_values]) + ']'
             return formatted_value
 
         if unit == 'ms':
             unit = 's'
             mean = float(mean) / 1000
             values = list([float(value) / 1000 for value in values])
+            if iteration_values is not None:
+                iteration_values = list([value / 1000 for value in iteration_values])
             sample_stdev /= 1000
 
         base = 1024 if unit == 'B' else 1000
@@ -138,9 +154,15 @@ class BenchmarkResults(object):
         if mean:
             delta = sample_stdev / mean
         formatted_value = '{mean}{prefix}{unit} stdev={delta:.1%}'.format(mean=format_scaled(scaled_mean), delta=delta, prefix=SI_prefix, unit=unit)
-        if show_iteration_values:
-            formatted_value += ' [' + ', '.join([format_scaled(value * scaling_factor) for value in values]) + ']'
+        if show_iteration_raw_values:
+            formatted_value += ' raw=[' + ', '.join([format_scaled(value * scaling_factor) for value in values]) + ']'
+        if iteration_values is not None:
+            formatted_value += ' per-iteration=[' + ', '.join([format_scaled(value * scaling_factor) for value in iteration_values]) + ']'
         return formatted_value
+
+    @classmethod
+    def _mean(cls, values):
+        return sum(values) / len(values)
 
     @classmethod
     def _unit_from_metric(cls, metric_name):
@@ -163,7 +185,7 @@ class BenchmarkResults(object):
             if not isinstance(metric, list):
                 results[metric_name] = {None: {}}
                 for config_name, values in iteritems(metric):
-                    results[metric_name][None][config_name] = cls._flatten_list(values)
+                    results[metric_name][None][config_name] = values
                 continue
 
             # Filter duplicate aggregators that could have arisen from merging JSONs.
@@ -173,9 +195,15 @@ class BenchmarkResults(object):
                 values_by_config_iteration = cls._subtest_values_by_config_iteration(subtest_results, metric_name, aggregator)
                 for config_name, values_by_iteration in iteritems(values_by_config_iteration):
                     results[metric_name].setdefault(aggregator, {})
-                    results[metric_name][aggregator][config_name] = [cls._aggregate_values(aggregator, values) for values in values_by_iteration]
+                    results[metric_name][aggregator][config_name] = cls._aggregate_values_by_iteration(aggregator, values_by_iteration)
 
         return {'metrics': results, 'tests': subtest_results}
+
+    @classmethod
+    def _aggregate_values_by_iteration(cls, aggregator, values_by_iteration):
+        if values_by_iteration and values_by_iteration[0] and isinstance(values_by_iteration[0][0], list):
+            return [cls._aggregate_values_by_iteration(aggregator, group) for group in values_by_iteration]
+        return [cls._aggregate_values(aggregator, values) for values in values_by_iteration]
 
     @classmethod
     def _flatten_list(cls, nested_list):
@@ -201,10 +229,24 @@ class BenchmarkResults(object):
             else:
                 results_for_aggregator = {}
             for config_name, values in iteritems(results_for_aggregator):
-                values_by_config_iteration.setdefault(config_name, [[] for _ in values])
-                for iteration, value in enumerate(values):
-                    values_by_config_iteration[config_name][iteration].append(value)
+                if config_name not in values_by_config_iteration:
+                    values_by_config_iteration[config_name] = cls._value_buckets_like(values)
+                cls._collect_values(values_by_config_iteration[config_name], values)
         return values_by_config_iteration
+
+    @classmethod
+    def _value_buckets_like(cls, values):
+        return [cls._value_buckets_like(value) if isinstance(value, list) else [] for value in values]
+
+    @classmethod
+    def _collect_values(cls, buckets, values):
+        if len(buckets) != len(values):
+            raise TypeError('Subtests have mismatching value shapes: %s' % json.dumps(values))
+        for bucket, value in zip(buckets, values):
+            if isinstance(value, list):
+                cls._collect_values(bucket, value)
+            else:
+                bucket.append(value)
 
     @classmethod
     def _aggregate_values(cls, aggregator, values):

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py
@@ -35,12 +35,12 @@ class BenchmarkResultsTest(unittest.TestCase):
 
     def test_format(self):
         result = BenchmarkResults({'SomeTest': {'metrics': {'Time': {'current': [1, 2, 3]}}}})
-        self.assertEqual(result.format(), 'SomeTest:Time: 2.0ms stdev=50.0%\n')
+        self.assertEqual(result.format(), 'SomeTest:Time: 2.0ms stdev=50.0% per-iteration=[1.0, 2.0, 3.0]\n')
 
         result = BenchmarkResults({'SomeTest': {'metrics': {'Time': {'current': [1, 2, 3]}, 'Score': {'current': [2, 3, 4]}}}})
         self.assertEqual(result.format(), '''
-SomeTest:Score: 3.0pt stdev=33.3%
-        :Time: 2.0ms stdev=50.0%
+SomeTest:Score: 3.0pt stdev=33.3% per-iteration=[2.0, 3.0, 4.0]
+        :Time: 2.0ms stdev=50.0% per-iteration=[1.0, 2.0, 3.0]
 '''[1:])
 
         result = BenchmarkResults({'SomeTest': {
@@ -49,10 +49,17 @@ SomeTest:Score: 3.0pt stdev=33.3%
                 'SubTest1': {'metrics': {'Time': {'current': [1, 2, 3]}}},
                 'SubTest2': {'metrics': {'Time': {'current': [4, 5, 6]}}}}}})
         self.assertEqual(result.format(), '''
-SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
-        :Time:Total: 7.0ms stdev=28.6%
-        SubTest1:Time: 2.0ms stdev=50.0%
-        SubTest2:Time: 5.0ms stdev=20.0%
+SomeTest:Time:Arithmetic: 3.0ms stdev=33.3% per-iteration=[2.0, 3.0, 4.0]
+        :Time:Total: 7.0ms stdev=28.6% per-iteration=[5.0, 7.0, 9.0]
+        SubTest1:Time: 2.0ms stdev=50.0% per-iteration=[1.0, 2.0, 3.0]
+        SubTest2:Time: 5.0ms stdev=20.0% per-iteration=[4.0, 5.0, 6.0]
+'''[1:])
+
+        self.assertEqual(result.format(show_iteration_raw_values=True), '''
+SomeTest:Time:Arithmetic: 3.0ms stdev=33.3% raw=[2.0, 3.0, 4.0]
+        :Time:Total: 7.0ms stdev=28.6% raw=[5.0, 7.0, 9.0]
+        SubTest1:Time: 2.0ms stdev=50.0% raw=[1.0, 2.0, 3.0]
+        SubTest2:Time: 5.0ms stdev=20.0% raw=[4.0, 5.0, 6.0]
 '''[1:])
 
     def test_format_with_depth_limit(self):
@@ -62,8 +69,28 @@ SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
                 'SubTest1': {'metrics': {'Time': {'current': [1, 2, 3]}}},
                 'SubTest2': {'metrics': {'Time': {'current': [4, 5, 6]}}}}}})
         self.assertEqual(result.format(max_depth=1), '''
-SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
-        :Time:Total: 7.0ms stdev=28.6%
+SomeTest:Time:Arithmetic: 3.0ms stdev=33.3% per-iteration=[2.0, 3.0, 4.0]
+        :Time:Total: 7.0ms stdev=28.6% per-iteration=[5.0, 7.0, 9.0]
+'''[1:])
+
+    def test_format_without_iteration_aggregates(self):
+        result = BenchmarkResults({'SomeTest': {
+            'metrics': {'Time': ['Total']},
+            'tests': {
+                'SubTest1': {'metrics': {'Time': {'current': [1, 2, 3]}}},
+                'SubTest2': {'metrics': {'Time': {'current': [4, 5, 6]}}}}}})
+        self.assertEqual(result.format(show_iteration_aggregates=False), '''
+SomeTest:Time:Total: 7.0ms stdev=28.6%
+        SubTest1:Time: 2.0ms stdev=50.0%
+        SubTest2:Time: 5.0ms stdev=20.0%
+'''[1:])
+        self.assertEqual(result.format(max_depth=1, show_iteration_aggregates=False), '''
+SomeTest:Time:Total: 7.0ms stdev=28.6%
+'''[1:])
+        self.assertEqual(result.format(), '''
+SomeTest:Time:Total: 7.0ms stdev=28.6% per-iteration=[5.0, 7.0, 9.0]
+        SubTest1:Time: 2.0ms stdev=50.0% per-iteration=[1.0, 2.0, 3.0]
+        SubTest2:Time: 5.0ms stdev=20.0% per-iteration=[4.0, 5.0, 6.0]
 '''[1:])
 
     def test_format_values_with_large_error(self):
@@ -123,31 +150,56 @@ SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
         self.assertEqual(BenchmarkResults._format_values('Runs', [0.00001, 0.00002, 0.00003], scale_unit=False), '0.000/s stdev=50.0%')
         self.assertEqual(BenchmarkResults._format_values('Runs', [0.000001, 0.000002, 0.000003], scale_unit=False), '0.000/s stdev=50.0%')
 
-    def test_format_values_with_iteration_values(self):
-        self.assertEqual(BenchmarkResults._format_values('Time', [1, 2, 3], show_iteration_values=True), '2.0ms stdev=50.0% [1.0, 2.0, 3.0]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [10, 20, 30], show_iteration_values=True), '20ms stdev=50.0% [10, 20, 30]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [100, 200, 300], show_iteration_values=True), '200ms stdev=50.0% [100, 200, 300]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [1000, 2000, 3000], show_iteration_values=True), '2.0s stdev=50.0% [1.0, 2.0, 3.0]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [10000, 20000, 30000], show_iteration_values=True), '20s stdev=50.0% [10, 20, 30]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [100000, 200000, 300000], show_iteration_values=True), '200s stdev=50.0% [100, 200, 300]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [0.11, 0.12, 0.13], show_iteration_values=True), '120us stdev=8.3% [110, 120, 130]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [0.011, 0.012, 0.013], show_iteration_values=True), '12.0us stdev=8.3% [11.0, 12.0, 13.0]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [0.0011, 0.0012, 0.0013], show_iteration_values=True), '1.20us stdev=8.3% [1.10, 1.20, 1.30]')
-        self.assertEqual(BenchmarkResults._format_values('Time', [0.00011, 0.00012, 0.00013], show_iteration_values=True), '120ns stdev=8.3% [110, 120, 130]')
+    def test_format_values_with_iteration_raw_values(self):
+        self.assertEqual(BenchmarkResults._format_values('Time', [1, 2, 3], show_iteration_raw_values=True), '2.0ms stdev=50.0% raw=[1.0, 2.0, 3.0]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [10, 20, 30], show_iteration_raw_values=True), '20ms stdev=50.0% raw=[10, 20, 30]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [100, 200, 300], show_iteration_raw_values=True), '200ms stdev=50.0% raw=[100, 200, 300]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [1000, 2000, 3000], show_iteration_raw_values=True), '2.0s stdev=50.0% raw=[1.0, 2.0, 3.0]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [10000, 20000, 30000], show_iteration_raw_values=True), '20s stdev=50.0% raw=[10, 20, 30]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [100000, 200000, 300000], show_iteration_raw_values=True), '200s stdev=50.0% raw=[100, 200, 300]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [0.11, 0.12, 0.13], show_iteration_raw_values=True), '120us stdev=8.3% raw=[110, 120, 130]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [0.011, 0.012, 0.013], show_iteration_raw_values=True), '12.0us stdev=8.3% raw=[11.0, 12.0, 13.0]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [0.0011, 0.0012, 0.0013], show_iteration_raw_values=True), '1.20us stdev=8.3% raw=[1.10, 1.20, 1.30]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [0.00011, 0.00012, 0.00013], show_iteration_raw_values=True), '120ns stdev=8.3% raw=[110, 120, 130]')
 
-    def test_format_values_with_no_unit_scaling_and_iteration_values(self):
-        self.assertEqual(BenchmarkResults._format_values('Runs', [1, 2, 3], scale_unit=False, show_iteration_values=True),
-            '2.000/s stdev=50.0% [1.000, 2.000, 3.000]')
-        self.assertEqual(BenchmarkResults._format_values('Runs', [100, 200, 300], scale_unit=False, show_iteration_values=True),
-            '200.000/s stdev=50.0% [100.000, 200.000, 300.000]')
-        self.assertEqual(BenchmarkResults._format_values('Runs', [1000, 2000, 3000], scale_unit=False, show_iteration_values=True),
-            '2000.000/s stdev=50.0% [1000.000, 2000.000, 3000.000]')
-        self.assertEqual(BenchmarkResults._format_values('Runs', [1000000, 2000000, 3000000], scale_unit=False, show_iteration_values=True),
-            '2000000.000/s stdev=50.0% [1000000.000, 2000000.000, 3000000.000]')
-        self.assertEqual(BenchmarkResults._format_values('Runs', [0.1, 0.2, 0.3], scale_unit=False, show_iteration_values=True),
-            '0.200/s stdev=50.0% [0.100, 0.200, 0.300]')
-        self.assertEqual(BenchmarkResults._format_values('Runs', [0.0001, 0.0002, 0.0003], scale_unit=False, show_iteration_values=True),
-            '0.000/s stdev=50.0% [0.000, 0.000, 0.000]')
+    def test_format_values_with_no_unit_scaling_and_iteration_raw_values(self):
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [1, 2, 3], scale_unit=False, show_iteration_raw_values=True),
+            '2.000/s stdev=50.0% raw=[1.000, 2.000, 3.000]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [100, 200, 300], scale_unit=False, show_iteration_raw_values=True),
+            '200.000/s stdev=50.0% raw=[100.000, 200.000, 300.000]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [1000, 2000, 3000], scale_unit=False, show_iteration_raw_values=True),
+            '2000.000/s stdev=50.0% raw=[1000.000, 2000.000, 3000.000]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [1000000, 2000000, 3000000], scale_unit=False, show_iteration_raw_values=True),
+            '2000000.000/s stdev=50.0% raw=[1000000.000, 2000000.000, 3000000.000]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [0.1, 0.2, 0.3], scale_unit=False, show_iteration_raw_values=True),
+            '0.200/s stdev=50.0% raw=[0.100, 0.200, 0.300]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [0.0001, 0.0002, 0.0003], scale_unit=False, show_iteration_raw_values=True),
+            '0.000/s stdev=50.0% raw=[0.000, 0.000, 0.000]')
+
+    def test_format_values_with_iteration_aggregates(self):
+        self.assertEqual(
+            BenchmarkResults._format_values('Time', [1, 2, 3], show_iteration_aggregates=True),
+            '2.0ms stdev=50.0% per-iteration=[1.0, 2.0, 3.0]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Time', [1000, 2000, 3000], show_iteration_aggregates=True),
+            '2.0s stdev=50.0% per-iteration=[1.0, 2.0, 3.0]')
+        self.assertEqual(BenchmarkResults._format_values('Time', [1, 2, 3]), '2.0ms stdev=50.0%')
+
+        self.assertEqual(
+            BenchmarkResults._format_values('Time', [[1000, 3000], [2000, 6000]], show_iteration_aggregates=True),
+            '3.0s stdev=72.0% per-iteration=[2.0, 4.0]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Runs', [[1, 3], [2, 6]], scale_unit=False, show_iteration_aggregates=True),
+            '3.000/s stdev=72.0% per-iteration=[2.000, 4.000]')
+        self.assertEqual(
+            BenchmarkResults._format_values('Time', [[1000, 3000], [2000, 6000]], show_iteration_raw_values=True),
+            '3.0s stdev=72.0% raw=[1.0, 3.0, 2.0, 6.0]')
 
     def test_format_values_with_no_error(self):
         self.assertEqual(BenchmarkResults._format_values('Time', [1, 1, 1]), '1.00ms stdev=0.0%')
@@ -199,10 +251,28 @@ SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
                     'SubTest1': {'metrics': {'Time': {'current': [[1, 2], [3, 4]]}}},
                     'SubTest2': {'metrics': {'Time': {'current': [[5, 6], [7, 8]]}}}}}}),
             {'SomeTest': {
-                'metrics': {'Time': {'Total': {'current': [6, 8, 10, 12]}}},
+                'metrics': {'Time': {'Total': {'current': [[6, 8], [10, 12]]}}},
                 'tests': {
-                    'SubTest1': {'metrics': {'Time': {None: {'current': [1, 2, 3, 4]}}}, 'tests': {}},
-                    'SubTest2': {'metrics': {'Time': {None: {'current': [5, 6, 7, 8]}}}, 'tests': {}}}}})
+                    'SubTest1': {'metrics': {'Time': {None: {'current': [[1, 2], [3, 4]]}}}, 'tests': {}},
+                    'SubTest2': {'metrics': {'Time': {None: {'current': [[5, 6], [7, 8]]}}}, 'tests': {}}}}})
+
+    def test_format_results_with_groups(self):
+        result = BenchmarkResults({'SomeTest': {
+            'metrics': {'Time': ['Total']},
+            'tests': {
+                'SubTest1': {'metrics': {'Time': {'current': [[1, 2], [3, 4]]}}},
+                'SubTest2': {'metrics': {'Time': {'current': [[5, 6], [7, 8]]}}}}}})
+        self.assertEqual(result.format(scale_unit=False), '''
+SomeTest:Time:Total: 9.000ms stdev=28.7% per-iteration=[7.000, 11.000]
+        SubTest1:Time: 2.500ms stdev=51.6% per-iteration=[1.500, 3.500]
+        SubTest2:Time: 6.500ms stdev=19.9% per-iteration=[5.500, 7.500]
+'''[1:])
+
+        self.assertEqual(result.format(scale_unit=False, show_iteration_raw_values=True), '''
+SomeTest:Time:Total: 9.000ms stdev=28.7% raw=[6.000, 8.000, 10.000, 12.000]
+        SubTest1:Time: 2.500ms stdev=51.6% raw=[1.000, 2.000, 3.000, 4.000]
+        SubTest2:Time: 6.500ms stdev=19.9% raw=[5.000, 6.000, 7.000, 8.000]
+'''[1:])
 
     def test_aggregate_nested_results(self):
         self.maxDiff = None

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -21,7 +21,7 @@ class BenchmarkRunner(object):
     name = 'benchmark_runner'
 
     def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform,
-                 browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None,
+                 browser, browser_path, subtests=None, scale_unit=True, show_iteration_raw_values=False, device_id=None,
                  diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None,
                  profiling_interval=None, browser_args=None, http_server_type=None, http_server_port=0):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
@@ -56,7 +56,7 @@ class BenchmarkRunner(object):
         self._profiling_interval = profiling_interval
         self._output_file = output_file
         self._scale_unit = scale_unit
-        self._show_iteration_values = show_iteration_values
+        self._show_iteration_raw_values = show_iteration_raw_values
         self._config = self._plan.get('config', {})
         if device_id:
             self._config['device_id'] = device_id
@@ -212,6 +212,7 @@ class BenchmarkRunner(object):
                     self._browser_driver.collect_pgo_profile(self._diagnose_dir)
 
                 _log.info('End the iteration {current_iteration} of {iterations} for current benchmark'.format(current_iteration=iteration, iterations=count))
+                self._show_iteration_results(iteration, results[-1])
         except Exception as error:
             raise error
         else:
@@ -220,7 +221,7 @@ class BenchmarkRunner(object):
         results = self._wrap(results)
         output_file = self._output_file if self._output_file else self._plan['output_file']
         self._dump(self._merge({'debugOutput': debug_outputs}, results), output_file)
-        self.show_results(results, self._scale_unit, self._show_iteration_values)
+        self.show_results(results, self._scale_unit, self._show_iteration_raw_values)
 
     def execute(self):
         with BenchmarkBuilder(self._plan_name, self._plan, self.name, enable_signposts=self._config['enable_signposts']) as web_root:
@@ -269,6 +270,19 @@ class BenchmarkRunner(object):
         return a + b
 
     @classmethod
-    def show_results(cls, results, scale_unit=True, show_iteration_values=False):
+    def show_results(cls, results, scale_unit=True, show_iteration_raw_values=False):
         results = BenchmarkResults(results)
-        print(results.format(scale_unit, show_iteration_values))
+        print(results.format(scale_unit, show_iteration_raw_values))
+
+    @classmethod
+    def _format_iteration_results(cls, result, scale_unit=True, show_iteration_raw_values=False):
+        tests = {test_name: test for test_name, test in result.items() if test_name != 'debugOutput'}
+        return BenchmarkResults(tests).format(scale_unit, show_iteration_raw_values, max_depth=1, show_iteration_aggregates=False)
+
+    def _show_iteration_results(self, iteration, result):
+        try:
+            formatted_results = self._format_iteration_results(result, self._scale_unit, self._show_iteration_raw_values)
+        except Exception as error:
+            _log.warning('Cannot format the results of the iteration {iteration}: {error}'.format(iteration=iteration, error=error))
+            return
+        _log.info('Top level results of the iteration {iteration}:\n{results}'.format(iteration=iteration, results=formatted_results))

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py
@@ -21,7 +21,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import collections
+import io
+import os
 import unittest
+from contextlib import redirect_stdout
 
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 
@@ -99,3 +102,129 @@ class ConstructSubtestURLTest(unittest.TestCase):
         self.assertEqual(
             self._construct(plan, subtests),
             '&test=HashSet-String&test=bomb-workers')
+
+
+def iteration_result_with_score(score):
+    return {'Speedometer': {
+        'metrics': {'Score': ['Geometric']},
+        'tests': {
+            'SubTest1': {'metrics': {'Score': {'current': [score]}}},
+            'SubTest2': {'metrics': {'Score': {'current': [score * 4]}}}}}}
+
+
+class FormatIterationResultsTest(unittest.TestCase):
+
+    def test_only_top_level_metrics_are_formatted(self):
+        self.assertEqual(
+            BenchmarkRunner._format_iteration_results(iteration_result_with_score(10)),
+            'Speedometer:Score:Geometric: 20.0pt stdev=0.0%\n')
+
+    def test_scale_unit_is_honored(self):
+        self.assertEqual(
+            BenchmarkRunner._format_iteration_results(iteration_result_with_score(10), scale_unit=False),
+            'Speedometer:Score:Geometric: 20.000pt stdev=0.0%\n')
+
+    def test_debug_output_is_ignored(self):
+        result = iteration_result_with_score(10)
+        result['debugOutput'] = ['some debug output']
+        self.assertEqual(
+            BenchmarkRunner._format_iteration_results(result),
+            'Speedometer:Score:Geometric: 20.0pt stdev=0.0%\n')
+
+    def test_grouped_values_within_one_iteration(self):
+        result = {'Speedometer': {
+            'metrics': {'Time': ['Total']},
+            'tests': {
+                'SubTest1': {'metrics': {'Time': {'current': [[1, 2]]}}},
+                'SubTest2': {'metrics': {'Time': {'current': [[5, 6]]}}}}}}
+        self.assertEqual(
+            BenchmarkRunner._format_iteration_results(result, scale_unit=False),
+            'Speedometer:Time:Total: 7.000ms stdev=20.2%\n')
+        self.assertEqual(
+            BenchmarkRunner._format_iteration_results(result, scale_unit=False, show_iteration_raw_values=True),
+            'Speedometer:Time:Total: 7.000ms stdev=20.2% raw=[6.000, 8.000]\n')
+
+
+class MockBrowserDriver:
+
+    def prepare_initial_env(self, config):
+        pass
+
+    def prepare_env(self, config):
+        pass
+
+    def restore_env(self):
+        pass
+
+    def restore_env_after_all_testing(self):
+        pass
+
+
+class FakeBenchmarkRunner(BenchmarkRunner):
+    def __init__(self, iteration_results, scale_unit=True, show_iteration_raw_values=False):
+        self._iteration_results = iteration_results
+        self._plan = {'entry_point': 'index.html', 'options': {}}
+        self._plan_name = 'fake'
+        self._subtests = None
+        self._browser_driver = MockBrowserDriver()
+        self._config = {}
+        self._generate_pgo_profiles = False
+        self._diagnose_dir = None
+        self._output_file = os.devnull
+        self._scale_unit = scale_unit
+        self._show_iteration_raw_values = show_iteration_raw_values
+
+    def _run_one_test(self, web_root, test_file, iteration):
+        return self._iteration_results[iteration - 1]
+
+
+class ShowIterationResultsTest(unittest.TestCase):
+
+    def test_logs_top_level_metrics(self):
+        runner = FakeBenchmarkRunner([])
+        with self.assertLogs('webkitpy.benchmark_runner.benchmark_runner', level='INFO') as logs:
+            runner._show_iteration_results(2, iteration_result_with_score(10))
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ['Top level results of the iteration 2:\nSpeedometer:Score:Geometric: 20.0pt stdev=0.0%\n'])
+
+    def test_honors_runner_formatting_options(self):
+        runner = FakeBenchmarkRunner([], scale_unit=False)
+        with self.assertLogs('webkitpy.benchmark_runner.benchmark_runner', level='INFO') as logs:
+            runner._show_iteration_results(1, iteration_result_with_score(10))
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ['Top level results of the iteration 1:\nSpeedometer:Score:Geometric: 20.000pt stdev=0.0%\n'])
+
+    def test_honors_show_iteration_raw_values(self):
+        runner = FakeBenchmarkRunner([], show_iteration_raw_values=True)
+        with self.assertLogs('webkitpy.benchmark_runner.benchmark_runner', level='INFO') as logs:
+            runner._show_iteration_results(1, iteration_result_with_score(10))
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ['Top level results of the iteration 1:\nSpeedometer:Score:Geometric: 20.0pt stdev=0.0% raw=[20.0]\n'])
+
+    def test_malformed_results_are_reported_but_not_raised(self):
+        runner = FakeBenchmarkRunner([])
+        with self.assertLogs('webkitpy.benchmark_runner.benchmark_runner', level='WARNING') as logs:
+            runner._show_iteration_results(3, {'Speedometer': {}})
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ['Cannot format the results of the iteration 3: "Speedometer" does not contain metrics or tests'])
+
+
+class RunBenchmarkIterationLoggingTest(unittest.TestCase):
+
+    def test_top_level_metrics_are_logged_after_each_iteration(self):
+        runner = FakeBenchmarkRunner([iteration_result_with_score(10), iteration_result_with_score(20)])
+        with self.assertLogs('webkitpy.benchmark_runner.benchmark_runner', level='INFO') as logs:
+            with redirect_stdout(io.StringIO()):
+                runner._run_benchmark(2, '/fake/web/root')
+        self.assertEqual([record.getMessage() for record in logs.records], [
+            'Start the iteration 1 of 2 for current benchmark',
+            'End the iteration 1 of 2 for current benchmark',
+            'Top level results of the iteration 1:\nSpeedometer:Score:Geometric: 20.0pt stdev=0.0%\n',
+            'Start the iteration 2 of 2 for current benchmark',
+            'End the iteration 2 of 2 for current benchmark',
+            'Top level results of the iteration 2:\nSpeedometer:Score:Geometric: 40.0pt stdev=0.0%\n',
+            'Dumping the results to file {}'.format(os.devnull)])

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -57,7 +57,7 @@ def config_argument_parser():
     parser.add_argument('--list-subtests', action='store_true', help='List valid subtests from the test plan.')
     parser.add_argument('--diagnose-directory', dest='diagnose_dir', default=diagnose_directory, help='Directory for storing diagnose information on test failure. Defaults to {}.'.format(diagnose_directory))
     parser.add_argument('--no-adjust-unit', dest='scale_unit', action='store_false', help="Don't convert to scientific notation.")
-    parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
+    parser.add_argument('--show-iteration-raw-values', '--show-iteration-values', dest='show_iteration_raw_values', action='store_true', help="Show every raw measurement taken within an iteration, instead of one aggregated value per iteration.")
     parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
     parser.add_argument('--profile', dest='trace_type', default=None, choices=["full", "full-no-clpc", "ktrace-full", "ktrace-profile"], help="Collect profiling traces, and copy them to the diagnostic directory. 'ktrace' tracing types are deprecated, but currently supported for backwards compatibility.")
     parser.add_argument('--profiling-interval', default=None, help="Specify the profiling sampling rate.")
@@ -98,7 +98,7 @@ def run_benchmark_plan(args, plan):
     runner = benchmark_runner_class(plan,
                                     args.local_copy, args.count, args.timeout, args.build_dir, args.output_file,
                                     args.platform, args.browser, args.browser_path, subtests=args.subtests, scale_unit=args.scale_unit,
-                                    show_iteration_values=args.show_iteration_values, device_id=args.device_id, diagnose_dir=args.diagnose_dir,
+                                    show_iteration_raw_values=args.show_iteration_raw_values, device_id=args.device_id, diagnose_dir=args.diagnose_dir,
                                     generate_pgo_profiles=args.generate_pgo_profiles,
                                     profile_output_dir=args.diagnose_dir if args.trace_type else None,
                                     trace_type=args.trace_type, profiling_interval=args.profiling_interval,
@@ -132,7 +132,7 @@ def start(args):
         results_json = json.load(open(args.json_file, 'r'))
         if 'debugOutput' in results_json:
             del results_json['debugOutput']
-        BenchmarkRunner.show_results(results_json, args.scale_unit, args.show_iteration_values)
+        BenchmarkRunner.show_results(results_json, args.scale_unit, args.show_iteration_raw_values)
         return
     if args.allplans:
         failed = []

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -16,11 +16,11 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None, http_server_type='twisted', http_server_port=0):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_raw_values=False, device_id=None, diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None, http_server_type='twisted', http_server_port=0):
         # Listen on all interfaces with browser "manual" to make easier test from another devices on the network.
         server_ip = '0.0.0.0' if browser == 'manual' else '127.0.0.1'
         self._http_server_driver = HTTPServerDriverFactory.create(platform, server_type=http_server_type, device_id=device_id, server_ip=server_ip, server_port=http_server_port)
-        super().__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=subtests, scale_unit=scale_unit, show_iteration_values=show_iteration_values, device_id=device_id, diagnose_dir=diagnose_dir, generate_pgo_profiles=generate_pgo_profiles, profile_output_dir=profile_output_dir, trace_type=trace_type, profiling_interval=profiling_interval, browser_args=browser_args, http_server_type=http_server_type, http_server_port=http_server_port)
+        super().__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=subtests, scale_unit=scale_unit, show_iteration_raw_values=show_iteration_raw_values, device_id=device_id, diagnose_dir=diagnose_dir, generate_pgo_profiles=generate_pgo_profiles, profile_output_dir=profile_output_dir, trace_type=trace_type, profiling_interval=profiling_interval, browser_args=browser_args, http_server_type=http_server_type, http_server_port=http_server_port)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 


### PR DESCRIPTION
#### 44d56510339c89635255d554d1a9754abba0b4d8
<pre>
`run-benchmark` should show per-iteration value after each iteration and in the final output
<a href="https://bugs.webkit.org/show_bug.cgi?id=323177">https://bugs.webkit.org/show_bug.cgi?id=323177</a>
<a href="https://rdar.apple.com/186420926">rdar://186420926</a>

Reviewed by Aakash Jain.

BenchmarkResults flattened the values of every iteration together before
aggregating them, so a run only ever reported one number per metric once all
of the iterations had finished. A long benchmark therefore gave no feedback
at all until the very end.

Keep the shape of the subtest values so that they can be aggregated per
iteration, and report the aggregate of each iteration as a &quot;per-iteration&quot;
suffix in the summary. BenchmarkResults.format() takes a new
show_iteration_aggregates argument so that a caller can ask for the summary
without that suffix. It defaults to None, which means &quot;not
show_iteration_raw_values&quot;, so the output of every existing caller is
unchanged.

BenchmarkRunner uses that to report progress while the benchmark is running.
After each iteration it formats that iteration&apos;s own result with max_depth=1,
which reports the top level metric only and never the subtests, and logs it
right after the &quot;End the iteration&quot; line. The iteration aggregates are turned
off there because they are meaningless for a single iteration. A result that
cannot be formatted is logged as a warning instead, so that it cannot abort an
otherwise successful run.

Rename --show-iteration-values to --show-iteration-raw-values, keeping the old
spelling as an alias, and label its output &quot;raw&quot; to tell it apart from the
per-iteration suffix.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py:
(BenchmarkResults.format):
(BenchmarkResults._format_tests):
(BenchmarkResults._format_values):
(BenchmarkResults._mean):
(BenchmarkResults._aggregate_results_for_test):
(BenchmarkResults._aggregate_values_by_iteration):
(BenchmarkResults._subtest_values_by_config_iteration):
(BenchmarkResults._value_buckets_like):
(BenchmarkResults._collect_values):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py:
(BenchmarkResultsTest.test_format):
(BenchmarkResultsTest.test_format_with_depth_limit):
(BenchmarkResultsTest.test_format_without_iteration_aggregates):
(BenchmarkResultsTest.test_format_values_with_iteration_raw_values):
(BenchmarkResultsTest.test_format_values_with_no_unit_scaling_and_iteration_raw_values):
(BenchmarkResultsTest.test_format_values_with_iteration_aggregates):
(BenchmarkResultsTest.test_aggregate_results_with_gropus):
(BenchmarkResultsTest.test_format_results_with_groups):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
(BenchmarkRunner._run_benchmark):
(BenchmarkRunner.show_results):
(BenchmarkRunner._format_iteration_results):
(BenchmarkRunner._show_iteration_results):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py:
(iteration_result_with_score):
(FormatIterationResultsTest.test_only_top_level_metrics_are_formatted):
(FormatIterationResultsTest.test_scale_unit_is_honored):
(FormatIterationResultsTest.test_debug_output_is_ignored):
(FormatIterationResultsTest.test_grouped_values_within_one_iteration):
(MockBrowserDriver.prepare_initial_env):
(MockBrowserDriver.prepare_env):
(MockBrowserDriver.restore_env):
(MockBrowserDriver.restore_env_after_all_testing):
(FakeBenchmarkRunner.__init__):
(FakeBenchmarkRunner._run_one_test):
(ShowIterationResultsTest.test_logs_top_level_metrics):
(ShowIterationResultsTest.test_honors_runner_formatting_options):
(ShowIterationResultsTest.test_honors_show_iteration_raw_values):
(ShowIterationResultsTest.test_malformed_results_are_reported_but_not_raised):
(RunBenchmarkIterationLoggingTest.test_top_level_metrics_are_logged_after_each_iteration):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(run_benchmark_plan):
(start):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/320873@main">https://commits.webkit.org/320873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a921dca24fdcfa6e07deffbbd44dfb7ca350394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196457 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/079b28fb-37af-4924-a316-a936488cdf51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59777 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72c3d327-089e-45cb-8142-3d32325e3813) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189122 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125788 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25706e2a-87da-4640-80de-70d3d2763fd2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185496 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45583 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7527 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198435 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59718 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60429 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49104 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129842 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58259 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->