### PR TITLE
VoiceOver announces aria-keyshortcuts Meta/Alt literally instead of Command/Option on macOS

### DIFF
--- a/LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names-expected.txt
+++ b/LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names-expected.txt
@@ -1,0 +1,33 @@
+This test ensures the platform-neutral aria-keyshortcuts modifier names Meta and Alt are exposed with the names printed on Apple keyboards.
+
+PASS: metaButton.stringAttributeValue('AXKeyShortcutsValue') === 'Command+Shift+M'
+PASS: altButton.stringAttributeValue('AXKeyShortcutsValue') === 'Option+Shift+M'
+
+Modifiers Apple keyboards label the same way are left alone.
+PASS: controlButton.stringAttributeValue('AXKeyShortcutsValue') === 'Control+Shift+X'
+PASS: altGraphButton.stringAttributeValue('AXKeyShortcutsValue') === 'AltGraph+Q'
+
+Every shortcut in a space-delimited list is mapped, and key names match case-insensitively.
+PASS: multipleShortcutsButton.stringAttributeValue('AXKeyShortcutsValue') === 'Command+k Option+P'
+
+Malformed shortcuts are passed through as authored. Only whole key names are renamed, so
+neither Alt-Q nor Metadata+Alternate+Q is rewritten.
+PASS: hyphenDelimitedButton.stringAttributeValue('AXKeyShortcutsValue') === 'Alt-Q'
+PASS: spaceDelimitedButton.stringAttributeValue('AXKeyShortcutsValue') === 'Shift Q'
+PASS: surroundingWhitespaceButton.stringAttributeValue('AXKeyShortcutsValue') === ' Shift Plus Q '
+PASS: emptyKeyButton.stringAttributeValue('AXKeyShortcutsValue') === 'Command++Q'
+PASS: modifierNamePrefixButton.stringAttributeValue('AXKeyShortcutsValue') === 'Metadata+Alternate+Q'
+
+Set aria-keyshortcuts to Alt+Meta+Z for #dynamic
+PASS: dynamicButton.stringAttributeValue('AXKeyShortcutsValue') === 'Option+Command+Z'
+
+Update aria-keyshortcuts to Meta+Shift+Z for #dynamic
+PASS: dynamicButton.stringAttributeValue('AXKeyShortcutsValue') === 'Command+Shift+Z'
+
+Update aria-keyshortcuts to a newline-delimited list for #dynamic
+PASS: dynamicButton.stringAttributeValue('AXKeyShortcutsValue') === 'Command+K\nOption+P'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+a b c d e f g h i j k

--- a/LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names.html
+++ b/LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<button id="meta" aria-keyshortcuts="Meta+Shift+M">a</button>
+<button id="alt" aria-keyshortcuts="Alt+Shift+M">b</button>
+<button id="control" aria-keyshortcuts="Control+Shift+X">c</button>
+<button id="alt-graph" aria-keyshortcuts="AltGraph+Q">d</button>
+<button id="multiple-shortcuts" aria-keyshortcuts="meta+k Alt+P">e</button>
+<button id="hyphen-delimited" aria-keyshortcuts="Alt-Q">f</button>
+<button id="space-delimited" aria-keyshortcuts="Shift Q">g</button>
+<button id="surrounding-whitespace" aria-keyshortcuts=" Shift Plus Q ">h</button>
+<button id="empty-key" aria-keyshortcuts="Meta++Q">i</button>
+<button id="modifier-name-prefix" aria-keyshortcuts="Metadata+Alternate+Q">j</button>
+<button id="dynamic">k</button>
+
+<script>
+var output = "This test ensures the platform-neutral aria-keyshortcuts modifier names Meta and Alt are exposed with the names printed on Apple keyboards.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var metaButton = accessibilityController.accessibleElementById("meta");
+    var altButton = accessibilityController.accessibleElementById("alt");
+    var controlButton = accessibilityController.accessibleElementById("control");
+    var altGraphButton = accessibilityController.accessibleElementById("alt-graph");
+    var multipleShortcutsButton = accessibilityController.accessibleElementById("multiple-shortcuts");
+    var hyphenDelimitedButton = accessibilityController.accessibleElementById("hyphen-delimited");
+    var spaceDelimitedButton = accessibilityController.accessibleElementById("space-delimited");
+    var surroundingWhitespaceButton = accessibilityController.accessibleElementById("surrounding-whitespace");
+    var emptyKeyButton = accessibilityController.accessibleElementById("empty-key");
+    var modifierNamePrefixButton = accessibilityController.accessibleElementById("modifier-name-prefix");
+    var dynamicButton = accessibilityController.accessibleElementById("dynamic");
+
+    output += expect("metaButton.stringAttributeValue('AXKeyShortcutsValue')", "'Command+Shift+M'");
+    output += expect("altButton.stringAttributeValue('AXKeyShortcutsValue')", "'Option+Shift+M'");
+
+    output += "\nModifiers Apple keyboards label the same way are left alone.\n";
+    output += expect("controlButton.stringAttributeValue('AXKeyShortcutsValue')", "'Control+Shift+X'");
+    output += expect("altGraphButton.stringAttributeValue('AXKeyShortcutsValue')", "'AltGraph+Q'");
+
+    output += "\nEvery shortcut in a space-delimited list is mapped, and key names match case-insensitively.\n";
+    output += expect("multipleShortcutsButton.stringAttributeValue('AXKeyShortcutsValue')", "'Command+k Option+P'");
+
+    output += "\nMalformed shortcuts are passed through as authored. Only whole key names are renamed, so\n";
+    output += "neither Alt-Q nor Metadata+Alternate+Q is rewritten.\n";
+    output += expect("hyphenDelimitedButton.stringAttributeValue('AXKeyShortcutsValue')", "'Alt-Q'");
+    output += expect("spaceDelimitedButton.stringAttributeValue('AXKeyShortcutsValue')", "'Shift Q'");
+    output += expect("surroundingWhitespaceButton.stringAttributeValue('AXKeyShortcutsValue')", "' Shift Plus Q '");
+    output += expect("emptyKeyButton.stringAttributeValue('AXKeyShortcutsValue')", "'Command++Q'");
+    output += expect("modifierNamePrefixButton.stringAttributeValue('AXKeyShortcutsValue')", "'Metadata+Alternate+Q'");
+
+    setTimeout(async function() {
+        output += "\nSet aria-keyshortcuts to Alt+Meta+Z for #dynamic\n";
+        document.getElementById("dynamic").setAttribute("aria-keyshortcuts", "Alt+Meta+Z");
+        output += await expectAsync("dynamicButton.stringAttributeValue('AXKeyShortcutsValue')", "'Option+Command+Z'");
+
+        output += "\nUpdate aria-keyshortcuts to Meta+Shift+Z for #dynamic\n";
+        document.getElementById("dynamic").setAttribute("aria-keyshortcuts", "Meta+Shift+Z");
+        output += await expectAsync("dynamicButton.stringAttributeValue('AXKeyShortcutsValue')", "'Command+Shift+Z'");
+
+        output += "\nUpdate aria-keyshortcuts to a newline-delimited list for #dynamic\n";
+        document.getElementById("dynamic").setAttribute("aria-keyshortcuts", "Meta+K\nAlt+P");
+        output += await expectAsync("dynamicButton.stringAttributeValue('AXKeyShortcutsValue')", "'Command+K\\nOption+P'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1000,6 +1000,8 @@ accessibility/table-cell-hit-test-not-column.html [ Skip ]
 
 accessibility/aria-owns-crash-after-subtree-update.html [ Skip ]
 
+accessibility/aria-keyshortcuts-platform-modifier-names.html [ Skip ]
+
 # installImageOverlay is a no-op on platforms without IMAGE_ANALYSIS.
 accessibility/image-overlay-elements-presentational.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -844,6 +844,10 @@ public:
     String currentValue() const;
     virtual bool supportsKeyShortcuts() const = 0;
     virtual String keyShortcuts() const = 0;
+#if PLATFORM(COCOA)
+    // keyShortcuts(), with the modifier keys renamed to match the labels printed on Apple keyboards.
+    String keyShortcutsPlatformString() const;
+#endif
 
     virtual bool isModalNode() const = 0;
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -86,6 +86,44 @@ String AXCoreObject::speechHint() const
     return builder.toString();
 }
 
+static StringView platformNameForShortcutKey(StringView key)
+{
+    // aria-keyshortcuts names keys using the platform-neutral UI Events KeyboardEvent key values,
+    // but no Apple keyboard has a key labeled Meta or Alt, so substitute the labels users can see.
+    if (equalLettersIgnoringASCIICase(key, "meta"_s))
+        return "Command"_s;
+    if (equalLettersIgnoringASCIICase(key, "alt"_s))
+        return "Option"_s;
+    return key;
+}
+
+String AXCoreObject::keyShortcutsPlatformString() const
+{
+    String shortcuts = keyShortcuts();
+    if (shortcuts.isEmpty())
+        return shortcuts;
+
+    // Shortcuts are delimited by whitespace, and the keys comprising each shortcut by plus signs.
+    // Everything between those delimiters is a key name. Rather than trying to validate the author's
+    // shortcut, copy the delimiters through verbatim and rename only the keys we recognize, so a
+    // malformed value is spoken exactly as it was written.
+    auto isDelimiter = [] (char16_t character) {
+        return character == '+' || isASCIIWhitespace(character);
+    };
+
+    StringView view { shortcuts };
+    StringBuilder builder;
+    unsigned keyStart = 0;
+    for (unsigned i = 0; i < view.length(); ++i) {
+        if (!isDelimiter(view[i]))
+            continue;
+        builder.append(platformNameForShortcutKey(view.substring(keyStart, i - keyStart)), view[i]);
+        keyStart = i + 1;
+    }
+    builder.append(platformNameForShortcutKey(view.substring(keyStart)));
+    return builder.toString();
+}
+
 // When modifying attributed strings, the range can come from a source which may provide faulty information (e.g. the spell checker).
 // To protect against such cases, the range should be validated before adding or removing attributes.
 bool attributedStringContainsRange(NSAttributedString *attributedString, const NSRange& range)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -3471,7 +3471,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return protect(self.axBackingObject)->keyShortcuts().createNSString().autorelease();
+    return protect(self.axBackingObject)->keyShortcutsPlatformString().createNSString().autorelease();
 }
 
 - (NSArray *)_associatedActionElements

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2224,7 +2224,7 @@ static id handleAssociatedPluginParentAttribute(WebAccessibilityObjectWrapper* w
 
 static id handleKeyShortcutsAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
 {
-    return backingObject.keyShortcuts().createNSString().autorelease();
+    return backingObject.keyShortcutsPlatformString().createNSString().autorelease();
 }
 
 static id handleIsInDescriptionListTermAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)


### PR DESCRIPTION
#### 4588e2f827d5f26549d89869f9865030fc3f660f
<pre>
VoiceOver announces aria-keyshortcuts Meta/Alt literally instead of Command/Option on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=323089">https://bugs.webkit.org/show_bug.cgi?id=323089</a>
<a href="https://rdar.apple.com/186342070">rdar://186342070</a>

Reviewed by Dominic Mazzoni.

aria-keyshortcuts values name keys using the platform-neutral UI Events
KeyboardEvent key values, so a correctly-authored shortcut is written
&quot;Meta+Shift+M&quot; or &quot;Alt+Shift+M&quot;. We exposed those strings through
AXKeyShortcutsValue untouched, and VoiceOver speaks the attribute verbatim,
so it announced &quot;Meta Shift M&quot; for keys that Apple keyboards label Command
and Option. No Mac keyboard has a key named Meta, so the announcement named
a key the user could not find.

Add AXCoreObject::keyShortcutsPlatformString(), which rewrites Meta to
Command and Alt to Option, and use it from the Mac and iOS wrappers.

* LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names-expected.txt: Added.
* LayoutTests/accessibility/aria-keyshortcuts-platform-modifier-names.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::platformNameForShortcutKey):
(WebCore::AXCoreObject::keyShortcutsPlatformString const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityKeyboardShortcuts]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleKeyShortcutsAttribute):

Canonical link: <a href="https://commits.webkit.org/320424@main">https://commits.webkit.org/320424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f58729335428fefc412d698c5bc06768192e08e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148918 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f347d356-114e-448e-9cca-735e3a256be5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144291 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100179 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124574 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d487c815-58a4-49ec-86ed-44a78c89d43d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44819 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44445 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6041 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196931 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153756 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41178 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58945 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153414 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131233 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127749 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57446 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19466 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->