### PR TITLE
[EWS] JSC EWS blames the pull request author for pre-existing flaky test failures

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -689,6 +689,14 @@ class ResultsDBReportMixin(abc.ABC):
             return False
         return reported
 
+    def results_db_ignore_message(self) -> str:
+        parts = []
+        if self.preexisting_failures_in_results_db:
+            parts.append(f"pre-existing failures: {', '.join(self.preexisting_failures_in_results_db)}")
+        if self.flaky_failures_in_results_db:
+            parts.append(f"flaky tests: {', '.join(sorted(self.flaky_failures_in_results_db))}")
+        return f"Ignored {'; '.join(parts)} based on results-db"
+
 
 class Contributors(object):
     url = f'https://raw.githubusercontent.com/{CANONICAL_GITHUB_PROJECT}/main/metadata/contributors.json'
@@ -3503,7 +3511,7 @@ class CompileJSCWithoutChange(CompileJSC):
         return shell.Compile.evaluateCommand(self, cmd)
 
 
-class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
+class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     name = 'jscore-test'
     description = ['jscore-tests running']
     descriptionDone = ['jscore-tests']
@@ -3522,8 +3530,17 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
     # results before printing out the summary).
     command_extra = ['--treat-failing-as-flaky=0.6,10,200', '--max-timeout', '800']
     prefix = 'jsc_'
+    suite = 'javascriptcore-tests'
+    results_db_flaky_type = 'WithinStepDirtyTree'
+    results_db_stage = 'with-change'
     NUM_FAILURES_TO_DISPLAY_IN_STATUS = 5
     FAILURE_THRESHOLD = 1000
+    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
+    INCLUDED_FLAKY_VERDICTS = frozenset({
+        ResultsDatabase.CLEAN_TREE_VERDICT,
+        ResultsDatabase.DIRTY_TREE_VERDICT,
+        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
+    })
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, sigtermTime=10, timeout=1 * 60 * 60, **kwargs)
@@ -3533,6 +3550,9 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
         self.stressTestFailures_filtered = []
         self.binaryFailures_filtered = []
         self.preexisting_failures_in_results_db = []
+        self.flaky_failures_in_results_db = {}
+        self.unsupported_flakes_in_results_db = []
+        self.unknown_flakes_in_results_db = []
 
     @defer.inlineCallbacks
     def run(self):
@@ -3566,6 +3586,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield super().runCommand(command)
 
         yield self._addToLog('json', '\n')
@@ -3589,9 +3610,17 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             self.binaryFailures.append('testapi')
         if jsc_results.get('allLibJSCToolsTestsPassed') is False:
             self.binaryFailures.append('testLibJSCTools')
-        self.flaky = jsc_results.get('flakyAndPassed')
+        flaky = jsc_results.get('flaky') or {}
+        # run-javascriptcore-tests builds this from jsc-stress-results/flaky, where 'S' is that file's successful
+        # int: nonzero means the retries ended in a pass, zero a test retried to the threshold and still failing.
+        self.flaky = {test: info for test, info in flaky.items() if info.get('S')}
         if self.flaky:
             self.setProperty(self.prefix + 'flaky_and_passed', self.flaky)
+        results = jsc_results.get('results') or {}
+        yield self.report_to_results_db(
+            {test: results[test] for test in self.flaky if test in results},
+            flaky_type=self.results_db_flaky_type, stage=self.results_db_stage,
+        )
         if self.binaryFailures:
             self.setProperty(self.prefix + 'binary_failures', self.binaryFailures)
 
@@ -3602,12 +3631,17 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             return
 
         self.setProperty(self.prefix + 'stress_test_failures', self.stressTestFailures)
+        if results:
+            self.setProperty(self.prefix + 'results', results)
         is_main = self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH
         if is_main and (self.stressTestFailures or self.binaryFailures):
             yield self.filter_failures_using_results_db(self.stressTestFailures, self.binaryFailures)
-            self.setProperty('jsc_stress_test_failures_filtered', sorted(self.stressTestFailures_filtered))
-            self.setProperty('jsc_binary_failures_filtered', sorted(self.binaryFailures_filtered))
-            self.setProperty('results-db_jsc_pre_existing', sorted(self.preexisting_failures_in_results_db))
+            self.setProperty(self.prefix + 'stress_test_failures_filtered', sorted(self.stressTestFailures_filtered))
+            self.setProperty(self.prefix + 'binary_failures_filtered', sorted(self.binaryFailures_filtered))
+            self.setProperty('results-db_' + self.prefix + 'pre_existing', sorted(self.preexisting_failures_in_results_db))
+            self.setProperty('results-db_' + self.prefix + 'flaky', self.flaky_failures_in_results_db)
+            self.setProperty('results-db_' + self.prefix + 'flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
+            self.setProperty('results-db_' + self.prefix + 'flaky_unknown', sorted(self.unknown_flakes_in_results_db))
 
     def evaluateCommand(self, cmd):
         platform = self.getProperty('platform')
@@ -3632,9 +3666,8 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             message = 'Passed JSC tests'
             self.descriptionDone = message
             self.build.results = SUCCESS
-        elif (self.preexisting_failures_in_results_db and not self.stressTestFailures_filtered and not self.binaryFailures_filtered):
-            # This means all the tests which failed in this run were also failing or flaky in results database
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and not self.stressTestFailures_filtered and not self.binaryFailures_filtered):
+            message = self.results_db_ignore_message()
             self.descriptionDone = message
             self.build.results = SUCCESS
             self.setProperty('build_summary', message)
@@ -3668,7 +3701,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
 
     @defer.inlineCallbacks
     def _check_for_preexisting_failures(self, tests, filtered_tests, configuration, identifier, has_commit):
-        for test in tests:
+        for test in tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
             data = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
@@ -3680,9 +3713,6 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
                 filtered_tests.remove(test)
             else:
                 yield self._addToLog(self.results_db_log_name, f'{test} is not a pre-existing failure, continuing with retry...')
-                # Optimization to skip consulting results-db for every failure if we encounter any new failure,
-                # since until there is atleast one failure which is not pre-existing, we will anayways have to continue with retry logic.
-                break
 
     @defer.inlineCallbacks
     def filter_failures_using_results_db(self, stress_test_failures, binary_failures):
@@ -3708,8 +3738,46 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
         yield self._check_for_preexisting_failures(stress_test_failures, self.stressTestFailures_filtered, configuration, identifier, has_commit)
         yield self._check_for_preexisting_failures(binary_failures, self.binaryFailures_filtered, configuration, identifier, has_commit)
 
+        # TODO: Ask for a verdict on binary failures too. AnalyzeJSCTestsResults.report_failure reports
+        # only stress failures, so the database holds no binary-test row to match one against.
+        checked = stress_test_failures[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
+        unexplained = [test for test in checked if test in self.stressTestFailures_filtered]
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(unexplained, configuration=configuration, suite='javascriptcore-tests')
+        if flake_logs:
+            yield self._addToLog(self.results_db_log_name, flake_logs)
+
+        ignored, shadowed = [], []
+        for test in unexplained:
+            flake = flakes.get(test, FlakyVerdict(request_failed=True))
+            flake_summary = 'False'
+            if flake.is_flaky:
+                self.flaky_failures_in_results_db[test] = flake.flaky_type
+                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
+                    self.unsupported_flakes_in_results_db.append(test)
+                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
+                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS and test not in self.unsupported_flakes_in_results_db:
+                    ignored.append(test)
+                    if test in self.stressTestFailures_filtered:
+                        self.stressTestFailures_filtered.remove(test)
+                else:
+                    shadowed.append(test)
+            elif flake.request_failed:
+                self.unknown_flakes_in_results_db.append(test)
+                flake_summary = 'Unknown'
+
+            yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
+
+        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
+            if acted_on:
+                yield self._addToLog(
+                    self.results_db_log_name,
+                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
+                )
+
     def getResultSummary(self):
-        if self.results != SUCCESS and (self.stressTestFailures or self.binaryFailures):
+        if self.results != SUCCESS and not self.stressTestFailures_filtered and not self.binaryFailures_filtered and (self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db):
+            return {'step': self.results_db_ignore_message()}
+        elif self.results != SUCCESS and (self.stressTestFailures or self.binaryFailures):
             status = ''
             if self.stressTestFailures:
                 num_failures = len(self.stressTestFailures)
@@ -3750,8 +3818,11 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
 
 
 class RunJSCTestsWithoutChange(RunJavaScriptCoreTests):
+    results_db_flaky_type = 'WithinStepCleanTree'
+    results_db_stage = 'clean-tree'
     name = 'jscore-test-without-change'
     prefix = 'jsc_clean_tree_'
+    INCLUDED_FLAKY_VERDICTS = ()
 
     def evaluateCommand(self, cmd):
         rc = shell.Test.evaluateCommand(self, cmd)
@@ -3759,8 +3830,9 @@ class RunJSCTestsWithoutChange(RunJavaScriptCoreTests):
         return rc
 
 
-class AnalyzeJSCTestsResults(buildstep.BuildStep, AddToLogMixin):
+class AnalyzeJSCTestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLogMixin):
     name = 'analyze-jsc-tests-results'
+    suite = 'javascriptcore-tests'
     description = ['analyze-jsc-test-results']
     descriptionDone = ['analyze-jsc-tests-results']
     NUM_FAILURES_TO_DISPLAY = 10
@@ -3779,11 +3851,6 @@ class AnalyzeJSCTestsResults(buildstep.BuildStep, AddToLogMixin):
         flaky_stress_failures = sorted(list(flaky_stress_failures_with_change) + list(clean_tree_flaky_stress_failures))[:self.NUM_FAILURES_TO_DISPLAY]
         flaky_failures_string = ', '.join(flaky_stress_failures)
 
-        new_stress_failures = stress_failures_with_change - clean_tree_stress_failures
-        new_binary_failures = binary_failures_with_change - clean_tree_binary_failures
-        self.new_stress_failures_to_display = ', '.join(sorted(list(new_stress_failures))[:self.NUM_FAILURES_TO_DISPLAY])
-        self.new_binary_failures_to_display = ', '.join(sorted(list(new_binary_failures))[:self.NUM_FAILURES_TO_DISPLAY])
-
         yield self._addToLog('stderr', '\nFailures with change: {}'.format(list(binary_failures_with_change) + list(stress_failures_with_change))[:self.NUM_FAILURES_TO_DISPLAY])
         yield self._addToLog('stderr', '\nFlaky Tests with change: {}'.format(', '.join(flaky_stress_failures_with_change)))
         yield self._addToLog('stderr', '\nFailures on clean tree: {}'.format(clean_tree_failures_string))
@@ -3794,15 +3861,29 @@ class AnalyzeJSCTestsResults(buildstep.BuildStep, AddToLogMixin):
             # there should have been some test failures. Otherwise there is some unexpected issue.
             clean_tree_run_status = self.getProperty('clean_tree_run_status', FAILURE)
             if clean_tree_run_status in [SUCCESS, WARNINGS]:
-                self.report_failure(set(), set())
+                yield self.report_failure(set(), set())
                 defer.returnValue(FAILURE)
             # TODO: email EWS admins
             self.retry_build('Unexpected infrastructure issue, retrying build')
             defer.returnValue(RETRY)
 
+        # Only set for builds against the default branch, hence the fallback. After the empty-check
+        # above, which needs the raw lists to tell an infrastructure issue from a filtered-away run.
+        stress_failures_filtered = self.getProperty('jsc_stress_test_failures_filtered', None)
+        if stress_failures_filtered is not None:
+            stress_failures_with_change = set(stress_failures_filtered)
+        binary_failures_filtered = self.getProperty('jsc_binary_failures_filtered', None)
+        if binary_failures_filtered is not None:
+            binary_failures_with_change = set(binary_failures_filtered)
+
+        new_stress_failures = stress_failures_with_change - clean_tree_stress_failures
+        new_binary_failures = binary_failures_with_change - clean_tree_binary_failures
+        self.new_stress_failures_to_display = ', '.join(sorted(list(new_stress_failures))[:self.NUM_FAILURES_TO_DISPLAY])
+        self.new_binary_failures_to_display = ', '.join(sorted(list(new_binary_failures))[:self.NUM_FAILURES_TO_DISPLAY])
+
         if new_stress_failures or new_binary_failures:
             yield self._addToLog('stderr', '\nNew binary failures: {}.\nNew stress test failures: {}\n'.format(self.new_binary_failures_to_display, self.new_stress_failures_to_display))
-            self.report_failure(new_binary_failures, new_stress_failures)
+            yield self.report_failure(new_binary_failures, new_stress_failures)
             defer.returnValue(FAILURE)
         else:
             yield self._addToLog('stderr', '\nNo new failures\n')
@@ -3827,7 +3908,12 @@ class AnalyzeJSCTestsResults(buildstep.BuildStep, AddToLogMixin):
         self.descriptionDone = message
         self.build.buildFinished([message], RETRY)
 
+    @defer.inlineCallbacks
     def report_failure(self, new_binary_failures, new_stress_failures):
+        # TODO: Include new_binary_failures, run-javascriptcore-tests:838-839 runs testapi twice under
+        # the one 'testapi' key in %reportData, so the second run's result overwrites the first's failure.
+        results = self.getProperty('jsc_results', None) or {}
+        yield self.report_to_results_db({test: results[test] for test in new_stress_failures if test in results})
         message = ''
         if (not new_binary_failures) and (not new_stress_failures):
             message = 'Found unexpected failure with change'
@@ -4124,7 +4210,6 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                 commit=identifier if has_commit else None,
             )
 
-        # Only tests the database does not already expect to fail need a flakiness verdict
         unexplained = [test for test in tests if not pre_existing[test]['is_existing_failure']]
         flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(unexplained, configuration=configuration, suite=self.suite)
         if flake_logs:
@@ -4166,14 +4251,6 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                     self.results_db_log_name,
                     f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
                 )
-
-    def results_db_ignore_message(self) -> str:
-        parts = []
-        if self.preexisting_failures_in_results_db:
-            parts.append(f"pre-existing failures: {', '.join(self.preexisting_failures_in_results_db)}")
-        if self.flaky_failures_in_results_db:
-            parts.append(f"flaky tests: {', '.join(sorted(self.flaky_failures_in_results_db))}")
-        return f"Ignored {'; '.join(parts)} based on results-db"
 
     def evaluateResult(self, cmd):
         result = SUCCESS

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1596,6 +1596,16 @@ class TestRunJavaScriptCoreTests(BuildStepMixinAdditions, unittest.TestCase):
         self.jsc_single_stress_test_failure = '''{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":true,"allAirTestsPassed":true,"stressTestFailures":["stress/switch-on-char-llint-rope.js.dfg-eager"],"allApiTestsPassed":true}\n'''
         self.jsc_multiple_stress_test_failures = '''{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":true,"allAirTestsPassed":true,"stressTestFailures":["stress/switch-on-char-llint-rope.js.dfg-eager","stress/switch-on-char-llint-rope.js.dfg-eager-no-cjit-validate","stress/switch-on-char-llint-rope.js.eager-jettison-no-cjit","stress/switch-on-char-llint-rope.js.ftl-eager","stress/switch-on-char-llint-rope.js.ftl-eager-no-cjit","stress/switch-on-char-llint-rope.js.ftl-eager-no-cjit-b3o1","stress/switch-on-char-llint-rope.js.ftl-no-cjit-b3o0","stress/switch-on-char-llint-rope.js.ftl-no-cjit-no-inline-validate","stress/switch-on-char-llint-rope.js.ftl-no-cjit-no-put-stack-validate","stress/switch-on-char-llint-rope.js.ftl-no-cjit-small-pool","stress/switch-on-char-llint-rope.js.ftl-no-cjit-validate-sampling-profiler","stress/switch-on-char-llint-rope.js.no-cjit-collect-continuously","stress/switch-on-char-llint-rope.js.no-cjit-validate-phases","stress/switch-on-char-llint-rope.js.no-ftl"],"allApiTestsPassed":true}\n'''
         self.jsc_passed_with_flaky = '''{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":true,"allAirTestsPassed":true,"stressTestFailures":[],"flakyAndPassed":{"stress/switch-on-char-llint-rope.js.default":{"P":"7","T":"10"}},"allApiTestsPassed":true}\n'''
+        self.jsc_stress_test_failure_with_results = '''{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":true,"allAirTestsPassed":true,"stressTestFailures":["stress/weakset-gc.js"],"allApiTestsPassed":true,"results":{"stress/weakset-gc.js":{"report":"REGRESSION","expected":"PASS","actual":"FAIL"}}}\n'''
+        self.jsc_too_many_stress_test_failures_with_results = json.dumps({
+            'allDFGTestsPassed': True,
+            'allMasmTestsPassed': True,
+            'allB3TestsPassed': True,
+            'allAirTestsPassed': True,
+            'allApiTestsPassed': True,
+            'stressTestFailures': [f'stress/test-{i}.js' for i in range(RunJavaScriptCoreTests.FAILURE_THRESHOLD + 1)],
+            'results': {'stress/test-0.js': {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'FAIL'}},
+        }) + '\n'
         return self.setup_test_build_step()
 
     def tearDown(self):
@@ -1770,6 +1780,136 @@ class TestRunJavaScriptCoreTests(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_property(self.prefix + 'binary_test_failures', None)
         return rc
 
+    def test_stress_test_failure_with_results(self) -> defer.Deferred:
+        self.configureStep(platform='mac', fullPlatform='mac-highsierra', configuration='release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        timeout=1 * 60 * 60,
+                        logfiles={'json': self.jsonFileName},
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'perl Tools/Scripts/run-javascriptcore-tests --no-build --no-fail-fast --json-output={self.jsonFileName} --release --treat-failing-as-flaky=0.6,10,200 --max-timeout 800 2>&1 | Tools/Scripts/filter-test-logs jsc'],
+                        )
+            .exit(2)
+            .log('json', stdout=self.jsc_stress_test_failure_with_results),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Found 1 jsc stress test failure: stress/weakset-gc.js')
+        rc = self.run_step()
+        self.expect_property(self.prefix + 'stress_test_failures', ['stress/weakset-gc.js'])
+        self.expect_property(self.prefix + 'results', {'stress/weakset-gc.js': {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'FAIL'}})
+        return rc
+
+    def test_too_many_stress_test_failures_does_not_set_results(self) -> defer.Deferred:
+        self.configureStep(platform='mac', fullPlatform='mac-highsierra', configuration='release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        timeout=1 * 60 * 60,
+                        logfiles={'json': self.jsonFileName},
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'perl Tools/Scripts/run-javascriptcore-tests --no-build --no-fail-fast --json-output={self.jsonFileName} --release --treat-failing-as-flaky=0.6,10,200 --max-timeout 800 2>&1 | Tools/Scripts/filter-test-logs jsc'],
+                        )
+            .exit(2)
+            .log('json', stdout=self.jsc_too_many_stress_test_failures_with_results),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Found 1001 jsc stress test failures: stress/test-0.js, stress/test-1.js, stress/test-2.js, stress/test-3.js, stress/test-4.js ...')
+        rc = self.run_step()
+        self.expect_no_property(self.prefix + 'results')
+        return rc
+
+
+class TestRunJavaScriptCoreTestsResultsDBIgnoreBranch(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self) -> defer.Deferred:
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self) -> defer.Deferred:
+        return self.tear_down_test_build_step()
+
+    def _configure(self) -> RunJavaScriptCoreTests:
+        self.setup_step(RunJavaScriptCoreTests())
+        step = self.get_nth_step(0)
+        step.countFailures = lambda: 0
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-highsierra')
+        self.setProperty('configuration', 'release')
+        self.steps_added = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda steps: self.steps_added.append(steps))
+        return step
+
+    class _FailedCmd:
+        def results(self) -> int:
+            return FAILURE
+
+    def test_flaky_verdict_takes_the_ignore_branch(self) -> None:
+        step = self._configure()
+        step.stressTestFailures_filtered = []
+        step.binaryFailures_filtered = []
+        step.flaky_failures_in_results_db = {'stress/flaky.js': 'CleanTree'}
+
+        rc = step.evaluateCommand(self._FailedCmd())
+
+        self.assertEqual(rc, WARNINGS)
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: stress/flaky.js based on results-db')
+        self.assertEqual(self.build.results, SUCCESS)
+        self.assertEqual(self.steps_added, [])
+
+    def test_pre_existing_failure_still_takes_the_ignore_branch(self) -> None:
+        # Regression guard: the message used to be hand-built here ("Ignored pre-existing failure: ...")
+        # and now comes from the shared results_db_ignore_message() helper, which pluralizes
+        # "failures" and appends "based on results-db".
+        step = self._configure()
+        step.stressTestFailures_filtered = []
+        step.binaryFailures_filtered = []
+        step.preexisting_failures_in_results_db = ['stress/pre-existing.js']
+
+        rc = step.evaluateCommand(self._FailedCmd())
+
+        self.assertEqual(rc, WARNINGS)
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing failures: stress/pre-existing.js based on results-db')
+        self.assertEqual(self.build.results, SUCCESS)
+        self.assertEqual(self.steps_added, [])
+
+    def test_unexcused_flaky_verdict_takes_the_normal_failure_path(self) -> None:
+        # A flaky verdict outside INCLUDED_FLAKY_VERDICTS leaves stressTestFailures_filtered
+        # non-empty, so the ignore branch must not fire even though flaky_failures_in_results_db
+        # is populated.
+        step = self._configure()
+        step.stressTestFailures_filtered = ['stress/flaky.js']
+        step.binaryFailures_filtered = []
+        step.flaky_failures_in_results_db = {'stress/flaky.js': 'BetweenBuilds'}
+
+        rc = step.evaluateCommand(self._FailedCmd())
+
+        self.assertEqual(rc, FAILURE)
+        self.assertEqual(len(self.steps_added), 1)
+        step_names = [added.name for added in self.steps_added[0] if hasattr(added, 'name')]
+        self.assertIn(RunJSCTestsWithoutChange.name, step_names)
+        self.assertIn(AnalyzeJSCTestsResults.name, step_names)
+
+    def test_getResultSummary_reports_the_ignore_message_instead_of_the_raw_failures(self) -> None:
+        step = self._configure()
+        step.results = WARNINGS
+        step.stressTestFailures = ['stress/flaky.js']
+        step.stressTestFailures_filtered = []
+        step.binaryFailures = []
+        step.binaryFailures_filtered = []
+        step.flaky_failures_in_results_db = {'stress/flaky.js': 'CleanTree'}
+
+        summary = step.getResultSummary()
+
+        self.assertEqual(summary, {'step': 'Ignored flaky tests: stress/flaky.js based on results-db'})
+
+    def test_getResultSummary_still_reports_raw_failures_when_not_excused(self) -> None:
+        step = self._configure()
+        step.results = FAILURE
+        step.stressTestFailures = ['stress/flaky.js']
+        step.stressTestFailures_filtered = ['stress/flaky.js']
+        step.binaryFailures = []
+        step.binaryFailures_filtered = []
+
+        summary = step.getResultSummary()
+
+        self.assertEqual(summary, {'step': 'Found 1 jsc stress test failure: stress/flaky.js'})
+
 
 class TestRunJSCTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -1813,6 +1953,64 @@ class TestRunJSCTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=FAILURE, state_string='jscore-tests (failure)')
         return self.run_step()
+
+    def test_a_clean_tree_failure_does_not_clobber_the_with_change_filtered_properties(self) -> defer.Deferred:
+        self.setup_step(RunJSCTestsWithoutChange())
+        self.setProperty('fullPlatform', 'jsc-only')
+        self.setProperty('configuration', 'debug')
+        self.setProperty('jsc_stress_test_failures_filtered', ['stress/force-error.js.bytecode-cache'])
+        self.setProperty('jsc_binary_failures_filtered', ['testapi'])
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+
+        def fake_filter(stress_test_failures: list, binary_failures: list) -> defer.Deferred:
+            step.stressTestFailures_filtered = ['stress/weakset-gc.js']
+            step.binaryFailures_filtered = ['testb3']
+            return defer.succeed(None)
+
+        step.filter_failures_using_results_db = fake_filter
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'perl Tools/Scripts/run-javascriptcore-tests --no-build --no-fail-fast --json-output={self.jsonFileName} --debug --treat-failing-as-flaky=0.6,10,200 --max-timeout 800 2>&1 | Tools/Scripts/filter-test-logs jsc'],
+                        logfiles={'json': self.jsonFileName},
+                        timeout=1 * 60 * 60,
+                        )
+            .log('json', stdout='''{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":false,"allAirTestsPassed":true,"allApiTestsPassed":true,"stressTestFailures":["stress/weakset-gc.js"]}\n''')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Found 1 jsc stress test failure: stress/weakset-gc.js, JSC test binary failure: testb3')
+        rc = self.run_step()
+        self.expect_property('jsc_stress_test_failures_filtered', ['stress/force-error.js.bytecode-cache'])
+        self.expect_property('jsc_binary_failures_filtered', ['testapi'])
+        self.expect_property('jsc_clean_tree_stress_test_failures_filtered', ['stress/weakset-gc.js'])
+        self.expect_property('jsc_clean_tree_binary_failures_filtered', ['testb3'])
+        return rc
+
+    @defer.inlineCallbacks
+    def test_does_not_excuse_a_flaky_verdict(self) -> Generator[Any, Any, None]:
+        # AnalyzeJSCTestsResults deliberately ignores the clean-tree run's own filtered/results-db
+        # properties (see test_pre_existing_flaky_stress_failure_is_not_blamed_on_the_author), so a
+        # clean-tree flaky verdict must never remove a failure from stressTestFailures_filtered.
+        self.setup_step(RunJSCTestsWithoutChange())
+        step = self.get_nth_step(0)
+        self.assertEqual(step.INCLUDED_FLAKY_VERDICTS, ())
+        self.setProperty('fullPlatform', 'jsc-only')
+        self.setProperty('configuration', 'debug')
+        self.setProperty('platform', 'mac')
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(
+            lambda cls, test, **kwargs: defer.succeed({
+                'is_existing_failure': False, 'pass_rate': 100, 'raw_data': {}, 'logs': '', 'request_failed': False,
+            })))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {test: FlakyVerdict(flaky_type='CleanTree') for test in tests}, ''))))
+
+        yield step.filter_failures_using_results_db(['stress/flaky.js'], [])
+
+        self.assertEqual(step.stressTestFailures_filtered, ['stress/flaky.js'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'stress/flaky.js': 'CleanTree'})
 
 
 class TestAnalyzeJSCTestsResults(BuildStepMixinAdditions, unittest.TestCase):
@@ -1919,6 +2117,209 @@ class TestAnalyzeJSCTestsResults(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('clean_tree_run_status', SUCCESS)
         self.expect_outcome(result=FAILURE, state_string='Found unexpected failure with change (failure)')
         return self.run_step()
+
+    def test_pre_existing_flaky_stress_failure_is_not_blamed_on_the_author(self) -> None:
+        # The flaky test failed with the change and passed on the clean tree, so subtracting the
+        # clean-tree failures cannot explain it away; only the results-db filtering can.
+        self.configureStep()
+        self.setProperty('jsc_stress_test_failures', ['stress/dfg-osr-entry-hoisted-clobber.js.default', 'stress/force-error.js.bytecode-cache'])
+        self.setProperty('jsc_stress_test_failures_filtered', ['stress/force-error.js.bytecode-cache'])
+        self.setProperty('jsc_clean_tree_stress_test_failures', ['stress/force-error.js.bytecode-cache'])
+        self.expect_outcome(result=SUCCESS, state_string='Passed JSC tests')
+        return self.run_step()
+
+    def test_pre_existing_flaky_binary_failure_is_not_blamed_on_the_author(self) -> None:
+        self.configureStep()
+        self.setProperty('jsc_binary_failures', ['testapi', 'testdfg'])
+        self.setProperty('jsc_binary_failures_filtered', ['testdfg'])
+        self.setProperty('jsc_clean_tree_binary_failures', ['testdfg'])
+        self.expect_outcome(result=SUCCESS, state_string='Passed JSC tests')
+        return self.run_step()
+
+    def test_new_failure_is_still_reported_when_the_filtered_lists_are_set(self) -> None:
+        self.configureStep()
+        self.setProperty('jsc_stress_test_failures', ['stress/dfg-osr-entry-hoisted-clobber.js.default', 'stress/force-error.js.bytecode-cache'])
+        self.setProperty('jsc_stress_test_failures_filtered', ['stress/force-error.js.bytecode-cache'])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new JSC stress test failure: stress/force-error.js.bytecode-cache (failure)')
+        return self.run_step()
+
+    def test_raw_failures_are_used_when_the_filtered_properties_are_absent(self) -> None:
+        # RunJavaScriptCoreTests only sets the filtered properties for builds against the default
+        # branch, so the raw lists still have to drive the verdict on every other branch.
+        self.configureStep()
+        self.setProperty('jsc_stress_test_failures', ['stress/dfg-osr-entry-hoisted-clobber.js.default'])
+        self.setProperty('jsc_binary_failures', ['testapi'])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new JSC binary failure: testapi, Found 1 new JSC stress test failure: stress/dfg-osr-entry-hoisted-clobber.js.default (failure)')
+        return self.run_step()
+
+
+class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self) -> defer.Deferred:
+        self.longMessage = True
+        self.queried = []
+        self.flake_queries = []
+        return self.setup_test_build_step()
+
+    def tearDown(self) -> defer.Deferred:
+        return self.tear_down_test_build_step()
+
+    def patch_flaky_verdicts(self, verdicts: dict) -> None:
+        def fake_flaky_verdicts_for(cls, tests: list, **kwargs) -> defer.Deferred:
+            self.flake_queries.append((list(tests), kwargs))
+            return defer.succeed(({test: verdicts.get(test, FlakyVerdict()) for test in tests}, ''))
+
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(fake_flaky_verdicts_for))
+
+    def configureStep(self, pre_existing: set) -> RunJavaScriptCoreTests:
+        self.setup_step(RunJavaScriptCoreTests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'release')
+
+        def fake_is_pre_existing(cls, test: str, **kwargs) -> defer.Deferred:
+            self.queried.append(test)
+            return defer.succeed({
+                'is_existing_failure': test in pre_existing,
+                'pass_rate': 0 if test in pre_existing else 100,
+                'raw_data': {},
+                'logs': '',
+                'request_failed': False,
+            })
+
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch_flaky_verdicts({})
+        return step
+
+    @defer.inlineCallbacks
+    def test_pre_existing_failure_after_an_unexplained_one_is_still_filtered(self) -> None:
+        # The lists have to be complete, since AnalyzeJSCTestsResults decides what to blame on the
+        # author from them; an early exit on the first unexplained failure would truncate them.
+        step = self.configureStep({'stress/dfg-osr-entry-hoisted-clobber.js.default', 'testapi'})
+        yield step.filter_failures_using_results_db(
+            ['stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default'],
+            ['testdfg', 'testapi'],
+        )
+        self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
+        self.assertEqual(step.binaryFailures_filtered, ['testdfg'])
+        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['stress/dfg-osr-entry-hoisted-clobber.js.default', 'testapi'])
+
+    @defer.inlineCallbacks
+    def test_caps_the_number_of_results_db_queries(self) -> None:
+        cap = RunJavaScriptCoreTests.MAX_FAILURES_TO_CHECK_RESULTS_DB
+        stress_test_failures = [f'stress/force-error.js.ftl-no-cjit-{i}' for i in range(cap + 10)]
+        binary_failures = ['testmasm', 'testair', 'testb3', 'testdfg', 'testapi', 'testLibJSCTools']
+        step = self.configureStep(set(stress_test_failures) | set(binary_failures))
+        yield step.filter_failures_using_results_db(stress_test_failures, binary_failures)
+        self.assertEqual(self.queried, stress_test_failures[:cap] + binary_failures)
+
+    @defer.inlineCallbacks
+    def test_a_verdict_in_the_included_set_removes_the_failure(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        self.patch_flaky_verdicts({'stress/force-error.js.bytecode-cache': FlakyVerdict(flaky_type='CleanTree', pr_numbers={12345})})
+
+        yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
+
+        self.assertEqual(step.stressTestFailures_filtered, [])
+        self.assertEqual(step.binaryFailures_filtered, ['testapi'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'CleanTree'})
+        self.assertEqual(step.preexisting_failures_in_results_db, [])
+        self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=CleanTree: {'pr_numbers': [12345]}\n", logs)
+        self.assertIn('\nIgnored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+        self.assertNotIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+
+    @defer.inlineCallbacks
+    def test_a_verdict_outside_the_included_set_is_recorded_without_ignoring_the_failure(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+        step.INCLUDED_FLAKY_VERDICTS = frozenset({'CleanTree'})
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        self.patch_flaky_verdicts({'stress/force-error.js.bytecode-cache': FlakyVerdict(flaky_type='BetweenBuilds', pr_numbers={12345})})
+
+        yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
+
+        self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
+        self.assertEqual(step.binaryFailures_filtered, ['testapi'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
+        self.assertEqual(step.preexisting_failures_in_results_db, [])
+        self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=BetweenBuilds: {'pr_numbers': [12345]}\n", logs)
+        self.assertIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+        self.assertNotIn('\nIgnored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+
+    @defer.inlineCallbacks
+    def test_a_between_builds_verdict_with_no_intra_build_evidence_is_not_excused(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        self.patch_flaky_verdicts({'stress/force-error.js.bytecode-cache': FlakyVerdict(flaky_type='BetweenBuilds', pr_numbers={12345})})
+
+        yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
+
+        self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
+        self.assertEqual(step.binaryFailures_filtered, ['testapi'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
+        self.assertEqual(step.unsupported_flakes_in_results_db, ['stress/force-error.js.bytecode-cache'])
+        self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=BetweenBuilds: {'pr_numbers': [12345]}\n", logs)
+        self.assertIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+        self.assertNotIn('\nIgnored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
+
+    @defer.inlineCallbacks
+    def test_a_pre_existing_failure_is_not_asked_for_a_flake_verdict(self) -> Generator[Any, Any, None]:
+        step = self.configureStep({'stress/dfg-osr-entry-hoisted-clobber.js.default', 'testapi'})
+
+        yield step.filter_failures_using_results_db(
+            ['stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default'],
+            ['testdfg', 'testapi'],
+        )
+
+        self.assertEqual([tests for tests, _ in self.flake_queries], [['stress/force-error.js.bytecode-cache']])
+
+    @defer.inlineCallbacks
+    def test_binary_failures_are_never_asked_for_a_flake_verdict(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+
+        yield step.filter_failures_using_results_db(
+            ['stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default'],
+            ['testdfg', 'testapi'],
+        )
+
+        self.assertEqual(self.queried, [
+            'stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default',
+            'testdfg', 'testapi',
+        ])
+        self.assertEqual(len(self.flake_queries), 1)
+        tests, kwargs = self.flake_queries[0]
+        self.assertEqual(tests, [
+            'stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default',
+        ])
+        self.assertEqual(kwargs, {'configuration': {'platform': 'mac', 'style': 'release'}, 'suite': 'javascriptcore-tests'})
+
+    @defer.inlineCallbacks
+    def test_caps_the_number_of_flake_verdict_queries(self) -> Generator[Any, Any, None]:
+        cap = RunJavaScriptCoreTests.MAX_FAILURES_TO_CHECK_RESULTS_DB
+        stress_test_failures = [f'stress/force-error.js.ftl-no-cjit-{i}' for i in range(cap + 10)]
+        step = self.configureStep(set())
+
+        yield step.filter_failures_using_results_db(stress_test_failures, [])
+
+        self.assertEqual(len(self.flake_queries), 1)
+        tests, _ = self.flake_queries[0]
+        self.assertEqual(tests, stress_test_failures[:cap])
+
+    @defer.inlineCallbacks
+    def test_a_failed_verdict_query_is_recorded_as_unknown(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+        self.patch_flaky_verdicts({'stress/force-error.js.bytecode-cache': FlakyVerdict(request_failed=True)})
+
+        yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
+
+        self.assertEqual(step.unknown_flakes_in_results_db, ['stress/force-error.js.bytecode-cache'])
+        self.assertEqual(step.flaky_failures_in_results_db, {})
+        self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
+        self.assertEqual(step.binaryFailures_filtered, ['testapi'])
 
 
 class TestRunWebKitTests(BuildStepMixinAdditions, unittest.TestCase):
@@ -4065,6 +4466,95 @@ class TestAPITestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase
             self.results_db_reports[0]['results']['suite.new']['actual_by_run'],
             {'first-run': 'FAIL', 'second-run': 'TIMEOUT'},
         )
+
+
+class TestJSCTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):
+    """AnalyzeJSCTestsResults ends the build on every exit, so a step queued after it never runs."""
+
+    JSC_JSON = '{"allDFGTestsPassed":true,"allMasmTestsPassed":true,"allB3TestsPassed":true,"allAirTestsPassed":true,"allApiTestsPassed":true,"stressTestFailures":["stress/broken.js"],"flaky":{"stress/flaky.js":{"P":"7","T":"10","S":1},"stress/broken.js":{"P":"1","T":"10","S":0}},"results":{"stress/broken.js":{"actual":"FAIL","flakiness_num_passes":1,"flakiness_num_tries":10},"stress/flaky.js":{"actual":"PASS","flakiness_num_passes":7,"flakiness_num_tries":10}}}'
+
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, StepClass):
+        self.setup_step(StepClass())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('configuration', 'release')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        return step
+
+    def configureRunStep(self, StepClass):
+        step = self.configureStep(StepClass)
+        step.log_observer_json = TestLayoutTestStepsReportAsTheyRun.FakeLogObserver(self.JSC_JSON)
+
+        def fake_filter(stress_test_failures, binary_failures):
+            step.stressTestFailures_filtered = list(stress_test_failures)
+            step.binaryFailures_filtered = list(binary_failures)
+            step.preexisting_failures_in_results_db = []
+            return defer.succeed(None)
+
+        step.filter_failures_using_results_db = fake_filter
+        self.patch(shell.Test, 'runCommand', lambda *args, **kwargs: defer.succeed(None))
+        return step
+
+    def reported(self):
+        return [
+            (report['flaky_type'], (report['details'] or {}).get('stage'), sorted(report['results']))
+            for report in self.results_db_reports
+        ]
+
+    @defer.inlineCallbacks
+    def test_reports_only_stress_tests_that_were_retried_and_then_passed(self):
+        # The runner retries stress tests itself, so a test it retried and that still failed is a
+        # failure, not evidence of flakiness. stress/broken.js never passed ("S":0).
+        step = self.configureRunStep(RunJavaScriptCoreTests)
+        yield step.runCommand(['run-javascriptcore-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'with-change', ['stress/flaky.js'])])
+        self.assertEqual(self.results_db_reports[0]['suite'], 'javascriptcore-tests')
+
+    @defer.inlineCallbacks
+    def test_the_clean_tree_jsc_run_reports_its_flakes_as_clean_tree(self):
+        step = self.configureRunStep(RunJSCTestsWithoutChange)
+        yield step.runCommand(['run-javascriptcore-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepCleanTree', 'clean-tree', ['stress/flaky.js'])])
+
+    @defer.inlineCallbacks
+    def test_the_analyze_step_reports_stress_failures_the_clean_tree_did_not_have(self):
+        step = self.configureStep(AnalyzeJSCTestsResults)
+        step.new_stress_failures_to_display = 'stress/a.js'
+        step.new_binary_failures_to_display = ''
+        self.setProperty('jsc_results', {
+            'stress/a.js': dict(actual='FAIL'),
+            'stress/b.js': dict(actual='FAIL'),
+        })
+        yield step.report_failure(set(), {'stress/a.js'})
+
+        # No flaky_type: a failure attributed to the change is not flakiness.
+        self.assertEqual(self.reported(), [(None, None, ['stress/a.js'])])
+
+    @defer.inlineCallbacks
+    def test_an_over_threshold_summary_is_not_reported_as_a_test(self):
+        # Past FAILURE_THRESHOLD the step records a summary line in place of the test names, and
+        # that line is not a test.
+        step = self.configureStep(AnalyzeJSCTestsResults)
+        step.new_stress_failures_to_display = 'Too many failures: 1500 jsc tests failed'
+        step.new_binary_failures_to_display = ''
+        self.setProperty('jsc_results', {'stress/a.js': dict(actual='FAIL')})
+        yield step.report_failure(set(), {'Too many failures: 1500 jsc tests failed'})
+
+        self.assertEqual(self.results_db_reports, [])
 
 
 class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -1155,6 +1155,11 @@ sub runJSCStressTests
     if (defined($jsonFileName)) {
         $jsonData{'flaky'} =  \%jscStressFlakyInfo;
         $jsonData{'stressTestFailures'} = \@jscStressFailList;
+        my %notableResults = ();
+        foreach my $test (@jscStressFailList, keys %jscStressFlakyInfo, @jscStressNoResultList) {
+            $notableResults{$test} = $reportData{$test} if exists $reportData{$test};
+        }
+        $jsonData{'results'} = \%notableResults;
     }
 
     writeJsonDataIfApplicable();


### PR DESCRIPTION
#### 09e7bd88eb16e6698f416042af509c085382d892
<pre>
[EWS] JSC EWS blames the pull request author for pre-existing flaky test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=323155">https://bugs.webkit.org/show_bug.cgi?id=323155</a>
<a href="https://rdar.apple.com/186409107">rdar://186409107</a>

Reviewed by Aakash Jain.

Extend results database reporting to JSC. The runner retries stress tests
itself, so flakiness comes from its own retries rather than a re-run pair, and a
test it retried that still failed is reported as a failure rather than as
evidence of flakiness. Every exit of `AnalyzeJSCTestsResults` ends the build, so
reporting happens inside the steps that produce each result rather than in a
step queued after them, which would never run.

`runJSCStressTests` writes only the notable per-test results to
`jsc_results.json`. `%reportData` carries a row for every test the stress run
executed, which the `uploadResults` path needs and the json file&apos;s consumers do
not: they read the failures and the flakes. Writing all of it made the file a
10 MB step log, parsed in the master and persisted as a build property on every
JSC run and again on the clean-tree retry, to carry two rows.

`AnalyzeJSCTestsResults` blamed the pull request author for pre-existing test
failures. It computed the failures it attributes to the change from the raw
`jsc_stress_test_failures` and `jsc_binary_failures` properties, so a test the
results database already recorded as failing was reported as new when it failed
with the change and passed on the clean tree. The filtered lists
`RunJavaScriptCoreTests` writes for exactly this purpose were read nowhere. The
analyzer now prefers `jsc_stress_test_failures_filtered` and
`jsc_binary_failures_filtered`, falling back to the raw properties for a build
that is not against the default branch, and filters below the check for no
failures at all, which needs the raw lists.

`_check_for_preexisting_failures` no longer stops at the first failure the
database does not recognize. That short circuit left the filtered lists
incomplete, which is harmless while nothing reads them and wrong now that the
analyzer does. `MAX_FAILURES_TO_CHECK_RESULTS_DB` bounds the queries instead, at
50 to match API tests. A failure past the cap is treated as new by both the
pre-existing check and the flakiness read.

Three property writes in `RunJavaScriptCoreTests.runCommand` hardcoded a `jsc_`
prefix while every write around them derives from `self.prefix`.
`RunJSCTestsWithoutChange` inherits `runCommand`, so a clean-tree run with any
failure of its own overwrote the with-change run&apos;s filtered lists, and the
analyzer would then subtract the clean-tree failures from themselves and report
nothing at all.

`RunJavaScriptCoreTests` also asks the database for a flakiness verdict on each
stress test failure it cannot otherwise explain, dropping the ones it recognizes
from the filtered lists so the analyzer never attributes them to the change. It
acts on the same three verdicts `RunWebKitTests` acts on. Binary test failures
are left out: nothing reports them to the database, so a verdict for one could
only ever come back unknown.

A build whose failures the database explains now ends at the run step, green
with a warning, instead of paying a revert, a recompile and two more JSC runs to
reach the same conclusion. Reaching that branch on a flakiness verdict rather
than only on a pre-existing failure is what makes the read worth running there.
`results_db_ignore_message` moved from `RunWebKitTests` to
`ResultsDBReportMixin` so both suites word that summary the same way, which
pluralizes JSC&apos;s pre-existing-only message and appends &quot;based on results-db&quot;.

A `BetweenBuilds` verdict with no intra-build evidence is recorded in
`results-db_jsc_flaky_unsupported` and not acted on. A test that fails on some
builds and passes on others, never twice within one build, is as consistent with
a configuration-dependent failure as with a flake, and the queue would excuse it
on every build. `RunJSCTestsWithoutChange` excuses nothing at all:
`AnalyzeJSCTestsResults` subtracts the clean-tree run&apos;s raw failures, so its
filtered lists are read by no one and the queries behind them buy nothing.

A verdict outside `INCLUDED_FLAKY_VERDICTS` is logged as would-have-ignored
rather than excused; nothing narrows the set today, so the path exists for a
queue that later does. The four new `results-db_jsc_` properties are read by
nothing, and are there for the build page and for measuring the read.

`jsc_results` is set below the failure-threshold return, so a run with more
failures than the step reports individually does not put the map back for the
analyzer to read. `jsc_flaky_and_passed` starts being set for the first time:
the property was read from a `flakyAndPassed` key the runner has never emitted,
so `send_email_for_flaky_failure` also fires for the first time.

Canonical link: <a href="https://commits.webkit.org/320409@main">https://commits.webkit.org/320409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93dd89a83414d2f0740c0ee2529472a75f978e3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144062 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100095 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44729 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6463 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13282 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44346 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5922 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45800 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196795 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183926 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58117 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153306 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47833 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127580 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57325 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->