### PR TITLE
[EWS] EWS ResultsDB reading and writing should be typed

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -29,9 +29,9 @@ import sys
 import time
 import urllib.parse
 
-from collections.abc import Callable, Iterable
-from dataclasses import dataclass, field
-from typing import Optional
+from collections.abc import Callable, Generator, Iterable
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
 
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
@@ -63,6 +63,85 @@ class FlakyVerdict:
                 ('authors', self.authors),
             ) if value
         }
+
+
+@dataclass
+class EWSRowDetails:
+    """A row's `details` blob: build provenance the results database stores but cannot be queried on."""
+    worker: Optional[str] = None
+    remote: Optional[str] = None
+    pr_number: Optional[int] = None
+    commit_hash: Optional[str] = None
+    retry_count: int = 0
+    authors: list[str] = field(default_factory=list)
+    build_url: Optional[str] = None
+    stage: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, data: Optional[dict]) -> 'EWSRowDetails':
+        data = data or {}
+        return cls(
+            worker=data.get('worker'),
+            remote=data.get('remote'),
+            pr_number=data.get('pr_number'),
+            commit_hash=data.get('commit_hash'),
+            retry_count=data.get('retry_count') or 0,
+            authors=[author for author in (data.get('authors') or []) if author],
+            build_url=data.get('build_url'),
+            stage=data.get('stage'),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EWSRow:
+    """One row the results database has recorded for one test in one configuration."""
+    uuid: int = 0
+    start_time: int = 0
+    # Whatever the suite that ran the test reports, which differs per suite.
+    result: dict[str, Any] = field(default_factory=dict)
+    flaky_type: Optional[str] = None
+    details: EWSRowDetails = field(default_factory=EWSRowDetails)
+
+    @classmethod
+    def from_json(cls, data: dict) -> 'EWSRow':
+        return cls(
+            uuid=data.get('uuid') or 0,
+            start_time=data.get('start_time') or 0,
+            result=data.get('result') or {},
+            flaky_type=data.get('flaky_type'),
+            details=EWSRowDetails.from_json(data.get('details')),
+        )
+
+
+@dataclass
+class EWSPayload:
+    """What EWS uploads about one run. The api_key is deliberately absent: this object is logged, and
+    a field would put the live key in every __repr__ and asdict of it."""
+    suite: str
+    configuration: dict
+    commits: list[dict]
+    results: dict
+    timestamp: int
+    details: EWSRowDetails
+    flaky_type: Optional[str] = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            'suite': self.suite,
+            'flaky_type': self.flaky_type,
+            'configuration': self.configuration,
+            'commits': self.commits,
+            'test_results': {'results': self.results},
+            'timestamp': self.timestamp,
+            'details': self.details.to_json(),
+        }
+
+
+EWSRowByTest = dict[str, list[EWSRow]]
+EWSRowByType = dict[str, list[EWSRow]]
 
 
 class ResultsDatabase(object):
@@ -236,29 +315,21 @@ class ResultsDatabase(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def report_ews(cls, suite, results, configuration, commits, timestamp, details, flaky_type=None, logger=lambda _: None):
-        if not results:
+    def report_ews(cls, payload: EWSPayload, logger: Callable[[str], None] = lambda _: None) -> Generator[Any, Any, bool]:
+        if not payload.results:
             return False
 
-        payload = {
-            'suite': suite,
-            'flaky_type': flaky_type,
-            'configuration': configuration,
-            'commits': commits,
-            'test_results': {'results': results},
-            'timestamp': timestamp,
-            'details': details,
-            'api_key': os.environ.get('RESULTS_SERVER_API_KEY', ''),
-        }
+        document = payload.to_json()
+        body = {**document, 'api_key': os.environ.get('RESULTS_SERVER_API_KEY', '')}
 
         url = f'{cls.HOSTNAME}/api/upload/ews'
-        label = f'{flaky_type} flaky tests' if flaky_type else 'failed tests'
-        logger(f"Reporting {label} to {url}: {', '.join(sorted(results))}\n")
+        label = f'{payload.flaky_type} flaky tests' if payload.flaky_type else 'failed tests'
+        logger(f"Reporting {label} to {url}: {', '.join(sorted(payload.results))}\n")
         # FIXME: Remove the request and response dumps once reporting has been validated against a
-        # deployed results database. api_key must stay redacted, build logs are not private.
-        logger(f"Request:\n{json.dumps({**payload, 'api_key': '<redacted>'}, indent=2, sort_keys=True)}\n")
+        # deployed results database.
+        logger(f'Request:\n{json.dumps(document, indent=2, sort_keys=True)}\n')
 
-        response = yield TwistedAdditions.request(url, type=b'POST', json=payload, logger=logger)
+        response = yield TwistedAdditions.request(url, type=b'POST', json=body, logger=logger)
         if not response:
             logger(f'No response from {url}, so {label} were not reported\n')
             return False
@@ -279,23 +350,22 @@ class ResultsDatabase(object):
             return True
 
         logger(f"Reported {label}: {', '.join(sorted(stored))}\n")
-        dropped = sorted(set(results) - set(stored))
+        dropped = sorted(set(payload.results) - set(stored))
         if dropped:
             logger(f"{url} did not store {', '.join(dropped)}\n")
             return False
         return True
 
     @classmethod
-    def _evidence_in(cls, rows):
+    def _evidence_in(cls, rows: list[EWSRow]) -> FlakyVerdict:
         """Who was building across these rows, as a verdict with no type decided yet."""
         evidence = FlakyVerdict()
         for row in rows:
-            details = row.get('details') or {}
-            if build_url := details.get('build_url'):
+            if build_url := row.details.build_url:
                 evidence.build_urls.add(build_url)
-            if pr_number := details.get('pr_number'):
+            if pr_number := row.details.pr_number:
                 evidence.pr_numbers.add(pr_number)
-            evidence.authors |= {author for author in (details.get('authors') or []) if author}
+            evidence.authors |= set(row.details.authors)
         return evidence
 
     @classmethod
@@ -313,34 +383,34 @@ class ResultsDatabase(object):
 
     @classmethod
     def _rows_by_type(
-        cls, entries: list[dict], curr_authors: Optional[Iterable[str]], curr_pr: Optional[int], logger: Callable[[str], None],
-    ) -> dict[str, list[dict]]:
+        cls, rows: list[EWSRow], curr_authors: Optional[Iterable[str]],
+        curr_pr: Optional[int], logger: Callable[[str], None],
+    ) -> EWSRowByType:
         """Rows grouped by `flaky_type`, dropping those attributable to the change being judged."""
         curr = {author for author in (curr_authors or []) if author}
 
-        def independent_of_this_pull_request(row: dict) -> bool:
-            return not curr_pr or (row.get('details') or {}).get('pr_number') != curr_pr
+        def independent_of_this_pull_request(row: EWSRow) -> bool:
+            return not curr_pr or row.details.pr_number != curr_pr
 
-        def independent_of_this_changes_authors(row: dict) -> bool:
-            recorded = {a for a in ((row.get('details') or {}).get('authors') or []) if a}
+        def independent_of_this_changes_authors(row: EWSRow) -> bool:
+            recorded = set(row.details.authors)
             return not recorded or bool(recorded - curr)
 
-        by_type = {}
-        same_pull_request = {}
-        same_authors = {}
-        for entry in entries:
-            for row in entry.get('results', []):
-                flaky_type = row.get('flaky_type') or cls.FAILED_ROWS
-                # A clean-tree row is recorded with the change reverted; its pr_number and authors name the build.
-                if flaky_type == cls.WITHIN_STEP_CLEAN_TREE:
-                    bucket = by_type
-                elif not independent_of_this_pull_request(row):
-                    bucket = same_pull_request
-                elif not independent_of_this_changes_authors(row):
-                    bucket = same_authors
-                else:
-                    bucket = by_type
-                bucket.setdefault(flaky_type, []).append(row)
+        by_type: EWSRowByType = {}
+        same_pull_request: EWSRowByType = {}
+        same_authors: EWSRowByType = {}
+        for row in rows:
+            flaky_type = row.flaky_type or cls.FAILED_ROWS
+            # A clean-tree row is recorded with the change reverted; its pr_number and authors name the build.
+            if flaky_type == cls.WITHIN_STEP_CLEAN_TREE:
+                bucket = by_type
+            elif not independent_of_this_pull_request(row):
+                bucket = same_pull_request
+            elif not independent_of_this_changes_authors(row):
+                bucket = same_authors
+            else:
+                bucket = by_type
+            bucket.setdefault(flaky_type, []).append(row)
 
         for flaky_type, dropped in sorted(same_pull_request.items()):
             logger(f"Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own pull request (#{curr_pr})\n")
@@ -349,10 +419,10 @@ class ResultsDatabase(object):
         return by_type
 
     @classmethod
-    def _is_intra_build_flake(cls, rows: dict[str, list[dict]], logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
+    def _is_intra_build_flake(cls, rows: EWSRowByType, logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
         if failed_with_no_flaky_type := rows.get(cls.FAILED_ROWS, []):
             logger(f'Ignored {len(failed_with_no_flaky_type)} flake row(s) that carried no flaky_type\n')
-        if unrecognized := {name for name in rows if name and name not in cls.WITHIN_BUILD_ROWS and name != cls.FAILED_ROWS}:
+        if unrecognized := {name for name in rows if name not in cls.WITHIN_BUILD_ROWS and name != cls.FAILED_ROWS}:
             logger(f"Ignored flakiness recorded as {', '.join(sorted(unrecognized))}\n")
 
         if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE, []):
@@ -372,7 +442,7 @@ class ResultsDatabase(object):
         )
 
     @classmethod
-    def _is_inter_build_flake(cls, rows: dict[str, list[dict]], logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
+    def _is_inter_build_flake(cls, rows: EWSRowByType, logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
         failed = rows.get(cls.FAILED_ROWS, [])
         evidence = cls._evidence_in(failed)
 
@@ -382,9 +452,7 @@ class ResultsDatabase(object):
         ):
             return verdict
 
-        rows_without_an_author = sum(
-            1 for row in failed if not {a for a in ((row.get('details') or {}).get('authors') or []) if a}
-        )
+        rows_without_an_author = sum(1 for row in failed if not row.details.authors)
         if rows_without_an_author and len(evidence.authors) < cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE:
             logger(
                 f'{rows_without_an_author} row(s) record no author, so the between-builds rule saw '
@@ -393,7 +461,7 @@ class ResultsDatabase(object):
             )
 
     @classmethod
-    def _parse_results_ews_response(cls, response, logger):
+    def _parse_results_ews_response(cls, response: 'TwistedAdditions.Response', logger: Callable[[str], None]) -> Optional[list[dict]]:
         """The response body as a list of per-test entries, or None if it is not one."""
         try:
             entries = response.json()
@@ -410,7 +478,10 @@ class ResultsDatabase(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def _query_flaky(cls, tests, flaky, configuration, suite, logger):
+    def _query_flaky(
+        cls, tests: Iterable[str], flaky: bool, configuration: Optional[dict],
+        suite: Optional[str], logger: Callable[[str], None],
+    ) -> Generator[Any, Any, Optional[EWSRowByTest]]:
         """Every test named, in chunks small enough to survive the request line, or None if any
         chunk failed: a partial answer would read as an absence of history for the rest."""
         base_params = {key: value for key, value in (configuration or {}).items() if key in cls.CONFIGURATION_KEYS}
@@ -421,7 +492,7 @@ class ResultsDatabase(object):
 
         url = f'{cls.HOSTNAME}/api/results-ews'
         tests = list(tests)
-        by_test = {}
+        by_test: EWSRowByTest = {}
 
         # Chunked because the names ride in the query string: a whole step's worth of long WPT
         # paths overflows nginx's 8k request line, and a 414 fails every test in the batch.
@@ -444,7 +515,8 @@ class ResultsDatabase(object):
                 return None
 
             for entry in entries:
-                by_test.setdefault(entry['test'], []).append(entry)
+                rows = [EWSRow.from_json(row) for row in (entry.get('results') or [])]
+                by_test.setdefault(entry['test'], []).extend(rows)
 
         return by_test
 
@@ -452,16 +524,16 @@ class ResultsDatabase(object):
     @defer.inlineCallbacks
     def flaky_verdicts_for(
         cls, tests: Iterable[str], configuration: Optional[dict] = None, suite: Optional[str] = None,
-        authors: Optional[Iterable] = None, pr_number: Optional[int] = None,
-    ) -> defer.Deferred:
+        authors: Optional[Iterable[str]] = None, pr_number: Optional[int] = None,
+    ) -> Generator[Any, Any, tuple[dict[str, FlakyVerdict], str]]:
         logs = []
 
         def logger(log):
             logs.append(log)
 
-        verdicts = {}
+        verdicts: dict[str, FlakyVerdict] = {}
         remaining = list(tests)
-        intra_build_rows = {}
+        intra_build_rows: dict[str, EWSRowByType] = {}
         for flaky, classify in ((True, cls._is_intra_build_flake), (False, cls._is_inter_build_flake)):
             if not remaining:
                 break
@@ -491,7 +563,7 @@ class ResultsDatabase(object):
 
         if unsupported := sorted(
             test for test, verdict in verdicts.items()
-            if verdict.flaky_type == 'BetweenBuilds' and not verdict.intra_build_evidence
+            if verdict.flaky_type == cls.BETWEEN_BUILDS_VERDICT and not verdict.intra_build_evidence
         ):
             logger(f"BetweenBuilds with no within-build flakiness recorded: {', '.join(unsupported)}\n")
         return verdicts, ''.join(logs)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -25,6 +25,7 @@ from buildbot.process import buildstep, logobserver, properties, remotecommand
 from buildbot.process.results import Results, SUCCESS, FAILURE, CANCELLED, WARNINGS, SKIPPED, EXCEPTION, RETRY
 from buildbot.steps import master, shell, transfer, trigger
 from buildbot.steps.source import git
+from dataclasses import replace
 from datetime import date
 from shlex import quote
 from typing import Any, Generator
@@ -34,7 +35,7 @@ from twisted.internet import defer, reactor, task
 
 from .layout_test_failures import LayoutTestFailures
 from .send_email import send_email_to_patch_author, send_email_to_bot_watchers, send_email_to_github_admin, FROM_EMAIL
-from .results_db import FlakyVerdict, ResultsDatabase
+from .results_db import EWSPayload, EWSRowDetails, FlakyVerdict, ResultsDatabase
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
 
@@ -599,18 +600,18 @@ class ResultsDBReportMixin(abc.ABC):
             'is_simulator': 'simulator' in (self.getProperty('fullPlatform', '') or ''),
         }
 
-    def results_db_details(self):
+    def results_db_details(self) -> EWSRowDetails:
         """Extra build metadata folded into each row's `details` blob, non-queryable."""
         authors = self.getProperty('owners', [])
-        return {
-            'worker': self.getProperty('workername', None),
-            'remote': self.getProperty('remote', None),
-            'pr_number': self.getProperty('github.number', None),
-            'commit_hash': self.getProperty('github.head.sha', None),
-            'retry_count': self.getProperty('retry_count', 0),
-            'authors': [author for author in authors if author],
-            'build_url': f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}',
-        }
+        return EWSRowDetails(
+            worker=self.getProperty('workername', None),
+            remote=self.getProperty('remote', None),
+            pr_number=self.getProperty('github.number', None),
+            commit_hash=self.getProperty('github.head.sha', None),
+            retry_count=self.getProperty('retry_count', 0),
+            authors=[author for author in authors if author],
+            build_url=f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}',
+        )
 
     def merged_results(self, test_filter, runs):
         """
@@ -675,13 +676,15 @@ class ResultsDBReportMixin(abc.ABC):
 
         try:
             reported = yield ResultsDatabase.report_ews(
-                configuration=config,
-                suite=self.suite,
-                commits=[commit],
-                flaky_type=flaky_type,
-                results=results,
-                timestamp=getattr(self, 'run_started_at', None) or int(time.time()),
-                details={**self.results_db_details(), 'stage': stage},
+                EWSPayload(
+                    configuration=config,
+                    suite=self.suite,
+                    commits=[commit],
+                    flaky_type=flaky_type,
+                    results=results,
+                    timestamp=getattr(self, 'run_started_at', None) or int(time.time()),
+                    details=replace(self.results_db_details(), stage=stage),
+                ),
                 logger=lambda log: self._addToLog(self.results_db_log_name, log),
             )
         except Exception as error:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Generator, Iterable, Optional
+from typing import Any, Callable, Generator, Iterable, Optional
 from unittest import skip as skipTest
 from unittest.mock import call, create_autospec, patch
 
@@ -50,7 +50,7 @@ from Shared.steps import *
 
 from . import send_email
 from .layout_test_failures import LayoutTestFailures
-from .results_db import FlakyVerdict
+from .results_db import EWSPayload, EWSRowDetails, FlakyVerdict
 from .steps import *
 
 # Workaround for https://github.com/buildbot/buildbot/issues/4669
@@ -157,10 +157,12 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
         # rather than each step that makes it.
         self.results_db_reports = []
 
-        def record_report_ews(suite=None, results=None, flaky_type=None, commits=None, configuration=None, details=None, timestamp=None, logger=None):
+        def record_report_ews(payload: EWSPayload, logger: Optional[Callable[[str], None]] = None) -> defer.Deferred:
+            # details is recorded as the blob that would be uploaded, so assertions can subscript it.
             self.results_db_reports.append(dict(
-                suite=suite, results=results, flaky_type=flaky_type, commits=commits,
-                configuration=configuration, details=details, timestamp=timestamp,
+                suite=payload.suite, results=payload.results, flaky_type=payload.flaky_type,
+                commits=payload.commits, configuration=payload.configuration,
+                details=payload.details.to_json(), timestamp=payload.timestamp,
             ))
             return defer.succeed(True)
 
@@ -4209,7 +4211,7 @@ class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
     @defer.inlineCallbacks
     def test_an_unreachable_results_database_does_not_fail_the_step(self):
         # Reporting runs inside the steps whose verdict gates the pull request.
-        def explode(**kwargs):
+        def explode(*args: Any, **kwargs: Any) -> None:
             raise RuntimeError('results.webkit.org is unreachable')
 
         step = self.configureStep()
@@ -13102,7 +13104,7 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
 
 
 class TestResultsDatabaseFailureHandling(unittest.TestCase):
-    def _mock_twisted_request(self, response):
+    def _mock_twisted_request(self, response: Optional['TwistedAdditions.Response']) -> Any:
         return patch('ews-build.results_db.TwistedAdditions.request', lambda *args, **kwargs: defer.succeed(response))
 
     def _ok_response(self, payload):
@@ -13142,9 +13144,11 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
         logs = []
         with self._mock_twisted_request(response):
             reported = yield ResultsDatabase.report_ews(
-                suite='layout-tests', results=self.REPORTED_RESULTS, flaky_type=flaky_type,
-                configuration=self.COMPLETE_CONFIGURATION, commits=self.REPORTED_COMMITS,
-                timestamp=1600000000, details={'stage': 'first-run'},
+                EWSPayload(
+                    suite='layout-tests', results=self.REPORTED_RESULTS, flaky_type=flaky_type,
+                    configuration=self.COMPLETE_CONFIGURATION, commits=self.REPORTED_COMMITS,
+                    timestamp=1600000000, details=EWSRowDetails(stage='first-run'),
+                ),
                 logger=lambda log: logs.append(log),
             )
         return (reported, ''.join(logs))
@@ -13165,7 +13169,8 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
                 'status': 'ok', 'tests': ['fast/a.html', 'fast/b.html'],
             }))
         self.assertTrue(reported)
-        self.assertIn('"api_key": "<redacted>"', logs)
+        self.assertIn('Request:\n{', logs)
+        self.assertNotIn('api_key', logs)
         self.assertNotIn('super-secret', logs)
         self.assertIn('"suite": "layout-tests"', logs)
         self.assertIn('(200):', logs)


### PR DESCRIPTION
#### 78f48dc7101088e81d3c32ca7d9b88f6d12276b5
<pre>
[EWS] EWS ResultsDB reading and writing should be typed
<a href="https://bugs.webkit.org/show_bug.cgi?id=323144">https://bugs.webkit.org/show_bug.cgi?id=323144</a>
<a href="https://rdar.apple.com/186403771">rdar://186403771</a>

Reviewed by Aakash Jain.

The results database helpers grew from a handful of query functions into the
path that decides whether a pull request gets blamed for a test failure, and
they pass that data around as bare dicts. A row&apos;s provenance is reached through
`(row.get(&apos;details&apos;) or {}).get(&apos;authors&apos;)` at four call sites, each repeating
the same guard against a key the server may omit, and nothing states what a row
or an upload contains.

`EWSRowDetails`, `EWSRow` and `EWSPayload` name those three shapes. `EWSRow`
holds a parsed `details`, so the guards collapse into attribute access and the
one place that filters empty author names is `EWSRowDetails.from_json`.
`report_ews` takes an `EWSPayload` rather than seven keyword arguments, and
`_query_flaky` returns `EWSRowByTest`, parsing the response into rows once
instead of leaving every consumer to walk `entry[&apos;results&apos;]`.

`EWSPayload` deliberately has no `api_key` field. The payload is logged, and a
field would put the live key in every `__repr__` of it; `report_ews` injects the
key into the request body alone. The request dump no longer substitutes a
redacted key either, since the dict it prints never held one.

Results blobs, `configuration` and `commits` stay `dict` below the top level.
They are results database JSON whose keys vary by suite and by which
configuration dimensions a queue supplies, so naming fields would be a lie
rather than a gap. `_parse_results_ews_response` still returns raw dicts for the
same reason: it is deliberately the pre-validation shape, converted to `EWSRow`
immediately after.

`report_ews`, `_query_flaky` and `flaky_verdicts_for` are `inlineCallbacks`
generators, so they carry `Generator[Any, Any, T]` describing the body rather
than the `Deferred` the decorator hands the caller, matching what the tests in
`steps_unittest.py` already do.

`_is_intra_build_flake` no longer guards against an empty flaky type. The only
producer of those keys is `_rows_by_type`, which buckets every row under
`row.flaky_type or cls.FAILED_ROWS`, so a key is never empty.

* Tools/CISupport/ews-build/results_db.py:
(EWSRowDetails):
(EWSRowDetails.from_json):
(EWSRowDetails.to_json):
(EWSRow):
(EWSRow.from_json):
(EWSPayload):
(EWSPayload.to_json):
(ResultsDatabase.report_ews):
(ResultsDatabase._evidence_in):
(ResultsDatabase._rows_by_type):
(ResultsDatabase._rows_by_type.independent_of_this_pull_request):
(ResultsDatabase._rows_by_type.independent_of_this_changes_authors):
(ResultsDatabase._is_intra_build_flake):
(ResultsDatabase._is_inter_build_flake):
(ResultsDatabase._parse_results_ews_response):
(ResultsDatabase._query_flaky):
(ResultsDatabase.flaky_verdicts_for):
* Tools/CISupport/ews-build/steps.py:
(ResultsDBReportMixin.results_db_details):
(ResultsDBReportMixin.report_to_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:
(BuildStepMixinAdditions.setup_test_build_step.record_report_ews):
(TestReportToResultsDB.test_an_unreachable_results_database_does_not_fail_the_step.explode):
(TestResultsDatabaseFailureHandling._mock_twisted_request):
(TestResultsDatabaseFailureHandling.report_ews):
(TestResultsDatabaseFailureHandling.test_report_ews_logs_the_request_without_the_api_key):

Canonical link: <a href="https://commits.webkit.org/320412@main">https://commits.webkit.org/320412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4341ffc2bb07b93596abe81ecaf8a94174734c6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184701 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186563 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/195036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187656 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/6092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184104 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/196985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28066 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57494 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56855 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->