### PR TITLE
Web Inspector: Frame selector popup disappears when paused in the debugger

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -242,7 +242,9 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             handler(result !== InspectorBackend.Enum.Runtime.SyntaxErrorType.Recoverable);
         }
 
-        WI.runtimeManager.activeExecutionContext.target.RuntimeAgent.parse(text, parseFinished.bind(this));
+        let activeCallFrame = WI.runtimeManager.useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
+        let target = activeCallFrame?.target || WI.runtimeManager.activeExecutionContext.target;
+        target.RuntimeAgent.parse(text, parseFinished.bind(this));
     }
 
     consolePromptTextCommitted(prompt, text)

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -44,6 +44,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         this._ongoingCompletionRequests = 0;
 
         WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ActiveCallFrameDidChange, this.clearCachedPropertyNames, this);
+        WI.runtimeManager.addEventListener(WI.RuntimeManager.Event.ActiveExecutionContextChanged, this.clearCachedPropertyNames, this);
     }
 
     // Static
@@ -160,7 +161,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         this._lastBase = base;
         this._lastPropertyNames = null;
 
-        var activeCallFrame = WI.debuggerManager.activeCallFrame;
+        let activeCallFrame = WI.runtimeManager.useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
         if (!base && activeCallFrame && !this._alwaysEvaluateInWindowContext)
             activeCallFrame.collectScopeChainVariableNames(receivedPropertyNames.bind(this));
         else {

--- a/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
@@ -30,6 +30,7 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
         super();
 
         this._activeExecutionContext = null;
+        this._useActiveCallFrame = true;
 
         WI.settings.consoleSavedResultAlias.addEventListener(WI.Setting.Event.Changed, function(event) {
             for (let target of WI.targets) {
@@ -84,6 +85,21 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
         this.dispatchEventToListeners(WI.RuntimeManager.Event.ActiveExecutionContextChanged);
     }
 
+    get useActiveCallFrame()
+    {
+        return this._useActiveCallFrame;
+    }
+
+    set useActiveCallFrame(useActiveCallFrame)
+    {
+        if (this._useActiveCallFrame === useActiveCallFrame)
+            return;
+
+        this._useActiveCallFrame = useActiveCallFrame;
+
+        this.dispatchEventToListeners(WI.RuntimeManager.Event.ActiveExecutionContextChanged);
+    }
+
     evaluateInInspectedWindow(expression, options, callback)
     {
         if (!this._activeExecutionContext) {
@@ -117,13 +133,8 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
 
         expression = sourceURLAppender(expression);
 
-        let target = this._activeExecutionContext.target;
-        let executionContextId = this._activeExecutionContext.id;
-
-        if (WI.debuggerManager.activeCallFrame) {
-            target = WI.debuggerManager.activeCallFrame.target;
-            executionContextId = target.executionContext.id;
-        }
+        let activeCallFrame = this._useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
+        let target = activeCallFrame?.target || this._activeExecutionContext.target;
 
         function evalCallback(error, result, wasThrown, savedResultIndex)
         {
@@ -141,9 +152,9 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
                 callback(WI.RemoteObject.fromPayload(result, target), wasThrown, savedResultIndex);
         }
 
-        if (WI.debuggerManager.activeCallFrame) {
+        if (activeCallFrame) {
             target.DebuggerAgent.evaluateOnCallFrame.invoke({
-                callFrameId: WI.debuggerManager.activeCallFrame.id,
+                callFrameId: activeCallFrame.id,
                 expression,
                 objectGroup,
                 includeCommandLineAPI,
@@ -161,7 +172,7 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
             objectGroup,
             includeCommandLineAPI,
             doNotPauseOnExceptionsAndMuteConsole,
-            contextId: executionContextId,
+            contextId: this._activeExecutionContext.id,
             returnByValue,
             generatePreview,
             saveResult,
@@ -173,18 +184,19 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
     {
         console.assert(remoteObject instanceof WI.RemoteObject);
 
-        let target = this._activeExecutionContext.target;
-        let executionContextId = this._activeExecutionContext.id;
-
         function mycallback(error, savedResultIndex)
         {
             callback(savedResultIndex);
         }
 
-        if (remoteObject.objectId)
-            target.RuntimeAgent.saveResult(remoteObject.asCallArgument(), mycallback);
-        else
-            target.RuntimeAgent.saveResult(remoteObject.asCallArgument(), executionContextId, mycallback);
+        if (remoteObject.objectId) {
+            remoteObject.target.RuntimeAgent.saveResult(remoteObject.asCallArgument(), mycallback);
+            return;
+        }
+
+        let activeCallFrame = this._useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
+        let executionContext = activeCallFrame?.target.executionContext || this._activeExecutionContext;
+        executionContext.target.RuntimeAgent.saveResult(remoteObject.asCallArgument(), executionContext.id, mycallback);
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -248,7 +248,8 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
         // Some results don't populate until further backend dispatches occur (like the DOM tree).
         // We want to remove focusable children after those pending dispatches too.
-        let target = messageView.message ? messageView.message.target : WI.runtimeManager.activeExecutionContext.target;
+        let activeCallFrame = WI.runtimeManager.useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
+        let target = messageView.message?.target || activeCallFrame?.target || WI.runtimeManager.activeExecutionContext.target;
         target.connection.runAfterPendingDispatches(clearFocusableChildren);
 
         if (!this._scopeBar.item(WI.LogContentView.Scopes.All).selected) {

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -33,7 +33,7 @@ WI.QuickConsole = class QuickConsole extends WI.View
         this._toggleOrFocusKeyboardShortcut.implicitlyPreventsDefault = false;
         this._keyboardShortcutDisabled = false;
 
-        this._useExecutionContextOfInspectedNode = this._canUseExecutionContextOfInspectedNode();
+        this._automaticallyPickExecutionContext = true;
         this._restoreSelectedExecutionContextForFrame = null;
 
         this.element.classList.add("quick-console");
@@ -131,6 +131,8 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
     _displayNameForExecutionContext(context, maxLength = Infinity)
     {
+        console.assert(context instanceof WI.ExecutionContext, context);
+
         function truncate(string, length) {
             if (!Number.isFinite(maxLength))
                 return string;
@@ -168,19 +170,27 @@ WI.QuickConsole = class QuickConsole extends WI.View
         return truncate(context.name, maxLength);
     }
 
-    _resolveDesiredActiveExecutionContext(forceInspectedNode)
+    _displayNameForCallFrame(callFrame, maxLength = Infinity)
+    {
+        console.assert(callFrame instanceof WI.CallFrame, callFrame);
+
+        let displayName = WI.UIString("%s \u2014 %s").format(callFrame.target.displayName, callFrame.displayName);
+        if (!Number.isFinite(maxLength))
+            return displayName;
+        return displayName.trim().truncateMiddle(maxLength);
+    }
+
+    _resolveDesiredActiveExecutionContext()
     {
         let executionContext = null;
 
-        if (this._useExecutionContextOfInspectedNode || forceInspectedNode) {
-            let inspectedNode = WI.domManager.inspectedNode;
-            if (inspectedNode) {
-                let frame = inspectedNode.frame;
-                if (frame) {
-                    let pageExecutionContext = frame.pageExecutionContext;
-                    if (pageExecutionContext)
-                        executionContext = pageExecutionContext;
-                }
+        let inspectedNode = WI.domManager.inspectedNode;
+        if (inspectedNode) {
+            let frame = inspectedNode.frame;
+            if (frame) {
+                let pageExecutionContext = frame.pageExecutionContext;
+                if (pageExecutionContext)
+                    executionContext = pageExecutionContext;
             }
         }
 
@@ -192,9 +202,12 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
     _setActiveExecutionContext(context)
     {
-        let wasActive = WI.runtimeManager.activeExecutionContext === context;
+        let useActiveCallFrame = this._automaticallyPickExecutionContext;
+
+        let wasActive = WI.runtimeManager.activeExecutionContext === context && WI.runtimeManager.useActiveCallFrame === useActiveCallFrame;
 
         WI.runtimeManager.activeExecutionContext = context;
+        WI.runtimeManager.useActiveCallFrame = useActiveCallFrame;
 
         if (wasActive)
             this._updateActiveExecutionContextDisplay();
@@ -207,20 +220,18 @@ WI.QuickConsole = class QuickConsole extends WI.View
             this._activeExecutionContextNavigationItem.hidden = hidden;
         };
 
-        if (WI.debuggerManager.activeCallFrame) {
-            toggleHidden(true);
-            return;
-        }
-
         if (!WI.runtimeManager.activeExecutionContext || !WI.networkManager.mainFrame) {
             toggleHidden(true);
             return;
         }
 
+        let activeCallFrame = WI.runtimeManager.useActiveCallFrame ? WI.debuggerManager.activeCallFrame : null;
+        let activeContext = activeCallFrame || WI.runtimeManager.activeExecutionContext;
+
         // Check if we should show the picker: multiple frames, workers, or frame targets
         let frameTargets = this._frameTargetsWithExecutionContext();
 
-        if (WI.networkManager.frames.length === 1 && !WI.targetManager.workerTargets.length && !frameTargets.length) {
+        if (!WI.debuggerManager.activeCallFrame && WI.networkManager.frames.length === 1 && !WI.targetManager.workerTargets.length && !frameTargets.length) {
             let mainFrameContexts = WI.networkManager.mainFrame.executionContextList.contexts;
             let contextsToShow = mainFrameContexts.filter((context) => context.type !== WI.ExecutionContext.Type.Internal || WI.settings.engineeringShowInternalExecutionContexts.value);
             if (contextsToShow.length <= 1) {
@@ -230,15 +241,25 @@ WI.QuickConsole = class QuickConsole extends WI.View
         }
 
         const maxLength = 40;
+        let displayName = activeCallFrame ? this._displayNameForCallFrame(activeCallFrame, maxLength) : this._displayNameForExecutionContext(activeContext, maxLength);
 
-        if (this._useExecutionContextOfInspectedNode) {
+        if (this._automaticallyPickExecutionContext) {
             this._activeExecutionContextNavigationItem.element.classList.add("automatic");
-            this._activeExecutionContextNavigationItem.element.textContent = WI.UIString("Auto \u2014 %s").format(this._displayNameForExecutionContext(WI.runtimeManager.activeExecutionContext, maxLength));
-            this._activeExecutionContextNavigationItem.tooltip = WI.UIString("Execution context for %s").format(WI.RuntimeManager.preferredSavedResultPrefix() + "0");
+            this._activeExecutionContextNavigationItem.element.textContent = WI.UIString("Auto \u2014 %s").format(displayName);
+            if (!activeCallFrame)
+                this._activeExecutionContextNavigationItem.tooltip = WI.UIString("Execution context for %s").format(WI.RuntimeManager.preferredSavedResultPrefix() + "0");
         } else {
             this._activeExecutionContextNavigationItem.element.classList.remove("automatic");
-            this._activeExecutionContextNavigationItem.element.textContent = this._displayNameForExecutionContext(WI.runtimeManager.activeExecutionContext, maxLength);
-            this._activeExecutionContextNavigationItem.tooltip = this._displayNameForExecutionContext(WI.runtimeManager.activeExecutionContext);
+            this._activeExecutionContextNavigationItem.element.textContent = displayName;
+            if (!activeCallFrame)
+                this._activeExecutionContextNavigationItem.tooltip = this._displayNameForExecutionContext(activeContext);
+        }
+
+        if (activeCallFrame) {
+            let tooltip = this._displayNameForCallFrame(activeCallFrame);
+            if (activeCallFrame.sourceCodeLocation)
+                tooltip += "\n" + activeCallFrame.sourceCodeLocation.tooltipString();
+            this._activeExecutionContextNavigationItem.tooltip = tooltip;
         }
 
         this._activeExecutionContextNavigationItem.element.appendChild(WI.ImageUtilities.useSVGSymbol("Images/UpDownArrows.svg", "selector-arrows"));
@@ -251,16 +272,16 @@ WI.QuickConsole = class QuickConsole extends WI.View
         const maxLength = 120;
 
         let activeExecutionContext = WI.runtimeManager.activeExecutionContext;
+        let activeCallFrame = WI.debuggerManager.activeCallFrame;
 
-        if (this._canUseExecutionContextOfInspectedNode()) {
-            let executionContextForInspectedNode = this._resolveDesiredActiveExecutionContext(true);
-            contextMenu.appendCheckboxItem(WI.UIString("Auto \u2014 %s").format(this._displayNameForExecutionContext(executionContextForInspectedNode, maxLength)), () => {
-                this._useExecutionContextOfInspectedNode = true;
-                this._setActiveExecutionContext(executionContextForInspectedNode);
-            }, this._useExecutionContextOfInspectedNode);
+        let automaticContext = this._resolveDesiredActiveExecutionContext();
+        let automaticContextDisplayName = activeCallFrame ? this._displayNameForCallFrame(activeCallFrame, maxLength) : this._displayNameForExecutionContext(automaticContext, maxLength);
+        contextMenu.appendCheckboxItem(WI.UIString("Auto \u2014 %s").format(automaticContextDisplayName), () => {
+            this._automaticallyPickExecutionContext = true;
+            this._setActiveExecutionContext(automaticContext);
+        }, this._automaticallyPickExecutionContext);
 
-            contextMenu.appendSeparator();
-        }
+        contextMenu.appendSeparator();
 
         let addExecutionContext = (context, indent) => {
             if (context.type === WI.ExecutionContext.Type.Internal && !WI.settings.engineeringShowInternalExecutionContexts.value)
@@ -270,9 +291,9 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
             // Mimic macOS `-[NSMenuItem setIndentationLevel]`.
             contextMenu.appendCheckboxItem("   ".repeat(indent + additionalIndent) + this._displayNameForExecutionContext(context, maxLength), () => {
-                this._useExecutionContextOfInspectedNode = false;
+                this._automaticallyPickExecutionContext = false;
                 this._setActiveExecutionContext(context);
-            }, activeExecutionContext === context);
+            }, activeExecutionContext === context && (!activeCallFrame || !WI.runtimeManager.useActiveCallFrame));
         };
 
         let addExecutionContextsForFrame = (frame, indent) => {
@@ -401,7 +422,7 @@ WI.QuickConsole = class QuickConsole extends WI.View
         if (WI.runtimeManager.activeExecutionContext.type !== WI.ExecutionContext.Type.Internal)
             return;
 
-        this._useExecutionContextOfInspectedNode = this._canUseExecutionContextOfInspectedNode();
+        this._automaticallyPickExecutionContext = true;
         this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
     }
 
@@ -414,7 +435,7 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
         this._restoreSelectedExecutionContextForFrame = null;
 
-        this._useExecutionContextOfInspectedNode = false;
+        this._automaticallyPickExecutionContext = false;
         this._setActiveExecutionContext(frame.pageExecutionContext);
     }
 
@@ -434,8 +455,8 @@ WI.QuickConsole = class QuickConsole extends WI.View
         }
 
         // If this frame is navigating and it is selected in the UI we want to reselect its new item after navigation,
-        // however when `_useExecutionContextOfInspectedNode` is true, we should keep the execution context set to `Auto`.
-        if (committingProvisionalLoad && !this._restoreSelectedExecutionContextForFrame && !this._useExecutionContextOfInspectedNode) {
+        // however when `_automaticallyPickExecutionContext` is true, we should keep the execution context set to `Auto`.
+        if (committingProvisionalLoad && !this._restoreSelectedExecutionContextForFrame && !this._automaticallyPickExecutionContext) {
             this._restoreSelectedExecutionContextForFrame = event.target;
 
             // As a fail safe, if the frame never gets an execution context, clear the restore value.
@@ -444,13 +465,13 @@ WI.QuickConsole = class QuickConsole extends WI.View
                     return;
                 this._restoreSelectedExecutionContextForFrame = null;
 
-                this._useExecutionContextOfInspectedNode = this._canUseExecutionContextOfInspectedNode();
+                this._automaticallyPickExecutionContext = true;
                 this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
             }, 100);
             return;
         }
 
-        this._useExecutionContextOfInspectedNode = this._canUseExecutionContextOfInspectedNode();
+        this._automaticallyPickExecutionContext = true;
         this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
     }
 
@@ -477,18 +498,18 @@ WI.QuickConsole = class QuickConsole extends WI.View
     _handleTargetRemoved(event)
     {
         let {target} = event.data;
-        if (target !== WI.runtimeManager.activeExecutionContext) {
+        if (target !== WI.runtimeManager.activeExecutionContext?.target) {
             this._updateActiveExecutionContextDisplay();
             return;
         }
 
-        this._useExecutionContextOfInspectedNode = this._canUseExecutionContextOfInspectedNode();
+        this._automaticallyPickExecutionContext = true;
         this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
     }
 
     _handleInspectedNodeChanged(event)
     {
-        if (!this._useExecutionContextOfInspectedNode)
+        if (!this._automaticallyPickExecutionContext)
             return;
 
         this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
@@ -497,11 +518,6 @@ WI.QuickConsole = class QuickConsole extends WI.View
     _handleFrameTargetExecutionContextAdded(event)
     {
         this._updateActiveExecutionContextDisplay();
-    }
-
-    _canUseExecutionContextOfInspectedNode()
-    {
-        return InspectorBackend.hasDomain("DOM");
     }
 
     _frameTargetsWithExecutionContext()


### PR DESCRIPTION
#### 9da50641b6d0491c328c5c8b3a023c17a4b7016e
<pre>
Web Inspector: Frame selector popup disappears when paused in the debugger
<a href="https://bugs.webkit.org/show_bug.cgi?id=323101">https://bugs.webkit.org/show_bug.cgi?id=323101</a>

Reviewed by NOBODY (OOPS!).

Previously, the execution context picker was hidden when paused as the selected call frame was used instead.
This unnecessarily limits developers to only evaluating in execution contexts and/or call frames that are shown in the Sources Tab.
For example, a `Worker` may show &quot;Idle&quot; instead of any call frames, meaning there&apos;s no way for a developer to evaluate anything there.

Instead, expand the &quot;Auto&quot; execution context to also account for the selected call frame when paused.
This way, developers can evaluate in other execution contexts even without a corresponding call frame.

* Source/WebInspectorUI/UserInterface/Views/QuickConsole.js:
(WI.QuickConsole):
(WI.QuickConsole.prototype._displayNameForExecutionContext):
(WI.QuickConsole.prototype._displayNameForCallFrame): Added.
(WI.QuickConsole.prototype._resolveDesiredActiveExecutionContext):
(WI.QuickConsole.prototype._setActiveExecutionContext):
(WI.QuickConsole.prototype._updateActiveExecutionContextDisplay):
(WI.QuickConsole.prototype._populateActiveExecutionContextNavigationItemContextMenu):
(WI.QuickConsole.prototype._handleEngineeringShowInternalExecutionContextsSettingChanged):
(WI.QuickConsole.prototype._handleFramePageExecutionContextChanged):
(WI.QuickConsole.prototype._handleFrameExecutionContextsCleared):
(WI.QuickConsole.prototype._handleTargetRemoved):
(WI.QuickConsole.prototype._handleInspectedNodeChanged):
(WI.QuickConsole.prototype._canUseExecutionContextOfInspectedNode): Deleted.

* Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js:
(WI.RuntimeManager):
(WI.RuntimeManager.prototype.get useActiveCallFrame): Added.
(WI.RuntimeManager.prototype.set useActiveCallFrame): Added.
(WI.RuntimeManager.prototype.evaluateInInspectedWindow):
(WI.RuntimeManager.prototype.saveResult):
Expose a flag for whether the `activeCallFrame` (if any) is used instead of the `activeExecutionContext`.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController.prototype.consolePromptShouldCommitText):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype.didAppendConsoleMessageView):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded):
Use the selected call frame if the developer has selected the &quot;Auto&quot; execution context.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9da50641b6d0491c328c5c8b3a023c17a4b7016e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148696 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143962 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100047 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46462 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44646 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44253 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5808 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58003 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58707 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153208 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47736 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130997 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57212 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19268 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->