### PR TITLE
[EWS] API test results are not reported to the results database

### DIFF
--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from . import loadConfig
-from .steps import ResultsDatabase, ResultsDBReportMixin, RunJavaScriptCoreTests
+from .steps import ResultsDatabase, ResultsDBReportMixin, RunAPITests, RunJavaScriptCoreTests
 import os
 import unittest
 
@@ -1002,7 +1002,12 @@ class TestExpectedBuildSteps(unittest.TestCase):
                 if not issubclass(step_class, ResultsDBReportMixin) or not step_class.reports_to_results_db:
                     continue
 
-                expected_suite = 'javascriptcore-tests' if issubclass(step_class, RunJavaScriptCoreTests) else 'layout-tests'
+                if issubclass(step_class, RunJavaScriptCoreTests):
+                    expected_suite = 'javascriptcore-tests'
+                elif issubclass(step_class, RunAPITests):
+                    expected_suite = 'api-tests'
+                else:
+                    expected_suite = 'layout-tests'
                 self.assertIn(step_class.suite, ResultsDatabase.SUITES, msg='%s reports %s to the unknown suite %r' % (
                     builder['name'], step_class.__name__, step_class.suite,
                 ))

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -27,6 +27,7 @@ from buildbot.steps import master, shell, transfer, trigger
 from buildbot.steps.source import git
 from datetime import date
 from shlex import quote
+from typing import Any, Generator
 from unittest import mock
 
 from twisted.internet import defer, reactor, task
@@ -5726,15 +5727,16 @@ class ExtractBuiltProduct(shell.ShellCommand):
         super().__init__(logEnviron=False, **kwargs)
 
 
-class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
+class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     name = 'run-api-tests'
+    suite = 'api-tests'
     description = ['api tests running']
     descriptionDone = ['api-tests']
     jsonFileName = 'api_test_results.json'
     logfiles = {'json': jsonFileName}
     test_failures_log_name = 'test-failures'
     results_db_log_name = 'results-db'
-    suffix = 'first_run'
+    suffix = 'api_first_run'
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
     command = ['python3', 'Tools/Scripts/run-api-tests', '--timestamps', '--no-build',
                WithProperties('--%(configuration)s'), '--verbose', '--json-output={0}'.format(jsonFileName)]
@@ -5772,8 +5774,8 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
             self.command += additionalArguments
 
         if self.name == RunAPITestsWithoutChange.name:
-            first_results_failing_tests = set(self.getProperty('first_run_failures', set()))
-            second_results_failing_tests = set(self.getProperty('second_run_failures', set()))
+            first_results_failing_tests = set(self.getProperty('api_first_run_failures', set()))
+            second_results_failing_tests = set(self.getProperty('api_second_run_failures', set()))
             list_failed_tests_with_change = sorted(first_results_failing_tests.union(second_results_failing_tests))
             if list_failed_tests_with_change:
                 self.command = self.command + [quote(t) for t in list_failed_tests_with_change]
@@ -5805,7 +5807,7 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
         if rc in [SUCCESS, WARNINGS]:
             message = 'Passed API tests'
             if self.name == ReRunAPITests.name:
-                first_results_failing_tests = self.getProperty('first_run_failures', [])
+                first_results_failing_tests = self.getProperty('api_first_run_failures', [])
                 flaky_failures_string = ', '.join(first_results_failing_tests)
                 pluralSuffix = 's' if len(first_results_failing_tests) > 1 else ''
                 message = f'Found flaky test{pluralSuffix}: {flaky_failures_string}'
@@ -5868,7 +5870,10 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
     @defer.inlineCallbacks
     def parse_and_set_failures(self):
         yield self._addToLog('json', '\n')
-        failures = self.parse_api_failures_from_string(self.log_observer_json.getStdout().rstrip())
+        results = self.parse_api_test_json(self.log_observer_json.getStdout().rstrip())
+        failures = self.api_failures_from_json(results)
+        if results.get('results'):
+            self.setProperty(f'{self.suffix}_results', results['results'])
         self.setProperty(f'{self.suffix}_failures', sorted(failures))
         defer.returnValue(failures)
 
@@ -5888,8 +5893,17 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
         ]
 
     def parse_api_failures_from_string(self, string):
+        return self.api_failures_from_json(self.parse_api_test_json(string))
+
+    @staticmethod
+    def api_failures_from_json(result):
+        return ([failure.get('name') for failure in result.get('Timedout', [])] +
+                [failure.get('name') for failure in result.get('Crashed', [])] +
+                [failure.get('name') for failure in result.get('Failed', [])])
+
+    def parse_api_test_json(self, string):
         if not string:
-            return []
+            return {}
         try:
             # Workaround for https://github.com/buildbot/buildbot/issues/4906
             string = ''.join(string.splitlines())
@@ -5903,15 +5917,12 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
                 result = json.loads(string)
             except Exception as e:
                 print(f'ERROR: unable to parse data, exception: {e}')
-                return []
+                return {}
         except Exception as e:
             print(f'ERROR: unexcepted error while parsing data: {e}')
-            return []
+            return {}
 
-        failures = ([failure.get('name') for failure in result.get('Timedout', [])] +
-                    [failure.get('name') for failure in result.get('Crashed', [])] +
-                    [failure.get('name') for failure in result.get('Failed', [])])
-        return failures
+        return result
 
     @defer.inlineCallbacks
     def filter_api_test_failures_using_results_db(self, failing_tests):
@@ -5946,7 +5957,20 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
 
 class ReRunAPITests(RunAPITests):
     name = 're-run-api-tests'
-    suffix = 'second_run'
+    suffix = 'api_second_run'
+
+    @defer.inlineCallbacks
+    def parse_and_set_failures(self):
+        failures = yield super().parse_and_set_failures()
+
+        # A test failing one of the two runs and passing the other flaked across the steps.
+        if (first_run_failures := self.getProperty('api_first_run_failures', None)) is not None:
+            results = self.merged_results(set(first_run_failures) ^ set(failures), {
+                'first-run': 'api_first_run_results',
+                'second-run': 'api_second_run_results',
+            })
+            yield self.report_to_results_db(results, flaky_type='BetweenStepsDirtyTree')
+        defer.returnValue(failures)
 
     def doOnFailure(self):
         self.steps_to_add += [RevertAppliedChanges(), CleanWorkingDirectory(), ValidateChange(verifyBugClosed=False, addURLs=False)]
@@ -5969,7 +5993,7 @@ class ReRunAPITests(RunAPITests):
 
 class RunAPITestsWithoutChange(RunAPITests):
     name = 'run-api-tests-without-change'
-    suffix = 'clean_tree_run'
+    suffix = 'api_clean_tree_run'
 
     def doOnFailure(self):
         pass
@@ -5978,16 +6002,23 @@ class RunAPITestsWithoutChange(RunAPITests):
         pass
 
 
-class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
+class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLogMixin):
     name = 'analyze-api-tests-results'
+    suite = 'api-tests'
     description = ['analyze-api-test-results']
     descriptionDone = ['analyze-api-tests-results']
     NUM_FAILURES_TO_DISPLAY = 10
+    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
+    INCLUDED_FLAKY_VERDICTS = frozenset({
+        ResultsDatabase.CLEAN_TREE_VERDICT,
+        ResultsDatabase.DIRTY_TREE_VERDICT,
+        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
+    })
 
     @defer.inlineCallbacks
     def run(self):
-        first_run_failures = set(self.getProperty('first_run_failures', []))
-        second_run_failures = set(self.getProperty('second_run_failures', []))
+        first_run_failures = set(self.getProperty('api_first_run_failures', []))
+        second_run_failures = set(self.getProperty('api_second_run_failures', []))
 
         # This step runs only after both runs failed, so a missing or empty failure list means a run
         # failed without producing parseable results: an infrastructure issue that should retry.
@@ -5999,14 +6030,14 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
 
         # Prefer the results-db-filtered lists (pre-existing failures already removed) so a known
         # pre-existing flaky failure is not reported as new even if it passed on the clean tree.
-        first_run_failures_filtered = self.getProperty('first_run_failures_filtered', None)
+        first_run_failures_filtered = self.getProperty('api_first_run_failures_filtered', None)
         if first_run_failures_filtered is not None:
             first_run_failures = set(first_run_failures_filtered)
-        second_run_failures_filtered = self.getProperty('second_run_failures_filtered', None)
+        second_run_failures_filtered = self.getProperty('api_second_run_failures_filtered', None)
         if second_run_failures_filtered is not None:
             second_run_failures = set(second_run_failures_filtered)
 
-        clean_tree_failures = set(self.getProperty('clean_tree_run_failures', []))
+        clean_tree_failures = set(self.getProperty('api_clean_tree_run_failures', []))
         clean_tree_failures_to_display = list(clean_tree_failures)[:self.NUM_FAILURES_TO_DISPLAY]
         clean_tree_failures_string = ', '.join(clean_tree_failures_to_display)
 
@@ -6015,6 +6046,15 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
         flaky_failures = list(flaky_failures)[:self.NUM_FAILURES_TO_DISPLAY]
         flaky_failures_string = ', '.join(flaky_failures)
         new_failures = failures_with_patch - clean_tree_failures
+        ignored_flaky_failures = set()
+        if new_failures:
+            ignored_flaky_failures = yield self.flaky_new_failures_using_results_db(new_failures)
+            results = self.merged_results(new_failures, {
+                'first-run': 'api_first_run_results',
+                'second-run': 'api_second_run_results',
+            })
+            yield self.report_to_results_db(results)
+            new_failures = new_failures - ignored_flaky_failures
         new_failures_to_display = list(new_failures)[:self.NUM_FAILURES_TO_DISPLAY]
         new_failures_string = ', '.join(new_failures_to_display)
 
@@ -6025,6 +6065,7 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
 
         if new_failures:
             yield self._addToLog('stderr', '\nNew failures: {}\n'.format(new_failures_string))
+            self.setProperty('new_api_failures_introduced_by_patch', sorted(new_failures))
             self.build.results = FAILURE
             pluralSuffix = 's' if len(new_failures) > 1 else ''
             message = 'Found {} new API test failure{}: {}'.format(len(new_failures), pluralSuffix, new_failures_string)
@@ -6049,8 +6090,56 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
                 message += ' Found flaky tests: {}'.format(flaky_failures_string)
                 for flaky_failure in flaky_failures:
                     self.send_email_for_flaky_failure(flaky_failure)
+            if ignored_flaky_failures:
+                message += f" Ignored flaky tests: {', '.join(sorted(ignored_flaky_failures))} based on results-db"
+                self.setProperty('build_summary', message.strip())
             self.build.buildFinished([message], SUCCESS)
             defer.returnValue(SUCCESS)
+
+    @defer.inlineCallbacks
+    def flaky_new_failures_using_results_db(self, new_failures: set[str]) -> Generator[Any, Any, set[str]]:
+        """
+        Verdicts for the failures the clean-tree run did not explain, returning the ones with a
+        verdict in INCLUDED_FLAKY_VERDICTS.
+        """
+        tests = sorted(new_failures)[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
+        configuration = self.results_db_query_configuration()
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for flakiness of {len(tests)} new failure(s). Configuration: {configuration}\n')
+
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(tests, configuration=configuration, suite=self.suite)
+        if flake_logs:
+            yield self._addToLog(self.results_db_log_name, flake_logs)
+
+        flaky, unsupported, unknown, ignored, shadowed = {}, [], [], [], []
+        for test in tests:
+            flake = flakes.get(test, FlakyVerdict(request_failed=True))
+            flake_summary = 'False'
+            if flake.is_flaky:
+                flaky[test] = flake.flaky_type
+                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
+                    unsupported.append(test)
+                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
+                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS and test not in unsupported:
+                    ignored.append(test)
+                else:
+                    shadowed.append(test)
+            elif flake.request_failed:
+                unknown.append(test)
+                flake_summary = 'Unknown'
+
+            yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
+
+        self.setProperty('results-db_api_flaky', flaky)
+        self.setProperty('results-db_api_flaky_unsupported', sorted(unsupported))
+        self.setProperty('results-db_api_flaky_unknown', sorted(unknown))
+
+        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
+            if acted_on:
+                yield self._addToLog(
+                    self.results_db_log_name,
+                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
+                )
+        defer.returnValue(set(ignored))
 
     def send_email_for_flaky_failure(self, test_name):
         try:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 from unittest import skip as skipTest
 from unittest.mock import call, create_autospec, patch
 
@@ -153,8 +153,8 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
         self._expected_local_commands = []
         self.setup_test_reactor()
 
-        # Test steps report to the results database as they run, so stub the one network call they
-        # make rather than each step that makes it.
+        # Test steps report to the results database as they run, so stub the network calls they make
+        # rather than each step that makes it.
         self.results_db_reports = []
 
         def record_report_ews(suite=None, results=None, flaky_type=None, commits=None, configuration=None, details=None, timestamp=None, logger=None):
@@ -165,6 +165,8 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
             return defer.succeed(True)
 
         self.patch(ResultsDatabase, 'report_ews', record_report_ews)
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({test: FlakyVerdict() for test in tests}, ''))))
 
         self._temp_directory = tempfile.mkdtemp()
         os.chdir(self._temp_directory)
@@ -3852,6 +3854,219 @@ class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
         )
 
 
+class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.TestCase):
+    """The read lives in AnalyzeAPITestsResults: excusing a failure in the first run's step would
+    empty its filtered failures, so the clean-tree run that produces the evidence for the verdict
+    would never be queued."""
+
+    def setUp(self) -> defer.Deferred:
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self) -> defer.Deferred:
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, first_run: list, second_run: list, clean_tree: list) -> AnalyzeAPITestsResults:
+        self.setup_step(AnalyzeAPITestsResults())
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'release')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+        self.setProperty('api_first_run_failures', first_run)
+        self.setProperty('api_second_run_failures', second_run)
+        self.setProperty('api_clean_tree_run_failures', clean_tree)
+        self.setProperty('api_first_run_results', {test: {'actual': 'FAIL'} for test in first_run})
+        self.setProperty('api_second_run_results', {test: {'actual': 'FAIL'} for test in second_run})
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        return step
+
+    @staticmethod
+    def fake_verdicts(verdicts: dict, queried: Optional[list] = None) -> classmethod:
+        def flaky_verdicts_for(cls, tests: list, configuration: Optional[dict] = None, suite: Optional[str] = None) -> defer.Deferred:
+            if queried is not None:
+                queried.append((sorted(tests), configuration, suite))
+            return defer.succeed(({test: verdicts.get(test, FlakyVerdict()) for test in tests}, ''))
+        return classmethod(flaky_verdicts_for)
+
+    @defer.inlineCallbacks
+    def test_a_verdict_outside_the_included_set_changes_nothing(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'], [])
+        step.INCLUDED_FLAKY_VERDICTS = frozenset({'DirtyTree'})
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='BetweenBuilds', build_urls={'https://build.webkit.org/#/builders/1/builds/11'})}))
+
+        result = yield step.run()
+
+        self.assertEqual(result, FAILURE)
+        self.assertEqual(self.build.text, ['Found 1 new API test failure: suite.flaky'])
+        self.assertEqual(self.getProperty('new_api_failures_introduced_by_patch'), ['suite.flaky'])
+        self.assertEqual(self.getProperty('results-db_api_flaky'), {'suite.flaky': 'BetweenBuilds'})
+        self.assertEqual([sorted(report['results']) for report in self.results_db_reports], [['suite.flaky']])
+
+    @defer.inlineCallbacks
+    def test_an_included_verdict_removes_the_failure(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'], [])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+
+        result = yield step.run()
+
+        self.assertEqual(result, SUCCESS)
+        self.assertIsNone(self.getProperty('new_api_failures_introduced_by_patch'))
+        self.assertEqual([sorted(report['results']) for report in self.results_db_reports], [['suite.flaky']])
+
+    @defer.inlineCallbacks
+    def test_an_excused_build_names_the_ignored_test_in_the_summary(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'], [])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+
+        result = yield step.run()
+
+        self.assertEqual(result, SUCCESS)
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertIn('Ignored flaky tests: suite.flaky based on results-db', self.build.text[0])
+
+    @defer.inlineCallbacks
+    def test_a_clean_tree_only_build_sets_no_build_summary(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.pre_existing'], ['suite.pre_existing'], ['suite.pre_existing'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts({}))
+
+        result = yield step.run()
+
+        self.assertEqual(result, SUCCESS)
+        self.assertIsNone(self.getProperty('build_summary'))
+
+    @defer.inlineCallbacks
+    def test_only_the_failures_the_clean_tree_did_not_explain_are_queried(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(
+            ['suite.new', 'suite.pre_existing'], ['suite.new', 'suite.pre_existing'], ['suite.pre_existing'],
+        )
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts({}, queried))
+
+        yield step.run()
+
+        self.assertEqual(queried, [(['suite.new'], {'platform': 'mac', 'style': 'release'}, 'api-tests')])
+
+    @defer.inlineCallbacks
+    def test_a_test_flaky_only_between_builds_without_intra_build_evidence_is_unsupported(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.a', 'suite.b'], ['suite.a', 'suite.b'], [])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts({
+            'suite.a': FlakyVerdict(flaky_type='BetweenBuilds'),
+            'suite.b': FlakyVerdict(flaky_type='BetweenBuilds', intra_build_evidence=True),
+        }))
+
+        result = yield step.run()
+
+        self.assertEqual(self.getProperty('results-db_api_flaky_unsupported'), ['suite.a'])
+        self.assertEqual(result, FAILURE)
+        self.assertEqual(self.getProperty('new_api_failures_introduced_by_patch'), ['suite.a'])
+
+    @defer.inlineCallbacks
+    def test_a_failed_request_is_recorded_as_unknown(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.new'], ['suite.new'], [])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({test: FlakyVerdict(request_failed=True) for test in tests}, ''))))
+
+        result = yield step.run()
+
+        self.assertEqual(result, FAILURE)
+        self.assertEqual(self.getProperty('results-db_api_flaky_unknown'), ['suite.new'])
+        self.assertEqual(self.getProperty('results-db_api_flaky'), {})
+
+    @defer.inlineCallbacks
+    def test_caps_the_number_of_results_db_queries(self) -> Generator[Any, Any, None]:
+        queried = []
+        cap = AnalyzeAPITestsResults.MAX_FAILURES_TO_CHECK_RESULTS_DB
+        failures = [f'suite.test{index}' for index in range(cap + 10)]
+        step = self.configureStep(failures, failures, [])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', self.fake_verdicts({}, queried))
+
+        yield step.run()
+
+        self.assertEqual([len(tests) for tests, _, _ in queried], [cap])
+
+
+class TestAPITestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):
+    """Every exit of AnalyzeAPITestsResults ends the build, so a step queued after it never runs."""
+
+    SECOND_RUN_JSON = '{"Failed":[{"name":"suite.b"},{"name":"suite.both"}],"Timedout":[],"Crashed":[],"results":{"suite.b":{"actual":"FAIL"},"suite.both":{"actual":"FAIL"}}}'
+
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, StepClass):
+        self.setup_step(StepClass())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('configuration', 'release')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        return step
+
+    def reported(self):
+        return [
+            (report['flaky_type'], sorted(report['results']), report['suite'])
+            for report in self.results_db_reports
+        ]
+
+    @defer.inlineCallbacks
+    def test_api_properties_do_not_collide_with_the_layout_ones(self):
+        # Both suites run in one build for API-Tests-* queues, and the names were byte for byte
+        # identical, so an unprefixed API run would overwrite the layout run's failures.
+        step = self.configureStep(RunAPITests)
+        step.log_observer_json = TestLayoutTestStepsReportAsTheyRun.FakeLogObserver(self.SECOND_RUN_JSON)
+
+        yield step.parse_and_set_failures()
+
+        self.assertEqual(self.getProperty('api_first_run_failures'), ['suite.b', 'suite.both'])
+        self.assertIsNone(self.getProperty('first_run_failures'))
+        self.assertIsNone(self.getProperty('first_run_results'))
+
+    @defer.inlineCallbacks
+    def test_the_rerun_reports_what_differed_from_the_first_run(self):
+        step = self.configureStep(ReRunAPITests)
+        step.log_observer_json = TestLayoutTestStepsReportAsTheyRun.FakeLogObserver(self.SECOND_RUN_JSON)
+        self.setProperty('api_first_run_failures', ['suite.a', 'suite.both'])
+        self.setProperty('api_first_run_results', {'suite.a': dict(actual='FAIL'), 'suite.both': dict(actual='FAIL')})
+
+        yield step.parse_and_set_failures()
+
+        # suite.both failed both runs, so it is a consistent failure rather than flakiness.
+        self.assertEqual(self.reported(), [('BetweenStepsDirtyTree', ['suite.a', 'suite.b'], 'api-tests')])
+
+    @defer.inlineCallbacks
+    def test_the_analyze_step_reports_the_failures_it_attributes_to_the_change(self):
+        step = self.configureStep(AnalyzeAPITestsResults)
+        self.setProperty('api_first_run_failures', ['suite.new'])
+        self.setProperty('api_second_run_failures', ['suite.new'])
+        self.setProperty('api_clean_tree_run_failures', [])
+        self.setProperty('api_first_run_results', {'suite.new': dict(actual='FAIL')})
+        self.setProperty('api_second_run_results', {'suite.new': dict(actual='TIMEOUT')})
+
+        yield step.run()
+
+        # No flaky_type: a failure attributed to the change is not flakiness.
+        self.assertEqual(self.reported(), [(None, ['suite.new'], 'api-tests')])
+        self.assertEqual(
+            self.results_db_reports[0]['results']['suite.new']['actual_by_run'],
+            {'first-run': 'FAIL', 'second-run': 'TIMEOUT'},
+        )
+
+
 class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):
     """Each report has to leave the step that derived it: the analyze steps end the build outright,
     so anything queued behind them never runs."""
@@ -6571,8 +6786,8 @@ class TestRunAPITestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('buildername', 'API-Tests-macOS-EWS')
         self.setProperty('buildnumber', '11525')
         self.setProperty('workername', 'ews155')
-        self.setProperty('first_run_failures', ['suite.test1', 'suite.test2', 'suite.test3'])
-        self.setProperty('second_run_failures', ['suite.test3', 'suite.test4', 'suite.test5'])
+        self.setProperty('api_first_run_failures', ['suite.test1', 'suite.test2', 'suite.test3'])
+        self.setProperty('api_second_run_failures', ['suite.test3', 'suite.test4', 'suite.test5'])
 
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
@@ -6605,8 +6820,8 @@ All tests successfully passed!
         self.setProperty('buildername', 'API-Tests-macOS-EWS')
         self.setProperty('buildnumber', '11525')
         self.setProperty('workername', 'ews155')
-        self.setProperty('first_run_failures', ['suite.test1(foo:)', 'suite.test2'])
-        self.setProperty('second_run_failures', ['suite.test1(foo:)', 'suite.test3'])
+        self.setProperty('api_first_run_failures', ['suite.test1(foo:)', 'suite.test2'])
+        self.setProperty('api_second_run_failures', ['suite.test1(foo:)', 'suite.test3'])
 
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
@@ -6639,8 +6854,8 @@ All tests successfully passed!
         self.setProperty('buildername', 'API-Tests-iOS-EWS')
         self.setProperty('buildnumber', '123')
         self.setProperty('workername', 'ews156')
-        self.setProperty('first_run_failures', ['suite.test-one-failure1'])
-        self.setProperty('second_run_failures', ['suite.test-one-failure2'])
+        self.setProperty('api_first_run_failures', ['suite.test-one-failure1'])
+        self.setProperty('api_second_run_failures', ['suite.test-one-failure2'])
 
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
@@ -6774,28 +6989,28 @@ class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self):
         self.setup_step(AnalyzeAPITestsResults())
-        self.setProperty('clean_tree_run_failures', [])
+        self.setProperty('api_clean_tree_run_failures', [])
 
     def test_new_failure_introduced_by_change(self):
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.test1'])
-        self.setProperty('second_run_failures', ['suite.test1'])
+        self.setProperty('api_first_run_failures', ['suite.test1'])
+        self.setProperty('api_second_run_failures', ['suite.test1'])
         self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.test1 (failure)')
         return self.run_step()
 
     def test_pre_existing_failure_on_clean_tree(self):
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.test1'])
-        self.setProperty('second_run_failures', ['suite.test1'])
-        self.setProperty('clean_tree_run_failures', ['suite.test1'])
+        self.setProperty('api_first_run_failures', ['suite.test1'])
+        self.setProperty('api_second_run_failures', ['suite.test1'])
+        self.setProperty('api_clean_tree_run_failures', ['suite.test1'])
         self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
         return self.run_step()
 
     def test_flaky_failure(self):
         # test1 and test2 fail in different runs (never both), so they are flaky, not new failures.
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.test1'])
-        self.setProperty('second_run_failures', ['suite.test2'])
+        self.setProperty('api_first_run_failures', ['suite.test1'])
+        self.setProperty('api_second_run_failures', ['suite.test2'])
         self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
         return self.run_step()
 
@@ -6803,8 +7018,8 @@ class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
         # This step runs only after both runs failed, so empty failure lists mean the results could
         # not be parsed (an infrastructure issue), which should retry.
         self.configureStep()
-        self.setProperty('first_run_failures', [])
-        self.setProperty('second_run_failures', [])
+        self.setProperty('api_first_run_failures', [])
+        self.setProperty('api_second_run_failures', [])
         self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
         return self.run_step()
 
@@ -6817,7 +7032,7 @@ class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_retry_when_second_run_results_missing(self):
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.test1'])
+        self.setProperty('api_first_run_failures', ['suite.test1'])
         self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
         return self.run_step()
 
@@ -6825,41 +7040,41 @@ class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
         # A pre-existing flaky failure fails in both runs but passes on the clean tree. It is stripped
         # from the *_filtered lists by results-db, so it must not be reported as a new failure.
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
-        self.setProperty('second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
-        self.setProperty('first_run_failures_filtered', ['suite.real_failure'])
-        self.setProperty('second_run_failures_filtered', ['suite.real_failure'])
-        self.setProperty('clean_tree_run_failures', ['suite.real_failure'])
+        self.setProperty('api_first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('api_second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('api_first_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('api_second_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('api_clean_tree_run_failures', ['suite.real_failure'])
         self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
         return self.run_step()
 
     def test_new_failure_still_reported_with_filtered_lists(self):
         # A genuinely new failure remains in the *_filtered lists, so it must still be reported.
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
-        self.setProperty('second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
-        self.setProperty('first_run_failures_filtered', ['suite.real_failure'])
-        self.setProperty('second_run_failures_filtered', ['suite.real_failure'])
-        self.setProperty('clean_tree_run_failures', [])
+        self.setProperty('api_first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('api_second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('api_first_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('api_second_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('api_clean_tree_run_failures', [])
         self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.real_failure (failure)')
         return self.run_step()
 
     def test_all_failures_pre_existing_filtered_lists_empty(self):
         # If every failure was pre-existing, both *_filtered lists are empty and the build passes.
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.MultipleAccounts'])
-        self.setProperty('second_run_failures', ['suite.MultipleAccounts'])
-        self.setProperty('first_run_failures_filtered', [])
-        self.setProperty('second_run_failures_filtered', [])
-        self.setProperty('clean_tree_run_failures', [])
+        self.setProperty('api_first_run_failures', ['suite.MultipleAccounts'])
+        self.setProperty('api_second_run_failures', ['suite.MultipleAccounts'])
+        self.setProperty('api_first_run_failures_filtered', [])
+        self.setProperty('api_second_run_failures_filtered', [])
+        self.setProperty('api_clean_tree_run_failures', [])
         self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
         return self.run_step()
 
     def test_falls_back_to_unfiltered_when_filtered_absent(self):
         # When the *_filtered properties are absent, behavior degrades to the unfiltered lists.
         self.configureStep()
-        self.setProperty('first_run_failures', ['suite.test1'])
-        self.setProperty('second_run_failures', ['suite.test1'])
+        self.setProperty('api_first_run_failures', ['suite.test1'])
+        self.setProperty('api_second_run_failures', ['suite.test1'])
         self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.test1 (failure)')
         return self.run_step()
 

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -493,6 +493,25 @@ class Manager(object):
                 result_dictionary['UnexpectedPasses'].append({'name': test})
             self._stream.writeln('')
 
+        status_to_test_result = {
+            runner.STATUS_PASSED: None,
+            runner.STATUS_FAILED: Upload.Expectations.FAIL,
+            runner.STATUS_CRASHED: Upload.Expectations.CRASH,
+            runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
+        }
+        upload_results = {}
+        for test, test_result in iteritems(runner.results):
+            if test_result[0] not in status_to_test_result:
+                continue
+            upload_results[test] = Upload.create_test_result(
+                expected=self._expected_results_for_upload(self._expectations.get_expectation(test, current_config)),
+                actual=status_to_test_result[test_result[0]],
+                time=int(test_result[2] * 1000),
+            )
+
+        # A passing test has no 'actual' and passing tests are not worth the size when reporting.
+        result_dictionary['results'] = {test: test_result for test, test_result in upload_results.items() if test_result.get('actual')}
+
         if json_output:
             self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
 
@@ -500,21 +519,6 @@ class Manager(object):
             self._stream.writeln('\n')
             self._stream.write_update('Preparing upload data ...')
 
-            status_to_test_result = {
-                runner.STATUS_PASSED: None,
-                runner.STATUS_FAILED: Upload.Expectations.FAIL,
-                runner.STATUS_CRASHED: Upload.Expectations.CRASH,
-                runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
-            }
-            upload_results = {}
-            for test, test_result in iteritems(runner.results):
-                if test_result[0] not in status_to_test_result:
-                    continue
-                upload_results[test] = Upload.create_test_result(
-                    expected=self._expected_results_for_upload(self._expectations.get_expectation(test, current_config)),
-                    actual=status_to_test_result[test_result[0]],
-                    time=int(test_result[2] * 1000),
-                )
             upload = Upload(
                 suite=self._options.suite or 'api-tests',
                 configuration=configuration_for_upload,


### PR DESCRIPTION
#### 66615c600f5c30183209d9383444224e91d5d347
<pre>
[EWS] API test results are not reported to the results database
<a href="https://bugs.webkit.org/show_bug.cgi?id=323180">https://bugs.webkit.org/show_bug.cgi?id=323180</a>
<a href="https://rdar.apple.com/186426179">rdar://186426179</a>

Reviewed by Aakash Jain.

Extend results database reporting to API tests, and use the flakiness verdicts that reporting
makes possible so a pull request is not blamed for a flaky API test failure.

Every exit of AnalyzeAPITestsResults ends the build, so reporting happens inside the steps that
derive each report rather than in a step queued after them, which would never run. The API run
properties are prefixed to namespace them from the identically named layout ones.

AnalyzeAPITestsResults blames the change for a test that failed both runs with the change and
passed on the clean tree. RunAPITests already drops failures the results database records as
pre-existing, but a test recorded as flaky rather than failing survives that filter and fails that
way routinely, so the pull request is blamed for a failure it did not cause and the author is left
to rerun the queue until the flake goes the other way.

The analyzer now asks the database for a flakiness verdict on each of those tests and drops the
ones it recognizes, which turns the build green and names them in the build summary when they are
the only new failures. A CleanTree verdict can never come back for an API test: no API step reports
WithinStepCleanTree, so the database holds no clean-tree row one could match against. A query that
fails leaves the failure attributed to the change and records the test in
results-db_api_flaky_unknown. A verdict outside INCLUDED_FLAKY_VERDICTS is logged as
would-have-ignored rather than excused; nothing narrows the set today, so the path exists for a
queue that later does.

A BetweenBuilds verdict with no intra-build evidence is recorded in
results-db_api_flaky_unsupported and not acted on. A test that fails on some builds and passes on
others, never twice within one build, is as consistent with a configuration-dependent failure as
with a flake, and the queue would excuse it on every build.

The report to the database covers the failures the clean-tree run did not explain, before the
excused ones are removed from that set. Reporting the narrowed set instead would starve the verdict
that earned the excuse: the rows behind it would stop being written the moment it started working,
and it would age out of the flakiness window.

The read belongs in the analyzer rather than beside the pre-existing-failure filter in RunAPITests.
run-api-tests has no per-test retry, so the only flakiness an API build observes for itself is the
symmetric difference between the two runs with the change, which ReRunAPITests reports as
BetweenStepsDirtyTree. Excusing a failure during the first run would pass the step before the rerun
that produces that evidence ever happens.

* Tools/CISupport/ews-build/factories_unittest.py:
* Tools/CISupport/ews-build/steps.py:
(RunAPITests): Prefix the run properties, and split the json parse so the per-test results survive
rather than only the failure names.
(RunAPITests.parse_and_set_failures):
(RunAPITests.parse_api_failures_from_string):
(RunAPITests.api_failures_from_json):
(RunAPITests.parse_api_test_json):
(ReRunAPITests.parse_and_set_failures): Report the tests that failed one of the two runs and passed
the other.
(AnalyzeAPITestsResults):
(AnalyzeAPITestsResults.run): Report the failures attributed to the change before the build is
finished, and drop the ones the results database recognizes as flaky.
(AnalyzeAPITestsResults.flaky_new_failures_using_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run): Expose the per-test results already collected for the results database upload,
limited to the tests that did not pass so a build log is not swamped.

Canonical link: <a href="https://commits.webkit.org/320321@main">https://commits.webkit.org/320321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c96e18b4ed5c556f11db7762441fa373c1be701

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58386 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cb7e0c4-211a-49fb-928c-0d4c7adf10aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186328 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/194795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c5c92a0-8719-497a-a491-fe4a2512dedd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dad50ca6-5b34-4c89-aa3d-792022e2a6f0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183794 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/194795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/5867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/183869 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58056 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/196738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58760 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28009 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47779 "Build is being retried. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127493 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56630 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56874 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56699 "Failed to checkout and rebase branch from PR 73019") | | | | 
<!--EWS-Status-Bubble-End-->