### PR TITLE
[MathML Core] Non-MathML children of <annotation> and <annotation-xml> are not rendered

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2466,7 +2466,6 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/table-width-3.html 
 webkit.org/b/322327 imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-navigation.html [ Skip ]
 webkit.org/b/322327 imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-rel-policy.html [ Skip ]
 webkit.org/b/322327 imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-target-base.html [ Skip ]
-imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative.html [ ImageOnlyFailure ]
 
 # This MathML test should be rewritten.
 webkit.org/b/201356 mathml/presentation/stretchy-depth-height-symmetric.html [ Skip ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
@@ -1,3 +1,4 @@
+&lt;/xmp&gt;&lt;img>
 
 
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
@@ -1,4 +1,5 @@
 
+
 PASS HTML parsing doesn't apply in <annotation-xml> without encoding attribute
 PASS HTML parsing does apply in <annotation-xml encoding="application/xhtml+xml">
 

--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -70,7 +70,7 @@ RenderPtr<RenderElement> MathMLAnnotationElement::createElementRenderer(Style::C
 bool MathMLAnnotationElement::childShouldCreateRenderer(const Node& child) const
 {
     if (document().settings().coreMathMLEnabled())
-        return MathMLElement::childShouldCreateRenderer(child);
+        return StyledElement::childShouldCreateRenderer(child);
 
     // For <annotation>, only text children are allowed.
     if (hasTagName(MathMLNames::annotationTag))


### PR DESCRIPTION
#### 81ff30d194362ef7ec042d47ee0b9e6d73432f36
<pre>
[MathML Core] Non-MathML children of &lt;annotation&gt; and &lt;annotation-xml&gt; are not rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=323185">https://bugs.webkit.org/show_bug.cgi?id=323185</a>
<a href="https://rdar.apple.com/186429768">rdar://186429768</a>

Reviewed by Frédéric Wang Nélar.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per MathML Core [1], &quot;the layout algorithm of the &lt;annotation-xml&gt; and
&lt;annotation&gt; element is the same as the mtext element&quot;, and annotation-xml may
contain arbitrary non-MathML markup (SVG, HTML, content MathML).

In Core mode MathMLAnnotationElement::childShouldCreateRenderer() delegated to
MathMLElement::childShouldCreateRenderer(), which only permits MathML children
(is&lt;MathMLElement&gt;(child)), so annotation text and non-MathML content got no
renderer and rendered blank. Route them through
StyledElement::childShouldCreateRenderer() instead, matching the non-core
annotation-xml branch.

[1] <a href="https://w3c.github.io/mathml-core/#semantics-and-presentation">https://w3c.github.io/mathml-core/#semantics-and-presentation</a>

* LayoutTests/TestExpectations: Unskip passing test
* Source/WebCore/mathml/MathMLAnnotationElement.cpp:
(WebCore::MathMLAnnotationElement::childShouldCreateRenderer const):

&gt; Rebaselines:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320334@main">https://commits.webkit.org/320334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbca5b092d48424122fd364247bed1faac70ae5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148780 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebcc62ff-90fd-4c63-a396-1b5aa68d45e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144039 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100083 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6a220db-1e7e-4241-b5b3-02c4070fe21b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47831 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124455 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46542 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44324 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5895 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196767 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41130 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58794 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153283 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47811 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131086 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127546 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57297 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19338 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->