### PR TITLE
Web Inspector: clear the active call frame when its target is removed

### DIFF
--- a/LayoutTests/inspector/worker/debugger-multiple-targets-pause-expected.txt
+++ b/LayoutTests/inspector/worker/debugger-multiple-targets-pause-expected.txt
@@ -52,6 +52,11 @@ TARGET: worker-debugger-thread-1.js
 TARGET: worker-debugger-thread-2.js
    CALL FRAME #1: laterWorkInThread2
 
+-- Running test case: Worker.Debugger.Threads.Paused.RemoveActiveTarget
+PASS: Worker 1 should be removed.
+PASS: The active call frame should be cleared when its target is removed.
+PASS: The debugger should remain paused while other targets are paused.
+
 -- Running test case: Worker.Debugger.Threads.Complete
 PASS: Received Resume event.
 PASS: All Targets should be unpaused.

--- a/LayoutTests/inspector/worker/debugger-multiple-targets-pause.html
+++ b/LayoutTests/inspector/worker/debugger-multiple-targets-pause.html
@@ -191,6 +191,26 @@ function test()
     });
 
     suite.addTestCase({
+        name: "Worker.Debugger.Threads.Paused.RemoveActiveTarget",
+        description: "Removing the active call frame's target should preserve the remaining paused targets.",
+        async test() {
+            let worker1CallFrame = WI.debuggerManager.dataForTarget(workerTarget1).stackTrace.callFrames[0];
+            WI.debuggerManager.activeCallFrame = worker1CallFrame;
+
+            let targetRemovedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
+            let activeCallFrameDidChangePromise = WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.ActiveCallFrameDidChange);
+
+            let mainCallFrame = WI.debuggerManager.dataForTarget(mainTarget).stackTrace.callFrames[0];
+            let terminatePromise = mainTarget.DebuggerAgent.evaluateOnCallFrame.invoke({callFrameId: mainCallFrame.id, expression: "worker1.terminate()", objectGroup: "test"});
+
+            let [targetRemovedEvent] = await Promise.all([targetRemovedPromise, activeCallFrameDidChangePromise, terminatePromise]);
+            InspectorTest.expectEqual(targetRemovedEvent.data.target, workerTarget1, "Worker 1 should be removed.");
+            InspectorTest.expectNull(WI.debuggerManager.activeCallFrame, "The active call frame should be cleared when its target is removed.");
+            InspectorTest.expectTrue(WI.debuggerManager.paused, "The debugger should remain paused while other targets are paused.");
+        }
+    });
+
+    suite.addTestCase({
         name: "Worker.Debugger.Threads.Complete",
         description: "Resume all threads for the test to complete.",
         test(resolve, reject) {

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -1716,6 +1716,10 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         let wasPaused = this.paused;
         let {target} = event.data;
 
+        let activeCallFrameDidChange = this._activeCallFrame?.target === target;
+        if (activeCallFrameDidChange)
+            this._activeCallFrame = null;
+
         target.extraScriptCollection.clear();
         for (let frame of WI.networkManager.frames) {
             for (let script of Array.from(frame.extraScriptCollection)) {
@@ -1728,6 +1732,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         if (!this.paused && wasPaused)
             this.dispatchEventToListeners(WI.DebuggerManager.Event.Resumed);
+
+        if (activeCallFrameDidChange)
+            this.dispatchEventToListeners(WI.DebuggerManager.Event.ActiveCallFrameDidChange);
     }
 
     _handleFrameWasAdded(event)


### PR DESCRIPTION
#### 047840088176ce4446e38e6ecd4c95c5f0f14231
<pre>
Web Inspector: clear the active call frame when its target is removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=323186">https://bugs.webkit.org/show_bug.cgi?id=323186</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype._targetRemoved):
Clear the active `WI.CallFrame` when its `WI.Target` is removed/destroyed so consumers can&apos;t keep using it while another `WI.Target` remains paused.

* LayoutTests/inspector/worker/debugger-multiple-targets-pause.html:
* LayoutTests/inspector/worker/debugger-multiple-targets-pause-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/047840088176ce4446e38e6ecd4c95c5f0f14231

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148699 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59685 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143968 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100049 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46466 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44649 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44257 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5817 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196683 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58711 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47741 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131002 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127416 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57216 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->