### PR TITLE
AX: isolated tree can serve old page's content after navigation

### DIFF
--- a/LayoutTests/accessibility/mac/client/isolated-tree-after-navigation-expected.txt
+++ b/LayoutTests/accessibility/mac/client/isolated-tree-after-navigation-expected.txt
@@ -1,0 +1,11 @@
+Checks that a new document's accessibility tree is served after a navigation, rather than the previous document's stale isolated tree. The first page builds an isolated tree, then navigates here.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: the accessibility tree serves the current document
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Second Page Heading

--- a/LayoutTests/accessibility/mac/client/isolated-tree-after-navigation.html
+++ b/LayoutTests/accessibility/mac/client/isolated-tree-after-navigation.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+<h1>First Page Heading</h1>
+<script>
+// This test navigates to a second document. Both pages use client accessibility mode, which serves
+// the tree from the UI process by walking down from the WKWebView, the same path VoiceOver uses.
+// Building the tree on the first page is what leaves a tree behind for the second page to trip over.
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        // Force the first document's isolated tree to be built and cached by the page's
+        // accessibility element, so that navigating away leaves a tree that must be discarded.
+        await waitForElements([(element) => element.role.includes("Heading")]);
+
+        location.href = "resources/isolated-tree-after-navigation-second.html";
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/client/resources/isolated-tree-after-navigation-second.html
+++ b/LayoutTests/accessibility/mac/client/resources/isolated-tree-after-navigation-second.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+<h1>Second Page Heading</h1>
+<script>
+description("Checks that a new document's accessibility tree is served after a navigation, rather than the previous document's stale isolated tree. The first page builds an isolated tree, then navigates here.");
+
+var output = "";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        // Collects every heading the client can reach from the root. If the previous document's
+        // isolated tree is still being served, this finds "First Page Heading" instead, or nothing
+        // at all if that tree has been torn down but not replaced.
+        function collectHeadings(element, headings) {
+            if (!element || !element.role)
+                return headings;
+            if (element.role.endsWith("AXHeading"))
+                headings.push(element.title);
+            for (var i = 0; i < element.childrenCount; i++)
+                collectHeadings(element.childAtIndex(i), headings);
+            return headings;
+        }
+
+        var headings = [];
+        await waitFor(() => {
+            headings = collectHeadings(accessibilityController.rootElement, []);
+            return headings.length;
+        });
+
+        if (headings.length === 1 && headings[0].includes("Second Page Heading"))
+            output += "PASS: the accessibility tree serves the current document\n";
+        else
+            output += `FAIL: expected only the current document's heading, got [${headings}]\n`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1471,17 +1471,21 @@ DidTearDown AXIsolatedTree::applyPendingChangesOrTearDown()
 {
     AX_ASSERT(!isMainThread());
 
-    if (!hasPendingChanges())
-        return DidTearDown::No;
-
     PendingChanges committedChanges;
     {
         Locker locker { m_changeLogLock };
 
+        // Check for destruction before consulting m_hasPendingChanges. Any other thread can consume
+        // that flag via applyPendingChanges() between queueForDestruction() and this sweep, and if it
+        // does, the tree would never be torn down: the sweep clears s_anyTreeNeedsTearDown afterwards,
+        // so the teardown signal is lost for good and the stale tree keeps serving clients forever.
         if (m_queuedForDestruction) [[unlikely]] {
             clearTreeContentsLocked();
             return DidTearDown::Yes;
         }
+
+        if (!hasPendingChanges())
+            return DidTearDown::No;
 
         committedChanges = takeCommittedChangesLocked();
     }


### PR DESCRIPTION
#### 733ef2764b021031b2789c7664379615f1f479a4
<pre>
AX: isolated tree can serve old page&apos;s content after navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=323182">https://bugs.webkit.org/show_bug.cgi?id=323182</a>
<a href="https://rdar.apple.com/186427494">rdar://186427494</a>

Reviewed by Tyler Wilcock.

In-between queueForDestruction and applyPendingChangesOrTearDown, if
accessibilityRootObjectWrapper got called it applied pending changes
and cleared m_hasPendingChanges, which prevented it from being torn
down.

The stale tree then kept the bug alive on its own: because
m_isolatedTree only clears when the tree dies, and because a
non-null tree short-circuits the off-main-thread fast path, the
main-thread path that would have built a replacement tree was
never reached again.

The fix is to check m_queuedForDestruction first, so teardown does not
depend on a flag any other thread can consume.

Test: accessibility/mac/client/isolated-tree-after-navigation.html

* LayoutTests/accessibility/mac/client/isolated-tree-after-navigation-expected.txt: Added.
* LayoutTests/accessibility/mac/client/isolated-tree-after-navigation.html: Added.
* LayoutTests/accessibility/mac/client/resources/isolated-tree-after-navigation-second.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesOrTearDown):

Canonical link: <a href="https://commits.webkit.org/320351@main">https://commits.webkit.org/320351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7cae7679d98ed9ce697653267410eaacb2c3ff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194741 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148700 "Hash b7cae767 for PR 73022 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143969 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148700 "Hash b7cae767 for PR 73022 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124387 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46465 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44651 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44258 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5814 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196684 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153214 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47738 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131003 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127417 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57217 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->