### PR TITLE
YouTube captions freeze on the previous video's text in fullscreen

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -47,9 +47,10 @@
             this._mirrorTrack.mode = 'hidden';
             this._captionObserver = null;
             this._waitObserver = null;
+            this._observedCaptionContainer = null;
 
-            this._onCaptionsTrackListChanged = () => this._syncTrackList();
-            this._onCaptionsChanged = () => this._syncTrackList();
+            this._onCaptionsTrackListChanged = () => this._handleCaptionStateChanged();
+            this._onCaptionsChanged = () => this._handleCaptionStateChanged();
             this._player.addEventListener('onCaptionsTrackListChanged', this._onCaptionsTrackListChanged);
             this._player.addEventListener('captionschanged', this._onCaptionsChanged);
 
@@ -58,6 +59,9 @@
 
             this._onPresentationModeChanged = () => this._handlePresentationModeChanged();
             this._video.addEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+
+            this._onEmptied = () => this._handleResourceChanged();
+            this._video.addEventListener('emptied', this._onEmptied);
 
             this._attachCaptionWindowObserver();
 
@@ -73,13 +77,26 @@
                 this._waitObserver.disconnect();
                 this._waitObserver = null;
             }
+            this._observedCaptionContainer = null;
             this._mirrorTrack.mode = 'disabled';
             this._player.removeEventListener('onCaptionsTrackListChanged', this._onCaptionsTrackListChanged);
             this._player.removeEventListener('captionschanged', this._onCaptionsChanged);
             this._video.removeEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+            this._video.removeEventListener('emptied', this._onEmptied);
         }
 
         // Private methods:
+        _handleCaptionStateChanged() {
+            this._syncTrackList();
+            this._updateCues();
+        }
+
+        _handleResourceChanged() {
+            this._removeAllCues();
+            this._detachCaptionObserver();
+            this._attachCaptionWindowObserver();
+        }
+
         _syncTrackList() {
             var trackList = this._getTrackList();
             var activeTrack = this._getActiveTrack();
@@ -89,9 +106,28 @@
             navigator.mediaSession.captionsEnabled = this._player.isSubtitlesOn();
         }
 
-        _syncCues(captionWindowContainer) {
+        _updateCues() {
+            var container = this._player.querySelector(this._captionWindowSelector);
+            if (!container) {
+                this._removeAllCues();
+                this._detachCaptionObserver();
+                this._attachCaptionWindowObserver();
+                return;
+            }
+
+            if (container !== this._observedCaptionContainer)
+                this._attachCaptionObserver(container);
+
+            this._syncCues(container);
+        }
+
+        _removeAllCues() {
             while (this._mirrorTrack.cues?.length)
                 this._mirrorTrack.removeCue(this._mirrorTrack.cues[0]);
+        }
+
+        _syncCues(captionWindowContainer) {
+            this._removeAllCues();
             for (var captionWindow of captionWindowContainer.querySelectorAll('.caption-window')) {
                 var text = Array.from(captionWindow.querySelectorAll('.captions-text > span')).map(span => span.textContent).join('\n');
                 if (!text)
@@ -133,28 +169,38 @@
 
         _attachCaptionWindowObserver() {
             var container = this._player.querySelector(this._captionWindowSelector);
-            if (container)
+            if (container) {
                 this._attachCaptionObserver(container);
-            else {
-                this._waitObserver = new MutationObserver(() => {
-                    var container = this._player.querySelector(this._captionWindowSelector);
-                    if (container) {
-                        this._attachCaptionObserver(container);
-                        this._waitObserver.disconnect();
-                        this._waitObserver = null;
-                    }
-                });
-                this._waitObserver.observe(this._player, { childList: true, subtree: true });
+                return;
             }
+
+            if (this._waitObserver)
+                return;
+
+            this._waitObserver = new MutationObserver(() => {
+                var container = this._player.querySelector(this._captionWindowSelector);
+                if (container) {
+                    this._attachCaptionObserver(container);
+                    this._waitObserver.disconnect();
+                    this._waitObserver = null;
+                    this._syncCues(container);
+                }
+            });
+            this._waitObserver.observe(this._player, { childList: true, subtree: true });
+        }
+
+        _detachCaptionObserver() {
+            if (this._captionObserver) {
+                this._captionObserver.disconnect();
+                this._captionObserver = null;
+            }
+            this._observedCaptionContainer = null;
         }
 
         _attachCaptionObserver(container) {
-            if (this._captionObserver)
-                this._captionObserver.disconnect();
-            this._captionObserver = new MutationObserver(() => {
-                var container = this._player.querySelector(this._captionWindowSelector);
-                if (container) this._syncCues(container);
-            });
+            this._detachCaptionObserver();
+            this._observedCaptionContainer = container;
+            this._captionObserver = new MutationObserver(() => this._updateCues());
             this._captionObserver.observe(container, {
                 childList: true,
                 subtree: true,
@@ -169,17 +215,20 @@
         }
 
         _handlePresentationModeChanged() {
-            var captionContainer = this._player.querySelector(this._captionWindowSelector);
-            if (this._getIsInline()) {
-                this._mirrorTrack.mode = 'hidden';
-                if (captionContainer)
-                    captionContainer.style.removeProperty('visibility');
-                return;
-            }
+            var isInline = this._getIsInline();
+            if (!isInline)
+                this._player.loadModule('captions');
 
-            this._player.loadModule('captions');
-            this._mirrorTrack.mode = 'showing';
-            if (captionContainer)
+            this._updateCues();
+            this._mirrorTrack.mode = isInline ? 'hidden' : 'showing';
+
+            var captionContainer = this._player.querySelector(this._captionWindowSelector);
+            if (!captionContainer)
+                return;
+
+            if (isInline)
+                captionContainer.style.removeProperty('visibility');
+            else
                 captionContainer.style.setProperty('visibility', 'hidden', 'important');
         }
 


### PR DESCRIPTION
#### 8d0af7a74aebae5d49c28a6a1f8251e744f995ee
<pre>
YouTube captions freeze on the previous video&apos;s text in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=323189">https://bugs.webkit.org/show_bug.cgi?id=323189</a>
<a href="https://rdar.apple.com/186384656">rdar://186384656</a>

Reviewed by Jean-Yves Avenard.

Enabling captions inline, entering fullscreen, then going back inline and playing a different video
left a frozen caption frame on screen in fullscreen showing the earlier video&apos;s text, and it
reappeared every subsequent time that video was put into fullscreen.

CaptionMirror scrapes YouTube&apos;s in-page caption windows into a hidden text track that the system
displays in fullscreen. Its cues are created with an effectively infinite end time, so they only go
away when something removes them, and the only thing that removed them was a MutationObserver bound
to the single .ytp-caption-window-container node found at setup. Nothing re-attached that observer
when YouTube replaced the container, and the wait observer disconnected permanently after its first
success, so the cues stopped being updated and stayed active forever. Entering fullscreen then
flipped the track to &apos;showing&apos; without re-syncing, displaying whichever stale cue was added last.

Re-resolve the container before every sync and re-attach the observer when it has changed, drop the
cues when the media resource changes, and re-sync before making the mirror track visible.

* Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js:
(CaptionMirror):
(CaptionMirror.prototype.invalidate):
(CaptionMirror.prototype._handleCaptionStateChanged):
(CaptionMirror.prototype._handleResourceChanged):
(CaptionMirror.prototype._updateCues):
(CaptionMirror.prototype._removeAllCues):
(CaptionMirror.prototype._syncCues):
(CaptionMirror.prototype._attachCaptionWindowObserver):
(CaptionMirror.prototype._detachCaptionObserver):
(CaptionMirror.prototype._attachCaptionObserver):
(CaptionMirror.prototype._handlePresentationModeChanged):

Canonical link: <a href="https://commits.webkit.org/320345@main">https://commits.webkit.org/320345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b758cb105e1b73f0c1c1ea8be244ccabe34dd10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148702 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07367cdb-ce42-475b-8fae-a78df4c34407) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143970 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100051 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b36146e7-1be3-4b89-8591-431eebb6da4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5915328e-edd8-448f-8a2d-acd621be8066) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44660 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44256 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5816 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196686 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58010 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164201 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41137 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58714 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153215 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47742 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131005 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127419 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57219 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19271 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56584 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->