### PR TITLE
Web Inspector: add JavaScript runtime completions for `BigInt` values

### DIFF
--- a/LayoutTests/inspector/console/js-completions-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-expected.txt
@@ -16,6 +16,10 @@ PASS: Completions should not contain myVariable after it's deleted by code run i
 -- Running test case: console.jsCompletions.revokedProxy
 PASS: Completions for a revoked proxy should return an empty array and should not crash.
 
+-- Running test case: console.jsCompletions.bigInt
+PASS: Completions for a BigInt value should include toString.
+PASS: Completions for a BigInt value should include valueOf.
+
 -- Running test case: console.jsCompletions.completionOrdering
 Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""}:
 [

--- a/LayoutTests/inspector/console/js-completions.html
+++ b/LayoutTests/inspector/console/js-completions.html
@@ -78,6 +78,16 @@ function test()
     });
 
     suite.addTestCase({
+        name: "console.jsCompletions.bigInt",
+        description: "Test that completions handle BigInt values.",
+        async test() {
+            let completions = await generateJSCompletions({baseString: "1n.", prefix: ""});
+            InspectorTest.expectTrue(completions.includes("toString"), "Completions for a BigInt value should include toString.");
+            InspectorTest.expectTrue(completions.includes("valueOf"), "Completions for a BigInt value should include valueOf.");
+        }
+    });
+
+    suite.addTestCase({
         name: "console.jsCompletions.completionOrdering",
         description: "Test that the JavaScript completions are ordered correctly.",
         async test() {

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -227,6 +227,8 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                     object = new Boolean(false);
                 else if (primitiveType === "symbol")
                     object = Symbol();
+                else if (primitiveType === "bigint")
+                    object = Object(BigInt(0));
                 else
                     object = this;
 
@@ -246,7 +248,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                 result.callFunctionJSON(inspectedPage_evalResult_getArrayCompletions, undefined, receivedArrayPropertyNames.bind(this));
             else if (result.type === "object" || result.type === "function")
                 result.callFunctionJSON(inspectedPage_evalResult_getCompletions, undefined, receivedObjectPropertyNames.bind(this));
-            else if (result.type === "string" || result.type === "number" || result.type === "boolean" || result.type === "symbol") {
+            else if (result.type === "string" || result.type === "number" || result.type === "boolean" || result.type === "symbol" || result.type === "bigint") {
                 let options = {objectGroup: "completion", includeCommandLineAPI: false, doNotPauseOnExceptionsAndMuteConsole: true, returnByValue: true, generatePreview: false, saveResult: false};
                 WI.runtimeManager.evaluateInInspectedWindow("(" + inspectedPage_evalResult_getCompletions + ")(\"" + result.type + "\")", options, receivedPropertyNamesFromEvaluate.bind(this));
             } else


### PR DESCRIPTION
#### 839a3137bbda52c0d20633d8da2db338a3259eeb
<pre>
Web Inspector: add JavaScript runtime completions for `BigInt` values
<a href="https://bugs.webkit.org/show_bug.cgi?id=323188">https://bugs.webkit.org/show_bug.cgi?id=323188</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.evaluated):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.evaluated.inspectedPage_evalResult_getCompletions):

* LayoutTests/inspector/console/js-completions.html:
* LayoutTests/inspector/console/js-completions-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/839a3137bbda52c0d20633d8da2db338a3259eeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194744 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148703 "Hash 839a3137 for PR 73025 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143973 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148703 "Hash 839a3137 for PR 73025 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44661 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44259 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5818 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153217 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47757 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131006 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57220 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19274 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->