### PR TITLE
[JSC] Vectorize `Array#indexOf` and `Array#includes` on long Int32 and Double arrays

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-includes-int32-miss.js
+++ b/JSTests/microbenchmarks/array-prototype-includes-int32-miss.js
@@ -1,0 +1,11 @@
+function test(array, searchElement) {
+    return array.includes(searchElement);
+}
+noInline(test);
+
+var array = new Array(1024);
+for (var i = 0; i < array.length; i++)
+    array[i] = i;
+
+for (var i = 0; i < 1e6; ++i)
+    test(array, -1);

--- a/JSTests/microbenchmarks/array-prototype-indexOf-double-long.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-double-long.js
@@ -1,0 +1,11 @@
+function test(array, searchElement) {
+    return array.indexOf(searchElement);
+}
+noInline(test);
+
+var array = new Array(1024);
+for (var i = 0; i < array.length; i++)
+    array[i] = i + 0.5;
+
+for (var i = 0; i < 1e6; ++i)
+    test(array, (i % 1024) + 0.5);

--- a/JSTests/stress/array-indexof-includes-long-int32-double.js
+++ b/JSTests/stress/array-indexof-includes-long-int32-double.js
@@ -1,0 +1,89 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function referenceIndexOf(array, value, fromIndex) {
+    let length = array.length;
+    let index = fromIndex | 0;
+    if (index < 0)
+        index = Math.max(0, length + index);
+    for (; index < length; ++index) {
+        if (index in array && array[index] === value)
+            return index;
+    }
+    return -1;
+}
+
+function int32IndexOf(array, value) { return array.indexOf(value); }
+function int32IndexOfFrom(array, value, fromIndex) { return array.indexOf(value, fromIndex); }
+function int32Includes(array, value) { return array.includes(value); }
+function int32IncludesFrom(array, value, fromIndex) { return array.includes(value, fromIndex); }
+function doubleIndexOf(array, value) { return array.indexOf(value); }
+function doubleIndexOfFrom(array, value, fromIndex) { return array.indexOf(value, fromIndex); }
+function doubleIncludes(array, value) { return array.includes(value); }
+function doubleIncludesFrom(array, value, fromIndex) { return array.includes(value, fromIndex); }
+noInline(int32IndexOf);
+noInline(int32IndexOfFrom);
+noInline(int32Includes);
+noInline(int32IncludesFrom);
+noInline(doubleIndexOf);
+noInline(doubleIndexOfFrom);
+noInline(doubleIncludes);
+noInline(doubleIncludesFrom);
+
+function makeInt32Array(length) {
+    let array = [];
+    for (let i = 0; i < length; ++i)
+        array.push(i * 3 - 7);
+    return array;
+}
+
+function makeDoubleArray(length) {
+    let array = [];
+    for (let i = 0; i < length; ++i)
+        array.push(i * 0.5 - 7.25);
+    return array;
+}
+
+let lengths = [0, 1, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 47, 48, 49, 63, 64, 65, 100, 127, 128, 129, 200, 1000];
+let holeyInt32 = makeInt32Array(200);
+delete holeyInt32[50];
+delete holeyInt32[150];
+let holeyDouble = makeDoubleArray(200);
+delete holeyDouble[50];
+delete holeyDouble[150];
+holeyDouble[120] = -0;
+
+let cases = [];
+for (let length of lengths) {
+    let fromIndexes = [0, 1, 5, 40, length - 1, length, length + 5, -1, -3, -40, -length, -length - 1];
+    let int32Array = makeInt32Array(length);
+    for (let value of [-7, -8, 0, 2, 3 * (length - 1) - 7, 3 * (length >> 1) - 7, 3 * length - 7, 3 * (length - 5) - 7, 2147483647, -2147483648]) {
+        cases.push({ array: int32Array, value, expected: referenceIndexOf(int32Array, value, 0) });
+        for (let fromIndex of fromIndexes)
+            cases.push({ array: int32Array, value, fromIndex, expected: referenceIndexOf(int32Array, value, fromIndex) });
+    }
+    let doubleArray = makeDoubleArray(length);
+    for (let value of [-7.25, -7.5, 0, 0.5 * (length - 1) - 7.25, 0.5 * (length >> 1) - 7.25, 0.5 * length - 7.25, 0.5 * (length - 5) - 7.25, NaN, -0, 1e300]) {
+        cases.push({ array: doubleArray, value, expected: referenceIndexOf(doubleArray, value, 0), isDouble: true });
+        for (let fromIndex of fromIndexes)
+            cases.push({ array: doubleArray, value, fromIndex, expected: referenceIndexOf(doubleArray, value, fromIndex), isDouble: true });
+    }
+}
+for (let value of [143, 443, 0, -7, 590, 1000])
+    cases.push({ array: holeyInt32, value, expected: referenceIndexOf(holeyInt32, value, 0) });
+for (let value of [17.75, 67.75, NaN, 0, -0, 52.75, 92.75, 100])
+    cases.push({ array: holeyDouble, value, expected: referenceIndexOf(holeyDouble, value, 0), isDouble: true });
+
+for (let i = 0; i < testLoopCount / 50; ++i) {
+    for (let { array, value, fromIndex, expected, isDouble } of cases) {
+        if (fromIndex === undefined) {
+            shouldBe((isDouble ? doubleIndexOf : int32IndexOf)(array, value), expected);
+            shouldBe((isDouble ? doubleIncludes : int32Includes)(array, value), expected !== -1);
+        } else {
+            shouldBe((isDouble ? doubleIndexOfFrom : int32IndexOfFrom)(array, value, fromIndex), expected);
+            shouldBe((isDouble ? doubleIncludesFrom : int32IncludesFrom)(array, value, fromIndex), expected !== -1);
+        }
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5371,6 +5371,23 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSG
     OPERATION_RETURN(scope, toUCPUStrictInt32(0));
 }
 
+static ALWAYS_INLINE UCPUStrictInt32 arrayIncludesDouble(const double* data, int32_t length, double searchElement, int32_t index)
+{
+    if (index >= length)
+        return toUCPUStrictInt32(0);
+    return toUCPUStrictInt32(!!WTF::findDouble(data + index, searchElement, length - index));
+}
+
+static ALWAYS_INLINE UCPUStrictInt32 arrayIndexOfDouble(const double* data, int32_t length, double searchElement, int32_t index)
+{
+    if (index >= length)
+        return toUCPUStrictInt32(-1);
+    auto* result = WTF::findDouble(data + index, searchElement, length - index);
+    if (result)
+        return toUCPUStrictInt32(result - data);
+    return toUCPUStrictInt32(-1);
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictInt32, (Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
 {
     // We do not cause any exceptions, thus we do not need FrameTracers.
@@ -5386,13 +5403,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictI
     if (!searchElement.isNumber())
         return toUCPUStrictInt32(0);
 
-    double number = searchElement.asNumber();
-    for (; index < length; ++index) {
-        // This comparison ignores NaN.
-        if (data[index] == number)
-            return toUCPUStrictInt32(1);
-    }
-    return toUCPUStrictInt32(0);
+    return arrayIncludesDouble(data, length, searchElement.asNumber(), index);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesDouble, UCPUStrictInt32, (Butterfly* butterfly, double searchElement, int32_t index))
+{
+    return arrayIncludesDouble(butterfly->contiguousDouble().data(), butterfly->publicLength(), searchElement, index);
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly* butterfly, EncodedJSValue searchElement, int32_t index))
@@ -5565,16 +5581,13 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfValueDouble, UCPUStrictIn
 
     if (!searchElement.isNumber())
         return toUCPUStrictInt32(-1);
-    double number = searchElement.asNumber();
 
-    int32_t length = butterfly->publicLength();
-    const double* data = butterfly->contiguousDouble().data();
-    for (; index < length; ++index) {
-        // This comparison ignores NaN.
-        if (data[index] == number)
-            return toUCPUStrictInt32(index);
-    }
-    return toUCPUStrictInt32(-1);
+    return arrayIndexOfDouble(butterfly->contiguousDouble().data(), butterfly->publicLength(), searchElement.asNumber(), index);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfDouble, UCPUStrictInt32, (Butterfly* butterfly, double searchElement, int32_t index))
+{
+    return arrayIndexOfDouble(butterfly->contiguousDouble().data(), butterfly->publicLength(), searchElement, index);
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly* butterfly, EncodedJSValue searchElement, int32_t index))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -435,11 +435,14 @@ JSC_DECLARE_JIT_OPERATION(operationThrowStaticError, void, (JSGlobalObject*, JSS
 
 JSC_DECLARE_JIT_OPERATION(operationHasOwnProperty, size_t, (JSGlobalObject*, JSObject*, EncodedJSValue));
 
+static constexpr unsigned arrayIndexOfVectorizedThreshold = 32;
+
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesDouble, UCPUStrictInt32, (Butterfly*, double, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
@@ -447,6 +450,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfValueDouble, UCPUStrictI
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfDouble, UCPUStrictInt32, (Butterfly*, double, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9823,50 +9823,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         }
     };
 
-    switch (searchElementEdge.useKind()) {
-    case Int32Use: {
-        auto emitLoop = [&] (auto emitCompare) {
-#if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
-            clearRegisterAllocationOffsets();
-#endif
-
-            zeroExtend32ToWord(lengthGPR, lengthGPR);
-            zeroExtend32ToWord(indexGPR, indexGPR);
-
-            auto loop = label();
-            auto notFound = branch32(Equal, indexGPR, lengthGPR);
-
-            auto found = emitCompare();
-
-            add32(TrustedImm32(1), indexGPR);
-            jump().linkTo(loop, this);
-
-            emitResult(notFound, found);
-            if (isArrayIncludes)
-                unblessedBooleanResult(indexGPR, node);
-            else
-                strictInt32Result(indexGPR, node);
-        };
-
-        ASSERT(node->arrayMode().type() == Array::Int32);
-        JSValueOperand searchElement(this, searchElementEdge, ManualOperandSpeculation);
-        GPRReg searchElementGPR = searchElement.gpr();
-        speculateInt32(searchElementEdge, searchElementGPR);
-        emitLoop([&] () {
-            auto found = branch64(Equal, BaseIndex(storageGPR, indexGPR, TimesEight), searchElementGPR);
-            return found;
-        });
-        return;
-    }
-
-    case DoubleRepUse: {
-        ASSERT(node->arrayMode().type() == Array::Double);
-        SpeculateDoubleOperand searchElement(this, searchElementEdge);
-        FPRTemporary tempDouble(this);
-
-        FPRReg searchElementFPR = searchElement.fpr();
-        FPRReg tempFPR = tempDouble.fpr();
-
+    auto emitLoop = [&](auto searchElementReg, GPRReg scratchGPR, auto emitCompare, auto operation) {
 #if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
         clearRegisterAllocationOffsets();
 #endif
@@ -9874,18 +9831,49 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         zeroExtend32ToWord(lengthGPR, lengthGPR);
         zeroExtend32ToWord(indexGPR, indexGPR);
 
+        sub32(lengthGPR, indexGPR, scratchGPR);
+        auto vectorized = branch32(AboveOrEqual, scratchGPR, TrustedImm32(arrayIndexOfVectorizedThreshold));
+
         auto loop = label();
         auto notFound = branch32(Equal, indexGPR, lengthGPR);
-        loadDouble(BaseIndex(storageGPR, indexGPR, TimesEight), tempFPR);
-        auto found = branchDouble(DoubleEqualAndOrdered, tempFPR, searchElementFPR);
+        auto found = emitCompare();
         add32(TrustedImm32(1), indexGPR);
         jump().linkTo(loop, this);
 
         emitResult(notFound, found);
+        addSlowPathGenerator(slowPathCall(vectorized, this, operation, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, indexGPR, storageGPR, searchElementReg, indexGPR));
         if (isArrayIncludes)
             unblessedBooleanResult(indexGPR, node);
         else
             strictInt32Result(indexGPR, node);
+    };
+
+    switch (searchElementEdge.useKind()) {
+    case Int32Use: {
+        ASSERT(node->arrayMode().type() == Array::Int32);
+        JSValueOperand searchElement(this, searchElementEdge, ManualOperandSpeculation);
+        GPRTemporary scratch(this);
+        GPRReg searchElementGPR = searchElement.gpr();
+        GPRReg scratchGPR = scratch.gpr();
+        speculateInt32(searchElementEdge, searchElementGPR);
+        emitLoop(searchElementGPR, scratchGPR, [&] {
+            return branch64(Equal, BaseIndex(storageGPR, indexGPR, TimesEight), searchElementGPR);
+        }, isArrayIncludes ? operationArrayIncludesNonStringIdentityValueContiguous : operationArrayIndexOfNonStringIdentityValueContiguous);
+        return;
+    }
+
+    case DoubleRepUse: {
+        ASSERT(node->arrayMode().type() == Array::Double);
+        SpeculateDoubleOperand searchElement(this, searchElementEdge);
+        FPRTemporary tempDouble(this);
+        GPRTemporary scratch(this);
+        FPRReg searchElementFPR = searchElement.fpr();
+        FPRReg tempFPR = tempDouble.fpr();
+        GPRReg scratchGPR = scratch.gpr();
+        emitLoop(searchElementFPR, scratchGPR, [&] {
+            loadDouble(BaseIndex(storageGPR, indexGPR, TimesEight), tempFPR);
+            return branchDouble(DoubleEqualAndOrdered, tempFPR, searchElementFPR);
+        }, isArrayIncludes ? operationArrayIncludesDouble : operationArrayIndexOfDouble);
         return;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8650,6 +8650,7 @@ IGNORE_CLANG_WARNINGS_END
         switch (searchElementEdge.useKind()) {
         case Int32Use:
         case DoubleRepUse: {
+            LBasicBlock vectorized = m_out.newBlock();
             LBasicBlock loopHeader = m_out.newBlock();
             LBasicBlock loopBody = m_out.newBlock();
             LBasicBlock loopNext = m_out.newBlock();
@@ -8676,14 +8677,30 @@ IGNORE_CLANG_WARNINGS_END
             length = m_out.zeroExtPtr(length);
 
             ValueFromBlock initialStartIndex = m_out.anchor(startIndex);
-            m_out.jump(loopHeader);
+            m_out.branch(m_out.aboveOrEqual(m_out.sub(length, startIndex), m_out.constIntPtr(arrayIndexOfVectorizedThreshold)), unsure(vectorized), unsure(loopHeader));
 
-            LBasicBlock lastNext = m_out.appendTo(loopHeader, loopBody);
+            LBasicBlock lastNext = m_out.appendTo(vectorized, loopHeader);
+            LValue vectorizedResult;
+            switch (searchElementEdge.useKind()) {
+            case Int32Use:
+                vectorizedResult = vmCall(Int32, isArrayIncludes ? operationArrayIncludesNonStringIdentityValueContiguous : operationArrayIndexOfNonStringIdentityValueContiguous, storage, searchElement, m_out.castToInt32(startIndex));
+                break;
+            case DoubleRepUse:
+                vectorizedResult = vmCall(Int32, isArrayIncludes ? operationArrayIncludesDouble : operationArrayIndexOfDouble, storage, searchElement, m_out.castToInt32(startIndex));
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+            ValueFromBlock vectorizedResultValue = m_out.anchor(vectorizedResult);
+            m_out.jump(continuation);
+
+            m_out.appendTo(loopHeader, loopBody);
             LValue index = m_out.phi(pointerType(), initialStartIndex);
             m_out.branch(m_out.notEqual(index, length), unsure(loopBody), unsure(notFound));
 
             m_out.appendTo(loopBody, loopNext);
-            ValueFromBlock foundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(index);
+            ValueFromBlock foundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(m_out.castToInt32(index));
             switch (searchElementEdge.useKind()) {
             case Int32Use: {
                 // Empty value is ignored because of JSValue::NumberTag.
@@ -8708,16 +8725,16 @@ IGNORE_CLANG_WARNINGS_END
             m_out.jump(loopHeader);
 
             m_out.appendTo(notFound, continuation);
-            ValueFromBlock notFoundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(false)) : m_out.anchor(m_out.constIntPtr(-1));
+            ValueFromBlock notFoundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(false)) : m_out.anchor(m_out.constInt32(-1));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);
             // We have to keep base alive since that keeps content of storage alive.
             ensureStillAliveHere(base);
             if (isArrayIncludes)
-                setBoolean(m_out.phi(Int32, notFoundResult, foundResult));
+                setBoolean(m_out.phi(Int32, notFoundResult, foundResult, vectorizedResultValue));
             else
-                setInt32(m_out.castToInt32(m_out.phi(pointerType(), notFoundResult, foundResult)));
+                setInt32(m_out.phi(Int32, notFoundResult, foundResult, vectorizedResultValue));
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1367,18 +1367,13 @@ ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray*
         double searchNumber = searchElement.asNumber();
         auto& butterfly = *array->butterfly();
         auto data = butterfly.contiguousDouble().data();
-        if constexpr (direction == IndexOfDirection::Forward) {
-            for (; index < length; ++index) {
-                // Array#indexOf uses `===` semantics (not UncheckedKeyHashMap isEqual semantics).
-                // And the hole never matches since it is NaN.
-                if (data[index] == searchNumber)
-                    return jsNumber(index);
-            }
-        } else {
-            auto* result = WTF::reverseFindDouble(data, searchNumber, static_cast<uint64_t>(index) + 1);
-            if (result)
-                return jsNumber(result - data);
-        }
+        const double* result = nullptr;
+        if constexpr (direction == IndexOfDirection::Forward)
+            result = WTF::findDouble(data + index, searchNumber, length - index);
+        else
+            result = WTF::reverseFindDouble(data, searchNumber, static_cast<uint64_t>(index) + 1);
+        if (result)
+            return jsNumber(result - data);
         return jsNumber(-1);
     }
     default:

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -863,12 +863,7 @@ std::optional<bool> JSArray::fastIncludes(JSGlobalObject* globalObject, JSValue 
         if (!searchElement.isNumber())
             return false;
 
-        double searchNumber = searchElement.asNumber();
-        for (; index < length; ++index) {
-            if (data[index] == searchNumber)
-                return true;
-        }
-        return false;
+        return !!WTF::findDouble(data + index, searchElement.asNumber(), length - index);
     }
     default:
         return std::nullopt;

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -115,10 +115,17 @@ constexpr simde_uint64x2_t splat64(uint64_t code)
     return simde_uint64x2_t { code, code };
 }
 
+constexpr simde_float64x2_t splatDouble(double value)
+{
+    return simde_float64x2_t { value, value };
+}
+
 template<typename LaneType>
 ALWAYS_INLINE constexpr decltype(auto) splat(LaneType lane)
 {
-    if constexpr (sizeof(LaneType) == sizeof(uint8_t))
+    if constexpr (std::is_same_v<LaneType, double>)
+        return splatDouble(lane);
+    else if constexpr (sizeof(LaneType) == sizeof(uint8_t))
         return splat8(static_cast<uint8_t>(lane));
     else if constexpr (sizeof(LaneType) == sizeof(uint16_t))
         return splat16(static_cast<uint16_t>(lane));

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -63,37 +63,6 @@ const float* findFloatAlignedImpl(const float* pointer, float target, size_t len
 }
 
 SUPPRESS_NODELETE SUPPRESS_ASAN
-const double* findDoubleAlignedImpl(const double* pointer, double target, size_t length)
-{
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0b111));
-
-    constexpr simde_uint32x2_t indexMask { 0, 1 };
-
-    ASSERT(length);
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
-    ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
-    const double* cursor = pointer;
-    constexpr size_t stride = SIMD::stride<double>;
-
-    simde_float64x2_t targetsVector = simde_vdupq_n_f64(target);
-
-    while (true) {
-        simde_float64x2_t value = simde_vld1q_f64(cursor);
-        simde_uint64x2_t mask = simde_vceqq_f64(value, targetsVector);
-        simde_uint32x2_t reducedMask = simde_vmovn_u64(mask);
-        if (simde_vget_lane_u64(simde_vreinterpret_u64_u32(reducedMask), 0)) {
-            simde_uint32x2_t ranked = simde_vorn_u32(indexMask, reducedMask);
-            uint32_t index = simde_vminv_u32(ranked);
-            return (index < length) ? cursor + index : nullptr;
-        }
-        if (length <= stride)
-            return nullptr;
-        length -= stride;
-        cursor += stride;
-    }
-}
-
-SUPPRESS_NODELETE SUPPRESS_ASAN
 const Latin1Character* find8NonASCIIAlignedImpl(std::span<const Latin1Character> data)
 {
     constexpr simde_uint8x16_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -666,58 +666,54 @@ ALWAYS_INLINE const uint32_t* NODELETE find32(const uint32_t* pointer, uint32_t 
     return findImpl(pointer, character, length);
 }
 
-SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE find64(const uint64_t* pointer, uint64_t character, size_t length)
+template<typename LaneType>
+SUPPRESS_NODELETE ALWAYS_INLINE const LaneType* NODELETE find64BitLaneImpl(const LaneType* pointer, LaneType target, size_t length)
 {
+    static_assert(sizeof(LaneType) == sizeof(uint64_t));
     constexpr size_t scalarThreshold = 4;
     size_t index = 0;
     size_t runway = std::min(scalarThreshold, length);
     for (; index < runway; ++index) {
-        if (pointer[index] == character)
+        if (pointer[index] == target)
             return pointer + index;
     }
     if (runway == length)
         return nullptr;
 
-    constexpr size_t stride = SIMD::stride<uint64_t>;
+    constexpr size_t stride = SIMD::stride<LaneType>;
     constexpr size_t unrollFactor = 4;
     constexpr size_t unrolledStride = stride * unrollFactor;
 
-    auto charactersVector = SIMD::splat<uint64_t>(character);
-    auto vectorMatch = [&](auto value) ALWAYS_INLINE_LAMBDA {
-        auto mask = SIMD::equal(value, charactersVector);
-        return SIMD::findFirstNonZeroIndex(mask);
-    };
-
+    auto targetsVector = SIMD::splat<LaneType>(target);
     auto* cursor = pointer + index;
     auto* end = pointer + length;
 
     for (; cursor + unrolledStride <= end; cursor += unrolledStride) {
-        auto v0 = SIMD::load(cursor);
-        auto v1 = SIMD::load(cursor + stride);
-        auto v2 = SIMD::load(cursor + stride * 2);
-        auto v3 = SIMD::load(cursor + stride * 3);
-
-        if (auto idx = vectorMatch(v0))
-            return cursor + idx.value();
-        if (auto idx = vectorMatch(v1))
-            return cursor + stride + idx.value();
-        if (auto idx = vectorMatch(v2))
-            return cursor + stride * 2 + idx.value();
-        if (auto idx = vectorMatch(v3))
-            return cursor + stride * 3 + idx.value();
+        auto eq0 = SIMD::equal(SIMD::load(cursor), targetsVector);
+        auto eq1 = SIMD::equal(SIMD::load(cursor + stride), targetsVector);
+        auto eq2 = SIMD::equal(SIMD::load(cursor + stride * 2), targetsVector);
+        auto eq3 = SIMD::equal(SIMD::load(cursor + stride * 3), targetsVector);
+        if (SIMD::findFirstNonZeroIndex(SIMD::bitOr(eq0, eq1, eq2, eq3))) [[unlikely]] {
+            for (size_t offset = 0; offset < unrolledStride; ++offset) {
+                if (cursor[offset] == target)
+                    return cursor + offset;
+            }
+        }
     }
 
     for (; cursor + stride <= end; cursor += stride) {
-        if (auto idx = vectorMatch(SIMD::load(cursor)))
+        if (auto idx = SIMD::findFirstNonZeroIndex(SIMD::equal(SIMD::load(cursor), targetsVector)))
             return cursor + idx.value();
     }
 
-    if (cursor < end) {
-        if (auto idx = vectorMatch(SIMD::load(end - stride)))
-            return end - stride + idx.value();
-    }
-
+    if (cursor < end && *cursor == target)
+        return cursor;
     return nullptr;
+}
+
+SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE find64(const uint64_t* pointer, uint64_t character, size_t length)
+{
+    return find64BitLaneImpl(pointer, character, length);
 }
 
 SUPPRESS_NODELETE ALWAYS_INLINE const uint8_t* NODELETE reverseFind8(const uint8_t* pointer, uint8_t character, size_t length)
@@ -1072,38 +1068,10 @@ ALWAYS_INLINE const float* NODELETE findFloat(const float* pointer, float target
 }
 #endif
 
-WTF_EXPORT_PRIVATE const double* NODELETE findDoubleAlignedImpl(const double* pointer, double target, size_t length);
-
-#if CPU(ARM64)
 SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findDouble(const double* pointer, double target, size_t length)
 {
-    constexpr size_t thresholdLength = 32;
-    static_assert(!(thresholdLength % (16 / sizeof(double))), "length threshold should be16-byte aligned to make doubleFindAlignedImpl simpler");
-
-    uintptr_t unaligned = reinterpret_cast<uintptr_t>(pointer) & 0xf;
-
-    size_t index = 0;
-    size_t runway = std::min(thresholdLength - (unaligned / sizeof(double)), length);
-    for (; index < runway; ++index) {
-        if (pointer[index] == target)
-            return pointer + index;
-    }
-    if (runway == length)
-        return nullptr;
-
-    ASSERT(index < length);
-    return findDoubleAlignedImpl(pointer + index, target, length - index);
+    return find64BitLaneImpl(pointer, target, length);
 }
-#else
-ALWAYS_INLINE const double* NODELETE findDouble(const double* pointer, double target, size_t length)
-{
-    for (size_t index = 0; index < length; ++index) {
-        if (pointer[index] == target)
-            return pointer + index;
-    }
-    return nullptr;
-}
-#endif
 
 WTF_EXPORT_PRIVATE const Latin1Character* NODELETE find8NonASCIIAlignedImpl(std::span<const Latin1Character>);
 WTF_EXPORT_PRIVATE const char16_t* NODELETE find16NonASCIIAlignedImpl(std::span<const char16_t>);


### PR DESCRIPTION
#### 0d6cf47c3b1211a20135cc74ae54768dbeb1aa93
<pre>
[JSC] Vectorize `Array#indexOf` and `Array#includes` on long Int32 and Double arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=323192">https://bugs.webkit.org/show_bug.cgi?id=323192</a>

Reviewed by Yusuke Suzuki.

DFG and FTL compile ArrayIndexOf / ArrayIncludes on Int32 and Double arrays
into a scalar loop, while the C++ paths for Int32 arrays already scan the
butterfly with the vectorized WTF::find64. On a long array the JIT-compiled
code was slower per element than the interpreter, about 1.8x slower than V8.

When at least 32 elements remain, the JIT now calls a NOEXCEPT operation that
runs WTF::find64 / WTF::findDouble and keeps the inline loop for shorter scans;
the threshold is where the call overhead stops mattering on Apple Silicon.
findDouble is rewritten to share find64&apos;s unrolled kernel, since its aligned
variant was slower than the scalar loop, and the remaining scalar double
searches in the runtime call it too.

                                                   baseline                  patched

array-prototype-indexOf-int32-from-contiguous
                                               13.2918+-0.4091           13.0476+-0.3309          might be 1.0187x faster
array-prototype-includes-int32-from-contiguous
                                               12.9337+-0.0922           12.8622+-0.4050
array-prototype-includes-int32-miss           285.7966+-0.9708     ^     85.4147+-1.1408        ^ definitely 3.3460x faster
array-prototype-includes-double                12.5542+-0.5818     ^      6.5374+-0.1602        ^ definitely 1.9204x faster
array-prototype-includes-int32                148.5482+-2.2786     ^     53.7430+-0.5775        ^ definitely 2.7640x faster
array-prototype-indexOf-int32                 148.3728+-2.5853     ^     53.8890+-0.9227        ^ definitely 2.7533x faster
array-prototype-includes-double-from-contiguous
                                               32.8554+-1.6434     ?     32.8829+-1.2574        ?
array-prototype-indexOf-double-long           153.0529+-4.8413     ^     62.5287+-1.7941        ^ definitely 2.4477x faster

Tests: JSTests/microbenchmarks/array-prototype-includes-int32-miss.js
       JSTests/microbenchmarks/array-prototype-indexOf-double-long.js
       JSTests/stress/array-indexof-includes-long-int32-double.js

* JSTests/microbenchmarks/array-prototype-includes-int32-miss.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-indexOf-double-long.js: Added.
(test):
* JSTests/stress/array-indexof-includes-long-int32-double.js: Added.
(shouldBe):
(int32IndexOf):
(int32IndexOfFrom):
(int32Includes):
(int32IncludesFrom):
(doubleIndexOf):
(doubleIndexOfFrom):
(doubleIncludes):
(doubleIncludesFrom):
(makeInt32Array):
(makeDoubleArray):
(let.length.of.lengths.3):
(let.length.of.lengths.0.5):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::arrayIncludesDouble):
(JSC::DFG::arrayIndexOfDouble):
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastIndexOf):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastIncludes):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::splatDouble):
(WTF::SIMD::splat):
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::findFloatAlignedImpl):
(WTF::findDoubleAlignedImpl): Deleted.
* Source/WTF/wtf/text/StringCommon.h:
(WTF::find64BitLaneImpl):
(WTF::find64):
(WTF::findDouble):

Canonical link: <a href="https://commits.webkit.org/320488@main">https://commits.webkit.org/320488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eca49d449be90fb832ad7ebccdf276b5eb3624ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194748 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148707 "Hash eca49d44 for PR 73027 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143988 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148707 "Hash eca49d44 for PR 73027 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44671 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6370 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13210 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44274 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5822 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45699 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58015 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41227 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47759 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131010 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127424 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57224 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->