### PR TITLE
Web Inspector: keep JavaScript runtime completions isolated by execution context

### DIFF
--- a/LayoutTests/inspector/console/js-completions-execution-context-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-execution-context-expected.txt
@@ -1,0 +1,12 @@
+
+Tests that JavaScript code completions are isolated by execution context.
+
+
+== Running test suite: console.jsCompletions.ExecutionContext
+-- Running test case: console.jsCompletions.ExecutionContext.Cache
+PASS: The test page should have one subframe.
+PASS: Main frame completions should include the main frame property.
+PASS: Main frame completions should not include the subframe property.
+PASS: Subframe completions should include the subframe property.
+PASS: Subframe completions should not include the main frame property.
+

--- a/LayoutTests/inspector/console/js-completions-execution-context.html
+++ b/LayoutTests/inspector/console/js-completions-execution-context.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+var completionContextObject = {mainFrameProperty: true};
+
+function test()
+{
+    const generateJSCompletions = () => new Promise((resolve, reject) => {
+        let mockCompletionController = {
+            mode: WI.CodeMirrorCompletionController.Mode.FullConsoleCommandLineAPI,
+            updateCompletions: resolve,
+        };
+
+        WI.javaScriptRuntimeCompletionProvider.completionControllerCompletionsNeeded(mockCompletionController, [], "completionContextObject.", "", "", true);
+    });
+
+    let suite = InspectorTest.createAsyncSuite("console.jsCompletions.ExecutionContext");
+
+    suite.addTestCase({
+        name: "console.jsCompletions.ExecutionContext.Cache",
+        description: "Test that JavaScript completions are cached separately for each execution context.",
+        async test() {
+            let mainFrame = WI.networkManager.mainFrame;
+            let subframes = WI.networkManager.frames.filter((frame) => frame !== mainFrame);
+            InspectorTest.expectEqual(subframes.length, 1, "The test page should have one subframe.");
+
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+            WI.runtimeManager.activeExecutionContext = mainFrame.pageExecutionContext;
+            let mainFrameCompletions = await generateJSCompletions();
+            InspectorTest.expectTrue(mainFrameCompletions.includes("mainFrameProperty"), "Main frame completions should include the main frame property.");
+            InspectorTest.expectFalse(mainFrameCompletions.includes("subframeProperty"), "Main frame completions should not include the subframe property.");
+
+            WI.runtimeManager.activeExecutionContext = subframes[0].pageExecutionContext;
+            let subframeCompletions = await generateJSCompletions();
+            InspectorTest.expectTrue(subframeCompletions.includes("subframeProperty"), "Subframe completions should include the subframe property.");
+            InspectorTest.expectFalse(subframeCompletions.includes("mainFrameProperty"), "Subframe completions should not include the main frame property.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body>
+<iframe src="resources/js-completions-execution-context-subframe.html" onload="runTest()"></iframe>
+<p>Tests that JavaScript code completions are isolated by execution context.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/console/resources/js-completions-execution-context-subframe.html
+++ b/LayoutTests/inspector/console/resources/js-completions-execution-context-subframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+var completionContextObject = {subframeProperty: true};
+</script>
+</head>
+</html>
+

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -143,6 +143,11 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                 bracketNotation = false;
         }
 
+        function currentCompletionContext() {
+            return WI.debuggerManager.activeCallFrame || WI.runtimeManager.activeExecutionContext;
+        }
+        let completionContext = currentCompletionContext();
+
         // Start an completion request. We must now decrement before calling completionController.updateCompletions.
         this._incrementOngoingCompletionRequests();
 
@@ -151,16 +156,17 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         // and functions once instead of repetitively. Sure, there can be difference each time the base is evaluated,
         // but this optimization gives us more of a win. We clear the cache when a new command gets executed in the
         // quick console and at least every 30 seconds, to make sure we don't use stale properties in most cases.
-        if (this._lastMode === completionController.mode && this._lastBase === base && this._lastPropertyNames) {
+        if (this._lastMode === completionController.mode && this._lastBase === base && this._lastCompletionContext === completionContext && this._lastPropertyNames) {
             receivedPropertyNames.call(this, this._lastPropertyNames);
             return;
         }
 
         this._lastMode = completionController.mode;
         this._lastBase = base;
+        this._lastCompletionContext = completionContext;
         this._lastPropertyNames = null;
 
-        var activeCallFrame = WI.debuggerManager.activeCallFrame;
+        let activeCallFrame = completionContext instanceof WI.CallFrame ? completionContext : null;
         if (!base && activeCallFrame && !this._alwaysEvaluateInWindowContext)
             activeCallFrame.collectScopeChainVariableNames(receivedPropertyNames.bind(this));
         else {
@@ -181,6 +187,11 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         function evaluated(result, wasThrown)
         {
+            if (currentCompletionContext() !== completionContext) {
+                this._decrementOngoingCompletionRequests();
+                return;
+            }
+
             if (wasThrown || !result || result.type === "undefined" || (result.type === "object" && result.subtype === "null")) {
                 this._decrementOngoingCompletionRequests();
 
@@ -280,9 +291,12 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
             console.assert(!propertyNames || Array.isArray(propertyNames));
             propertyNames = propertyNames || [];
 
-            updateLastPropertyNames.call(this, propertyNames);
-
             this._decrementOngoingCompletionRequests();
+
+            if (currentCompletionContext() !== completionContext)
+                return;
+
+            updateLastPropertyNames.call(this, propertyNames);
 
             if (!base) {
                 propertyNames.pushAll(JavaScriptRuntimeCompletionProvider._commandLineAPIKeys);


### PR DESCRIPTION
#### 34eb38073427543c29c9821b9a4dce7f83aef91f
<pre>
Web Inspector: keep JavaScript runtime completions isolated by execution context
<a href="https://bugs.webkit.org/show_bug.cgi?id=323191">https://bugs.webkit.org/show_bug.cgi?id=323191</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.currentCompletionContext): Added.
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.evaluated):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.receivedPropertyNames):
Keep track of the current `WI.CallFrame` or `WI.ExecutionContext` to prevent reusing results when switching.

* LayoutTests/inspector/console/resources/js-completions-execution-context-subframe.html: Added.
* LayoutTests/inspector/console/js-completions-execution-context.html: Added.
* LayoutTests/inspector/console/js-completions-execution-context-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34eb38073427543c29c9821b9a4dce7f83aef91f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194834 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148792 "Hash 34eb3807 for PR 73028 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144044 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148792 "Hash 34eb3807 for PR 73028 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44720 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44329 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5906 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153631 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58805 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153290 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47818 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131097 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->