### PR TITLE
Web Inspector: use the paused target for JavaScript runtime completions

### DIFF
--- a/LayoutTests/inspector/worker/js-completions-expected.txt
+++ b/LayoutTests/inspector/worker/js-completions-expected.txt
@@ -1,0 +1,12 @@
+Tests JavaScript code completions while paused in a Worker.
+
+
+== Running test suite: Worker.JavaScriptRuntimeCompletions
+-- Running test case: Worker.JavaScriptRuntimeCompletions.Paused
+PASS: Creating a Worker completion object should not throw.
+PASS: The Worker completion object should have an object identifier.
+PASS: Worker completions should include Worker Command Line API functions.
+PASS: Worker completions should not include page-only Command Line API functions.
+PASS: The Worker completion object group should be released after the request finishes.
+PASS: The active call frame should belong to the Worker.
+

--- a/LayoutTests/inspector/worker/js-completions.html
+++ b/LayoutTests/inspector/worker/js-completions.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let worker = new Worker("resources/worker-debugger-pause.js");
+
+function test()
+{
+    let workerTarget = Array.from(WI.targets).find((target) => target.type === WI.TargetType.Worker);
+    if (!workerTarget) {
+        InspectorTest.fail("Missing Worker Target");
+        InspectorTest.completeTest();
+        return;
+    }
+
+    const generateJSCompletions = () => new Promise((resolve, reject) => {
+        let mockCompletionController = {
+            mode: WI.CodeMirrorCompletionController.Mode.FullConsoleCommandLineAPI,
+            updateCompletions: resolve,
+        };
+
+        WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+        WI.javaScriptRuntimeCompletionProvider.completionControllerCompletionsNeeded(mockCompletionController, [], "", "", "", true);
+    });
+
+    let suite = InspectorTest.createAsyncSuite("Worker.JavaScriptRuntimeCompletions");
+
+    suite.addTestCase({
+        name: "Worker.JavaScriptRuntimeCompletions.Paused",
+        description: "Test JavaScript completions while paused in a Worker.",
+        async test() {
+            let pausePromise = WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Paused);
+            let triggerPromise = InspectorTest.evaluateInPage(`worker.postMessage("triggerDebuggerStatement")`);
+            await pausePromise;
+
+            let activeCallFrame = WI.debuggerManager.activeCallFrame;
+            InspectorTest.expectEqual(activeCallFrame.target, workerTarget, "The active call frame should belong to the Worker.");
+
+            let {result, wasThrown} = await workerTarget.DebuggerAgent.evaluateOnCallFrame.invoke({callFrameId: activeCallFrame.id, expression: "({test: true})", objectGroup: "completion"});
+            InspectorTest.expectFalse(wasThrown, "Creating a Worker completion object should not throw.");
+            InspectorTest.expectThat(result.objectId, "The Worker completion object should have an object identifier.");
+
+            let completions = await generateJSCompletions();
+            InspectorTest.expectTrue(completions.includes("getEventListeners"), "Worker completions should include Worker Command Line API functions.");
+            InspectorTest.expectFalse(["$", "$$", "$0", "$x"].some((completion) => completions.includes(completion)), "Worker completions should not include page-only Command Line API functions.");
+
+            let completionObjectWasReleased = false;
+            try {
+                await workerTarget.RuntimeAgent.callFunctionOn.invoke({objectId: result.objectId, functionDeclaration: "function() { }"});
+            } catch (error) {
+                completionObjectWasReleased = error.message.includes("Could not find object with given id");
+            }
+            InspectorTest.expectTrue(completionObjectWasReleased, "The Worker completion object group should be released after the request finishes.");
+
+            await WI.debuggerManager.resume();
+            await triggerPromise;
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests JavaScript code completions while paused in a Worker.</p>
+</body>
+</html>
+

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -143,6 +143,9 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                 bracketNotation = false;
         }
 
+        let activeCallFrame = WI.debuggerManager.activeCallFrame;
+        let target = activeCallFrame?.target || WI.runtimeManager.activeExecutionContext.target;
+
         // Start an completion request. We must now decrement before calling completionController.updateCompletions.
         this._incrementOngoingCompletionRequests();
 
@@ -160,7 +163,6 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         this._lastBase = base;
         this._lastPropertyNames = null;
 
-        var activeCallFrame = WI.debuggerManager.activeCallFrame;
         if (!base && activeCallFrame && !this._alwaysEvaluateInWindowContext)
             activeCallFrame.collectScopeChainVariableNames(receivedPropertyNames.bind(this));
         else {
@@ -291,8 +293,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                 if (savedResultAlias)
                     propertyNames.push(savedResultAlias + "_");
 
-                let target = WI.runtimeManager.activeExecutionContext.target;
-                let targetData = (WI.debuggerManager.paused && WI.debuggerManager.dataForTarget(target)) || {};
+                let targetData = (activeCallFrame && WI.debuggerManager.dataForTarget(target)) || {};
 
                 function shouldExposeEvent() {
                     switch (completionController.mode) {
@@ -423,7 +424,15 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         console.assert(this._ongoingCompletionRequests >= 0, "Unbalanced increments / decrements.");
 
-        if (this._ongoingCompletionRequests <= 0)
-            WI.runtimeManager.activeExecutionContext.target.RuntimeAgent.releaseObjectGroup("completion");
+        if (this._ongoingCompletionRequests > 0)
+            return;
+
+        for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
+            target.RuntimeAgent.releaseObjectGroup("completion");
+        }
     }
 };


### PR DESCRIPTION
#### c0e16e223fae1cf981ab1e4390d752dfafe6044e
<pre>
Web Inspector: use the paused target for JavaScript runtime completions
<a href="https://bugs.webkit.org/show_bug.cgi?id=323193">https://bugs.webkit.org/show_bug.cgi?id=323193</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.receivedPropertyNames):
(WI.JavaScriptRuntimeCompletionProvider.prototype._decrementOngoingCompletionRequests):
When paused use the `WI.Target` of the active `WI.CallFrame` when adding Command Line API completions.
Also release the `completion` object group on every `WI.Target` after all requests finish.

* LayoutTests/inspector/worker/js-completions.html: Added.
* LayoutTests/inspector/worker/js-completions-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0e16e223fae1cf981ab1e4390d752dfafe6044e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148793 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100089 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46549 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44719 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44331 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5907 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58101 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164273 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58806 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153292 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47819 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131098 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127559 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57309 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19345 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->