### PR TITLE
[CMake] Merge Cocoa port's API test executables into TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -1,4 +1,15 @@
 set(TESTWEBKITAPI_DIR "${TOOLS_DIR}/TestWebKitAPI")
+
+# Cocoa uses a single TestWebKitAPI binary combining WebCore, WebKitLegacy,
+# JavaScriptCore and Misc tests into one executable. The other ports produce
+# multiple executables. run-api-tests expects this discrepancy; see
+# API_TEST_BINARY_NAMES in webkitpy/port/glib.py and webkitpy/port/win.py.
+if (APPLE AND ENABLE_WEBKIT)
+    set(TESTWEBKITAPI_MERGED_BINARY ON)
+else ()
+    set(TESTWEBKITAPI_MERGED_BINARY OFF)
+endif ()
+
 set(TestWebKitAPI_DISABLED_WARNINGS
     -Wno-dangling-else
     -Wno-sign-compare
@@ -209,7 +220,9 @@ if (ENABLE_JAVASCRIPTCORE)
         ${TESTWEBKITAPI_DIR}
     )
 
-    WEBKIT_EXECUTABLE_DECLARE(TestJavaScriptCore)
+    if (NOT TESTWEBKITAPI_MERGED_BINARY)
+        WEBKIT_EXECUTABLE_DECLARE(TestJavaScriptCore)
+    endif ()
 endif ()
 
 # TestWebCore definitions
@@ -313,10 +326,11 @@ if (ENABLE_WEBCORE)
         ${TESTWEBKITAPI_DIR}
     )
 
-    WEBKIT_EXECUTABLE_DECLARE(TestWebCore)
-    # TestWebCore gains Swift sources via WEBKIT_TEST_ENABLE_SWIFT.
-    webkit_target_compile_definitions(TestWebCore PUBLIC
-        "WEBKIT_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
+    if (NOT TESTWEBKITAPI_MERGED_BINARY)
+        WEBKIT_EXECUTABLE_DECLARE(TestWebCore)
+        webkit_target_compile_definitions(TestWebCore PUBLIC
+            "WEBKIT_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
+    endif ()
 endif ()
 
 # TestWebKitLegacy definitions
@@ -345,7 +359,9 @@ if (ENABLE_WEBKIT_LEGACY)
         ${TESTWEBKITAPI_DIR}
     )
 
-    WEBKIT_EXECUTABLE_DECLARE(TestWebKitLegacy)
+    if (NOT TESTWEBKITAPI_MERGED_BINARY)
+        WEBKIT_EXECUTABLE_DECLARE(TestWebKitLegacy)
+    endif ()
 endif ()
 
 # TestWebKit definitions
@@ -597,21 +613,54 @@ endif ()
 # Include platform specific files
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
+if (TESTWEBKITAPI_MERGED_BINARY)
+    list(APPEND TestWebKit_SOURCES
+        ${TestWebCore_SOURCES}
+        ${TestJavaScriptCore_SOURCES}
+        ${TestWebKitLegacy_SOURCES}
+    )
+    list(REMOVE_DUPLICATES TestWebKit_SOURCES)
+
+    # Already in the TestWebKitAPIBase static library that TestWebKit links.
+    list(REMOVE_ITEM TestWebKit_SOURCES Runner/TestsController.cpp)
+
+    list(APPEND TestWebKit_FRAMEWORKS
+        ${TestWebCore_FRAMEWORKS}
+        ${TestJavaScriptCore_FRAMEWORKS}
+        ${TestWebKitLegacy_FRAMEWORKS}
+    )
+    list(REMOVE_DUPLICATES TestWebKit_FRAMEWORKS)
+
+    list(APPEND TestWebKit_LIBRARIES
+        ${TestWebCore_LIBRARIES}
+        ${TestJavaScriptCore_LIBRARIES}
+        ${TestWebKitLegacy_LIBRARIES}
+    )
+    list(REMOVE_DUPLICATES TestWebKit_LIBRARIES)
+
+    list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
+        ${TestWebCore_PRIVATE_INCLUDE_DIRECTORIES}
+        ${TestJavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES}
+        ${TestWebKitLegacy_PRIVATE_INCLUDE_DIRECTORIES}
+    )
+    list(REMOVE_DUPLICATES TestWebKit_PRIVATE_INCLUDE_DIRECTORIES)
+endif ()
+
 # TestWTF target
 WEBKIT_TEST(TestWTF)
 
 # TestJavaScriptCore target
-if (ENABLE_JAVASCRIPTCORE)
+if (ENABLE_JAVASCRIPTCORE AND NOT TESTWEBKITAPI_MERGED_BINARY)
     WEBKIT_TEST(TestJavaScriptCore)
 endif ()
 
 # TestWebCore target
-if (ENABLE_WEBCORE)
+if (ENABLE_WEBCORE AND NOT TESTWEBKITAPI_MERGED_BINARY)
     WEBKIT_TEST(TestWebCore)
 endif ()
 
 # TestWebKitLegacy target
-if (ENABLE_WEBKIT_LEGACY)
+if (ENABLE_WEBKIT_LEGACY AND NOT TESTWEBKITAPI_MERGED_BINARY)
     WEBKIT_TEST(TestWebKitLegacy)
 endif ()
 

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -187,6 +187,8 @@ list(APPEND TestWebKit_SOURCES
     Helpers/mac/GamepadMappings/SteelSeriesNimbus.mm
     Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
 
+    Tests/Misc/TestRunnerTests.cpp
+
     Tests/WebCore/ASN1Utilities.cpp
     Tests/WebCore/CachedMatchFinder.cpp
     Tests/WebCore/TestPlatformStrategies.cpp
@@ -632,6 +634,7 @@ list(APPEND TestWebKitLegacy_SOURCES
 )
 
 # TestWebKit
+# generic/main.cpp is also in the lists above; the merge deduplicates.
 list(APPEND TestWebKit_SOURCES
     ${_test_main_SOURCES}
     Helpers/cocoa/UtilitiesCocoa.mm
@@ -718,8 +721,6 @@ endif ()
 
 set_target_properties(TestWebKit PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(TestWTF PROPERTIES LINKER_LANGUAGE CXX)
-set_target_properties(TestWebCore PROPERTIES LINKER_LANGUAGE CXX)
-set_target_properties(TestWebKitLegacy PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(TestWebKitAPIInjectedBundle PROPERTIES LINKER_LANGUAGE CXX)
 
 endif ()


### PR DESCRIPTION
#### 32342a3fda171b2ca917a285eb7c51d02a46de10
<pre>
[CMake] Merge Cocoa port&apos;s API test executables into TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=323194">https://bugs.webkit.org/show_bug.cgi?id=323194</a>
<a href="https://rdar.apple.com/problem/186432709">rdar://problem/186432709</a>

Reviewed by Richard Robinson.

This matches what Xcode produces and what run-webkit-tests expects.
TestWTF and TestWebKitAPI test executables are built, and the latter
contains tests for JavaScriptCore, WebCore, and WebKitLegacy.

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/320433@main">https://commits.webkit.org/320433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e843f722ff17a79dd96e221a2da97b384a1a2be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148714 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9bf75aa4-12ba-4867-b563-bee71fa904c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143980 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100056 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a17ab288-a184-4996-a3b6-2378b69586c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124398 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/779e2140-6a70-4e81-8553-76043d2f6386) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46483 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44669 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44264 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5829 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196699 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58022 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153226 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47751 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57231 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19279 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56596 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->