### PR TITLE
[TestWebKitAPI] Add missing Cocoa test sources to CMakeLists.txt

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TestWTF_SOURCES
     Runner/TestsController.cpp
     Helpers/Utilities.cpp
 
+    Tests/WTF/ASCIILiteral.cpp
     Tests/WTF/AtomString.cpp
     Tests/WTF/Base64.cpp
     Tests/WTF/BitSet.cpp
@@ -63,6 +64,7 @@ set(TestWTF_SOURCES
     Tests/WTF/CompactRefPtr.cpp
     Tests/WTF/CompactRefPtrTuple.cpp
     Tests/WTF/CompactUniquePtrTuple.cpp
+    Tests/WTF/CompactVariant.cpp
     Tests/WTF/CompletionHandlerTests.cpp
     Tests/WTF/ConcurrentPtrHashSet.cpp
     Tests/WTF/Condition.cpp
@@ -73,7 +75,9 @@ set(TestWTF_SOURCES
     Tests/WTF/Deque.cpp
     Tests/WTF/DragonBoxTest.cpp
     Tests/WTF/EmbeddedFixedVector.cpp
+    Tests/WTF/EnumSet.cpp
     Tests/WTF/EnumTraits.cpp
+    Tests/WTF/EnumeratedArray.cpp
     Tests/WTF/EscapableByteSpan.cpp
     Tests/WTF/FileSystem.cpp
     Tests/WTF/FormattedLogging.cpp
@@ -111,6 +115,7 @@ set(TestWTF_SOURCES
     Tests/WTF/NakedPtr.cpp
     Tests/WTF/NativePromise.cpp
     Tests/WTF/NeverDestroyed.cpp
+    Tests/WTF/Observer.cpp
     Tests/WTF/OptionCountedSet.cpp
     Tests/WTF/OptionSet.cpp
     Tests/WTF/OrderedHashMap.cpp
@@ -140,8 +145,11 @@ set(TestWTF_SOURCES
     Tests/WTF/ScopedLambda.cpp
     Tests/WTF/SegmentedVector.cpp
     Tests/WTF/SentinelLinkedList.cpp
+    Tests/WTF/SequenceLockedTest.cpp
     Tests/WTF/SetForScope.cpp
     Tests/WTF/Signals.cpp
+    Tests/WTF/SmallSet.cpp
+    Tests/WTF/SortedArrayMap.cpp
     Tests/WTF/SparseBitVector.cpp
     Tests/WTF/StackTraceTest.cpp
     Tests/WTF/StdLibExtrasTests.cpp
@@ -155,20 +163,24 @@ set(TestWTF_SOURCES
     Tests/WTF/StringSearch.cpp
     Tests/WTF/StringToIntegerConversion.cpp
     Tests/WTF/StringView.cpp
+    Tests/WTF/SuspendableWorkQueueTests.cpp
     Tests/WTF/SynchronizedFixedQueue.cpp
     Tests/WTF/TextBreakIterator.cpp
-    Tests/WTF/TinyLRUCache.cpp
+    Tests/WTF/ThreadAssertionsTest.cpp
     Tests/WTF/ThreadGroup.cpp
     Tests/WTF/ThreadMessages.cpp
     Tests/WTF/Threading.cpp
     Tests/WTF/Time.cpp
+    Tests/WTF/TinyLRUCache.cpp
     Tests/WTF/TruncateFloat.cpp
     Tests/WTF/URL.cpp
     Tests/WTF/URLParser.cpp
     Tests/WTF/UTF8Conversion.cpp
+    Tests/WTF/UUID.cpp
     Tests/WTF/UniqueArray.cpp
     Tests/WTF/UniqueRef.cpp
     Tests/WTF/UniqueRefVector.cpp
+    Tests/WTF/VariantList.cpp
     Tests/WTF/Vector.cpp
     Tests/WTF/VectorBorrow.cpp
     Tests/WTF/WTFString.cpp
@@ -176,6 +188,12 @@ set(TestWTF_SOURCES
     Tests/WTF/WorkQueue.cpp
     Tests/WTF/WorkerPool.cpp
 )
+
+# These tests check conversions that copy elision would otherwise remove.
+if (COMPILER_IS_GCC_OR_CLANG)
+    set_source_files_properties(Tests/WTF/ScopedLambda.cpp PROPERTIES
+        COMPILE_OPTIONS -fno-elide-constructors)
+endif ()
 
 set(TestWTF_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
@@ -234,9 +252,17 @@ if (ENABLE_WEBCORE)
         Helpers/WebCoreTestUtilities.cpp
 
         Tests/WebCore/AffineTransform.cpp
+        Tests/WebCore/AnimationFrameRate.cpp
+        Tests/WebCore/ApduTest.cpp
+        Tests/WebCore/ApplicationManifestParser.cpp
         Tests/WebCore/AudioSampleFormat.cpp
         Tests/WebCore/BezierUtilitiesTests.cpp
+        Tests/WebCore/CARingBufferTest.cpp
+        Tests/WebCore/CBORReaderTest.cpp
+        Tests/WebCore/CBORValueTest.cpp
+        Tests/WebCore/CBORWriterTest.cpp
         Tests/WebCore/CSSParser.cpp
+        Tests/WebCore/CSSParserFastPaths.cpp
         Tests/WebCore/CSSTokenizerTests.cpp
         Tests/WebCore/CachedMatchFinder.cpp
         Tests/WebCore/ColorTests.cpp
@@ -244,7 +270,15 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ContextMenuAction.cpp
         Tests/WebCore/CookieJar.cpp
         Tests/WebCore/CryptoDigest.cpp
+        Tests/WebCore/CtapPinTest.cpp
+        Tests/WebCore/CtapRequestTest.cpp
+        Tests/WebCore/CtapResponseTest.cpp
+        Tests/WebCore/DFACombiner.cpp
+        Tests/WebCore/DFAMinimizer.cpp
         Tests/WebCore/Decimal.cpp
+        Tests/WebCore/DisplayListRecorderTests.cpp
+        Tests/WebCore/DocumentOrder.cpp
+        Tests/WebCore/FidoHidMessageTest.cpp
         Tests/WebCore/FileMonitor.cpp
         Tests/WebCore/FloatPointTests.cpp
         Tests/WebCore/FloatQuadTests.cpp
@@ -252,12 +286,17 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/FloatSegmentTest.cpp
         Tests/WebCore/FloatSizeTests.cpp
         Tests/WebCore/FlowModeTests.cpp
+        Tests/WebCore/FontCascade.cpp
+        Tests/WebCore/FontShadowTests.cpp
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp
+        Tests/WebCore/HTTPHeaderField.cpp
+        Tests/WebCore/HTTPHeaderMap.cpp
         Tests/WebCore/HTTPParsers.cpp
         Tests/WebCore/IDBKeyData.cpp
         Tests/WebCore/IDBSerializationTest.cpp
         Tests/WebCore/IPAddressSpaceTests.cpp
+        Tests/WebCore/IPAddressTests.cpp
         Tests/WebCore/ImageBackingStoreTests.cpp
         Tests/WebCore/ImageBufferTests.cpp
         Tests/WebCore/IntPointTests.cpp
@@ -266,6 +305,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutRoundedRectTests.cpp
         Tests/WebCore/LayoutUnitTests.cpp
+        Tests/WebCore/LoginStatus.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
         Tests/WebCore/MediaConstraintsTests.cpp
@@ -276,27 +316,43 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/NowPlayingInfoTests.cpp
         Tests/WebCore/PODIntervalTree.cpp
         Tests/WebCore/ParsedContentRange.cpp
+        Tests/WebCore/ParsedContentType.cpp
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PixelBufferConversionTests.cpp
         Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
         Tests/WebCore/PlatformMediaSessionManagerTests.cpp
+        Tests/WebCore/PrivateClickMeasurement.cpp
         Tests/WebCore/PublicSuffix.cpp
+        Tests/WebCore/PushDatabase.cpp
         Tests/WebCore/PushMessageCrypto.cpp
         Tests/WebCore/Quirks.cpp
         Tests/WebCore/RegionTests.cpp
+        Tests/WebCore/RegistrableDomain.cpp
         Tests/WebCore/RenderStyleChange.cpp
+        Tests/WebCore/STUNMessageParsingTest.cpp
+        Tests/WebCore/SVGImageCasts.cpp
+        Tests/WebCore/SampleMap.cpp
         Tests/WebCore/SecurityOrigin.cpp
+        Tests/WebCore/SerializedScriptValue.cpp
+        Tests/WebCore/ServiceWorkerRoutines.cpp
         Tests/WebCore/ShareableBitmap.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
+        Tests/WebCore/SharedMemoryTests.cpp
+        Tests/WebCore/SharedTimebaseTests.cpp
+        Tests/WebCore/StaticRangeValidity.cpp
+        Tests/WebCore/StringWithDirection.cpp
         Tests/WebCore/StyleGradient.cpp
         Tests/WebCore/TestPlatformStrategies.cpp
+        Tests/WebCore/TextCodec.cpp
         Tests/WebCore/TextIterator.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
+        Tests/WebCore/U2fCommandConstructorTest.cpp
         Tests/WebCore/URLMatch.cpp
         Tests/WebCore/URLParserTextEncoding.cpp
         Tests/WebCore/URLPatternTests.cpp
+        Tests/WebCore/WebGPUFramePacer.cpp
         Tests/WebCore/WebTransportHeaderValidation.cpp
         Tests/WebCore/WellKnownOriginList.cpp
         Tests/WebCore/WritingModeTests.cpp
@@ -371,12 +427,17 @@ if (ENABLE_WEBKIT)
 
         Tests/WebKit/WKPage/AboutBlankLoad.cpp
         Tests/WebKit/WKPage/CanHandleRequest.cpp
+        Tests/WebKit/WKPage/CloseFromWithinCreatePage.cpp
+        Tests/WebKit/WKPage/CloseThenTerminate.cpp
         Tests/WebKit/WKPage/DOMWindowExtensionBasic.cpp
         Tests/WebKit/WKPage/DOMWindowExtensionNoCache.cpp
+        Tests/WebKit/WKPage/DidAssociateFormControls.cpp
         Tests/WebKit/WKPage/DidNotHandleKeyDown.cpp
         Tests/WebKit/WKPage/DocumentStartUserScriptAlertCrash.cpp
         Tests/WebKit/WKPage/DownloadDecideDestinationCrash.cpp
+        Tests/WebKit/WKPage/EphemeralSessionPushStateNoHistoryCallback.cpp
         Tests/WebKit/WKPage/EvaluateJavaScript.cpp
+        Tests/WebKit/WKPage/EventModifiers.cpp
         Tests/WebKit/WKPage/FailedLoad.cpp
         Tests/WebKit/WKPage/Find.cpp
         Tests/WebKit/WKPage/FirstMeaningfulPaintMilestone.cpp
@@ -387,8 +448,11 @@ if (ENABLE_WEBKIT)
         Tests/WebKit/WKPage/GetInjectedBundleInitializationUserDataCallback.cpp
         Tests/WebKit/WKPage/HitTestResultNodeHandle.cpp
         Tests/WebKit/WKPage/InjectedBundleBasic.cpp
+        Tests/WebKit/WKPage/InjectedBundleDisableOverrideBuiltinsBehavior.cpp
         Tests/WebKit/WKPage/InjectedBundleFrameHitTest.cpp
         Tests/WebKit/WKPage/InjectedBundleInitializationUserDataCallbackWins.cpp
+        Tests/WebKit/WKPage/InjectedBundleMakeAllShadowRootsOpen.cpp
+        Tests/WebKit/WKPage/LayoutMilestonesWithAllContentInFrame.cpp
         Tests/WebKit/WKPage/LoadAlternateHTMLStringWithNonDirectoryURL.cpp
         Tests/WebKit/WKPage/LoadCanceledNoServerRedirectCallback.cpp
         Tests/WebKit/WKPage/LoadPageOnCrash.cpp
@@ -405,20 +469,27 @@ if (ENABLE_WEBKIT)
         Tests/WebKit/WKPage/PendingAPIRequestURL.cpp
         Tests/WebKit/WKPage/PreventEmptyUserAgent.cpp
         Tests/WebKit/WKPage/PrivateBrowsingPushStateNoHistoryCallback.cpp
+        Tests/WebKit/WKPage/ProcessDidTerminate.cpp
         Tests/WebKit/WKPage/ProvisionalURLAfterWillSendRequestCallback.cpp
         Tests/WebKit/WKPage/ReloadPageAfterCrash.cpp
+        Tests/WebKit/WKPage/ResizeReversePaginatedWebView.cpp
         Tests/WebKit/WKPage/ResizeWindowAfterCrash.cpp
         Tests/WebKit/WKPage/RestoreSessionStateContainingFormData.cpp
+        Tests/WebKit/WKPage/SpacebarScrolling.cpp
+        Tests/WebKit/WKPage/TerminateTwice.cpp
         Tests/WebKit/WKPage/TextFieldDidBeginAndEndEditing.cpp
         Tests/WebKit/WKPage/UserMedia.cpp
         Tests/WebKit/WKPage/UserMessage.cpp
+        Tests/WebKit/WKPage/WKPageConfiguration.cpp
         Tests/WebKit/WKPage/WKPageCopySessionStateWithFiltering.cpp
         Tests/WebKit/WKPage/WKPageGetScaleFactorNotZero.cpp
         Tests/WebKit/WKPage/WKPreferences.cpp
         Tests/WebKit/WKPage/WKRetainPtr.cpp
+        Tests/WebKit/WKPage/WKSecurityOrigin.cpp
         Tests/WebKit/WKPage/WKString.cpp
         Tests/WebKit/WKPage/WKStringJSString.cpp
         Tests/WebKit/WKPage/WKURL.cpp
+        Tests/WebKit/WKPage/WillLoad.cpp
         Tests/WebKit/WKPage/WillSendSubmitEvent.cpp
     )
 
@@ -474,8 +545,10 @@ if (ENABLE_WEBKIT)
         Tests/WebKit/WKPage/GetInjectedBundleInitializationUserDataCallback_Bundle.cpp
         Tests/WebKit/WKPage/HitTestResultNodeHandle_Bundle.cpp
         Tests/WebKit/WKPage/InjectedBundleBasic_Bundle.cpp
+        Tests/WebKit/WKPage/InjectedBundleDisableOverrideBuiltinsBehavior_Bundle.cpp
         Tests/WebKit/WKPage/InjectedBundleFrameHitTest_Bundle.cpp
         Tests/WebKit/WKPage/InjectedBundleInitializationUserDataCallbackWins_Bundle.cpp
+        Tests/WebKit/WKPage/InjectedBundleMakeAllShadowRootsOpen_Bundle.cpp
         Tests/WebKit/WKPage/LoadCanceledNoServerRedirectCallback_Bundle.cpp
         Tests/WebKit/WKPage/MouseMoveAfterCrash_Bundle.cpp
         Tests/WebKit/WKPage/NewFirstVisuallyNonEmptyLayoutFails_Bundle.cpp
@@ -488,6 +561,7 @@ if (ENABLE_WEBKIT)
         Tests/WebKit/WKPage/ResponsivenessTimerDoesntFireEarly_Bundle.cpp
         Tests/WebKit/WKPage/TextFieldDidBeginAndEndEditing_Bundle.cpp
         Tests/WebKit/WKPage/UserMessage_Bundle.cpp
+        Tests/WebKit/WKPage/WebArchive_Bundle.cpp
         Tests/WebKit/WKPage/WillLoad_Bundle.cpp
         Tests/WebKit/WKPage/WillSendSubmitEvent_Bundle.cpp
     )

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -92,7 +92,49 @@ set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 # TestWTF
 list(APPEND TestWTF_SOURCES
     Helpers/cocoa/UtilitiesCocoa.mm
+
+    Tests/WTF/cf/RetainPtr.cpp
+    Tests/WTF/cf/RetainPtrHashing.cpp
+    Tests/WTF/cf/RetainRef.cpp
+    Tests/WTF/cf/StringCF.cpp
+    Tests/WTF/cf/VectorCF.cpp
+
+    Tests/WTF/cocoa/BlockPtr.mm
+    Tests/WTF/cocoa/ContextualizedNSString.mm
+    Tests/WTF/cocoa/LoggerCocoa.mm
+    Tests/WTF/cocoa/RetainPtr.mm
+    Tests/WTF/cocoa/RetainPtrARC.mm
+    Tests/WTF/cocoa/RetainPtrHashingCocoa.mm
+    Tests/WTF/cocoa/RetainPtrHashingCocoaARC.mm
+    Tests/WTF/cocoa/RetainRef.mm
+    Tests/WTF/cocoa/RetainRefARC.mm
+    Tests/WTF/cocoa/TextStreamCocoa.cpp
+    Tests/WTF/cocoa/TextStreamCocoa.mm
+    Tests/WTF/cocoa/TypeCastsCocoa.mm
+    Tests/WTF/cocoa/TypeCastsCocoaARC.mm
+    Tests/WTF/cocoa/UUIDCocoa.mm
+    Tests/WTF/cocoa/VectorCocoa.mm
+
+    Tests/WTF/darwin/MachSendRight.cpp
+    Tests/WTF/darwin/OSObjectPtr.cpp
+    Tests/WTF/darwin/OSObjectPtrCocoa.mm
+    Tests/WTF/darwin/OSObjectPtrCocoaARC.mm
+    Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+    Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
+    Tests/WTF/darwin/TypeCastsOSObjectCocoaARC.mm
 )
+
+# The shared prefix header is precompiled without ARC, so these can't reuse it.
+set_source_files_properties(
+    Tests/WTF/cocoa/RetainPtrARC.mm
+    Tests/WTF/cocoa/RetainPtrHashingCocoaARC.mm
+    Tests/WTF/cocoa/RetainRefARC.mm
+    Tests/WTF/cocoa/TypeCastsCocoaARC.mm
+    Tests/WTF/darwin/OSObjectPtrCocoaARC.mm
+    Tests/WTF/darwin/TypeCastsOSObjectCocoaARC.mm
+    PROPERTIES
+    COMPILE_FLAGS "-fobjc-arc -include ${CMAKE_CURRENT_SOURCE_DIR}/Helpers/TestWebKitAPIPrefix.h"
+    SKIP_PRECOMPILE_HEADERS ON)
 
 list(APPEND TestWTF_LIBRARIES
     ${CARBON_LIBRARY}
@@ -100,14 +142,56 @@ list(APPEND TestWTF_LIBRARIES
     "-framework CoreFoundation"
 )
 
+# Tests/WTF/{cf,cocoa,darwin} include headers from Tests/WTF by name.
+list(APPEND TestWTF_PRIVATE_INCLUDE_DIRECTORIES
+    ${TESTWEBKITAPI_DIR}/Tests/WTF
+)
+
 # TestJavaScriptCore
 list(APPEND TestJavaScriptCore_SOURCES
+    Tests/JavaScriptCore/JSRunLoopTimer.mm
 )
 
 # TestWebCore
 list(APPEND TestWebCore_SOURCES
     Helpers/cocoa/TestNSBundleExtras.m
     Helpers/cocoa/UtilitiesCocoa.mm
+
+    Tests/WebCore/ContentExtensions.cpp
+    Tests/WebCore/HysteresisActivityTests.cpp
+    Tests/WebCore/ISOBox.cpp
+    Tests/WebCore/Logging.cpp
+    Tests/WebCore/PlatformCAAnimationKeyPath.cpp
+    Tests/WebCore/StringUtilities.mm
+    Tests/WebCore/TextBoundaries.cpp
+    Tests/WebCore/UserAgentStringParser.cpp
+    Tests/WebCore/YouTubePluginReplacement.cpp
+
+    Tests/WebCore/cocoa/AttributedStringFontCache.mm
+    Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm
+    Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
+    Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
+    Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+    Tests/WebCore/cocoa/CoreMediaUtilities.mm
+    Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+    Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm
+    Tests/WebCore/cocoa/IOSurfaceTests.mm
+    Tests/WebCore/cocoa/ImageRotationSessionVT.cpp
+    Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
+    Tests/WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp
+    Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm
+    Tests/WebCore/cocoa/ResourceMonitor.mm
+    Tests/WebCore/cocoa/ScrollbarWidthCrash.mm
+    Tests/WebCore/cocoa/SerializedCryptoKeyWrap.mm
+    Tests/WebCore/cocoa/ShareableSpatialImageTests.mm
+    Tests/WebCore/cocoa/SharedBuffer.mm
+    Tests/WebCore/cocoa/SharedVideoFrame.mm
+    Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+    Tests/WebCore/cocoa/TestUTIRegistry.cpp
+    Tests/WebCore/cocoa/TestUTIUtilities.cpp
+    Tests/WebCore/cocoa/WebCoreDecompressionSessionTests.mm
+    Tests/WebCore/cocoa/WebCoreNSURLSession.mm
+    Tests/WebCore/cocoa/XMLParsing.mm
 )
 
 list(APPEND TestWebCore_LIBRARIES
@@ -117,6 +201,22 @@ list(APPEND TestWebCore_LIBRARIES
 # TestWebKitLegacy
 list(APPEND TestWebKitLegacy_SOURCES
     Helpers/cocoa/TestNSBundleExtras.m
+
+    Tests/WebKitLegacy/cocoa/WebPreferencesTest.mm
+
+    Tests/WebKitLegacy/mac/AccessingPastedImage.mm
+    Tests/WebKitLegacy/mac/ClosingWebView.mm
+    Tests/WebKitLegacy/mac/CustomProtocolsInvalidScheme.mm
+    Tests/WebKitLegacy/mac/CustomProtocolsTest.mm
+    Tests/WebKitLegacy/mac/DeallocWebViewInEventListener.mm
+    Tests/WebKitLegacy/mac/DownloadThread.mm
+    Tests/WebKitLegacy/mac/EarlyKVOCrash.mm
+    Tests/WebKitLegacy/mac/EmbeddedPrintPagination.mm
+    Tests/WebKitLegacy/mac/PDFEmbeddedPrintScript.mm
+    Tests/WebKitLegacy/mac/PreventImageLoadWithAutoResizing.mm
+    Tests/WebKitLegacy/mac/URLExtras.mm
+    Tests/WebKitLegacy/mac/UserContentTest.mm
+    Tests/WebKitLegacy/mac/WKBrowsingContextLoadDelegateTest.mm
 )
 
 list(APPEND TestWebKitLegacy_LIBRARIES
@@ -187,6 +287,8 @@ list(APPEND TestWebKit_SOURCES
     Helpers/mac/GamepadMappings/SteelSeriesNimbus.mm
     Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
 
+    Tests/TestWebKitAPIAdditionsHook.mm
+
     Tests/Misc/TestRunnerTests.cpp
 
     Tests/WebCore/ASN1Utilities.cpp
@@ -196,7 +298,83 @@ list(APPEND TestWebKit_SOURCES
     Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
     Tests/WebCore/cocoa/PlatformScreenTests.mm
 
+    Tests/WebKit/DeviceIdHashSaltStorage.cpp
+
+    Tests/WebKit/WKPage/DidRemoveFrameFromHiearchyInPageCache.cpp
+    Tests/WebKit/WKPage/EnvironmentUtilitiesTest.cpp
+    Tests/WebKit/WKPage/MenuTypesForMouseEvents.cpp
+    Tests/WebKit/WKPage/ModalAlertsSPI.cpp
+    Tests/WebKit/WKPage/NavigationClientDefaultCrypto.cpp
+    Tests/WebKit/WKPage/RestoreSessionState.cpp
+    Tests/WebKit/WKPage/ShouldKeepCurrentBackForwardListItemInList.cpp
+    Tests/WebKit/WKPage/WKImageCreateCGImageCrash.cpp
+    Tests/WebKit/WKPage/WKPageIsPlayingAudio.cpp
+    Tests/WebKit/WKPage/WebArchive.cpp
+
+    Tests/WebKit/WKPage/cocoa/AccessibilityIncreaseContrast.mm
+    Tests/WebKit/WKPage/cocoa/AccessibilityReduceMotion.mm
+    Tests/WebKit/WKPage/cocoa/AccessibilityRemoteUIApp.mm
+    Tests/WebKit/WKPage/cocoa/AttributedSubstringForProposedRangeCAPI.mm
+    Tests/WebKit/WKPage/cocoa/Battery.mm
+    Tests/WebKit/WKPage/cocoa/ContextMenuDownload.mm
+    Tests/WebKit/WKPage/cocoa/ContextMenuImgWithVideo.mm
+    Tests/WebKit/WKPage/cocoa/CustomBundleObject.mm
+    Tests/WebKit/WKPage/cocoa/CustomBundleParameter.mm
+    Tests/WebKit/WKPage/cocoa/EditorCommands.mm
+    Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm
+    Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm
+    Tests/WebKit/WKPage/cocoa/FindMatches.mm
+    Tests/WebKit/WKPage/cocoa/FontRegistrySandboxCheck.mm
+    Tests/WebKit/WKPage/cocoa/ForceLightAppearanceInBundle.mm
+    Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor.mm
+    Tests/WebKit/WKPage/cocoa/GetPIDAfterAbortedProcessLaunch.cpp
+    Tests/WebKit/WKPage/cocoa/InjectedBundleAppleEvent.cpp
+    Tests/WebKit/WKPage/cocoa/LogForwarding.mm
+    Tests/WebKit/WKPage/cocoa/MediaSessionCoordinatorTest.mm
+    Tests/WebKit/WKPage/cocoa/MobileAssetSandboxCheck.mm
+    Tests/WebKit/WKPage/cocoa/NetworkProcessCrashWithPendingConnection.mm
+    Tests/WebKit/WKPage/cocoa/OverrideAppleLanguagesPreference.mm
+    Tests/WebKit/WKPage/cocoa/PasteboardNotifications.mm
+    Tests/WebKit/WKPage/cocoa/PictureInPictureSupport.mm
+    Tests/WebKit/WKPage/cocoa/PreferenceChanges.mm
+    Tests/WebKit/WKPage/cocoa/ResponsivenessTimerCrash.mm
+    Tests/WebKit/WKPage/cocoa/RestoreStateAfterTermination.mm
+    Tests/WebKit/WKPage/cocoa/ScrollPinningBehaviors.mm
+    Tests/WebKit/WKPage/cocoa/SleepDisabler.mm
+    Tests/WebKit/WKPage/cocoa/SyscallUnixSandboxCheck.mm
+    Tests/WebKit/WKPage/cocoa/SystemBeep.mm
+    Tests/WebKit/WKPage/cocoa/WeakObjCPtr.mm
+    Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
+
+    Tests/WebKit/WKPage/mac/CustomProtocolsSyncXHRTest.mm
+    Tests/WebKit/WKPage/mac/DeferredViewInWindowStateChange.mm
+    Tests/WebKit/WKPage/mac/WKThumbnailView.mm
+
+    Tests/WebKit/WKWebView/AnimationControl.mm
+    Tests/WebKit/WKWebView/FullscreenLifecycle.mm
+    Tests/WebKit/WKWebView/GetUserMediaNavigation.mm
+    Tests/WebKit/WKWebView/InjectedBundleHitTest.mm
+    Tests/WebKit/WKWebView/InstanceMethodSwizzler.mm
+    Tests/WebKit/WKWebView/MSEIsTypeSupportedCaching.mm
+    Tests/WebKit/WKWebView/MediaStreamTrackDetached.mm
+    Tests/WebKit/WKWebView/MediaStreamingActivitySuspended.mm
+    Tests/WebKit/WKWebView/NoHistoryItemScrollToFragment.mm
+    Tests/WebKit/WKWebView/NowPlayingMetadataObserver.mm
+    Tests/WebKit/WKWebView/OrthogonalFlowAvailableSize.mm
+    Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
+    Tests/WebKit/WKWebView/SmartLists.mm
+    Tests/WebKit/WKWebView/SpatialAudioExperience.mm
     Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+    Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+    Tests/WebKit/WKWebView/WKWebViewLogging.mm
+    Tests/WebKit/WKWebView/WKWebViewSpatialTrackingLabels.mm
+    Tests/WebKit/WKWebView/WebRTC.mm
+
+    Tests/WebKit/WKWebView/mac/AttributedSubstringForProposedRange.mm
+    Tests/WebKit/WKWebView/mac/GrammarMarkerPrecedence.mm
+    Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm
+    Tests/WebKit/WKWebView/mac/RunningBoardManagement.mm
+    Tests/WebKit/WKWebView/mac/WordBoundaryTypingAttributes.mm
 )
 
 list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
@@ -218,10 +396,14 @@ list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView/ios
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView/mac
     ${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source
+    ${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/webrtc
+    ${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp
     ${WEBKIT_DIR}/Platform/spi/Cocoa
     ${WEBKIT_DIR}/Platform/IPC
     ${WEBKIT_DIR}/Platform/IPC/cocoa
     ${WEBKIT_DIR}/Shared
+    ${WEBKIT_DIR}/Shared/Cocoa
+    ${WEBKIT_DIR}/UIProcess
     ${WebKit_DERIVED_SOURCES_DIR}
     ${WebKit_DERIVED_SOURCES_DIR}/IPC
     ${WEBKIT_DIR}/Platform/cocoa
@@ -241,7 +423,10 @@ list(APPEND TestWebKit_LIBRARIES
     ${CARBON_LIBRARY}
 )
 
-set_source_files_properties(Helpers/cocoa/WebExtensionUtilities.mm PROPERTIES
+set_source_files_properties(
+    Helpers/cocoa/WebExtensionUtilities.mm
+    Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+    PROPERTIES
     COMPILE_FLAGS "-fobjc-arc -include ${CMAKE_CURRENT_SOURCE_DIR}/Helpers/TestWebKitAPIPrefix.h"
     SKIP_PRECOMPILE_HEADERS ON)
 
@@ -392,6 +577,18 @@ target_sources(TestWebKitAPIInjectedBundle PRIVATE
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/UtilitiesCocoa.mm
     ${TESTWEBKITAPI_DIR}/InjectedBundle/mac/InjectedBundleControllerMac.mm
     ${TESTWEBKITAPI_DIR}/Helpers/mac/PlatformUtilitiesMac.mm
+
+    # CustomBundleObject.mm is also in TestWebKit; both targets compile it.
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/CustomBundleObject.mm
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/CustomBundleParameter_Bundle.mm
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/ForceLightAppearanceInBundle_Bundle.mm
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor_Bundle.mm
+    ${TESTWEBKITAPI_DIR}/Tests/InjectInternals_Bundle.cpp
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/PasteboardNotifications_Bundle.cpp
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/InjectedBundleAppleEvent_Bundle.cpp
+    ${TESTWEBKITAPI_DIR}/Tests/WebKitLegacy/mac/CustomProtocolsInvalidScheme_Bundle.cpp
+    ${TESTWEBKITAPI_DIR}/Tests/WebKitLegacy/mac/PreventImageLoadWithAutoResizing_Bundle.cpp
 )
 
 target_include_directories(TestWebKitAPIInjectedBundle PRIVATE


### PR DESCRIPTION
#### f50c6572e5e0e52b5c48f69b3170bb943c653e39
<pre>
[TestWebKitAPI] Add missing Cocoa test sources to CMakeLists.txt
<a href="https://bugs.webkit.org/show_bug.cgi?id=323195">https://bugs.webkit.org/show_bug.cgi?id=323195</a>
<a href="https://rdar.apple.com/186280311">rdar://186280311</a>

Reviewed by Richard Robinson.

Adds about 2k test cases (per --list-tests).

Also, make a drive-by fix for ScopedLambda.cpp: Compile it with
-fno-elide-constructors to make the test meaningful. Matches what we do
in Xcode.

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/320449@main">https://commits.webkit.org/320449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8fcd751e733d062f3ee1d2e0d556e2fd8c5901

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58717 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ffd79e6-ccfc-49bd-bc5a-b4b43e1728c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58446 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1303e7dd-17db-44c4-9c71-09f679fb87b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187752 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4f3b913-d022-45e3-8a5a-9bbd7d0bd681) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6187 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197080 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184200 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58387 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/41199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59091 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48055 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127933 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57589 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57198 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->