### PR TITLE
[TestWebKitAPI] Fix use of RETAIN_PTR_TEST_NAME outside of RetainPtr.mm

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/allowlist.txt
+++ b/Tools/Scripts/webkitpy/api_tests/allowlist.txt
@@ -70,7 +70,6 @@ TestWTF.NativePromise
 TestWTF.OSObjectPtr
 TestWTF.OSObjectPtrCocoa
 TestWTF.OSObjectPtrCocoaARC
-TestWTF.RETAIN_PTR_TEST_NAME
 TestWTF.RedBlackTreeTest
 TestWTF.RetainPtr
 TestWTF.RetainPtrARC

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -181,7 +181,7 @@ TEST(RetainPtr, RetainPtrCF)
     EXPECT_EQ(1, CFGetRetainCount(object2.get()));
 }
 
-TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)
+TEST(RetainPtr, RetainPtrTypeCF)
 {
     static_assert(std::is_same_v<RetainPtr<CFTypeRef>, RetainPtr<WTF::RetainPtrType<CFTypeRef>>>);
     static_assert(std::is_same_v<RetainPtr<CFStringRef>, RetainPtr<WTF::RetainPtrType<CFStringRef>>>);


### PR DESCRIPTION
#### 82db7a45d91f421fcb552b2a9054cd01b015673b
<pre>
[TestWebKitAPI] Fix use of RETAIN_PTR_TEST_NAME outside of RetainPtr.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=323196">https://bugs.webkit.org/show_bug.cgi?id=323196</a>
<a href="https://rdar.apple.com/problem/186432858">rdar://problem/186432858</a>

Reviewed by Richard Robinson.

This macro is used for ObjC-based tests in the cocoa/ tree, but this
test is C++ code in cf/. The macro isn&apos;t defined, so it was ending up in
results as a literally-named &quot;RETAIN_PTR_TEST_NAME&quot;. Fix it to match its
siblings.

* Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp:
(TestWebKitAPI::TEST(RetainPtr, RetainPtrTypeCF)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)): Deleted.
* Tools/Scripts/webkitpy/api_tests/allowlist.txt:

Canonical link: <a href="https://commits.webkit.org/320354@main">https://commits.webkit.org/320354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dc94e03a2a59c01adb55608229e30e6aa4e3b4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194759 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148717 "Hash 1dc94e03 for PR 73033 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/450dc9c9-3f2a-4449-a75f-2f28cc90ad91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143984 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148717 "Hash 1dc94e03 for PR 73033 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cedac85a-e3ed-451f-9e9d-75ae723f7172) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124402 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8094d780-4d83-49b1-9c64-ffa5027835cf) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/183763 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46487 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44674 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44270 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5832 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196702 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58025 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41144 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58729 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153231 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47754 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127434 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57234 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19285 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->