### PR TITLE
Cherry-pick 320222@main (1e92f67ec44b). https://bugs.webkit.org/show_bug.cgi?id=322997

### DIFF
--- a/LayoutTests/fast/css/display-contents-no-empty-text-update-expected.txt
+++ b/LayoutTests/fast/css/display-contents-no-empty-text-update-expected.txt
@@ -1,0 +1,18 @@
+Text children of a display: contents element should only be part of the style update when the imaginary wrapper style actually changes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS sizes[0] is 1
+PASS sizes[1] is 2
+PASS sizes[2] is 2
+PASS sizes[3] is 1
+PASS sizes[4] is 1
+PASS sizes[5] is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+a b
+a
+b
+Text child of a display: contents element.

--- a/LayoutTests/fast/css/display-contents-no-empty-text-update.html
+++ b/LayoutTests/fast/css/display-contents-no-empty-text-update.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<my-card id="host"><b>a</b>
+<b>b</b></my-card>
+<my-list id="blockHost"><div>a</div>
+<div>b</div></my-list>
+<div id="boxParent" style="color: black">
+  <span id="contents" style="display: contents">Text child of a display: contents element.</span>
+</div>
+<script>
+description("Text children of a display: contents element should only be part of the style update when the imaginary wrapper style actually changes.");
+
+if (!window.internals)
+    testFailed("This test requires internals.lastStyleUpdateSize.");
+else {
+
+    var contentsElement = document.getElementById("contents");
+    var boxParent = document.getElementById("boxParent");
+
+    var host = document.getElementById("host");
+    host.attachShadow({ mode: "open" }).innerHTML = "<div id='frame' style='color: black'><slot></slot></div>";
+    var slot = host.shadowRoot.querySelector("slot");
+
+    var blockHost = document.getElementById("blockHost");
+    blockHost.attachShadow({ mode: "open" }).innerHTML = "<div style='color: black'><slot></slot></div>";
+    var blockSlot = blockHost.shadowRoot.querySelector("slot");
+
+    // NOTE: Do not log before measuring - that would mutate the DOM and end up in the next style update by itself!
+    var sizes = [];
+
+    document.body.offsetTop;
+
+    // 1. A non-inherited change leaves the imaginary wrapper style identical.
+    contentsElement.style.outlineColor = "red";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    // 2. An inherited change alters the wrapper style -> text needs update.
+    contentsElement.style.color = "green";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    // 3. Reverting the change, also requires a text update.
+    contentsElement.style.color = "";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    // 4. Changing only the box-generating parent, should not affect the text child.
+    boxParent.style.outlineColor = "blue";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    // 5. The slotted whitespace must not affect a resolution that does not touch the wrapper style.
+    slot.style.outlineColor = "red";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    // 6. Whitespace slotted between block children has no renderer at all -> don't include in the update.
+    blockSlot.style.outlineColor = "red";
+    document.body.offsetTop;
+    sizes.push(internals.lastStyleUpdateSize);
+
+    shouldBe("sizes[0]", "1");
+    shouldBe("sizes[1]", "2");
+    shouldBe("sizes[2]", "2");
+    shouldBe("sizes[3]", "1");
+    shouldBe("sizes[4]", "1");
+    shouldBe("sizes[5]", "1");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/display-contents-text-wrapper-removal-expected.html
+++ b/LayoutTests/fast/css/display-contents-text-wrapper-removal-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<div style="color: black;">
+  <span>Passes if this text is black.</span>
+</div>

--- a/LayoutTests/fast/css/display-contents-text-wrapper-removal.html
+++ b/LayoutTests/fast/css/display-contents-text-wrapper-removal.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<div style="color: black;">
+  <span id="contents" style="display: contents;">Passes if this text is black.</span>
+</div>
+<script>
+document.body.offsetTop;
+
+let contents = document.getElementById("contents");
+contents.style.color = "green";
+document.body.offsetTop;
+
+contents.style.color = "";
+</script>

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -176,6 +176,7 @@ public:
 
     Vector<std::pair<unsigned, unsigned>> contentRangesBetweenOffsetsForType(const DocumentMarkerType, unsigned startOffset, unsigned endOffset) const;
 
+    bool hasInlineWrapperForDisplayContents() const { return m_hasInlineWrapperForDisplayContents; }
     RenderInline* NODELETE inlineWrapperForDisplayContents();
     void setInlineWrapperForDisplayContents(RenderInline*);
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1290,19 +1290,31 @@ void TreeResolver::resolveComposedTree()
 
         if (RefPtr text = dynamicDowncast<Text>(node)) {
             auto containsOnlyASCIIWhitespace = text->containsOnlyASCIIWhitespace();
+            auto isDisplayContentsParent = parent.style.display() == DisplayType::Contents;
+            auto inheritedDisplayContentsStyle = isDisplayContentsParent ? createInheritedDisplayContentsStyleIfNeeded(parent.style, parentBoxStyle()) : nullptr;
+
             auto needsTextUpdate = [&] {
-                if ((text->hasInvalidRenderer() && parent.changes != Change::Renderer) || parent.style.display() == DisplayType::Contents)
+                if ((text->hasInvalidRenderer() && parent.changes != Change::Renderer) || inheritedDisplayContentsStyle)
                     return true;
-                if (!text->renderer() && containsOnlyASCIIWhitespace && parent.style.preserveNewline()) {
+
+                auto* textRenderer = text->renderer();
+                if (isDisplayContentsParent) {
+                    if (textRenderer)
+                        return textRenderer->hasInlineWrapperForDisplayContents();
+                    if (!containsOnlyASCIIWhitespace)
+                        return true;
+                }
+
+                if (!textRenderer && containsOnlyASCIIWhitespace && parent.style.preserveNewline()) {
                     // FIXME: This really needs to be done only when parent.style.preserveNewline() changes value.
                     return true;
                 }
                 return false;
             };
+
             if (needsTextUpdate()) {
                 TextUpdate textUpdate;
-                textUpdate.inheritedDisplayContentsStyle = createInheritedDisplayContentsStyleIfNeeded(parent.style, parentBoxStyle());
-
+                textUpdate.inheritedDisplayContentsStyle = WTF::move(inheritedDisplayContentsStyle);
                 m_update->addText(*text, protect(parent.element), WTF::move(textUpdate));
             }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4726,13 +4726,12 @@ static void webkitWebViewCallAsyncJavascriptFunctionInternal(WebKitWebView* webV
  *     }
  *
  *     if (jsc_value_is_number (value)) {
- *         gint32        int_value = jsc_value_to_string (value);
+ *         gint32        int_value = jsc_value_to_int32 (value);
  *         JSCException *exception = jsc_context_get_exception (jsc_value_get_context (value));
  *         if (exception)
  *             g_warning ("Error running javascript: %s", jsc_exception_get_message (exception));
  *         else
  *             g_print ("Script result: %d\n", int_value);
- *         g_free (str_value);
  *     } else {
  *         g_warning ("Error running javascript: unexpected return value");
  *     }
@@ -4747,7 +4746,7 @@ static void webkitWebViewCallAsyncJavascriptFunctionInternal(WebKitWebView* webV
  *     g_variant_dict_insert (&dict, "count", "u", 42);
  *     GVariant *args = g_variant_dict_end (&dict);
  *     const gchar *body = "return new Promise((resolve) => { resolve(count); });";
- *     webkit_web_view_call_async_javascript_function (web_view, body, -1, arguments, NULL, NULL, NULL, web_view_javascript_finished, NULL);
+ *     webkit_web_view_call_async_javascript_function (web_view, body, -1, args, NULL, NULL, NULL, web_view_javascript_finished, NULL);
  * }
  * ```
  *

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -1011,7 +1011,7 @@ webkit_web_view_leave_immersive_mode                 (WebKitWebView             
  *     g_variant_dict_insert (&dict, "count", "u", 42);
  *     GVariant *args = g_variant_dict_end (&dict);
  *     const gchar *body = "return new Promise((resolve) => { resolve(count); });";
- *     webkit_web_view_run_async_javascript_function_in_world (web_view, body, arguments, NULL, NULL, web_view_javascript_finished, NULL);
+ *     webkit_web_view_run_async_javascript_function_in_world (web_view, body, args, NULL, NULL, web_view_javascript_finished, NULL);
  * }
  * ```
  *
@@ -1081,7 +1081,7 @@ webkit_web_view_leave_immersive_mode                 (WebKitWebView             
  *     g_variant_dict_insert (&dict, "count", "u", 42);
  *     GVariant *args = g_variant_dict_end (&dict);
  *     const gchar *body = "return new Promise((resolve) => { resolve(count); });";
- *     webkit_web_view_run_async_javascript_function_in_world (web_view, body, arguments, NULL, NULL, web_view_javascript_finished, NULL);
+ *     webkit_web_view_run_async_javascript_function_in_world (web_view, body, args, NULL, NULL, web_view_javascript_finished, NULL);
  * }
  * ```
  *


### PR DESCRIPTION
#### 06633b5fbe22219cfd440e95a26d99cdf57ad26f
<pre>
Cherry-pick 320222@main (1e92f67ec44b). <a href="https://bugs.webkit.org/show_bug.cgi?id=322997">https://bugs.webkit.org/show_bug.cgi?id=322997</a>

    [GTK] Fix documentation of webkit_web_view_call_async_javascript_function
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322997">https://bugs.webkit.org/show_bug.cgi?id=322997</a>

    Reviewed by Patrick Griffis.

    * Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
    * Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:

    Canonical link: <a href="https://commits.webkit.org/320222@main">https://commits.webkit.org/320222@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.182@webkitglib/2.54">https://commits.webkit.org/317695.182@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1929caf5c8fc6e86e8ee8a8832d44f20fa7c4cab
<pre>
Cherry-pick 320144@main (3a5e8ecc480b). <a href="https://bugs.webkit.org/show_bug.cgi?id=322479">https://bugs.webkit.org/show_bug.cgi?id=322479</a>

    Redundant text updates for every &quot;display: contents&quot; text child
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322479">https://bugs.webkit.org/show_bug.cgi?id=322479</a>

    Reviewed by Antti Koivisto.

    Profiling a Lit-based Web Component application showed up dozens of useless
    TextUpdates per style recalc and component, related to the &lt;slot&gt; element
    usage. A &lt;slot&gt; element is a placeholder inside a Web Component that is filled
    with the markup passed in when the component is used. That markup is placed
    below the slot element, and it includes the newlines and indentation between
    the elements it passes in. Furthermore a &lt;slot&gt; element uses &quot;display: contents&quot;
    and each of those whitespace text nodes got a TextUpdate on every style resolution:
    TreeResolver::resolveComposedTree() unconditionally created a TextUpdate for
    every text child of a &quot;display: contents&quot; element.

    An element with &quot;display: contents&quot; has no renderer of its own - no box is generated
    by definition. But its text children still need a style for rendering. We compute
    one for them, pretending each text node is wrapped in an unstyled span. That wrapper
    style is only interesting if it differs from the style of the nearest ancestor that
    does have a renderer. If it doesn&apos;t differ, then there is nothing to update.

    However, the old code looked at the display value of the text nodes parent and created
    an update for every &quot;display: contents&quot; parent it found. That value says nothing about
    whether anything changed. The wrapper style is what actually changes, so decide on
    that instead: compute the wrapper style first, and create a TextUpdate only if
    createInheritedDisplayContentsStyleIfNeeded() returned a non-null style.

    One exception is removal: A wrapper that is no longer needed only disappears if
    RenderTreeUpdater::updateTextRenderer() sees a TextUpdate for that text, so keep
    creating one while the old wrapper is still there.

    Cover both scenarios with two new tests.

    Tests: fast/css/display-contents-no-empty-text-update.html
           fast/css/display-contents-text-wrapper-removal.html

    * LayoutTests/fast/css/display-contents-no-empty-text-update-expected.txt: Added.
    * LayoutTests/fast/css/display-contents-no-empty-text-update.html: Added.
    Counts internals.lastStyleUpdateSize, including once on a &lt;slot&gt; with slotted
    whitespace between inline children, and once on a &lt;slot&gt; with slotted whitespace
    between block children, where that whitespace has no renderer at all. Without this
    change the two non-inherited cases are 2 instead of 1.
    * LayoutTests/fast/css/display-contents-text-wrapper-removal-expected.html: Added.
    * LayoutTests/fast/css/display-contents-text-wrapper-removal.html: Added.
    * Source/WebCore/rendering/RenderText.h:
    (WebCore::RenderText::hasInlineWrapperForDisplayContents const):
    * Source/WebCore/style/StyleTreeResolver.cpp:
    (WebCore::Style::TreeResolver::resolveComposedTree):

    Canonical link: <a href="https://commits.webkit.org/320144@main">https://commits.webkit.org/320144@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.181@webkitglib/2.54">https://commits.webkit.org/317695.181@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d411cd8b489966a0f1b456b5a6af20df5cb584e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184443 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58364 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194768 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148726 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186306 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59713 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58097 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143993 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148726 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187398 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59713 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124411 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59713 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58097 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59713 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5841 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51027 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58097 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196711 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58034 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153575 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/58738 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153239 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28006 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/58738 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131029 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127448 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57243 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52183 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56608 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/56852 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56677 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->