### PR TITLE
[css-mixins-1] A typed function parameter should keep its type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/functions/function-parameter-types.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/functions/function-parameter-types.tentative-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL A parameter retains its type assert_equals: expected "PASS" but got "FAIL"
-FAIL A parameter type acts as a local registration assert_equals: expected "PASS" but got "FAIL"
-FAIL A parameter retains its type (parent stack frame) assert_equals: expected "PASS" but got "FAIL"
-FAIL A parameter type acts as a local registration (parent stack frame) assert_equals: expected "PASS" but got "FAIL"
+PASS A parameter retains its type
+PASS A parameter type acts as a local registration
+PASS A parameter retains its type (parent stack frame)
+PASS A parameter type acts as a local registration (parent stack frame)
 PASS Universally typed parameter can shadow other parameters
-FAIL Invalid value for typed local becomes IACVT assert_equals: expected "PASS" but got "3"
+PASS Invalid value for typed local becomes IACVT
 PASS if() within @function can query registered custom property
 PASS A local is untyped even where a registration of the same name exists
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
@@ -54,11 +54,11 @@ PASS random(e-s) in untyped arg defaults, same function on different elements
 PASS random(e-s) in untyped arg defaults, same function in different properties
 PASS random(e-s) in untyped arg defaults, same function at different indexes
 PASS random(p-i-s) in typed arg and set in body, same function on different elements
-FAIL random(p-i-s) in typed arg and set in body, same function in different properties assert_true: Random values should be equal expected true got false
-FAIL random(p-i-s) in typed arg and set in body, same function at different indexes assert_true: Random values should be equal expected true got false
+PASS random(p-i-s) in typed arg and set in body, same function in different properties
+PASS random(p-i-s) in typed arg and set in body, same function at different indexes
 FAIL random(p-i-s) in typed arg and set in body, different function on different elements assert_false: Random values should not be equal expected false got true
-PASS random(p-i-s) in typed arg and set in body, different function in different properties
-PASS random(p-i-s) in typed arg and set in body, different function at different indexes
+FAIL random(p-i-s) in typed arg and set in body, different function in different properties assert_false: Random values should not be equal expected false got true
+FAIL random(p-i-s) in typed arg and set in body, different function at different indexes assert_false: Random values should not be equal expected false got true
 PASS random(e-s) in typed arg and set in body, same function on different elements
 FAIL random(e-s) in typed arg and set in body, same function in different properties assert_false: Random values should not be equal expected false got true
 FAIL random(e-s) in typed arg and set in body, same function at different indexes assert_false: Random values should not be equal expected false got true

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -246,16 +246,17 @@ void Builder::applyCustomProperty(const AtomString& name)
     applyCustomPropertyImpl(name, iterator->value);
 }
 
-// A custom property absent from a function's cascade is either a parameter (locally registered: it
-// shadows inheritance and resolves to its registered value) or one inherited from the calling context
-// (resolved lazily). https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+// A custom property absent from a function's cascade is either declared by this function (a parameter or
+// local: it shadows inheritance and resolves to its registered value) or one inherited from the calling
+// context (resolved lazily). An enclosing function's parameter is registered here but not declared here,
+// so it inherits. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
 void Builder::applyCustomPropertyFromCallingContext(const AtomString& name)
 {
     auto* callingContextBuilder = m_state->callingContextBuilder();
     ASSERT(callingContextBuilder);
 
     auto* localRegistry = m_state->localPropertyRegistry();
-    if (localRegistry && localRegistry->get(name))
+    if (localRegistry && localRegistry->declares(name))
         applyCustomProperty(name, CSSWideKeyword::Initial);
     else {
         callingContextBuilder->applyCustomProperty(name);

--- a/Source/WebCore/style/StyleLocalPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleLocalPropertyRegistry.cpp
@@ -35,7 +35,17 @@ namespace Style {
 const CSSRegisteredCustomProperty* LocalPropertyRegistry::get(const AtomString& name) const
 {
     ASSERT(isCustomPropertyName(name) || name == "result"_s);
-    return m_properties.get(name);
+    if (auto* property = m_properties.get(name))
+        return property;
+    // result belongs to the function being evaluated, not to an enclosing one.
+    if (m_enclosing && name != "result"_s)
+        return m_enclosing->get(name);
+    return nullptr;
+}
+
+bool LocalPropertyRegistry::declares(const AtomString& name) const
+{
+    return m_properties.contains(name);
 }
 
 bool LocalPropertyRegistry::isInherited(const AtomString& name) const

--- a/Source/WebCore/style/StyleLocalPropertyRegistry.h
+++ b/Source/WebCore/style/StyleLocalPropertyRegistry.h
@@ -36,12 +36,23 @@ namespace Style {
 // and no invalidation or prototype style management.
 class LocalPropertyRegistry {
 public:
+    explicit LocalPropertyRegistry(const LocalPropertyRegistry* enclosing = nullptr)
+        : m_enclosing(enclosing)
+    { }
+
+    // The registration for a name, from this function or an enclosing one.
     const CSSRegisteredCustomProperty* get(const AtomString&) const;
+    // Whether this function declares the name itself. A name declared by an enclosing function has its
+    // value inherited from the calling context rather than resolving to a registered value here.
+    bool declares(const AtomString&) const;
     bool isInherited(const AtomString&) const;
 
     void add(CSSRegisteredCustomProperty&&);
 
 private:
+    // The registry of the function this one was invoked from, so a typed parameter keeps its type across
+    // frames. https://github.com/w3c/csswg-drafts/issues/12315
+    const LocalPropertyRegistry* m_enclosing { nullptr };
     UncheckedKeyHashMap<AtomString, UniqueRef<CSSRegisteredCustomProperty>> m_properties;
 };
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -261,9 +261,13 @@ bool SubstitutionResolver::substituteNamedValueOrFallback(const std::optional<At
 
     if (functionId == CSSValueVar && name) {
         auto* registered = m_styleBuilder.state().registeredProperty(*name);
+        // A custom function's parameters and locals are registered to carry their type, but they are
+        // not author registrations, so a fallback for one is not held to its syntax.
+        auto* localRegistry = m_styleBuilder.state().localPropertyRegistry();
+        bool isLocalRegistration = localRegistry && localRegistry->get(*name);
         // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
         // A used fallback must match the referenced registered property's syntax.
-        if (registered && !registered->syntax.isUniversal()
+        if (registered && !isLocalRegistration && !registered->syntax.isUniversal()
             && !CSSPropertyParser::isValidCustomPropertyValueForSyntax(registered->syntax, *fallbackTokens, context))
             return false;
     }
@@ -355,8 +359,8 @@ bool SubstitutionResolver::substituteInheritFunction(CSSParserTokenRange range, 
 // https://drafts.csswg.org/css-mixins/#evaluate-a-custom-function
 // Computes each parameter from its argument, falling back to the default when there is no argument or
 // the argument does not match the parameter's type. Values are computed against the calling element.
-// Registers each parameter as universal with its computed value, and returns the properties to prepend
-// to the body rule, or nullptr on failure.
+// Registers each parameter with its declared type and computed value, and returns the properties to
+// prepend to the body rule, or nullptr on failure.
 RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>& parameters, const Vector<Vector<CSSParserToken>>& arguments, LocalPropertyRegistry& registrations, ScopeOrdinal definitionScope)
 {
     // A parameter without a default requires a corresponding argument. A missing one makes the whole
@@ -455,9 +459,12 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
 
         m_parameterValues.last().set(parameter.name, resolvedValue);
 
+        // A typed parameter keeps its type and acts as a local registration, so a body declaration
+        // assigning to its name is computed against it too.
+        // https://github.com/w3c/csswg-drafts/issues/12315
         registrations.add({
             .name = AtomString { parameter.name },
-            .syntax = CSSCustomPropertySyntax::universal(),
+            .syntax = parameter.type,
             .inherits = true,
             .initialValue = resolvedValue,
         });
@@ -530,7 +537,7 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
         return false;
 
     // "Let registrations be an initially empty set of custom property registrations."
-    auto registrations = LocalPropertyRegistry { };
+    auto registrations = LocalPropertyRegistry { m_styleBuilder.state().localPropertyRegistry() };
 
     auto resolvedArgumentProperties = resolveAndRegisterDashedFunctionArguments(parameters, *substitutedArguments, registrations, foundScopeOrdinal);
     if (!resolvedArgumentProperties)


### PR DESCRIPTION
#### c32254dca34ad0f86962bcb81d101e368a6b1647
<pre>
[css-mixins-1] A typed function parameter should keep its type
<a href="https://bugs.webkit.org/show_bug.cgi?id=323201">https://bugs.webkit.org/show_bug.cgi?id=323201</a>
<a href="https://rdar.apple.com/186439114">rdar://186439114</a>

Reviewed by Alan Baradlay.

Per

<a href="https://github.com/w3c/csswg-drafts/issues/12315">https://github.com/w3c/csswg-drafts/issues/12315</a>

something like

@function --f(--arg &lt;color&gt;) {
  result: if(
    style(--arg: red): 1;
    else: 2;
  );
}
--f(#f00) // red color

should return &apos;1&apos;.

The current implementation based on the spec text registers the parameters for result resolution as untyped.

Register them with the declared type instead. A body declaration assigning to the parameter name is then
computed against the type too, and style() compares computed values instead of token streams.

A parameter registration carries the type but is not an author registration, so a var() fallback for one
is no longer held to its syntax. Otherwise an invalid argument makes var(--arg, fallback) invalid instead
of using the fallback.

Also fix inheritance of the properties from calling context in nested function calls. LocalPropertyRegistry
chains to the enclosing frame, so a typed name keeps its type when a function is called from a function
body. Finding a registration and deciding which frame owns a name are separate now: get() chains,
declares() does not. applyCustomPropertyFromCallingContext uses declares(), since a name owned by an outer
frame is inherited from the calling context rather than resolved to its initial value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/functions/function-parameter-types.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyFromCallingContext):
* Source/WebCore/style/StyleLocalPropertyRegistry.cpp:
(WebCore::Style::LocalPropertyRegistry::get const):
(WebCore::Style::LocalPropertyRegistry::declares const):
* Source/WebCore/style/StyleLocalPropertyRegistry.h:
(WebCore::Style::LocalPropertyRegistry::LocalPropertyRegistry):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteNamedValueOrFallback):
(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Canonical link: <a href="https://commits.webkit.org/320340@main">https://commits.webkit.org/320340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c20e42ca4457e3591e39217c321e6ca3ced82bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41133 "Built successfully and passed tests") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->