### PR TITLE
[JSC] Align JSC shell's main thread QoS to WebContent process' one

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4597,6 +4597,9 @@ int jscmain(int argc, char** argv)
 
     WTF::initializeMainThread();
 
+    // Match the QoS of the WebKit WebContent process.
+    WTF::Thread::setCurrentThreadIsUserInteractive(-1);
+
     // Note that the options parsing can affect VM creation, and thus
     // comes first.
     mainCommandLine.construct(argc, argv);


### PR DESCRIPTION
#### c05b265132e42cfd6b406a32ab06a3ae3f89dff6
<pre>
[JSC] Align JSC shell&apos;s main thread QoS to WebContent process&apos; one
<a href="https://bugs.webkit.org/show_bug.cgi?id=323207">https://bugs.webkit.org/show_bug.cgi?id=323207</a>
<a href="https://rdar.apple.com/186449124">rdar://186449124</a>

Reviewed by Keith Miller.

To make performance measurement in JSC shell more aligned to WebContent
process, we call setCurrentThreadIsUserInteractive(-1) to adjust the
main thread&apos;s QoS.

* Source/JavaScriptCore/jsc.cpp:
(jscmain):

Canonical link: <a href="https://commits.webkit.org/320333@main">https://commits.webkit.org/320333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39e6dacfe6c279ca1dd1c4cc98590af20f333ce9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45154c90-99aa-4278-a9a7-3f84397be72e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58107 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144001 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; Ignored 1 flaky failure(s) based on results-db; Uploaded test results") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100065 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/426f443b-075f-44ad-95a6-050b6134be12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/668d6db0-ddd1-42a3-a53c-1b6664bfe015) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46501 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Running layout-tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6389 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13231 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156894 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44288 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5851 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45729 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51037 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48981 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196721 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58044 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153583 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; Running layout-tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58748 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40907 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153247 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47771 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131039 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Running scan-build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57253 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19303 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56618 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->