### PR TITLE
[line-clamp] Parse -webkit-legacy value on continue property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/continue-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/continue-valid-expected.txt
@@ -2,5 +2,5 @@
 FAIL e.style['continue'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['continue'] = "discard" should set the property value
 FAIL e.style['continue'] = "collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['continue'] = "-webkit-legacy" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['continue'] = "-webkit-legacy" should set the property value
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -435,7 +435,8 @@
             "initial": "auto",
             "values": [
                 "auto",
-                "discard"
+                "discard",
+                "-webkit-legacy"
             ],
             "codegen-properties": {
                 "settings-flag": "cssLineClampEnabled",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -2003,3 +2003,6 @@ orbit enable-if=ENABLE_SPATIAL_PORTAL
 
 // CSS Linked Parameters
 param
+
+// continue
+-webkit-legacy

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1369,6 +1369,9 @@ TextStream& operator<<(TextStream& ts, OverflowContinue overflowContinue)
     case OverflowContinue::Discard:
         ts << "discard"_s;
         break;
+    case OverflowContinue::WebkitLegacy:
+        ts << "-webkit-legacy"_s;
+        break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -781,9 +781,10 @@ enum class TransformBox : uint8_t {
     ViewBox
 };
 
-enum class OverflowContinue : bool {
+enum class OverflowContinue : uint8_t {
     Auto,
-    Discard
+    Discard,
+    WebkitLegacy
 };
 
 enum class Hyphens : uint8_t {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -142,7 +142,7 @@ enum class Order : bool;
 enum class OutlineStyle : uint8_t;
 enum class Overflow : uint8_t;
 enum class OverflowAnchor : bool;
-enum class OverflowContinue : bool;
+enum class OverflowContinue : uint8_t;
 enum class OverflowWrap : uint8_t;
 enum class OverscrollBehavior : uint8_t;
 enum class PaginationMode : uint8_t;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -262,7 +262,7 @@ public:
     PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;
     PREFERRED_TYPE(MarginTrim) unsigned marginTrim : 2;
     PREFERRED_TYPE(Contain) unsigned contain : 5;
-    PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 1;
+    PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 2;
     PREFERRED_TYPE(ScrollSnapStop) unsigned scrollSnapStop : 1;
     PREFERRED_TYPE(WhiteSpaceTrim) unsigned whiteSpaceTrim : 3;
 

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -2297,7 +2297,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef FOR_EACH
 
 #define TYPE OverflowContinue
-#define FOR_EACH(CASE) CASE(Auto) CASE(Discard)
+#define FOR_EACH(CASE) CASE(Auto) CASE(Discard) CASE(WebkitLegacy)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH


### PR DESCRIPTION
#### cbe007bfa510f6e8945aa9510307b4c22cf6c0d2
<pre>
[line-clamp] Parse -webkit-legacy value on continue property
<a href="https://bugs.webkit.org/show_bug.cgi?id=323208">https://bugs.webkit.org/show_bug.cgi?id=323208</a>

Reviewed by Tim Nguyen.

Parse -webkit-legacy value on continue property. This value
will be useful too to properly distinguish between the -webkit-line-clamp
and line-clamp behaviours.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/continue-valid-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
* Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h:

Canonical link: <a href="https://commits.webkit.org/320411@main">https://commits.webkit.org/320411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d38e697f56f0204c3093d11f607c42322d972b59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195025 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144328 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47990 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46706 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44480 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6081 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58282 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153449 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47968 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131272 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->