### PR TITLE
[visionOS] Enter Exit Spatial Browsing switching videos leads to Greyed Out Playback UI

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3308,6 +3308,9 @@ void HTMLMediaElement::durationChanged()
     if (m_textTracks)
         m_textTracks->setDuration(durationMediaTime());
     scheduleEvent(eventNames().durationchangeEvent);
+
+    // Every engine derives its seekable range from the duration, one way or another.
+    seekableRangesChanged();
 }
 
 void HTMLMediaElement::applyConfiguration(const RemotePlaybackConfiguration& configuration)
@@ -9192,6 +9195,11 @@ void HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged()
     });
 }
 
+void HTMLMediaElement::mediaPlayerSeekableTimeRangesChanged()
+{
+    seekableRangesChanged();
+}
+
 void HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture(MediaElementSession::BehaviorRestrictions mask)
 {
     MediaElementSession::BehaviorRestrictions restrictionsToRemove = mask &
@@ -10234,6 +10242,10 @@ void HTMLMediaElement::addClient(HTMLMediaElementClient& client)
 {
     ASSERT(!m_clients.contains(client));
     m_clients.add(client);
+
+    // The seekable range may have last changed long before this client subscribed, so hand it the
+    // current one now rather than leaving it to wait for a change that may never come.
+    client.seekableRangesChanged();
 }
 
 void HTMLMediaElement::removeClient(const HTMLMediaElementClient& client)
@@ -10307,6 +10319,13 @@ void HTMLMediaElement::mediaSessionCaptionsEnabledChanged()
 {
     m_clients.forEach([](auto& client) {
         client.captionsEnabledChanged();
+    });
+}
+
+void HTMLMediaElement::seekableRangesChanged()
+{
+    m_clients.forEach([](auto& client) {
+        client.seekableRangesChanged();
     });
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -162,6 +162,8 @@ public:
     virtual void captionTracksChanged() { }
     virtual void captionsEnabledChanged() { }
 
+    virtual void seekableRangesChanged() { }
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     virtual void hasObjectViewBoxChanged(bool) { }
 #endif
@@ -773,6 +775,8 @@ public:
     void mediaSessionCaptionTracksChanged();
     void mediaSessionCaptionsEnabledChanged();
 
+    void seekableRangesChanged();
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
@@ -950,6 +954,7 @@ private:
     const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const final;
 
     void mediaPlayerBufferedTimeRangesChanged() final;
+    void mediaPlayerSeekableTimeRangesChanged() final;
 
     bool mediaPlayerShouldDisableHDR() const final { return shouldDisableHDR(); }
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -161,6 +161,9 @@ private:
     void videoTrackConfigurationChanged();
     void captionTracksChanged() final;
     void captionsEnabledChanged() final;
+    void seekableRangesChanged() final;
+
+    void updateSeekableRanges();
 
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const final;
@@ -176,6 +179,9 @@ private:
     Vector<Ref<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;
     std::optional<ImmersiveVideoMetadata> m_immersiveVideoMetadata;
+    std::optional<PlatformTimeRanges> m_lastSeekableRanges;
+    double m_lastSeekableTimeRangesLastModifiedTime { 0 };
+    double m_lastLiveUpdateInterval { 0 };
 
     const Ref<Observer<void()>> m_videoTrackConfigurationObserver;
 };

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -119,6 +119,7 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
     }
 
     m_mediaElement = newMediaElement;
+    m_lastSeekableRanges.reset();
 
     if (newMediaElement) {
         newMediaElement->addClient(*this);
@@ -210,12 +211,8 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().progressEvent) {
         auto bufferedTime = this->bufferedTime();
-        auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
-        auto liveUpdateInterval = this->liveUpdateInterval();
-        for (auto& client : m_clients) {
+        for (auto& client : m_clients)
             client->bufferedTimeChanged(bufferedTime);
-            client->seekableRangesChanged(seekableRanges(), seekableTimeRangesLastModifiedTime, liveUpdateInterval);
-        }
     }
 
     if (all
@@ -273,6 +270,8 @@ void PlaybackSessionModelMediaElement::addClient(PlaybackSessionModelClient& cli
 {
     ASSERT(!m_clients.contains(&client));
     m_clients.add(&client);
+    // The new client has not been told anything yet; let the next update through.
+    m_lastSeekableRanges.reset();
 }
 
 void PlaybackSessionModelMediaElement::removeClient(PlaybackSessionModelClient& client)
@@ -907,6 +906,36 @@ void PlaybackSessionModelMediaElement::captionTracksChanged()
 void PlaybackSessionModelMediaElement::captionsEnabledChanged()
 {
     updateMediaSelectionOptions();
+}
+
+void PlaybackSessionModelMediaElement::seekableRangesChanged()
+{
+    updateSeekableRanges();
+}
+
+void PlaybackSessionModelMediaElement::updateSeekableRanges()
+{
+    if (m_clients.isEmpty())
+        return;
+
+    auto timeRanges = seekableRanges();
+    auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
+    auto liveUpdateInterval = this->liveUpdateInterval();
+
+    // The media source reports a buffered change on every append; only tell the clients when the
+    // seekable range they would show actually moved.
+    if (m_lastSeekableRanges
+        && *m_lastSeekableRanges == timeRanges
+        && m_lastSeekableTimeRangesLastModifiedTime == seekableTimeRangesLastModifiedTime
+        && m_lastLiveUpdateInterval == liveUpdateInterval)
+        return;
+
+    m_lastSeekableRanges = timeRanges;
+    m_lastSeekableTimeRangesLastModifiedTime = seekableTimeRangesLastModifiedTime;
+    m_lastLiveUpdateInterval = liveUpdateInterval;
+
+    for (auto& client : m_clients)
+        client->seekableRangesChanged(timeRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -67,6 +67,7 @@ public:
     virtual void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) = 0;
     virtual void readyStateFromMediaSourceChanged() { }
     virtual void characteristicsFromMediaSourceChanged() { }
+    virtual void seekableRangesFromMediaSourceChanged() { }
 #endif
 #if ENABLE(MEDIA_STREAM)
     virtual void load(MediaStreamPrivate&) = 0;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -355,15 +355,33 @@ void MediaSourcePrivate::durationChanged(const MediaTime& duration)
         Locker locker { m_lock };
         m_duration = duration;
     }
+    // seekable also moved, but HTMLMediaElement::durationChanged() covers that for every engine.
     for (Ref sourceBuffer : sourceBuffers())
         sourceBuffer->setMediaSourceDuration(duration);
 }
 
 void MediaSourcePrivate::bufferedChanged(PlatformTimeRanges&& buffered)
 {
-    Locker locker { m_lock };
+    {
+        Locker locker { m_lock };
+        m_buffered = WTF::move(buffered);
+    }
+    notifySeekableRangesChanged();
+}
 
-    m_buffered = WTF::move(buffered);
+// seekable is computed from m_duration, m_buffered and m_liveSeekable. Duration is handled by
+// HTMLMediaElement::durationChanged(); the other two end up here. Must be called with m_lock
+// released: ensureOnMainThread runs the lambda inline when already on the main thread, and
+// seekable() takes the lock.
+void MediaSourcePrivate::notifySeekableRangesChanged()
+{
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (RefPtr player = protectedThis->player())
+            player->seekableRangesFromMediaSourceChanged();
+    });
 }
 
 void MediaSourcePrivate::trackBufferedChanged(SourceBufferPrivate& sourceBuffer, Vector<PlatformTimeRanges>&& ranges)
@@ -570,16 +588,20 @@ PlatformTimeRanges MediaSourcePrivate::seekable() const
 
 void MediaSourcePrivate::setLiveSeekableRange(const PlatformTimeRanges& ranges)
 {
-    Locker locker { m_lock };
-
-    m_liveSeekable = ranges;
+    {
+        Locker locker { m_lock };
+        m_liveSeekable = ranges;
+    }
+    notifySeekableRangesChanged();
 }
 
 void MediaSourcePrivate::clearLiveSeekableRange()
 {
-    Locker locker { m_lock };
-
-    m_liveSeekable.clear();
+    {
+        Locker locker { m_lock };
+        m_liveSeekable.clear();
+    }
+    notifySeekableRangesChanged();
 }
 
 const PlatformTimeRanges& MediaSourcePrivate::liveSeekableRange() const

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -210,6 +210,7 @@ protected:
 private:
     void updateBufferedRanges();
     void updateTracksType();
+    void notifySeekableRangesChanged();
     bool canCompleteWaitForTarget() const WTF_REQUIRES_CAPABILITY(m_dispatcher.get());
     void completeWaitForTarget() WTF_REQUIRES_CAPABILITY(m_dispatcher.get());
     void tryCompleteWaitForTarget() WTF_REQUIRES_CAPABILITY(m_dispatcher.get());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -110,6 +110,7 @@ public:
     void notifyEndOfMediaIfNeeded();
     void setNaturalSize(const FloatSize&);
     void characteristicsFromMediaSourceChanged() final;
+    void seekableRangesFromMediaSourceChanged() final;
 
     MediaTime currentTime() const override;
     MediaTime currentOrPendingSeekTime() const final { return currentTime(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1311,6 +1311,13 @@ void MediaPlayerPrivateMediaSourceAVFObjC::characteristicsFromMediaSourceChanged
         player->characteristicChanged();
 }
 
+void MediaPlayerPrivateMediaSourceAVFObjC::seekableRangesFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->seekableTimeRangesChanged();
+}
+
 RetainPtr<PlatformLayer> MediaPlayerPrivateMediaSourceAVFObjC::createVideoFullscreenLayer()
 {
     return adoptNS([[CALayer alloc] init]);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -683,6 +683,13 @@ void MediaPlayerPrivateGStreamerMSE::characteristicsFromMediaSourceChanged()
         player->characteristicChanged();
 }
 
+void MediaPlayerPrivateGStreamerMSE::seekableRangesFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->seekableTimeRangesChanged();
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -81,6 +81,7 @@ public:
     void readyStateFromMediaSourceChanged() final;
     void mediaSourceHasRetrievedAllData() final;
     void characteristicsFromMediaSourceChanged() final;
+    void seekableRangesFromMediaSourceChanged() final;
 
     void setInitialVideoSize(const FloatSize&);
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -166,6 +166,13 @@ void MockMediaPlayerMediaSource::characteristicsFromMediaSourceChanged()
         player->characteristicChanged();
 }
 
+void MockMediaPlayerMediaSource::seekableRangesFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->seekableTimeRangesChanged();
+}
+
 void MockMediaPlayerMediaSource::setPageIsVisible(bool)
 {
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -68,6 +68,7 @@ public:
     MediaPlayer::ReadyState readyState() const override;
     void readyStateFromMediaSourceChanged() final;
     void characteristicsFromMediaSourceChanged() final;
+    void seekableRangesFromMediaSourceChanged() final;
     void setNetworkState(MediaPlayer::NetworkState);
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -91,6 +91,10 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 @property (nonatomic, setter=_setMediaCaptureReportingDelayForTesting:) double _mediaCaptureReportingDelayForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 @property (nonatomic, readonly) BOOL _wirelessVideoPlaybackDisabled;
 
+// Highest end time of the seekable ranges the playback controls manager knows about, NaN when it
+// has none. An empty range here is what leaves the fullscreen scrubber disabled.
+@property (nonatomic, readonly) double _maximumSeekableTime;
+
 - (void)_setIndexOfGetDisplayMediaDeviceSelectedForTesting:(nullable NSNumber *)index;
 - (void)_setSystemCanPromptForGetDisplayMediaForTesting:(BOOL)canPrompt;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -577,6 +577,18 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return false;
 }
 
+- (double)_maximumSeekableTime
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (RefPtr playbackSessionManager = _page->playbackSessionManager()) {
+        auto ranges = playbackSessionManager->seekableRanges();
+        if (ranges.length())
+            return ranges.maximumBufferedTime().toDouble();
+    }
+#endif
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action
 {
     _page->doAfterProcessingAllPendingMouseEvents([action = makeBlockPtr(action)] {

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -271,6 +271,7 @@ public:
 
     // For testing.
     bool wirelessVideoPlaybackDisabled();
+    WebCore::PlatformTimeRanges seekableRanges();
 
 private:
     friend class PlaybackSessionModelContext;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1160,6 +1160,18 @@ bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
     return protect(std::get<0>(it->value))->wirelessVideoPlaybackDisabled();
 }
 
+WebCore::PlatformTimeRanges PlaybackSessionManagerProxy::seekableRanges()
+{
+    if (!m_controlsManagerContextId)
+        return { };
+
+    auto it = m_contextMap.find(*m_controlsManagerContextId);
+    if (it == m_contextMap.end())
+        return { };
+
+    return protect(std::get<0>(it->value))->seekableRanges();
+}
+
 void PlaybackSessionManagerProxy::requestControlledElementID()
 {
     if (RefPtr page = m_page.get(); page && m_controlsManagerContextId)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -617,6 +617,10 @@ void MediaPlayerPrivateRemote::updateCachedState(RemoteMediaPlayerState&& state)
     const Seconds playbackQualityMetricsTimeout = 30_s;
 
     m_cachedState.duration = state.duration;
+    bool seekableRangesChanged = m_cachedState.minTimeSeekable != state.minTimeSeekable
+        || m_cachedState.maxTimeSeekable != state.maxTimeSeekable
+        || m_cachedState.seekableTimeRangesLastModifiedTime != state.seekableTimeRangesLastModifiedTime
+        || m_cachedState.liveUpdateInterval != state.liveUpdateInterval;
     m_cachedState.minTimeSeekable = state.minTimeSeekable;
     m_cachedState.maxTimeSeekable = state.maxTimeSeekable;
     m_cachedState.networkState = state.networkState;
@@ -652,6 +656,11 @@ void MediaPlayerPrivateRemote::updateCachedState(RemoteMediaPlayerState&& state)
 
     if (state.bufferedRanges)
         m_cachedBufferedTimeRanges = *state.bufferedRanges;
+
+    if (seekableRangesChanged) {
+        if (RefPtr player = m_player)
+            player->seekableTimeRangesChanged();
+    }
 }
 
 void MediaPlayerPrivateRemote::updatePlaybackQualityMetrics(VideoPlaybackQualityMetrics&& metrics)

--- a/Tools/TestWebKitAPI/Resources/cocoa/mse-seekable-ranges.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/mse-seekable-ranges.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script>
+      var source;
+
+      function isMP4Supported()
+      {
+        return MediaSource.isTypeSupported('video/mp4;codecs="avc1.4D4001,mp4a.40.2"');
+      }
+
+      function isWebMVP9Supported()
+      {
+        return MediaSource.isTypeSupported('video/webm;codecs="vp9,opus"');
+      }
+
+      function isWebMOpusSupported()
+      {
+        return MediaSource.isTypeSupported('video/webm;codecs="opus"');
+      }
+
+      function mediaType()
+      {
+        if (isMP4Supported())
+          return 'video/mp4;codecs="avc1.4D4001,mp4a.40.2"';
+        if (isWebMVP9Supported())
+          return 'video/webm;codecs="vp9,opus"';
+        return 'video/webm;codecs="opus"';
+      }
+
+      function mediaFile()
+      {
+        if (isMP4Supported())
+          return 'test-mse.mp4';
+        if (isWebMVP9Supported())
+          return 'test-mse.webm';
+        return 'test-mse-audio.webm';
+      }
+
+      function fetchMedia()
+      {
+        return new Promise((resolve, reject) => {
+          var request = new XMLHttpRequest();
+          request.responseType = 'arraybuffer';
+          request.open('GET', mediaFile(), true);
+          request.addEventListener('load', () => resolve(request.response));
+          request.addEventListener('error', reject);
+          request.send();
+        });
+      }
+
+      async function playVideo()
+      {
+        var data = await fetchMedia();
+        var video = document.getElementsByTagName('video')[0];
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await new Promise(resolve => source.addEventListener('sourceopen', resolve, { once: true }));
+
+        var sourceBuffer = source.addSourceBuffer(mediaType());
+        sourceBuffer.appendBuffer(data);
+        await new Promise(resolve => sourceBuffer.addEventListener('updateend', resolve, { once: true }));
+
+        await video.play();
+        return true;
+      }
+
+      function setDuration(duration)
+      {
+        source.duration = duration;
+      }
+  </script>
+</head>
+<body>
+    <video width=640 height=480></video>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -245,6 +245,7 @@ Tests/WebKit/WKWebView/PasteWebArchive.mm @nonARC
 Tests/WebKit/WKWebView/PermissionsAPI.mm @nonARC
 Tests/WebKit/WKWebView/PictureInPictureDelegate.mm @nonARC
 Tests/WebKit/WKWebView/PitchShiftAudioUnitTests.cpp
+Tests/WebKit/WKWebView/PlaybackSessionSeekableRanges.mm @nonARC
 Tests/WebKit/WKWebView/Preconnect.mm @nonARC
 Tests/WebKit/WKWebView/Preferences.mm @nonARC
 Tests/WebKit/WKWebView/PreferredAudioBufferSize.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PlaybackSessionSeekableRanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PlaybackSessionSeekableRanges.mm
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+// A MediaSource-backed element fires no "progress" events, so the playback session model must learn
+// about a new seekable range some other way. Without that, the fullscreen scrubber stays disabled
+// because the UI process still holds the ranges captured when the element was first attached.
+TEST(VideoControlsManager, MediaSourceSeekableRangesFollowDurationChange)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    [[configuration preferences] _setMediaSourceEnabled:YES];
+    [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"mse-seekable-ranges"];
+
+    if (![[webView objectByEvaluatingJavaScript:@"window.MediaSource !== undefined"] boolValue])
+        return;
+    if (![[webView objectByEvaluatingJavaScript:@"isMP4Supported() || isWebMVP9Supported() || isWebMOpusSupported()"] boolValue])
+        return;
+
+    EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return await playVideo()" withArguments:nil] boolValue]);
+
+    Util::waitForConditionWithLogging([&] {
+        return !![webView _hasActiveVideoForControlsManager];
+    }, 10, @"Timed out while waiting for the video controls manager");
+    EXPECT_TRUE([webView _hasActiveVideoForControlsManager]);
+
+    // The appended segment gives the media source a duration, so the controls manager starts out
+    // with a non-empty seekable range.
+    Util::waitForConditionWithLogging([&] {
+        return [webView _maximumSeekableTime] > 0;
+    }, 10, @"Timed out while waiting for the initial seekable range");
+    EXPECT_GT([webView _maximumSeekableTime], 0.0);
+
+    [webView objectByEvaluatingJavaScript:@"setDuration(60)"];
+    Util::waitForConditionWithLogging([&] {
+        return [webView _maximumSeekableTime] == 60.0;
+    }, 10, @"Timed out while waiting for the seekable range to follow the new duration");
+    EXPECT_EQ([webView _maximumSeekableTime], 60.0);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 7067ca63e9135059e8f2acd3f6e791a1c2e576c6
<pre>
[visionOS] Enter Exit Spatial Browsing switching videos leads to Greyed Out Playback UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=323206">https://bugs.webkit.org/show_bug.cgi?id=323206</a>
<a href="https://rdar.apple.com/183164198">rdar://183164198</a>

Reviewed by Jer Noble.

Setting the duration became asynchronous once the MediaSourcePrivate was made
to run in its own WorkQueue, so the UI process used the initial duration (NaN)
to calculate the range and that set canSeek = NO for AVKit.
From that point the calculated seekable range was stale and stayed empty.

If the UI process got the updated duration on time, then seekable range was
updated properly and  canSeek was set to YES ; the controls showed.

The main point of failure was that the PlaybackSessionModelMediaElement
listened to the HTMLMediaElement&apos;s progressEvent update its seekable range
and notify the UI process with the new range.

Since moving the MediaPlayerPrivateMediaSourceAVFObjC to the web content process,
we do not fire the progress event anymore and so seekableRangesChanged was
never called and the cached seekable range in the UI process stayed stale.

We stop relying on the progress event, instead we add a new seekableRangesFromMediaSourceChanged()
callback where the MediaPlayerPrivate can notify the seekable range has changed
and which in turns notifies the PlaybackSessionModelMediaElement via seekableRangesChanged().

Added API test and manually verified on device.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerSeekableTimeRangesChanged):
(WebCore::HTMLMediaElement::addClient):
(WebCore::HTMLMediaElement::seekableRangesChanged):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElementClient::seekableRangesChanged):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::setMediaElement):
(WebCore::PlaybackSessionModelMediaElement::updateForEventName):
(WebCore::PlaybackSessionModelMediaElement::addClient):
(WebCore::PlaybackSessionModelMediaElement::seekableRangesChanged):
(WebCore::PlaybackSessionModelMediaElement::updateSeekableRanges):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::seekableRangesFromMediaSourceChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::durationChanged):
(WebCore::MediaSourcePrivate::bufferedChanged):
(WebCore::MediaSourcePrivate::notifySeekableRangesChanged):
(WebCore::MediaSourcePrivate::setLiveSeekableRange):
(WebCore::MediaSourcePrivate::clearLiveSeekableRange):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekableRangesFromMediaSourceChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::seekableRangesFromMediaSourceChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekableRangesFromMediaSourceChanged):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _maximumSeekableTime]):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::seekableRanges):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::updateCachedState):

Canonical link: <a href="https://commits.webkit.org/320425@main">https://commits.webkit.org/320425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab6b8bd66ed7b22a0439b8cf4e58a976b076437

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148879 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0208d649-263f-43f9-8a7e-e6437147aedc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144253 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100148 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1241b94d-a8a5-4f8b-99a5-ba383bf76aca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7716cc2-1d31-487b-a83c-c2c73c66291f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44779 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44409 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5995 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196883 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58197 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153718 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41180 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58900 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153371 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47896 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131189 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57401 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19430 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56763 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57012 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->