### PR TITLE
[JSC] Preserve switch discriminant value in a temporary register

### DIFF
--- a/JSTests/stress/switch-with-side-effects.js
+++ b/JSTests/stress/switch-with-side-effects.js
@@ -1,0 +1,43 @@
+function test1() {
+    var p = 0;
+    switch (p) {
+    case (p = 1):
+        throw new Error("should not be reached");
+    case 0:
+        break;
+    }
+}
+
+function test2() {
+    var p = 1;
+    switch (p) {
+    case 2:
+        break;
+    case (p = 3):
+        throw new Error("should not be reached");
+    }
+}
+
+function test3() {
+    var p = 0;
+    var result;
+
+    switch (p) {
+    case (p = 1):
+        result = "wrong";
+        break;
+    case p:
+        result = "wrong";
+        break;
+    case 0:
+        result = "ok";
+        break;
+    }
+
+    if (result !== "ok")
+        throw new Error("Bad result: " + result);
+}
+
+test1();
+test2();
+test3();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4923,7 +4923,8 @@ void SwitchNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 
     Ref<LabelScope> scope = generator.newLabelScope(LabelScope::Switch);
 
-    RefPtr<RegisterID> r0 = generator.emitNode(m_expr);
+    RefPtr<RegisterID> r0 = generator.newTemporary();
+    generator.emitNode(r0.get(), m_expr);
 
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::DoNotOptimize, BytecodeGenerator::NestedScopeType::IsNested);
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 			script = (
 				"\"${SCRIPT_INPUT_FILE_0}\"",
 				"",
+				"",
 			);
 		};
 /* End PBXBuildRule section */


### PR DESCRIPTION
#### 11d59b5d4b51d8900e709f3d7cb358050e6b6c14
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
</pre>
----------------------------------------------------------------------
#### a04deda55d1a22f85d7a0de0f565459735cd5391
<pre>
[JSC] Preserve switch discriminant value in a temporary register
<a href="https://bugs.webkit.org/show_bug.cgi?id=323203">https://bugs.webkit.org/show_bug.cgi?id=323203</a>

Reviewed by NOBODY (OOPS!).

When a switch statement is evaluated, its discriminant value is evaluated before
any case expressions and must not be affected by side effects from evaluating those
expressions. [1][2]

However, the current implementation may keep the discriminant value in the same
register as the original local variable. If a case expression modifies that variable,
the saved discriminant value can be overwritten, causing incorrect case matching.

The following LLInt bytecode is generated for the `test` function shown below.

Before:
```
bb#1
Predecessors: [ ]
[   0] enter
[   1] mov                dst:loc5, src:Int32: 3(const0)
[   4] switch_imm         tableIndex:0, scrutinee:loc5
```

After:
```
bb#1
Predecessors: [ ]
[   0] enter
[   1] mov                dst:loc5, src:Int32: 3(const0)
[   4] mov                dst:loc7, src:loc5
[   7] switch_imm         tableIndex:0, scrutinee:loc7
```

I also measured the performance impact of the additional mov using the following
microbenchmark. No performance regression was observed in this measurement.

Before:
Time (mean ± σ):     122.0 ms ±   1.5 ms    [User: 73.0 ms, System: 36.8 ms]
Range (min … max):   119.2 ms … 125.7 ms    20 runs

After:
Time (mean ± σ):     122.8 ms ±   2.3 ms    [User: 73.5 ms, System: 37.5 ms]
Range (min … max):   120.3 ms … 131.5 ms    20 runs

For the code:

```js
function test() {
    var p = 3; var result;
    switch (p) {
    case 1:
        result = &quot;wrong&quot;; break;
    case 2:
        result = &quot;wrong&quot;; break;
    case 3:
        result = &quot;ok&quot;; break;
    case 0:
        result = &quot;ok&quot;; break;
    }
}
for (var i = 0; i &lt; 1e6; ++i) test();
for (var i = 0; i &lt; 1e6; ++i) test();
```

[1]: [ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation](<a href="https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation)">https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation)</a>
[2]: [ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected](<a href="https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected)">https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected)</a>

Test: JSTests/stress/switch-with-side-effects.js

* JSTests/stress/switch-with-side-effects.js: Added.
(test1):
(test2):
(test3):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::SwitchNode::emitBytecode):
</pre>