### PR TITLE
[JSC] Preserve `switch` discriminant value in a temporary register

### DIFF
--- a/JSTests/ChakraCore.yaml
+++ b/JSTests/ChakraCore.yaml
@@ -256,8 +256,7 @@
 - path: ChakraCore/test/Basics/StringSubstring.js
   cmd: runChakra :baseline, "NoException", "StringSubstring.baseline", []
 - path: ChakraCore/test/Basics/switch.js
-  # JSC doesn't handle computed case statements.
-  cmd: runChakra :skip, "NoException", "switch.baseline", []
+  cmd: runChakra :baseline, "NoException", "switch.baseline", []
 - path: ChakraCore/test/Basics/Switch2.js
   cmd: runChakra :baseline, "NoException", "switch2.baseline", []
 - path: ChakraCore/test/Basics/typeof.js

--- a/JSTests/stress/switch-with-side-effects.js
+++ b/JSTests/stress/switch-with-side-effects.js
@@ -1,0 +1,43 @@
+function test1() {
+    var p = 0;
+    switch (p) {
+    case (p = 1):
+        throw new Error("should not be reached");
+    case 0:
+        break;
+    }
+}
+
+function test2() {
+    var p = 1;
+    switch (p) {
+    case 2:
+        break;
+    case (p = 3):
+        throw new Error("should not be reached");
+    }
+}
+
+function test3() {
+    var p = 0;
+    var result;
+
+    switch (p) {
+    case (p = 1):
+        result = "wrong";
+        break;
+    case p:
+        result = "wrong";
+        break;
+    case 0:
+        result = "ok";
+        break;
+    }
+
+    if (result !== "ok")
+        throw new Error("Bad Result: " + result);
+}
+
+test1();
+test2();
+test3();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4872,19 +4872,28 @@ void CaseBlockNode::emitBytecodeForBlock(BytecodeGenerator& generator, RegisterI
             labelVector.append(generator.newLabel());
         generator.beginSwitch(switchExpression, switchType);
     } else {
+        RefPtr<RegisterID> preservedSwitchExpression;
+        RegisterID* originalSwitchExpression = switchExpression;
+
+        // We have to preserve the `switchExpression` to avoid being affected by side effects produced by case expressions.
+        if (!switchExpression->isTemporary()) {
+            preservedSwitchExpression = generator.move(generator.newTemporary(), switchExpression);
+            originalSwitchExpression = preservedSwitchExpression.get();
+        }
+
         // Setup jumps
         for (ClauseListNode* list = m_list1; list; list = list->getNext()) {
             RefPtr<RegisterID> clauseVal = generator.emitNode(list->getClause()->expr());
             Ref<Label> clauseLabel = generator.newLabel();
             labelVector.append(clauseLabel);
-            generator.emitJumpIfTrue(generator.emitEqualityOp<OpStricteq>(generator.newTemporary(), clauseVal.get(), switchExpression), clauseLabel.get());
+            generator.emitJumpIfTrue(generator.emitEqualityOp<OpStricteq>(generator.newTemporary(), clauseVal.get(), originalSwitchExpression), clauseLabel.get());
         }
         
         for (ClauseListNode* list = m_list2; list; list = list->getNext()) {
             RefPtr<RegisterID> clauseVal = generator.emitNode(list->getClause()->expr());
             Ref<Label> clauseLabel = generator.newLabel();
             labelVector.append(clauseLabel);
-            generator.emitJumpIfTrue(generator.emitEqualityOp<OpStricteq>(generator.newTemporary(), clauseVal.get(), switchExpression), clauseLabel.get());
+            generator.emitJumpIfTrue(generator.emitEqualityOp<OpStricteq>(generator.newTemporary(), clauseVal.get(), originalSwitchExpression), clauseLabel.get());
         }
         generator.emitJump(defaultLabel.get());
     }


### PR DESCRIPTION
#### fcad1f71d78912b1d87790445c496e5b3d5e6494
<pre>
[JSC] Preserve `switch` discriminant value in a temporary register
<a href="https://bugs.webkit.org/show_bug.cgi?id=323203">https://bugs.webkit.org/show_bug.cgi?id=323203</a>

Reviewed by NOBODY (OOPS!).

When a switch statement is evaluated, its discriminant value is evaluated before
any case expressions and must not be affected by side effects from evaluating those
expressions. [1][2]

However, the current implementation may keep the discriminant value in the same
register as the original local variable. If a case expression modifies that variable,
the saved discriminant value can be overwritten, causing incorrect case matching.

The following LLInt bytecode is generated for the `test` function shown below.

Before:
```
bb#1
Predecessors: [ ]
[   0] enter
[   7] mov                dst:loc5, src:Int32: 1(const1)
[  10] jstricteq          lhs:loc5, rhs:loc5, targetLabel:10(-&gt;20)
```

After:
```
bb#1
Predecessors: [ ]
[   0] enter
[   1] mov                dst:loc5, src:Int32: 0(const0)
[   4] mov                dst:loc6, src:loc5
[   7] mov                dst:loc5, src:Int32: 1(const1)
[  10] jstricteq          lhs:loc5, rhs:loc6, targetLabel:10(-&gt;20)
```

I also measured the performance impact of the additional mov using the &apos;switch&apos;
microbenchmark. No performance regression was observed in this measurement.

| base@2507145 | pathed | result |
| ----- | ----- | ------ |
| 121.1207+-0.4896 ? | 121.5071+-0.6284 ? | might be 1.0032x slower |

For the code:

```js
function test() {
    var p = 0;
    switch (p) {
    case (p = 1):
        return &quot;wrong&quot;;
    case 1:
        return &quot;ok&quot;;
    }
}
```

[1]: [ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation](<a href="https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation)">https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-switch-statement-runtime-semantics-evaluation)</a>
[2]: [ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected](<a href="https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected)">https://tc39.es/ecma262/2026/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-caseclauseisselected)</a>

Test: JSTests/stress/switch-with-side-effects.js

* JSTests/ChakraCore.yaml:
* JSTests/stress/switch-with-side-effects.js: Added.
(test1):
(test2):
(test3):
(test):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CaseBlockNode::emitBytecodeForBlock):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcad1f71d78912b1d87790445c496e5b3d5e6494

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150014 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144669 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100349 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45141 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6876 "Found 1 new JSC stress test failure: Too many failures: 2108 jsc tests failed (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13762 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44830 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6523 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46397 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197419 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58715 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59424 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153826 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48322 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131727 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128386 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->