### PR TITLE
dibsido QR scanner camera preview is not rendering

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS MediaStream video element migrated from an inert document must become intersecting
+

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>MediaStream video element migrated from an inert document must become intersecting</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    assert_true(!!window.internals, "test requires window.internals");
+
+    const inertDocument = document.implementation.createHTMLDocument("inert");
+    const video = inertDocument.createElement("video");
+    video.autoplay = true;
+    video.muted = true;
+    video.playsInline = true;
+    video.width = 320;
+    video.height = 240;
+
+    assert_not_equals(video.ownerDocument, document, "video created in inert document");
+
+    document.body.appendChild(video);
+    assert_equals(video.ownerDocument, document, "video adopted into main document");
+
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
+
+    await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+
+    let counter = 50;
+    while (!internals.isMediaElementIntersectingViewport(video) && --counter > 0)
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+    assert_true(internals.isMediaElementIntersectingViewport(video), "LazyLoadVideoObserver reports the on-screen <video> as intersecting after cross-document adoption");
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -514,6 +514,10 @@ void HTMLVideoElement::didMoveToNewDocument(Document& oldDocument, Document& new
 {
     if (m_imageLoader)
         m_imageLoader->elementDidMoveToNewDocument(oldDocument);
+
+    LazyLoadVideoObserver::unobserve(*this, oldDocument);
+    LazyLoadVideoObserver::observe(*this);
+
     HTMLMediaElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5696,6 +5696,11 @@ bool Internals::isPlayerVisibleInViewport(const HTMLMediaElement& element) const
     return player && player->viewportVisibility() == HTMLMediaElement::ViewportVisibility::VisibleInViewport;
 }
 
+bool Internals::isMediaElementIntersectingViewport(const HTMLMediaElement& element) const
+{
+    return element.isIntersectingViewport();
+}
+
 bool Internals::isPlayerMuted(const HTMLMediaElement& element) const
 {
     RefPtr player = element.player();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -951,6 +951,7 @@ public:
     void activeAudioRouteDidChange(bool shouldPause);
     bool NODELETE elementIsBlockingDisplaySleep(const HTMLMediaElement&) const;
     bool NODELETE isPlayerVisibleInViewport(const HTMLMediaElement&) const;
+    bool isMediaElementIntersectingViewport(const HTMLMediaElement&) const;
     bool isPlayerMuted(const HTMLMediaElement&) const;
     bool isPlayerPaused(const HTMLMediaElement&) const;
     double effectiveRate(const HTMLMediaElement&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1157,6 +1157,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined simulateSystemWake();
     [Conditional=VIDEO] boolean elementIsBlockingDisplaySleep(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerVisibleInViewport(HTMLMediaElement element);
+    [Conditional=VIDEO] boolean isMediaElementIntersectingViewport(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerMuted(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerPaused(HTMLMediaElement element);
     [Conditional=VIDEO] double effectiveRate(HTMLMediaElement element);


### PR DESCRIPTION
#### 61b11e2e9afe52d025b99dc454a16912843b4ee9
<pre>
dibsido QR scanner camera preview is not rendering
<a href="https://rdar.apple.com/185205409">rdar://185205409</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323213">https://bugs.webkit.org/show_bug.cgi?id=323213</a>

Reviewed by Jean-Yves Avenard.

311380@main added a LazyLoadVideoObserver to every &lt;video&gt; at construction time,
and gated HTMLVideoElement&apos;s accelerated rendering on the observer&apos;s m_isIntersectingViewport signal.

This gets broken when the element is migrated to a new document since the observer would stay bound to the previous document.
Video element would then no longer render as they would think they are not visible in view port.
This notably applies to frameworks that parse HTML in an inert document.

We fix this by migrating the observer from the old document to the new document in HTMLVideoElement::didMoveToNewDocument.

Test: fast/mediastream/MediaStream-video-element-cross-document-intersection-observer.html

* LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer-expected.txt: Added.
* LayoutTests/fast/mediastream/MediaStream-video-element-cross-document-intersection-observer.html: Added.
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::didMoveToNewDocument):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isMediaElementIntersectingViewport const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/320405@main">https://commits.webkit.org/320405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa322d13f29711dbef4ac2dacd1219f91423783b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148754 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a022567-048f-4567-83e5-1cc9b1d15008) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144015 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100071 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc57e9ae-9197-4ca7-8ebc-a4473f76f1f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124431 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c0f8ee0-fee5-461a-8618-da26f26e67d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46516 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44695 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44300 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196742 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164242 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153597 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41167 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58769 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153259 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47785 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131061 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19314 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->