### PR TITLE
[GStreamer] Outgoing WebRTC audio under-feeds the resampler and reads past its input

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5309,8 +5309,6 @@ webkit.org/b/322815 imported/w3c/web-platform-tests/mediacapture-record/MediaRec
 webkit.org/b/322816 imported/w3c/web-platform-tests/resource-timing/initiator-type/style.html [ Failure Pass ]
 
 webkit.org/b/323002 [ Debug ] fast/events/tabindex-focus-blur-all.html [ Crash Pass ]
-webkit.org/b/323003 [ Release ] imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Crash Pass ]
-webkit.org/b/323003 [ Release ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-connectionState.https.html [ Crash Pass ]
 webkit.org/b/314218 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-seeking.html [ Failure Pass ]
 
 webkit.org/b/323308 http/tests/web-locks/web-lock-in-third-party-serviceworker.html [ Failure Pass ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1293,7 +1293,6 @@ webkit.org/b/323611 imported/w3c/web-platform-tests/css/css-anchor-position/posi
 webkit.org/b/323611 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-008-rtl.html [ ImageOnlyFailure Pass ]
 
 webkit.org/b/323612 imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-line-height.html [ ImageOnlyFailure ]
-webkit.org/b/323615 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html?rest [ Pass Crash ]
 
 # Gardening 2026-09-02
 webkit.org/b/306026 media/video-muted-holds-sleep-assertion.html [ Failure ]

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
@@ -106,6 +106,24 @@ void RealtimeOutgoingAudioSourceLibWebRTC::audioSamplesAvailable(const MediaTime
     });
 }
 
+static std::optional<size_t> gstAudioConverterInputFramesForOutput(GstAudioConverter* converter, size_t outputFrames, size_t availableFrames)
+{
+    // gst_audio_converter_get_in_frames() derives its answer from the resampler phase and leaves out the
+    // filter history the resampler has yet to accumulate, so on its own it asks for fewer frames than a
+    // whole chunk needs and the resampler then reads past the end of its input. Only get_out_frames()
+    // accounts for that history, so it decides both whether a chunk fits and how large it has to be.
+    if (gst_audio_converter_get_out_frames(converter, availableFrames) < outputFrames)
+        return std::nullopt;
+
+    // With a fractional ratio the phase estimate can also sit one frame above what the accumulated
+    // history makes sufficient, so never start the search beyond the frames actually available.
+    auto inputFrames = std::min<size_t>(gst_audio_converter_get_in_frames(converter, outputFrames), availableFrames);
+    while (gst_audio_converter_get_out_frames(converter, inputFrames) < outputFrames)
+        inputFrames++;
+
+    return inputFrames;
+}
+
 void RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData()
 {
     if (!GST_AUDIO_INFO_IS_VALID(&m_inputStreamDescription) || !GST_AUDIO_INFO_IS_VALID(&m_outputStreamDescription)) {
@@ -115,15 +133,27 @@ void RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData()
 
     size_t outChunkSampleCount = LibWebRTCAudioFormat::chunkSampleCount;
     size_t outBufferSize = outChunkSampleCount * m_outputStreamDescription.bpf;
+    m_audioBuffer.grow(outBufferSize);
 
     Locker locker { m_adapterLock };
-    size_t inChunkSampleCount = gst_audio_converter_get_in_frames(m_sampleConverter.get(), outChunkSampleCount);
-    size_t inBufferSize = inChunkSampleCount * m_inputStreamDescription.bpf;
+    while (gst_adapter_available(m_adapter.get())) {
+        bool silenced = isSilenced();
+        size_t availableFrames = gst_adapter_available(m_adapter.get()) / m_inputStreamDescription.bpf;
+        size_t inChunkSampleCount;
+        if (silenced) {
+            // Silence bypasses the converter, so consume input at the nominal rate to keep pacing.
+            inChunkSampleCount = gst_audio_converter_get_in_frames(m_sampleConverter.get(), outChunkSampleCount);
+            if (inChunkSampleCount > availableFrames)
+                break;
+        } else {
+            auto frames = gstAudioConverterInputFramesForOutput(m_sampleConverter.get(), outChunkSampleCount, availableFrames);
+            if (!frames)
+                break;
+            inChunkSampleCount = *frames;
+        }
 
-    while (gst_adapter_available(m_adapter.get()) > inBufferSize) {
-        GRefPtr inBuffer = adoptGRef(gst_adapter_take_buffer(m_adapter.get(), inBufferSize));
-        m_audioBuffer.grow(outBufferSize);
-        if (isSilenced()) {
+        GRefPtr inBuffer = adoptGRef(gst_buffer_make_writable(gst_adapter_take_buffer(m_adapter.get(), inChunkSampleCount * m_inputStreamDescription.bpf)));
+        if (silenced) {
             GST_TRACE("Audio buffer will contain silence");
             webkitGstAudioFormatFillSilence(m_outputStreamDescription.finfo, m_audioBuffer.mutableSpan().data(), outBufferSize);
         } else {


### PR DESCRIPTION
#### 301315ef577356c7ec6a5af55b299aa1cf1f4b31
<pre>
[GStreamer] Outgoing WebRTC audio under-feeds the resampler and reads past its input
<a href="https://bugs.webkit.org/show_bug.cgi?id=323217">https://bugs.webkit.org/show_bug.cgi?id=323217</a>

Reviewed by Philippe Normand.

pullAudioData() converts capture data into the 480-frame chunks libwebrtc
requires and sizes its input with gst_audio_converter_get_in_frames(), which
derives its answer from the resampler phase alone and excludes the filter
history the resampler has yet to accumulate. The resulting chunk is too small:
for a 44.1 kHz source it is 441 frames, from which the converter can produce
only 453 of the 480 frames requested. The resampler checks only that it can
emit the first output sample and then walks past the end of its buffer for the
remainder, so it corrupts part of every chunk and occasionally crashes the
WebRTC signalling thread. Every capture rate other than 48 kHz is affected,
and the count was computed once outside the loop although it depends on the
phase.

Size the chunk with gst_audio_converter_get_out_frames() instead, which does
account for the history, and recompute it for each chunk. The search starts
from the phase estimate but never above the frames actually buffered, since
for fractional ratios such as 22.05 kHz the estimate can sit one frame above
what the accumulated history already makes sufficient. The first chunk
consumes a few extra frames, which become filter history rather than being
dropped, so long-run consumption stays at the nominal ratio. Silence keeps the
previous sizing because it bypasses the converter.

Tests: imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html
       imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-connectionState.https.html
       imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp:
(WebCore::gstAudioConverterInputFramesForOutput):
(WebCore::RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData):
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320924@main">https://commits.webkit.org/320924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6998123e7391ca3a2595702bc25c2b0ec0b6f954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145561 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47976 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45679 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7658 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59848 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60559 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154777 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49205 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130005 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20658 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58386 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->