### PR TITLE
[CMake][Swift] Add diagnostics for the intermittent Windows SwiftRebu…

### DIFF
--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -192,4 +192,11 @@ if (SWIFT_REQUIRED)
         # Single list item to avoid deduplication problems
         list(APPEND WebKit_PLATFORM_SWIFT_CLANG_FLAG_PAIRS "-Xcc -ivfsoverlay -Xcc ${_win_vfs_overlay}")
     endif ()
+    # The CONFIGURE_DEPENDS glob above makes Ninja re-check globs on every
+    # build, so this block can rerun in an environment that differs from the
+    # one the original configure saw. Log what it found, so two non-matching
+    # copies of these lines in one bot log expose that.
+    # https://bugs.webkit.org/show_bug.cgi?id=BUGNUMBER
+    message(STATUS "SwiftTrigger[Win]: SDKROOT=[$ENV{SDKROOT}] VCToolsInstallDir=[$ENV{VCToolsInstallDir}]")
+    message(STATUS "SwiftTrigger[Win]: modulemap_result=${_win_mm_result} vfs_overlay=[${_win_vfs_overlay}]")
 endif ()

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1210,6 +1210,26 @@ function(_WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS _outvar)
     set(${_outvar} ${_flags} PARENT_SCOPE)
 endfunction()
 
+# Diagnostics for the intermittent Windows "dependency cycle:
+# WebKit_SwiftRebuildTrigger.swift -> WebKit_SwiftRebuildTrigger.swift" failure.
+# https://bugs.webkit.org/show_bug.cgi?id=BUGNUMBER
+#
+# Interposes a named stamp between the Swift rebuild trigger and one group of
+# its dependencies. Ninja names every node on a cycle it reports, so routing
+# each group through a distinctly named stamp makes the error message say which
+# group closes the loop. A cycle that still reads as a bare trigger -> trigger
+# came in through the trigger's DEPFILE rather than through any of these.
+function(_webkit_swift_trigger_gate _target _label _outvar)
+    set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${_target}_SwiftTriggerGate_${_label}.stamp")
+    add_custom_command(
+        OUTPUT "${_stamp}"
+        DEPENDS ${ARGN}
+        COMMAND ${CMAKE_COMMAND} -E touch "${_stamp}"
+        COMMENT "Swift rebuild trigger gate: ${_target} ${_label}"
+        VERBATIM)
+    set(${_outvar} "${_stamp}" PARENT_SCOPE)
+endfunction()
+
 # Generates ${_resp_path}, a swiftc @-response file with the platform-derived
 # flags. Mirrors the Xcode "Generate Swift platform args" build phase.
 # Format (one token per line): -DNAME for truthy HAVE_/USE_/ENABLE_/
@@ -1550,7 +1570,9 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # Create a file whose mtime tracks various build changes that should
         # cause swift's driver to rerun.
         set(_trigger_path "${CMAKE_CURRENT_BINARY_DIR}/${_target}_SwiftRebuildTrigger.swift")
+        set(_trigger_existed TRUE)
         if (NOT EXISTS "${_trigger_path}")
+            set(_trigger_existed FALSE)
             file(WRITE "${_trigger_path}" "// Auto-generated; mtime tracks ${_target}'s Swift inputs.\n")
         endif ()
 
@@ -1584,10 +1606,17 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # cause Ninja to ingest changes made to it. swiftc-wrapper.py only
         # rewrites the file when it actually changes, so this settles instead
         # of looping.
-        set(_trigger_deps "${_resp_path}" "${_swift_depfile}")
+        #
+        # Each group goes through a named gate stamp so that a dependency-cycle
+        # error identifies the group. See _webkit_swift_trigger_gate.
+        _webkit_swift_trigger_gate(${_target} resp _gate_resp "${_resp_path}")
+        _webkit_swift_trigger_gate(${_target} swift-depfile _gate_depfile "${_swift_depfile}")
+        set(_trigger_deps "${_gate_resp}" "${_gate_depfile}")
         if (NOT (DEFINED ${_target}_SWIFT_INTEROP_SOURCES OR
             _skip_swift_cxx_header))
-            list(APPEND _trigger_deps "${_header_stamp_path}")
+            _webkit_swift_trigger_gate(${_target} cxx-header-stamp _gate_header
+                "${_header_stamp_path}")
+            list(APPEND _trigger_deps "${_gate_header}")
         endif ()
         add_custom_command(
             OUTPUT "${_trigger_path}"
@@ -1598,6 +1627,39 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         )
         target_sources(${_target} PRIVATE "${_trigger_path}")
         add_custom_target(${_target}_SwiftRebuildTrigger DEPENDS "${_trigger_path}")
+
+        # Fingerprint for the intermittent Windows dependency-cycle failure
+        # (https://bugs.webkit.org/show_bug.cgi?id=BUGNUMBER). Ninja reports a
+        # cycle before running any edge, so only configure-time output and
+        # Ninja's own error message survive a failing run. Paths are bracketed
+        # and unnormalized on purpose: the leading hypothesis is that two
+        # spellings of one path collapse onto a single Ninja node on Windows,
+        # which is invisible once the spelling has been cleaned up.
+        if (POLICY CMP0157)
+            cmake_policy(GET CMP0157 _cmp0157)
+        else ()
+            set(_cmp0157 "ABSENT")
+        endif ()
+        get_target_property(_swift_module_dir ${_target} Swift_MODULE_DIRECTORY)
+        set(_interop_defined FALSE)
+        if (DEFINED ${_target}_SWIFT_INTEROP_SOURCES)
+            set(_interop_defined TRUE)
+        endif ()
+        message(STATUS "SwiftTrigger[${_target}]: cmake=${CMAKE_VERSION} generator=${CMAKE_GENERATOR} "
+                       "CMP0157=[${_cmp0157}] swiftc=${CMAKE_Swift_COMPILER_VERSION}")
+        message(STATUS "SwiftTrigger[${_target}]: interop_sources_defined=${_interop_defined} "
+                       "skip_cxx_header=${_skip_swift_cxx_header} trigger_pre_existed=${_trigger_existed}")
+        message(STATUS "SwiftTrigger[${_target}]: trigger=[${_trigger_path}]")
+        message(STATUS "SwiftTrigger[${_target}]: depfile=[${_swift_depfile}]")
+        message(STATUS "SwiftTrigger[${_target}]: resp=[${_resp_path}]")
+        message(STATUS "SwiftTrigger[${_target}]: header_stamp=[${_header_stamp_path}]")
+        message(STATUS "SwiftTrigger[${_target}]: header_tmp=[${_header_tmp_path}]")
+        message(STATUS "SwiftTrigger[${_target}]: swiftmodule=[${CMAKE_CURRENT_BINARY_DIR}/${_module_name}.swiftmodule]")
+        message(STATUS "SwiftTrigger[${_target}]: module_dir=[${_swift_module_dir}]")
+        message(STATUS "SwiftTrigger[${_target}]: trigger_deps=[${_trigger_deps}]")
+        unset(_cmp0157)
+        unset(_swift_module_dir)
+        unset(_interop_defined)
 
         if (NOT _skip_swift_cxx_header)
             # WebKit-Swift-Generated.h.tmp must be written by exactly one target: the one

--- a/Tools/Scripts/swift/swiftc-wrapper.py
+++ b/Tools/Scripts/swift/swiftc-wrapper.py
@@ -79,6 +79,37 @@ def _unescape(path):
     return path.replace("\\ ", " ")
 
 
+def _canonical(path):
+    """A spelling-insensitive key for paths that name the same file."""
+    return os.path.normcase(os.path.normpath(path)).replace("\\", "/")
+
+
+def report_leaked_excludes(request, deps):
+    """Warn about deps that name an excluded file but spell it differently.
+
+    The exclude test below is an exact string match, so a dependency swiftc
+    spelled another way -- backslashes, a differently cased drive letter, an
+    unnormalized path -- survives it. CMake's depfile transform and Ninja then
+    normalize that spelling back onto the node the exclude meant to drop, and
+    the dependency reappears in the graph. For request.target, which is the
+    depfile's own output, that is a self-cycle: Ninja reports "dependency
+    cycle: X -> X" and fails before running anything.
+    https://bugs.webkit.org/show_bug.cgi?id=BUGNUMBER
+    """
+    expected = {_canonical(exclude): exclude for exclude in request.excludes}
+    expected.setdefault(_canonical(request.target), request.target)
+    expected.setdefault(_canonical(request.path), request.path)
+    for dep in deps:
+        wanted = expected.get(_canonical(dep))
+        if wanted is not None and dep != wanted:
+            print(
+                f"{Path(__file__).name}: warning: dependency [{dep}] escaped the "
+                f"exclude for [{wanted}]; the two spellings name one file, so "
+                f"Ninja will re-add it as a dependency of [{request.target}]",
+                file=sys.stderr,
+            )
+
+
 def parse_depfile(path):
     """Yield the dependencies recorded in one Makefile-syntax depfile."""
     text = Path(path).read_text(errors="replace").replace("\\\n", " ")
@@ -120,6 +151,8 @@ def write_ninja_depfile(request, output_file_map):
         for dep in parse_depfile(source)
         if dep not in request.excludes
     )
+
+    report_leaked_excludes(request, deps)
 
     lines = [f"{_escape(request.target)}:"]
     lines += (f"  {_escape(dep)}" for dep in deps)


### PR DESCRIPTION

DO NOT MERGE - diagnostics only.

Reviewed by NOBODY (OOPS!).

The Windows bot intermittently fails with "ninja: error: dependency cycle: Source/WebKit/WebKit_SwiftRebuildTrigger.swift ->
Source/WebKit/WebKit_SwiftRebuildTrigger.swift". Ninja detects cycles while planning, before it runs any edge, so nothing a build command prints survives a failing run. This adds diagnostics in the three places that do produce output on such a run: CMake's configure log, Ninja's own error message, and the Swift compile of a *preceding* successful build.

The leading hypothesis is that swiftc-wrapper.py's depfile exclude list is compared by exact string match, so a dependency swiftc spelled differently (backslashes, drive-letter case, an unnormalized path) escapes the filter and is then normalized back onto the excluded node by CMake's depfile transform and Ninja. When the escapee is the depfile's own target, that is a self-cycle. report_leaked_excludes() detects exactly that and names both spellings.

The trigger's explicit dependencies now each route through a named gate stamp. Ninja names every node on a cycle it reports, so the error message will say which dependency group closes the loop -- or, if it still reads as a bare trigger -> trigger, that the loop came in through the DEPFILE instead.

Diagnostics only; no behavior change is intended.

* Source/WebKit/PlatformWin.cmake:
* Source/cmake/WebKitMacros.cmake:
* Tools/Scripts/swift/swiftc-wrapper.py:

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72aba412eda525de5b34937c7b5dcb02c429533a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194815 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148771 "Hash 72aba412 for PR 73056 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58143 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148771 "Hash 72aba412 for PR 73056 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187441 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/13254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5887 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45763 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58080 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153616 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58785 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/47803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131077 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57288 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->