### PR TITLE
[WPE] Clipboard API tests always fail on the legacy API bot

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp
@@ -1753,7 +1753,12 @@ void beforeAll()
 #if ENABLE(POINTER_LOCK)
     UIClientTest::add("WebKitWebView", "pointer-lock-permission-request", testWebViewPointerLockPermissionRequest);
 #endif
-    UIClientTest::add("WebKitWebView", "clipboard-permission-request", testWebViewClipboardPermissionRequest);
+    bool clipboardPermissionRequestSupported = true;
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    clipboardPermissionRequestSupported = !Test::s_useWPELegacyAPI;
+#endif
+    if (clipboardPermissionRequestSupported)
+        UIClientTest::add("WebKitWebView", "clipboard-permission-request", testWebViewClipboardPermissionRequest);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewEditor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewEditor.cpp
@@ -119,8 +119,10 @@ static void testEditorArrowKeysStillScroll(EditorKeyBindingTest* test, gconstpoi
 
 void beforeAll()
 {
-    EditorKeyBindingTest::add("WebKitWebView", "editor-copy-key-binding-non-editable", testEditorCopyKeyBindingNonEditable);
-    EditorKeyBindingTest::add("WebKitWebView", "editor-copy-key-binding-editable", testEditorCopyKeyBindingEditable);
+    if (!Test::s_useWPELegacyAPI) {
+        EditorKeyBindingTest::add("WebKitWebView", "editor-copy-key-binding-non-editable", testEditorCopyKeyBindingNonEditable);
+        EditorKeyBindingTest::add("WebKitWebView", "editor-copy-key-binding-editable", testEditorCopyKeyBindingEditable);
+    }
     EditorKeyBindingTest::add("WebKitWebView", "editor-select-all-key-binding-non-editable", testEditorSelectAllKeyBindingNonEditable);
     EditorKeyBindingTest::add("WebKitWebView", "editor-arrow-keys-still-scroll", testEditorArrowKeysStillScroll);
 }


### PR DESCRIPTION
#### 8aebb0ac128e5f3e4fa99d3d9818e614357a4618
<pre>
[WPE] Clipboard API tests always fail on the legacy API bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=323219">https://bugs.webkit.org/show_bug.cgi?id=323219</a>

Reviewed by Carlos Garcia Campos.

The legacy API bot runs the same build as the regular WPE bot and only
passes --wpe-legacy-api at test time. That leaves the fixture without a
WPEDisplay, so webkit_web_view_get_wpe_view() returns null: the editor
tests assert on a valid WPEView before reaching the clipboard, and
PageClientImpl::requestDOMPasteAccess only emits a
WebKitClipboardPermissionRequest when a WPEPlatform view exists.

The legacy API has no clipboard, so there is nothing for these three
subtests to check there. Don&apos;t register them when it is in use. An
expectation cannot express this, as scope keys have no flavor dimension
and a wpe entry would also mask failures on the WPEPlatform bots

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestUIClient.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/TestWebViewEditor.cpp:
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/320404@main">https://commits.webkit.org/320404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79788f06007f87e07d224cedf70581b5dffa6782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144031 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100080 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46535 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44707 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44319 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5888 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45764 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58081 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58786 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153276 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47802 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127535 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57289 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19333 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->