### PR TITLE
Fix Windows build intermittency

### DIFF
--- a/Tools/Scripts/swift/swiftc-wrapper.py
+++ b/Tools/Scripts/swift/swiftc-wrapper.py
@@ -79,6 +79,21 @@ def _unescape(path):
     return path.replace("\\ ", " ")
 
 
+def _canonical(path):
+    """A spelling-insensitive key for paths that name the same file."""
+    return os.path.normcase(os.path.normpath(path)).replace("\\", "/")
+
+
+def excluded_paths(request):
+    """Canonical keys of everything that must not appear in the depfile."""
+    excludes = {_canonical(exclude): exclude for exclude in request.excludes}
+    # A depfile may never list its own target or itself, whatever the caller
+    # asked to exclude.
+    excludes.setdefault(_canonical(request.target), request.target)
+    excludes.setdefault(_canonical(request.path), request.path)
+    return excludes
+
+
 def parse_depfile(path):
     """Yield the dependencies recorded in one Makefile-syntax depfile."""
     text = Path(path).read_text(errors="replace").replace("\\\n", " ")
@@ -114,11 +129,12 @@ def write_ninja_depfile(request, output_file_map):
             "can't track Swift header dependencies"
         )
 
+    excludes = excluded_paths(request)
     deps = dict.fromkeys(
         dep
         for source in sources
         for dep in parse_depfile(source)
-        if dep not in request.excludes
+        if _canonical(dep) not in excludes
     )
 
     lines = [f"{_escape(request.target)}:"]


### PR DESCRIPTION
#### 6eb84d9263d323778eaea1ab3fe87e784a183706
<pre>
Fix Windows build intermittency
<a href="https://bugs.webkit.org/show_bug.cgi?id=323220">https://bugs.webkit.org/show_bug.cgi?id=323220</a>
<a href="https://rdar.apple.com/186466509">rdar://186466509</a>

Reviewed by Claudio Saavedra.

Windows build was failing with:
Source/WebKit/WebKit_SwiftRebuildTrigger.swift -&gt;
Source/WebKit/WebKit_SwiftRebuildTrigger.swift
due to backslash vs slash comparisons.

Canonical link: <a href="https://commits.webkit.org/320339@main">https://commits.webkit.org/320339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/153042f89f5810c5259b32c89f84690577049bac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148776 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/099fc6b4-3865-4b1d-aa60-65034d18ea53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144033 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100082 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdc36d73-1e20-474d-8850-b8345003e9a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64014189-cfe7-4a7e-aa6e-fe222c601701) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46537 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44320 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5891 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196763 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58085 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41134 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58790 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153278 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47805 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57293 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19334 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56657 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->