### PR TITLE
[Web Animations] Fully accelerated animations unnecessarily invalidate style while a non-accelerated animation is running

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A fully accelerated animation must not invalidate style only because another non-accelerated animation is running.
+

--- a/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html
+++ b/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html
@@ -1,0 +1,29 @@
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="threaded-animations/threaded-animations-utils.js"></script>
+<div id="pump" style="width: 100px; height: 100px;"></div>
+<div id="test" style="width: 100px; height: 100px;"></div>
+<script>
+
+promise_test(async () => {
+    // #pump can never run accelerated (animates layout-affecting "width"), so it keeps ticking the shared timeline;
+    // #test must not invalidate style only because it shares that timeline.
+
+    document.getElementById("pump").animate({ width: ["100px", "200px"] }, { duration: 50, iterations: Infinity });
+
+    const testElement = document.getElementById("test");
+    const testAnimation = testElement.animate({ opacity: [1, 0.4] }, { duration: 50, iterations: Infinity });
+    await animationAcceleration(testAnimation);
+
+    assert_equals(internals.acceleratedAnimationsForElement(testElement).length, 1, "The animation should be running accelerated.");
+
+    // It takes two frames for the style update to settle after the accelerated animation starts.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    assert_equals(internals.lastStyleUpdateSize, 1, "Only the non-accelerated #pump element should have had its style resolved.");
+}, "A fully accelerated animation must not invalidate style only because another non-accelerated animation is running.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2125,7 +2125,21 @@ void KeyframeEffect::addPendingAcceleratedAction(AcceleratedAction action)
 
 void KeyframeEffect::animationDidTick()
 {
-    invalidate();
+    auto canSkipInvalidation = [this]() {
+        if (!isCompletelyAccelerated() || !isRunningAccelerated())
+            return false;
+        if (getBasicTiming().phase != m_phaseAtLastApplication)
+            return false;
+#if ENABLE(THREADED_ANIMATIONS)
+        if (canHaveAcceleratedRepresentation() && m_isAssociatedWithProgressBasedTimeline)
+            return false;
+#endif
+        return true;
+    };
+
+    if (!canSkipInvalidation())
+        invalidate();
+
     updateAcceleratedActions();
 
 #if ENABLE(THREADED_ANIMATIONS)


### PR DESCRIPTION
#### 1508d59b56eb3107cd6fa41c726cc3c3d0a48b94
<pre>
[Web Animations] Fully accelerated animations unnecessarily invalidate style while a non-accelerated animation is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=323436">https://bugs.webkit.org/show_bug.cgi?id=323436</a>

Reviewed by Antoine Quint.

When a page has at least one animation that cannot run on the
compositor, that animation forces the page to process animation updates
on every frame. While this happens, other animations on the same page
that are otherwise running entirely on the compositor have their style
needlessly recalculated on every update too, and in some cases this can
force layout.

`KeyframeEffect::animationDidTick()` unconditionally invalidated the
target&apos;s style on every tick, even for effects that were fully
accelerated and confirmed running on the compositor, whenever some other
animation on the shared timeline forced that tick.

Skip `invalidate()` when the effect is completely accelerated, confirmed
running accelerated, and its phase hasn&apos;t changed since it was last
applied.

Progress-based (scroll/view) timeline effects are excluded from this
fast path, since their current time is driven by input rather than
tracked autonomously by the compositor, and can change within the same
phase.

Test: webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidTick):
* LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html: Added.

Canonical link: <a href="https://commits.webkit.org/320647@main">https://commits.webkit.org/320647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c24531640b65d36117cf97005926aa1dcd669920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100445 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45356 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45044 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6781 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41361 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59690 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154056 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48541 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132021 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128874 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58168 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57540 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->